### PR TITLE
[PLATFORM-33] Start/stop canvases + start options

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --hot",
     "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack",
-    "test": "jest ./test/* ./src/userpages/tests/*",
+    "test": "jest ./test/* ./src/userpages/tests/* ./src/editor/tests/*",
     "flow": "flow",
     "flow-stop": "flow stop",
     "eslint": "eslint .",

--- a/app/src/editor/components/Canvas.jsx
+++ b/app/src/editor/components/Canvas.jsx
@@ -79,6 +79,11 @@ export default DragDropContext(HTML5Backend)(class Canvas extends React.Componen
         ))
     }
 
+    onCanDrag = ({ canvas }) => (
+        // cannot drag anything while canvas is running
+        canvas.state !== 'RUNNING'
+    )
+
     /**
      * Module & Port Drag/Drop APIs
      * note: don't add state to this as the api object doesn't change
@@ -93,14 +98,14 @@ export default DragDropContext(HTML5Backend)(class Canvas extends React.Componen
             onDrag: this.onDragModule,
             onDrop: this.onDropModule,
             onCanDrop: () => true,
-            onCanDrag: () => true,
+            onCanDrag: this.onCanDrag,
         },
         port: {
             onDrag: this.onDragPort,
             onDrop: this.onDropPort,
             onCanDrop: this.onCanDropPort,
             onDragEnd: this.onDragEndPort,
-            onCanDrag: () => true,
+            onCanDrag: this.onCanDrag,
             onChange: this.setPortValue,
             setPortOptions: this.setPortOptions,
         },

--- a/app/src/editor/components/Canvas.jsx
+++ b/app/src/editor/components/Canvas.jsx
@@ -81,7 +81,7 @@ export default DragDropContext(HTML5Backend)(class Canvas extends React.Componen
 
     onCanDrag = ({ canvas }) => (
         // cannot drag anything while canvas is running
-        canvas.state !== 'RUNNING'
+        canvas.state !== CanvasState.RunStates.Running
     )
 
     /**

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -108,7 +108,13 @@ class CanvasModule extends React.Component {
     )
 
     render() {
-        const { api, module, connectDragSource, isDragging } = this.props
+        const {
+            api,
+            module,
+            canvas,
+            connectDragSource,
+            isDragging,
+        } = this.props
         const { outputs } = module
         const { isDraggable, layout } = this.state
 
@@ -183,6 +189,7 @@ class CanvasModule extends React.Component {
                                         size={portSize}
                                         adjustMinPortSize={this.adjustMinPortSize}
                                         setIsDraggable={this.setIsDraggable}
+                                        canvas={canvas}
                                         {...api.port}
                                     />
                                 )

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -139,7 +139,9 @@ class CanvasModule extends React.Component {
             isDraggable ? connectDragSource(el) : el
         )
 
+        const isRunning = canvas.state === 'RUNNING'
         const isResizable = isModuleResizable(module)
+
         return maybeConnectDragging((
             /* eslint-disable-next-line max-len */
             /* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-tabindex */
@@ -166,6 +168,7 @@ class CanvasModule extends React.Component {
                         className={styles.name}
                         value={module.displayName || module.name}
                         onChange={this.onChangeModuleName}
+                        disabled={!!isRunning}
                     />
                     <button
                         type="button"
@@ -198,7 +201,7 @@ class CanvasModule extends React.Component {
                         </div>
                     ))}
                 </div>
-                {!!isResizable && (
+                {!!isResizable && !isRunning && (
                     /* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */
                     <Resizer
                         module={module}

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -7,7 +7,7 @@ import withErrorBoundary from '$shared/utils/withErrorBoundary'
 import { Translate } from 'react-redux-i18n'
 
 import { DragSource } from '../utils/dnd'
-import { DragTypes } from '../state'
+import { DragTypes, RunStates } from '../state'
 
 import { Resizer, isModuleResizable } from './Resizer'
 import RenameInput from './RenameInput'
@@ -139,7 +139,7 @@ class CanvasModule extends React.Component {
             isDraggable ? connectDragSource(el) : el
         )
 
-        const isRunning = canvas.state === 'RUNNING'
+        const isRunning = canvas.state === RunStates.Running
         const isResizable = isModuleResizable(module)
 
         return maybeConnectDragging((

--- a/app/src/editor/components/ModuleSearch.jsx
+++ b/app/src/editor/components/ModuleSearch.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import startCase from 'lodash/startCase'
 
-import { moduleTreeSearch } from '../state'
 import { getModuleTree } from '../services'
+import { moduleTreeSearch } from '../state'
 
 import styles from './ModuleSearch.pcss'
 

--- a/app/src/editor/components/ModuleSearch.jsx
+++ b/app/src/editor/components/ModuleSearch.jsx
@@ -18,13 +18,14 @@ export default class ModuleSearch extends React.PureComponent {
     }
 
     componentWillUnmount() {
+        this.unmounted = true
         window.removeEventListener('keydown', this.onKeyDown)
     }
 
     async load() {
-        this.setState({
-            modules: await getModuleTree(),
-        })
+        const modules = await getModuleTree()
+        if (this.unmounted) { return }
+        this.setState({ modules })
     }
 
     onChange = (event) => {

--- a/app/src/editor/components/ModuleSidebar.jsx
+++ b/app/src/editor/components/ModuleSidebar.jsx
@@ -50,6 +50,7 @@ export default withErrorBoundary(ErrorComponentView)(class ModuleSidebar extends
             return <div className={cx(styles.sidebar)} hidden={!isOpen} />
         }
         const optionsKeys = Object.keys(module.options || {})
+        const isRunning = canvas.state === 'RUNNING'
         return (
             <div className={cx(styles.sidebar)} hidden={!isOpen}>
                 <div className={cx(styles.sidebarInner)}>
@@ -70,9 +71,19 @@ export default withErrorBoundary(ErrorComponentView)(class ModuleSidebar extends
                                                     <label htmlFor={id}>{startCase(name)}</label>
                                                     {option.possibleValues ? (
                                                         /* Select */
-                                                        <select id={id} value={option.value} onChange={this.onChangeValue(name)}>
+                                                        <select
+                                                            id={id}
+                                                            value={option.value}
+                                                            onChange={this.onChangeValue(name)}
+                                                        >
                                                             {option.possibleValues.map(({ text, value }) => (
-                                                                <option key={value} value={value}>{text}</option>
+                                                                <option
+                                                                    key={value}
+                                                                    value={value}
+                                                                    disabled={!!isRunning}
+                                                                >
+                                                                    {text}
+                                                                </option>
                                                             ))}
                                                         </select>
                                                     ) : (
@@ -83,10 +94,11 @@ export default withErrorBoundary(ErrorComponentView)(class ModuleSidebar extends
                                                                 checked={option.value}
                                                                 type="checkbox"
                                                                 onChange={this.onChangeChecked(name)}
+                                                                disabled={!!isRunning}
                                                             />
                                                         )) || (
                                                             /* Text */
-                                                            <TextInput value={option.value} onChange={this.onChange(name)}>
+                                                            <TextInput value={option.value} onChange={this.onChange(name)} disabled={!!isRunning}>
                                                                 {({ innerRef, ...props }) => (
                                                                     <input id={id} type="text" {...props} ref={innerRef} />
                                                                 )}

--- a/app/src/editor/components/ModuleSidebar.jsx
+++ b/app/src/editor/components/ModuleSidebar.jsx
@@ -50,7 +50,7 @@ export default withErrorBoundary(ErrorComponentView)(class ModuleSidebar extends
             return <div className={cx(styles.sidebar)} hidden={!isOpen} />
         }
         const optionsKeys = Object.keys(module.options || {})
-        const isRunning = canvas.state === 'RUNNING'
+        const isRunning = canvas.state === CanvasState.RunStates.Running
         return (
             <div className={cx(styles.sidebar)} hidden={!isOpen}>
                 <div className={cx(styles.sidebarInner)}>

--- a/app/src/editor/components/Port.jsx
+++ b/app/src/editor/components/Port.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames'
 import startCase from 'lodash/startCase'
 
 import { DragSource, DropTarget } from '../utils/dnd'
-import { DragTypes } from '../state'
+import { DragTypes, RunStates } from '../state'
 
 import styles from './Module.pcss'
 
@@ -52,7 +52,7 @@ class Port extends React.PureComponent {
         const { port, canvas, ...props } = this.props
         const isInput = !!port.acceptedTypes
         const isParam = 'defaultValue' in port
-        const isRunning = canvas.state === 'RUNNING'
+        const isRunning = canvas.state === RunStates.Running
         const portContent = [
             <div
                 role="gridcell"

--- a/app/src/editor/components/Port.jsx
+++ b/app/src/editor/components/Port.jsx
@@ -49,9 +49,10 @@ class Port extends React.PureComponent {
     }
 
     render() {
-        const { port, ...props } = this.props
+        const { port, canvas, ...props } = this.props
         const isInput = !!port.acceptedTypes
         const isParam = 'defaultValue' in port
+        const isRunning = canvas.state === 'RUNNING'
         const portContent = [
             <div
                 role="gridcell"
@@ -91,6 +92,7 @@ class Port extends React.PureComponent {
                                     value={!!port.drivingInput}
                                     className={styles.drivingInputOption}
                                     onClick={this.toggleOption('drivingInput')}
+                                    disabled={!!isRunning}
                                 >
                                     DI
                                 </button>
@@ -102,6 +104,7 @@ class Port extends React.PureComponent {
                                     value={port.initialValue !== ''}
                                     className={styles.initialValueOption}
                                     onClick={this.toggleOption('initialValue')}
+                                    disabled={!!isRunning}
                                 >
                                     IV
                                 </button>
@@ -113,6 +116,7 @@ class Port extends React.PureComponent {
                                     value={!!port.noRepeat}
                                     className={styles.noRepeatOption}
                                     onClick={this.toggleOption('noRepeat')}
+                                    disabled={!!isRunning}
                                 >
                                     NR
                                 </button>
@@ -139,7 +143,7 @@ class Port extends React.PureComponent {
                             className={styles.portValue}
                             value={this.state.value}
                             onChange={this.onChange}
-                            disabled={!!port.connected}
+                            disabled={!!port.connected || !!isRunning}
                             onMouseOver={() => this.props.setIsDraggable(false)}
                             onMouseOut={() => this.props.setIsDraggable(true)}
                             onBlur={this.onBlur}
@@ -157,7 +161,7 @@ class Port extends React.PureComponent {
                         <input
                             className={styles.portValue}
                             value={this.state.value}
-                            disabled={!!port.connected}
+                            disabled={!!port.connected || !!isRunning}
                             onChange={this.onChange}
                             size={portSize}
                             style={{

--- a/app/src/editor/components/TextInput.jsx
+++ b/app/src/editor/components/TextInput.jsx
@@ -20,7 +20,7 @@ export default class TextInput extends React.PureComponent {
         }
 
         return {
-            value: props.value,
+            value: props.value || '',
         }
     }
 

--- a/app/src/editor/components/Toolbar.jsx
+++ b/app/src/editor/components/Toolbar.jsx
@@ -77,7 +77,12 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
         return (
             <div className={cx(className, styles.CanvasToolbar)}>
                 <R.ButtonGroup className={cx(styles.Hollow, styles.CanvasNameContainer)}>
-                    <RenameInput value={canvas.name} onChange={renameCanvas} innerRef={this.onRenameRef} />
+                    <RenameInput
+                        value={canvas.name}
+                        onChange={renameCanvas}
+                        innerRef={this.onRenameRef}
+                        disabled={!!isRunning}
+                    />
                     <R.UncontrolledDropdown>
                         <R.DropdownToggle className={styles.Hollow}>
                             <Meatball />
@@ -85,9 +90,9 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                         <R.DropdownMenu>
                             <R.DropdownItem onClick={newCanvas}>New Canvas</R.DropdownItem>
                             <R.DropdownItem>Share</R.DropdownItem>
-                            <R.DropdownItem onClick={this.onRename}>Rename</R.DropdownItem>
+                            <R.DropdownItem onClick={this.onRename} disabled={!!isRunning}>Rename</R.DropdownItem>
                             <R.DropdownItem onClick={() => duplicateCanvas()}>Duplicate</R.DropdownItem>
-                            <R.DropdownItem onClick={() => deleteCanvas()}>Delete</R.DropdownItem>
+                            <R.DropdownItem onClick={() => deleteCanvas()} disabled={!!isRunning}>Delete</R.DropdownItem>
                         </R.DropdownMenu>
                     </R.UncontrolledDropdown>
                 </R.ButtonGroup>
@@ -98,7 +103,12 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                         open={this.canvasSearchOpen}
                     />
                 </R.ButtonGroup>
-                <R.Button onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}>+</R.Button>
+                <R.Button
+                    onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
+                    disabled={!!isRunning}
+                >
+                    +
+                </R.Button>
                 <div>
                     <R.Button
                         color="success"
@@ -108,7 +118,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                     </R.Button>
                     {editorState.runTab === RunTabs.historical ? (
                         <R.UncontrolledDropdown>
-                            <R.DropdownToggle caret className={styles.Hollow} />
+                            <R.DropdownToggle caret className={styles.Hollow} disabled={!!isRunning} />
                             <R.DropdownMenu>
                                 <R.DropdownItem
                                     onClick={() => setSpeed('0')}
@@ -144,11 +154,11 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                         </R.UncontrolledDropdown>
                     ) : (
                         <R.UncontrolledDropdown>
-                            <R.DropdownToggle caret className={styles.Hollow} />
+                            <R.DropdownToggle caret className={styles.Hollow} disabled={!!isRunning} />
                             <R.DropdownMenu>
                                 <R.DropdownItem
                                     onClick={() => canvasStart({ clearState: true })}
-                                    disabled={!canvas.serialized}
+                                    disabled={!canvas.serialized || !!isRunning}
                                 >
                                     Reset &amp; Start
                                 </R.DropdownItem>
@@ -160,12 +170,14 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                     <R.Button
                         active={editorState.runTab === RunTabs.realtime}
                         onClick={() => setRunTab(RunTabs.realtime)}
+                        disabled={!!isRunning}
                     >
                         Realtime
                     </R.Button>
                     <R.Button
                         active={editorState.runTab !== RunTabs.realtime}
                         onClick={() => setRunTab(RunTabs.historical)}
+                        disabled={!!isRunning}
                     >
                         Historical
                     </R.Button>
@@ -176,11 +188,13 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                             placeholder="From"
                             onChange={this.getOnChangeHistorical('beginDate')}
                             value={settings.beginDate}
+                            disabled={!!isRunning}
                         />
                         <TextInput
                             placeholder="To"
                             onChange={this.getOnChangeHistorical('endDate')}
                             value={settings.endDate}
+                            disabled={!!isRunning}
                         />
                     </div>
                 ) : (
@@ -198,6 +212,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                             className={styles.saveStateToggle}
                             value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
                             onChange={(value) => setSaveState(value)}
+                            disabled={!!isRunning}
                         />
                     </div>
                 )}

--- a/app/src/editor/components/Toolbar.jsx
+++ b/app/src/editor/components/Toolbar.jsx
@@ -67,11 +67,13 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
             canvasStop,
             newCanvas,
             setSpeed,
+            isWaiting,
         } = this.props
 
         if (!canvas) { return null }
 
         const isRunning = canvas.state === 'RUNNING'
+        const canEdit = !isWaiting && !isRunning
         const { settings = {} } = canvas
         const { editorState = {} } = settings
         return (
@@ -81,7 +83,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                         value={canvas.name}
                         onChange={renameCanvas}
                         innerRef={this.onRenameRef}
-                        disabled={!!isRunning}
+                        disabled={!canEdit}
                     />
                     <R.UncontrolledDropdown>
                         <R.DropdownToggle className={styles.Hollow}>
@@ -90,9 +92,9 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                         <R.DropdownMenu>
                             <R.DropdownItem onClick={newCanvas}>New Canvas</R.DropdownItem>
                             <R.DropdownItem>Share</R.DropdownItem>
-                            <R.DropdownItem onClick={this.onRename} disabled={!!isRunning}>Rename</R.DropdownItem>
+                            <R.DropdownItem onClick={this.onRename} disabled={!canEdit}>Rename</R.DropdownItem>
                             <R.DropdownItem onClick={() => duplicateCanvas()}>Duplicate</R.DropdownItem>
-                            <R.DropdownItem onClick={() => deleteCanvas()} disabled={!!isRunning}>Delete</R.DropdownItem>
+                            <R.DropdownItem onClick={() => deleteCanvas()} disabled={!canEdit}>Delete</R.DropdownItem>
                         </R.DropdownMenu>
                     </R.UncontrolledDropdown>
                 </R.ButtonGroup>
@@ -105,20 +107,21 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                 </R.ButtonGroup>
                 <R.Button
                     onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
-                    disabled={!!isRunning}
+                    disabled={!canEdit}
                 >
                     +
                 </R.Button>
                 <div>
                     <R.Button
                         color="success"
+                        disabled={isWaiting}
                         onClick={() => (isRunning ? canvasStop() : canvasStart())}
                     >
                         {isRunning ? 'Stop' : 'Start'}
                     </R.Button>
                     {editorState.runTab !== RunTabs.realtime ? (
                         <R.UncontrolledDropdown>
-                            <R.DropdownToggle caret className={styles.Hollow} disabled={!!isRunning} />
+                            <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
                             <R.DropdownMenu>
                                 <R.DropdownItem
                                     onClick={() => setSpeed('0')}
@@ -154,11 +157,11 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                         </R.UncontrolledDropdown>
                     ) : (
                         <R.UncontrolledDropdown>
-                            <R.DropdownToggle caret className={styles.Hollow} disabled={!!isRunning} />
+                            <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
                             <R.DropdownMenu>
                                 <R.DropdownItem
                                     onClick={() => canvasStart({ clearState: true })}
-                                    disabled={!canvas.serialized || !!isRunning}
+                                    disabled={!canvas.serialized || !canEdit}
                                 >
                                     Reset &amp; Start
                                 </R.DropdownItem>
@@ -170,14 +173,14 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                     <R.Button
                         active={editorState.runTab === RunTabs.realtime}
                         onClick={() => setRunTab(RunTabs.realtime)}
-                        disabled={!!isRunning}
+                        disabled={!canEdit}
                     >
                         Realtime
                     </R.Button>
                     <R.Button
                         active={editorState.runTab !== RunTabs.realtime}
                         onClick={() => setRunTab(RunTabs.historical)}
-                        disabled={!!isRunning}
+                        disabled={!canEdit}
                     >
                         Historical
                     </R.Button>
@@ -188,13 +191,13 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                             placeholder="From"
                             onChange={this.getOnChangeHistorical('beginDate')}
                             value={settings.beginDate}
-                            disabled={!!isRunning}
+                            disabled={!canEdit}
                         />
                         <TextInput
                             placeholder="To"
                             onChange={this.getOnChangeHistorical('endDate')}
                             value={settings.endDate}
-                            disabled={!!isRunning}
+                            disabled={!canEdit}
                         />
                     </div>
                 ) : (
@@ -212,7 +215,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                             className={styles.saveStateToggle}
                             value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
                             onChange={(value) => setSaveState(value)}
-                            disabled={!!isRunning}
+                            disabled={!canEdit}
                         />
                     </div>
                 )}

--- a/app/src/editor/components/Toolbar.jsx
+++ b/app/src/editor/components/Toolbar.jsx
@@ -41,11 +41,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
     }
 
     getOnChangeHistorical = (key) => (value) => {
-        const { settings } = this.props.canvas
-        const { beginDate, endDate } = settings
         this.props.setHistorical({
-            beginDate,
-            endDate,
             [key]: value,
         })
     }
@@ -67,11 +63,15 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
             setSaveState,
             setRunTab,
             renameCanvas,
+            canvasStart,
+            canvasStop,
             newCanvas,
+            setSpeed,
         } = this.props
 
         if (!canvas) { return null }
 
+        const isRunning = canvas.state === 'RUNNING'
         const { settings = {} } = canvas
         const { editorState = {} } = settings
         return (
@@ -100,13 +100,61 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                 </R.ButtonGroup>
                 <R.Button onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}>+</R.Button>
                 <div>
-                    <R.Button color="success">Start</R.Button>
-                    <R.UncontrolledDropdown>
-                        <R.DropdownToggle caret className={styles.Hollow} />
-                        <R.DropdownMenu>
-                            <R.DropdownItem>Reset &amp; Start</R.DropdownItem>
-                        </R.DropdownMenu>
-                    </R.UncontrolledDropdown>
+                    <R.Button
+                        color="success"
+                        onClick={() => (isRunning ? canvasStop() : canvasStart())}
+                    >
+                        {isRunning ? 'Stop' : 'Start'}
+                    </R.Button>
+                    {editorState.runTab === RunTabs.historical ? (
+                        <R.UncontrolledDropdown>
+                            <R.DropdownToggle caret className={styles.Hollow} />
+                            <R.DropdownMenu>
+                                <R.DropdownItem
+                                    onClick={() => setSpeed('0')}
+                                    active={!settings.speed || settings.speed === '0'}
+                                >
+                                    Full
+                                </R.DropdownItem>
+                                <R.DropdownItem
+                                    onClick={() => setSpeed('1')}
+                                    active={settings.speed === '1'}
+                                >
+                                    1x
+                                </R.DropdownItem>
+                                <R.DropdownItem
+                                    onClick={() => setSpeed('10')}
+                                    active={settings.speed === '10'}
+                                >
+                                    10x
+                                </R.DropdownItem>
+                                <R.DropdownItem
+                                    onClick={() => setSpeed('100')}
+                                    active={settings.speed === '100'}
+                                >
+                                    100x
+                                </R.DropdownItem>
+                                <R.DropdownItem
+                                    onClick={() => setSpeed('1000')}
+                                    active={settings.speed === '1000'}
+                                >
+                                    1000x
+                                </R.DropdownItem>
+                            </R.DropdownMenu>
+                        </R.UncontrolledDropdown>
+                    ) : (
+                        <R.UncontrolledDropdown>
+                            <R.DropdownToggle caret className={styles.Hollow} />
+                            <R.DropdownMenu>
+                                <R.DropdownItem
+                                    onClick={() => canvasStart({ clearState: true })}
+                                    disabled={!canvas.serialized}
+                                >
+                                    Reset &amp; Start
+                                </R.DropdownItem>
+                            </R.DropdownMenu>
+                        </R.UncontrolledDropdown>
+                    )}
                 </div>
                 <R.ButtonGroup className={styles.runTabToggle}>
                     <R.Button

--- a/app/src/editor/components/Toolbar.jsx
+++ b/app/src/editor/components/Toolbar.jsx
@@ -116,7 +116,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                     >
                         {isRunning ? 'Stop' : 'Start'}
                     </R.Button>
-                    {editorState.runTab === RunTabs.historical ? (
+                    {editorState.runTab !== RunTabs.realtime ? (
                         <R.UncontrolledDropdown>
                             <R.DropdownToggle caret className={styles.Hollow} disabled={!!isRunning} />
                             <R.DropdownMenu>
@@ -182,7 +182,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                         Historical
                     </R.Button>
                 </R.ButtonGroup>
-                {editorState.runTab === RunTabs.historical ? (
+                {editorState.runTab !== RunTabs.realtime ? (
                     <div className={styles.runTabInputs}>
                         <TextInput
                             placeholder="From"

--- a/app/src/editor/components/Toolbar.jsx
+++ b/app/src/editor/components/Toolbar.jsx
@@ -7,7 +7,7 @@ import Toggle from '$shared/components/Toggle'
 import withErrorBoundary from '$shared/utils/withErrorBoundary'
 import ErrorComponentView from '$shared/components/ErrorComponentView'
 
-import { RunTabs } from '../state'
+import { RunTabs, RunStates } from '../state'
 
 import RenameInput from './RenameInput'
 import TextInput from './TextInput'
@@ -72,7 +72,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
 
         if (!canvas) { return null }
 
-        const isRunning = canvas.state === 'RUNNING'
+        const isRunning = canvas.state === RunStates.Running
         const canEdit = !isWaiting && !isRunning
         const { settings = {} } = canvas
         const { editorState = {} } = settings

--- a/app/src/editor/components/UndoContainer.jsx
+++ b/app/src/editor/components/UndoContainer.jsx
@@ -93,12 +93,10 @@ export default class UndoContainer extends React.Component {
                 if (this.unmounted) { return null }
                 const prevHistory = history[pointer]
                 const prevState = prevHistory && prevHistory.state
-                const partialState = fn(prevState)
+                const nextState = fn(prevState)
                 // no update if same or null
-                if (partialState === null || partialState === prevState) { return null }
+                if (nextState === null || nextState === prevState) { return null }
 
-                // merge state update with existing state
-                const nextState = Object.assign({}, prevState, partialState)
                 const nextHistoryItem = {
                     action,
                     state: nextState,

--- a/app/src/editor/components/UndoContainer.jsx
+++ b/app/src/editor/components/UndoContainer.jsx
@@ -32,6 +32,7 @@ export default class UndoContainer extends React.Component {
      */
 
     undo = () => {
+        if (this.unmounted) { return }
         this.setState(({ history, historyPointer }) => {
             const nextPointer = historyPointer - 1
             if (!history[nextPointer]) { return null } // no more undos
@@ -46,6 +47,7 @@ export default class UndoContainer extends React.Component {
      */
 
     redo = () => {
+        if (this.unmounted) { return }
         this.setState(({ history, historyPointer }) => {
             const nextPointer = historyPointer + 1
             if (!history[nextPointer]) { return null } // no more redos
@@ -62,6 +64,7 @@ export default class UndoContainer extends React.Component {
      */
 
     pushHistory = (action, fn, done) => {
+        if (this.unmounted) { return }
         this.setState(({ history, historyPointer }) => {
             const prevState = history[historyPointer]
             if (!prevState || !prevState.state) { return null }
@@ -91,6 +94,7 @@ export default class UndoContainer extends React.Component {
      */
 
     replaceHistory = (fn, done) => {
+        if (this.unmounted) { return }
         this.setState(({ history, historyPointer }) => {
             const prevState = history[historyPointer]
             if (!prevState || !prevState.state) { return null }
@@ -107,6 +111,13 @@ export default class UndoContainer extends React.Component {
                 history: nextHistory,
             }
         }, done)
+    }
+
+    resetHistory = (state) => {
+        this.setState({
+            history: [null, { state }],
+            historyPointer: 1,
+        })
     }
 
     onKeyDown = (event) => {
@@ -137,10 +148,12 @@ export default class UndoContainer extends React.Component {
     }
 
     componentDidMount() {
+        this.unmounted = false
         window.addEventListener('keydown', this.onKeyDown)
     }
 
     componentWillUnmount() {
+        this.unmounted = true
         window.removeEventListener('keydown', this.onKeyDown)
     }
 
@@ -153,6 +166,7 @@ export default class UndoContainer extends React.Component {
             historyPointer,
             pushHistory: this.pushHistory,
             replaceHistory: this.replaceHistory,
+            resetHistory: this.resetHistory,
         })
     }
 }

--- a/app/src/editor/components/UndoContainer.jsx
+++ b/app/src/editor/components/UndoContainer.jsx
@@ -169,6 +169,7 @@ export default class UndoContainer extends React.Component {
 
 export class UndoControls extends React.Component {
     onKeyDown = (event) => {
+        if (this.props.disabled) { return }
         // ignore if focus in an input, select, textarea, etc
         if (document.activeElement) {
             const tagName = document.activeElement.tagName.toLowerCase()

--- a/app/src/editor/components/UndoContainer.jsx
+++ b/app/src/editor/components/UndoContainer.jsx
@@ -66,14 +66,14 @@ export default class UndoContainer extends React.Component {
     pushHistory = (action, fn, done) => {
         if (this.unmounted) { return }
         this.setState(({ history, historyPointer }) => {
-            const prevState = history[historyPointer]
-            if (!prevState || !prevState.state) { return null }
-            const partialState = fn(prevState.state)
+            const prevHistory = history[historyPointer]
+            const prevState = prevHistory && prevHistory.state
+            const partialState = fn(prevState)
             // no update if same or null
-            if (partialState === null || partialState === prevState.state) { return null }
+            if (partialState === null || partialState === prevState) { return null }
 
             // merge state update with existing state
-            const nextState = Object.assign({}, prevState.state, partialState)
+            const nextState = Object.assign({}, prevState, partialState)
             const nextHistoryItem = {
                 action,
                 state: nextState,
@@ -96,14 +96,24 @@ export default class UndoContainer extends React.Component {
     replaceHistory = (fn, done) => {
         if (this.unmounted) { return }
         this.setState(({ history, historyPointer }) => {
-            const prevState = history[historyPointer]
-            if (!prevState || !prevState.state) { return null }
-            const nextState = fn(prevState.state)
+            const prevHistory = history[historyPointer]
+            const prevState = prevHistory && prevHistory.state
+            const nextState = fn(prevState)
             // no update if same or null
-            if (nextState === null || nextState === prevState.state) { return null }
+            if (nextState === null || nextState === prevState) { return null }
             const nextHistory = history.slice()
+            // set first history item
+            if (!prevHistory) {
+                return {
+                    history: nextHistory.concat({
+                        state: nextState,
+                    }),
+                    historyPointer: 1,
+                }
+            }
+
             nextHistory[historyPointer] = {
-                ...prevState,
+                ...prevHistory,
                 state: nextState,
             }
 

--- a/app/src/editor/index.jsx
+++ b/app/src/editor/index.jsx
@@ -18,7 +18,7 @@ import Canvas from './components/Canvas'
 import CanvasToolbar from './components/Toolbar'
 import ModuleSearch from './components/ModuleSearch'
 import ModuleSidebar from './components/ModuleSidebar'
-import UndoContainer from './components/UndoContainer'
+import UndoContainer, { UndoControls } from './components/UndoContainer'
 
 import styles from './index.pcss'
 
@@ -381,17 +381,19 @@ export default withRouter((props) => (
     <Layout className={styles.layout} footer={false}>
         <UndoContainer key={props.match.params.id}>
             {({ state: canvas, ...undoApi }) => (
-                <CanvasLoader
-                    canvasId={(canvas && canvas.id) || props.match.params.id}
-                    canvas={canvas}
-                    {...undoApi}
-                >
-                    <CanvasEdit
-                        key={canvas && (canvas.id + canvas.updated)}
+                <UndoControls {...undoApi}>
+                    <CanvasLoader
+                        canvasId={(canvas && canvas.id) || props.match.params.id}
                         canvas={canvas}
                         {...undoApi}
-                    />
-                </CanvasLoader>
+                    >
+                        <CanvasEdit
+                            key={canvas && (canvas.id + canvas.updated)}
+                            canvas={canvas}
+                            {...undoApi}
+                        />
+                    </CanvasLoader>
+                </UndoControls>
             )}
         </UndoContainer>
     </Layout>

--- a/app/src/editor/index.jsx
+++ b/app/src/editor/index.jsx
@@ -81,6 +81,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     componentDidMount() {
         window.addEventListener('keydown', this.onKeyDown)
+        this.autosubscribe()
     }
 
     componentWillUnmount() {
@@ -339,7 +340,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 }
 
-const CanvasEdit = connect(mapStateToProps)(withRouter((props) => <CanvasEditComponent {...props} />))
+const CanvasEdit = connect(mapStateToProps)(withRouter(CanvasEditComponent))
 
 const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class CanvasLoader extends React.PureComponent {
     static contextType = UndoContainer.Context
@@ -359,8 +360,8 @@ const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class Canv
 
     init() {
         const canvas = this.context.state
-        const canvasId = (canvas && canvas.id) || this.props.match.params.id
         const currentId = canvas && canvas.id
+        const canvasId = currentId || this.props.match.params.id
         if (canvasId && currentId !== canvasId && this.state.isLoading !== canvasId) {
             // load canvas if needed and not already loading
             this.load(canvasId)

--- a/app/src/editor/index.jsx
+++ b/app/src/editor/index.jsx
@@ -381,7 +381,7 @@ export default withRouter((props) => (
     <Layout className={styles.layout} footer={false}>
         <UndoContainer key={props.match.params.id}>
             {({ state: canvas, ...undoApi }) => (
-                <UndoControls {...undoApi}>
+                <UndoControls {...undoApi} disabled={!canvas || (canvas.state === 'RUNNING' || canvas.adhoc)}>
                     <CanvasLoader
                         canvasId={(canvas && canvas.id) || props.match.params.id}
                         canvas={canvas}

--- a/app/src/editor/index.jsx
+++ b/app/src/editor/index.jsx
@@ -22,7 +22,7 @@ import UndoContainer, { UndoControls } from './components/UndoContainer'
 
 import styles from './index.pcss'
 
-const { RunTabs } = CanvasState
+const { RunTabs, RunStates } = CanvasState
 
 const MessageTypes = {
     Done: 'D',
@@ -97,7 +97,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     async autosave() {
         const { canvas } = this.props
-        if (canvas.state === 'RUNNING' || canvas.adhoc) {
+        if (canvas.state === RunStates.Running || canvas.adhoc) {
             // do not autosave running/adhoc canvases
             return
         }
@@ -111,7 +111,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     autosubscribe() {
         if (this.client) { return }
         const { canvas } = this.props
-        if (canvas.state === 'RUNNING') {
+        if (canvas.state === RunStates.Running) {
             this.subscribe(canvas)
         }
     }
@@ -386,7 +386,7 @@ const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class Canv
 }))
 
 function isDisabled({ state: canvas }) {
-    return !canvas || (canvas.state === 'RUNNING' || canvas.adhoc)
+    return !canvas || (canvas.state === RunStates.Running || canvas.adhoc)
 }
 
 const CanvasEditWrap = () => (

--- a/app/src/editor/services.js
+++ b/app/src/editor/services.js
@@ -60,3 +60,12 @@ export async function addModule({ id }) {
     }
     return moduleData
 }
+
+export async function start(canvas, { clearState }) {
+    await saveNow(canvas)
+    return API.post(`${canvasesUrl}/${canvas.id}/start`, { clearState: !!clearState })
+}
+
+export async function stop(canvas) {
+    return API.post(`${canvasesUrl}/${canvas.id}/stop`)
+}

--- a/app/src/editor/services.js
+++ b/app/src/editor/services.js
@@ -71,12 +71,9 @@ export async function loadCanvas({ id }) {
 
 async function startCanvas(canvas, { clearState }) {
     const savedCanvas = await saveNow(canvas)
-    await API.post(`${canvasesUrl}/${savedCanvas.id}/start`, {
+    return API.post(`${canvasesUrl}/${savedCanvas.id}/start`, {
         clearState: !!clearState,
     })
-    // ignore response body, just re-fetch
-    // if canvas crashed immediately after starting this will reflect that state
-    return loadCanvas(savedCanvas)
 }
 
 async function startAdhocCanvas(canvas, options = {}) {
@@ -99,5 +96,5 @@ export async function start(canvas, options = {}) {
 }
 
 export async function stop(canvas) {
-    await API.post(`${canvasesUrl}/${canvas.id}/stop`)
+    return API.post(`${canvasesUrl}/${canvas.id}/stop`)
 }

--- a/app/src/editor/services.js
+++ b/app/src/editor/services.js
@@ -62,7 +62,7 @@ export async function addModule({ id }) {
 }
 
 export async function start(canvas, { clearState }) {
-    await saveNow(canvas)
+    await saveNow(canvas) // save any pending edits before starting
     return API.post(`${canvasesUrl}/${canvas.id}/start`, { clearState: !!clearState })
 }
 

--- a/app/src/editor/services.js
+++ b/app/src/editor/services.js
@@ -1,7 +1,16 @@
-import * as API from '$shared/utils/api'
+import axios from 'axios'
 
 import Autosave from './utils/autosave'
 import { emptyCanvas } from './state'
+
+const API = axios.create({
+    headers: {
+        'Content-Type': 'application/json',
+    },
+    withCredentials: true,
+})
+
+const getData = ({ data }) => data
 
 const canvasesUrl = `${process.env.STREAMR_API_URL}/canvases`
 const getModuleURL = `${process.env.STREAMR_URL}/module/jsonGetModule`
@@ -10,7 +19,7 @@ const getModuleTreeURL = `${process.env.STREAMR_URL}/module/jsonGetModuleTree`
 const AUTOSAVE_DELAY = 3000
 
 async function save(canvas) {
-    return API.put(`${canvasesUrl}/${canvas.id}`, canvas)
+    return API.put(`${canvasesUrl}/${canvas.id}`, canvas).then(getData)
 }
 
 export const autosave = Autosave(save, AUTOSAVE_DELAY)
@@ -24,7 +33,7 @@ export async function saveNow(canvas, ...args) {
 }
 
 async function createCanvas(canvas) {
-    return API.post(canvasesUrl, canvas)
+    return API.post(canvasesUrl, canvas).then(getData)
 }
 
 export async function create() {
@@ -32,7 +41,7 @@ export async function create() {
 }
 
 export async function moduleHelp({ id }) {
-    return API.get(`${process.env.STREAMR_API_URL}/modules/${id}/help`)
+    return API.get(`${process.env.STREAMR_API_URL}/modules/${id}/help`).then(getData)
 }
 
 export async function duplicateCanvas(canvas) {
@@ -42,38 +51,28 @@ export async function duplicateCanvas(canvas) {
 
 export async function deleteCanvas({ id }) {
     await autosave.cancel()
-    return API.del(`${canvasesUrl}/${id}`)
+    return API.del(`${canvasesUrl}/${id}`).then(getData)
 }
 
 export async function getModuleTree() {
-    const moduleData = await API.get(getModuleTreeURL)
-    if (moduleData.error) {
-        // TODO handle this better
-        throw new Error(`error getting module tree ${moduleData.message}`)
-    }
-    return moduleData
+    return API.get(getModuleTreeURL).then(getData)
 }
 
 export async function addModule({ id }) {
     const form = new FormData()
     form.append('id', id)
-    const moduleData = await API.post(getModuleURL, form)
-    if (moduleData.error) {
-        // TODO handle this better
-        throw new Error(`error getting module ${moduleData.message}`)
-    }
-    return moduleData
+    return API.post(getModuleURL, form).then(getData)
 }
 
 export async function loadCanvas({ id }) {
-    return API.get(`${canvasesUrl}/${id}`)
+    return API.get(`${canvasesUrl}/${id}`).then(getData)
 }
 
 async function startCanvas(canvas, { clearState }) {
     const savedCanvas = await saveNow(canvas)
     return API.post(`${canvasesUrl}/${savedCanvas.id}/start`, {
         clearState: !!clearState,
-    })
+    }).then(getData)
 }
 
 async function startAdhocCanvas(canvas, options = {}) {
@@ -96,5 +95,5 @@ export async function start(canvas, options = {}) {
 }
 
 export async function stop(canvas) {
-    return API.post(`${canvasesUrl}/${canvas.id}/stop`)
+    return API.post(`${canvasesUrl}/${canvas.id}/stop`).then(getData)
 }

--- a/app/src/editor/services.js
+++ b/app/src/editor/services.js
@@ -61,6 +61,10 @@ export async function addModule({ id }) {
     return moduleData
 }
 
+export async function loadCanvas({ id }) {
+    return API.get(`${canvasesUrl}/${id}`)
+}
+
 export async function start(canvas, { clearState }) {
     await saveNow(canvas) // save any pending edits before starting
     return API.post(`${canvasesUrl}/${canvas.id}/start`, { clearState: !!clearState })

--- a/app/src/editor/services.js
+++ b/app/src/editor/services.js
@@ -1,63 +1,27 @@
-import debounce from 'lodash/debounce'
 import * as API from '$shared/utils/api'
+
+import Autosave from './utils/autosave'
 import { emptyCanvas } from './state'
 
 const canvasesUrl = `${process.env.STREAMR_API_URL}/canvases`
 const getModuleURL = `${process.env.STREAMR_URL}/module/jsonGetModule`
 const getModuleTreeURL = `${process.env.STREAMR_URL}/module/jsonGetModuleTree`
+
 const AUTOSAVE_DELAY = 3000
 
-function unsavedUnloadWarning(event) {
-    const confirmationMessage = 'You have unsaved changes'
-    const evt = (event || window.event)
-    evt.returnValue = confirmationMessage // Gecko + IE
-    return confirmationMessage // Webkit, Safari, Chrome etc.
-}
-
-// don't export this unless also adding handling to cancel autosaving
 async function save(canvas) {
     return API.put(`${canvasesUrl}/${canvas.id}`, canvas)
 }
 
-export const autosave = Object.assign(function autosave(canvas, ...args) {
-    // keep returning the same promise until autosave fires
-    // resolve/reject autosave when debounce finally runs & save is complete
-    autosave.promise = autosave.promise || new Promise((resolve, reject) => {
-        let isCancelled = false
-        // warn user if changes not yet saved
-        window.addEventListener('beforeunload', unsavedUnloadWarning)
+export const autosave = Autosave(save, AUTOSAVE_DELAY)
 
-        autosave.cancel = () => {
-            isCancelled = true
-            console.info('Autosave cancelled', canvas.id) // eslint-disable-line no-console
-            return Promise.resolve(false).then(resolve, reject)
-        }
+export async function saveNow(canvas, ...args) {
+    if (autosave.pending) {
+        return autosave.run(canvas, ...args) // do not wait for debounce
+    }
 
-        // capture debounced function
-        autosave.run = debounce(async (canvas, ...args) => {
-            // clear state for next run
-            window.removeEventListener('beforeunload', unsavedUnloadWarning)
-            autosave.run = undefined
-            autosave.cancel = Function.prototype
-            autosave.promise = undefined
-            if (isCancelled) { return } // noop if cancelled
-            try {
-                const result = await save(canvas, ...args)
-                // TODO: temporary logs until notifications work again
-                console.info('Autosaved', canvas.id) // eslint-disable-line no-console
-                resolve(result)
-            } catch (err) {
-                console.warn('Autosave failed', canvas.id, err) // eslint-disable-line no-console
-                reject(err)
-            }
-        }, AUTOSAVE_DELAY)
-    })
-
-    autosave.run(canvas, ...args) // run debounced save with latest args
-    return autosave.promise
-}, {
-    cancel: Function.prototype,
-})
+    return save(canvas, ...args)
+}
 
 export async function create() {
     return API.post(canvasesUrl, emptyCanvas())
@@ -68,7 +32,8 @@ export async function moduleHelp({ id }) {
 }
 
 export async function duplicateCanvas(canvas) {
-    return API.post(canvasesUrl, canvas)
+    const savedCanvas = await saveNow(canvas) // ensure canvas saved before duplicating
+    return API.post(canvasesUrl, savedCanvas)
 }
 
 export async function deleteCanvas({ id }) {

--- a/app/src/editor/state.js
+++ b/app/src/editor/state.js
@@ -3,6 +3,11 @@ import get from 'lodash/get'
 import cloneDeep from 'lodash/cloneDeep'
 import uuid from 'uuid'
 
+export const RunStates = {
+    Running: 'RUNNING',
+    Stopped: 'STOPPED',
+}
+
 export const DragTypes = {
     Module: 'Module',
     Port: 'Port',

--- a/app/src/editor/tests/UndoContainer.test.jsx
+++ b/app/src/editor/tests/UndoContainer.test.jsx
@@ -2,30 +2,17 @@ import React from 'react'
 import { mount } from 'enzyme'
 import UndoContainer from '../components/UndoContainer'
 
-function FindMe() {
-    return null
-}
-
 describe('UndoContainer', () => {
-    describe('children render prop', () => {
-        it('renders children', () => {
-            const el = mount((
-                <UndoContainer>
-                    {() => <FindMe />}
-                </UndoContainer>
-            ))
-            expect(el.children().length).toBe(1)
-            expect(el.find(FindMe).length).toBe(1)
-        })
-    })
     describe('initialState', () => {
         it('does not need a value', () => {
             mount((
                 <UndoContainer>
-                    {({ state }) => {
-                        expect(state).toBe(null)
-                        return null
-                    }}
+                    <UndoContainer.Consumer>
+                        {(props) => {
+                            expect(props.state).toBe(undefined)
+                            return null
+                        }}
+                    </UndoContainer.Consumer>
                 </UndoContainer>
             ))
         })
@@ -34,29 +21,32 @@ describe('UndoContainer', () => {
             const initialState = {}
             mount((
                 <UndoContainer initialState={initialState}>
-                    {({ state }) => {
-                        expect(state).toBe(initialState)
-                        return null
-                    }}
+                    <UndoContainer.Consumer>
+                        {(props) => {
+                            expect(props.state).toBe(initialState)
+                            return null
+                        }}
+                    </UndoContainer.Consumer>
                 </UndoContainer>
             ))
         })
-
         describe('undo/redo with initial state', () => {
             it('will not undo past initial state, redo does nothing', async () => {
                 let props
                 mount((
                     <UndoContainer>
-                        {(containerProps) => {
-                            props = containerProps
-                            return null
-                        }}
+                        <UndoContainer.Consumer>
+                            {(containerProps) => {
+                                props = containerProps
+                                return null
+                            }}
+                        </UndoContainer.Consumer>
                     </UndoContainer>
                 ))
                 const initialProps = props
-                await props.undoHistory()
+                await props.undo()
                 expect(props).toBe(initialProps)
-                await props.redoHistory()
+                await props.redo()
                 expect(props).toBe(initialProps)
             })
         })
@@ -69,22 +59,24 @@ describe('UndoContainer', () => {
             let props
             mount((
                 <UndoContainer initialState={initialState}>
-                    {(containerProps) => {
-                        props = containerProps
-                        return null
-                    }}
+                    <UndoContainer.Consumer>
+                        {(containerProps) => {
+                            props = containerProps
+                            return null
+                        }}
+                    </UndoContainer.Consumer>
                 </UndoContainer>
             ))
 
             const initialProps = props
             const action = { type: 'action' }
-            await props.pushHistory(action, (prevState) => {
+            await props.push(action, (prevState) => {
                 expect(prevState).toEqual(initialState) // history pointer should not change
                 return nextState
             })
             expect(props.state).toEqual(nextState)
             expect(props.action).toEqual(action)
-            expect(props.historyPointer).toBe(initialProps.historyPointer + 1)
+            expect(props.pointer).toBe(initialProps.pointer + 1)
         })
 
         it('push merges with existing', async () => {
@@ -93,22 +85,24 @@ describe('UndoContainer', () => {
             let props
             mount((
                 <UndoContainer initialState={initialState}>
-                    {(containerProps) => {
-                        props = containerProps
-                        return null
-                    }}
+                    <UndoContainer.Consumer>
+                        {(containerProps) => {
+                            props = containerProps
+                            return null
+                        }}
+                    </UndoContainer.Consumer>
                 </UndoContainer>
             ))
 
             const initialProps = props
             const action = { type: 'action' }
-            await props.pushHistory(action, () => nextState)
+            await props.push(action, () => nextState)
 
             const action2 = { type: 'action2' }
             const mergeState = { merged: true }
             // merge item
-            await props.pushHistory(action2, () => mergeState)
-            expect(props.historyPointer).toBe(initialProps.historyPointer + 2)
+            await props.push(action2, () => mergeState)
+            expect(props.pointer).toBe(initialProps.pointer + 2)
             expect(props.action).toEqual(action2)
             expect(props.state).toEqual({
                 ...nextState,
@@ -122,23 +116,25 @@ describe('UndoContainer', () => {
             let props
             mount((
                 <UndoContainer initialState={initialState}>
-                    {(containerProps) => {
-                        props = containerProps
-                        return null
-                    }}
+                    <UndoContainer.Consumer>
+                        {(containerProps) => {
+                            props = containerProps
+                            return null
+                        }}
+                    </UndoContainer.Consumer>
                 </UndoContainer>
             ))
 
             const initialProps = props
 
             // none of the below should cause re-render so check strictly equal
-            await props.pushHistory(action, () => null)
+            await props.push(action, () => null)
             expect(props).toBe(initialProps)
-            await props.pushHistory(action, (prev) => prev)
+            await props.push(action, (prev) => prev)
             expect(props).toBe(initialProps)
-            await props.replaceHistory(() => null)
+            await props.replace(() => null)
             expect(props).toBe(initialProps)
-            await props.replaceHistory((prev) => prev)
+            await props.replace((prev) => prev)
             expect(props).toBe(initialProps)
         })
 
@@ -148,40 +144,42 @@ describe('UndoContainer', () => {
             let props
             mount((
                 <UndoContainer initialState={initialState}>
-                    {(containerProps) => {
-                        props = containerProps
-                        return null
-                    }}
+                    <UndoContainer.Consumer>
+                        {(containerProps) => {
+                            props = containerProps
+                            return null
+                        }}
+                    </UndoContainer.Consumer>
                 </UndoContainer>
             ))
 
             const initialProps = props
             const action = { type: 'action' }
             // add item
-            await props.pushHistory(action, (prevState) => {
+            await props.push(action, (prevState) => {
                 expect(prevState).toEqual(initialState) // history pointer should not change
                 return nextState
             })
             // undo
-            await props.undoHistory()
+            await props.undo()
             expect(props.state).toEqual(initialState)
-            expect(props.historyPointer).toBe(initialProps.historyPointer)
+            expect(props.pointer).toBe(initialProps.pointer)
             // redo
-            await props.redoHistory()
+            await props.redo()
             const afterRedoProps = props
             expect(props.state).toEqual(nextState)
             expect(props.action).toEqual(action)
-            expect(props.historyPointer).toBe(initialProps.historyPointer + 1)
+            expect(props.pointer).toBe(initialProps.pointer + 1)
             // redo again does nothing
-            await props.redoHistory()
+            await props.redo()
             expect(props).toBe(afterRedoProps)
 
             // undo
-            await props.undoHistory()
+            await props.undo()
             // replace redo with new history
             const action2 = { type: 'action2' }
-            await props.pushHistory(action2, () => nextState)
-            expect(props.historyPointer).toBe(initialProps.historyPointer + 1)
+            await props.push(action2, () => nextState)
+            expect(props.pointer).toBe(initialProps.pointer + 1)
             expect(props.action).toEqual(action2)
             expect(props.state).toEqual(nextState)
         })
@@ -192,16 +190,18 @@ describe('UndoContainer', () => {
         let props
         mount((
             <UndoContainer>
-                {(containerProps) => {
-                    props = containerProps
-                    return null
-                }}
+                <UndoContainer.Consumer>
+                    {(containerProps) => {
+                        props = containerProps
+                        return null
+                    }}
+                </UndoContainer.Consumer>
             </UndoContainer>
         ))
 
         const initialProps = props
-        await props.replaceHistory(() => replaceState)
-        expect(props.historyPointer).toBe(initialProps.historyPointer)
+        await props.replace(() => replaceState)
+        expect(props.pointer).toBe(initialProps.pointer)
         expect(props.state).toEqual(replaceState)
     })
 
@@ -211,20 +211,22 @@ describe('UndoContainer', () => {
         let props
         mount((
             <UndoContainer initialState={initialState}>
-                {(containerProps) => {
-                    props = containerProps
-                    return null
-                }}
+                <UndoContainer.Consumer>
+                    {(containerProps) => {
+                        props = containerProps
+                        return null
+                    }}
+                </UndoContainer.Consumer>
             </UndoContainer>
         ))
 
         const initialProps = props
         const action = { type: 'action' }
-        await props.pushHistory(action, () => nextState)
+        await props.push(action, () => nextState)
 
         const replaceState = { replaced: true }
-        await props.replaceHistory(() => replaceState)
-        expect(props.historyPointer).toBe(initialProps.historyPointer + 1)
+        await props.replace(() => replaceState)
+        expect(props.pointer).toBe(initialProps.pointer + 1)
         expect(props.action).toEqual(action)
         expect(props.state).toEqual(replaceState)
     })
@@ -237,17 +239,19 @@ describe('UndoContainer', () => {
         let props
         mount((
             <UndoContainer initialState={initialState}>
-                {(containerProps) => {
-                    props = containerProps
-                    return null
-                }}
+                <UndoContainer.Consumer>
+                    {(containerProps) => {
+                        props = containerProps
+                        return null
+                    }}
+                </UndoContainer.Consumer>
             </UndoContainer>
         ))
 
         const initialProps = props
-        await props.pushHistory(action, () => nextState)
+        await props.push(action, () => nextState)
 
-        await props.resetHistory()
+        await props.reset()
         expect(props).toEqual(initialProps)
     })
 })

--- a/app/src/editor/tests/UndoContainer.test.jsx
+++ b/app/src/editor/tests/UndoContainer.test.jsx
@@ -18,18 +18,21 @@ describe('UndoContainer', () => {
         })
 
         it('can take a value', () => {
-            const initialState = {}
+            const initialState = { initial: true }
+            let props
             mount((
                 <UndoContainer initialState={initialState}>
                     <UndoContainer.Consumer>
-                        {(props) => {
-                            expect(props.state).toBe(initialState)
+                        {(containerProps) => {
+                            props = containerProps
                             return null
                         }}
                     </UndoContainer.Consumer>
                 </UndoContainer>
             ))
+            expect(props.state).toEqual(initialState)
         })
+
         describe('undo/redo with initial state', () => {
             it('will not undo past initial state, redo does nothing', async () => {
                 let props
@@ -54,7 +57,7 @@ describe('UndoContainer', () => {
 
     describe('push/undo/redo', () => {
         it('can push new state', async () => {
-            const initialState = {}
+            const initialState = { initial: true }
             const nextState = { next: true }
             let props
             mount((
@@ -79,39 +82,8 @@ describe('UndoContainer', () => {
             expect(props.pointer).toBe(initialProps.pointer + 1)
         })
 
-        it('push merges with existing', async () => {
-            const initialState = {}
-            const nextState = { next: true }
-            let props
-            mount((
-                <UndoContainer initialState={initialState}>
-                    <UndoContainer.Consumer>
-                        {(containerProps) => {
-                            props = containerProps
-                            return null
-                        }}
-                    </UndoContainer.Consumer>
-                </UndoContainer>
-            ))
-
-            const initialProps = props
-            const action = { type: 'action' }
-            await props.push(action, () => nextState)
-
-            const action2 = { type: 'action2' }
-            const mergeState = { merged: true }
-            // merge item
-            await props.push(action2, () => mergeState)
-            expect(props.pointer).toBe(initialProps.pointer + 2)
-            expect(props.action).toEqual(action2)
-            expect(props.state).toEqual({
-                ...nextState,
-                ...mergeState,
-            })
-        })
-
         it('push/replace does nothing if return null/same', async () => {
-            const initialState = {}
+            const initialState = { initial: true }
             const action = { type: 'action' }
             let props
             mount((
@@ -139,7 +111,7 @@ describe('UndoContainer', () => {
         })
 
         it('can undo then redo after pushing state', async () => {
-            const initialState = {}
+            const initialState = { initial: true }
             const nextState = { next: true }
             let props
             mount((
@@ -186,11 +158,12 @@ describe('UndoContainer', () => {
     })
 
     it('can replace initial state', async () => {
+        const initialState = { initial: true }
         const replaceState = { replaced: true }
         let props
         mount((
             <UndoContainer>
-                <UndoContainer.Consumer>
+                <UndoContainer.Consumer initialState={initialState}>
                     {(containerProps) => {
                         props = containerProps
                         return null
@@ -200,13 +173,18 @@ describe('UndoContainer', () => {
         ))
 
         const initialProps = props
+        inspect(props)
         await props.replace(() => replaceState)
         expect(props.pointer).toBe(initialProps.pointer)
+        function inspect(item) { // for debugging
+            console.log(require('util').inspect(item, {colors: true, depth: 30}))
+        }
+        inspect(props)
         expect(props.state).toEqual(replaceState)
     })
 
     it('can replace top item after push', async () => {
-        const initialState = {}
+        const initialState = { initial: true }
         const nextState = { next: true }
         let props
         mount((
@@ -232,7 +210,7 @@ describe('UndoContainer', () => {
     })
 
     it('can reset history', async () => {
-        const initialState = {}
+        const initialState = { initial: true }
         const nextState = { next: true }
         const action = { type: 'action' }
 

--- a/app/src/editor/tests/UndoContainer.test.jsx
+++ b/app/src/editor/tests/UndoContainer.test.jsx
@@ -1,0 +1,253 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import UndoContainer from '../components/UndoContainer'
+
+function FindMe() {
+    return null
+}
+
+describe('UndoContainer', () => {
+    describe('children render prop', () => {
+        it('renders children', () => {
+            const el = mount((
+                <UndoContainer>
+                    {() => <FindMe />}
+                </UndoContainer>
+            ))
+            expect(el.children().length).toBe(1)
+            expect(el.find(FindMe).length).toBe(1)
+        })
+    })
+    describe('initialState', () => {
+        it('does not need a value', () => {
+            mount((
+                <UndoContainer>
+                    {({ state }) => {
+                        expect(state).toBe(null)
+                        return null
+                    }}
+                </UndoContainer>
+            ))
+        })
+
+        it('can take a value', () => {
+            const initialState = {}
+            mount((
+                <UndoContainer initialState={initialState}>
+                    {({ state }) => {
+                        expect(state).toBe(initialState)
+                        return null
+                    }}
+                </UndoContainer>
+            ))
+        })
+
+        describe('undo/redo with initial state', () => {
+            it('will not undo past initial state, redo does nothing', async () => {
+                let props
+                mount((
+                    <UndoContainer>
+                        {(containerProps) => {
+                            props = containerProps
+                            return null
+                        }}
+                    </UndoContainer>
+                ))
+                const initialProps = props
+                await props.undoHistory()
+                expect(props).toBe(initialProps)
+                await props.redoHistory()
+                expect(props).toBe(initialProps)
+            })
+        })
+    })
+
+    describe('push/undo/redo', () => {
+        it('can push new state', async () => {
+            const initialState = {}
+            const nextState = { next: true }
+            let props
+            mount((
+                <UndoContainer initialState={initialState}>
+                    {(containerProps) => {
+                        props = containerProps
+                        return null
+                    }}
+                </UndoContainer>
+            ))
+
+            const initialProps = props
+            const action = { type: 'action' }
+            await props.pushHistory(action, (prevState) => {
+                expect(prevState).toEqual(initialState) // history pointer should not change
+                return nextState
+            })
+            expect(props.state).toEqual(nextState)
+            expect(props.action).toEqual(action)
+            expect(props.historyPointer).toBe(initialProps.historyPointer + 1)
+        })
+
+        it('push merges with existing', async () => {
+            const initialState = {}
+            const nextState = { next: true }
+            let props
+            mount((
+                <UndoContainer initialState={initialState}>
+                    {(containerProps) => {
+                        props = containerProps
+                        return null
+                    }}
+                </UndoContainer>
+            ))
+
+            const initialProps = props
+            const action = { type: 'action' }
+            await props.pushHistory(action, () => nextState)
+
+            const action2 = { type: 'action2' }
+            const mergeState = { merged: true }
+            // merge item
+            await props.pushHistory(action2, () => mergeState)
+            expect(props.historyPointer).toBe(initialProps.historyPointer + 2)
+            expect(props.action).toEqual(action2)
+            expect(props.state).toEqual({
+                ...nextState,
+                ...mergeState,
+            })
+        })
+
+        it('push/replace does nothing if return null/same', async () => {
+            const initialState = {}
+            const action = { type: 'action' }
+            let props
+            mount((
+                <UndoContainer initialState={initialState}>
+                    {(containerProps) => {
+                        props = containerProps
+                        return null
+                    }}
+                </UndoContainer>
+            ))
+
+            const initialProps = props
+
+            // none of the below should cause re-render so check strictly equal
+            await props.pushHistory(action, () => null)
+            expect(props).toBe(initialProps)
+            await props.pushHistory(action, (prev) => prev)
+            expect(props).toBe(initialProps)
+            await props.replaceHistory(() => null)
+            expect(props).toBe(initialProps)
+            await props.replaceHistory((prev) => prev)
+            expect(props).toBe(initialProps)
+        })
+
+        it('can undo then redo after pushing state', async () => {
+            const initialState = {}
+            const nextState = { next: true }
+            let props
+            mount((
+                <UndoContainer initialState={initialState}>
+                    {(containerProps) => {
+                        props = containerProps
+                        return null
+                    }}
+                </UndoContainer>
+            ))
+
+            const initialProps = props
+            const action = { type: 'action' }
+            // add item
+            await props.pushHistory(action, (prevState) => {
+                expect(prevState).toEqual(initialState) // history pointer should not change
+                return nextState
+            })
+            // undo
+            await props.undoHistory()
+            expect(props.state).toEqual(initialState)
+            expect(props.historyPointer).toBe(initialProps.historyPointer)
+            // redo
+            await props.redoHistory()
+            const afterRedoProps = props
+            expect(props.state).toEqual(nextState)
+            expect(props.action).toEqual(action)
+            expect(props.historyPointer).toBe(initialProps.historyPointer + 1)
+            // redo again does nothing
+            await props.redoHistory()
+            expect(props).toBe(afterRedoProps)
+
+            // undo
+            await props.undoHistory()
+            // replace redo with new history
+            const action2 = { type: 'action2' }
+            await props.pushHistory(action2, () => nextState)
+            expect(props.historyPointer).toBe(initialProps.historyPointer + 1)
+            expect(props.action).toEqual(action2)
+            expect(props.state).toEqual(nextState)
+        })
+    })
+
+    it('can replace initial state', async () => {
+        const replaceState = { replaced: true }
+        let props
+        mount((
+            <UndoContainer>
+                {(containerProps) => {
+                    props = containerProps
+                    return null
+                }}
+            </UndoContainer>
+        ))
+
+        const initialProps = props
+        await props.replaceHistory(() => replaceState)
+        expect(props.historyPointer).toBe(initialProps.historyPointer)
+        expect(props.state).toEqual(replaceState)
+    })
+
+    it('can replace top item after push', async () => {
+        const initialState = {}
+        const nextState = { next: true }
+        let props
+        mount((
+            <UndoContainer initialState={initialState}>
+                {(containerProps) => {
+                    props = containerProps
+                    return null
+                }}
+            </UndoContainer>
+        ))
+
+        const initialProps = props
+        const action = { type: 'action' }
+        await props.pushHistory(action, () => nextState)
+
+        const replaceState = { replaced: true }
+        await props.replaceHistory(() => replaceState)
+        expect(props.historyPointer).toBe(initialProps.historyPointer + 1)
+        expect(props.action).toEqual(action)
+        expect(props.state).toEqual(replaceState)
+    })
+
+    it('can reset history', async () => {
+        const initialState = {}
+        const nextState = { next: true }
+        const action = { type: 'action' }
+
+        let props
+        mount((
+            <UndoContainer initialState={initialState}>
+                {(containerProps) => {
+                    props = containerProps
+                    return null
+                }}
+            </UndoContainer>
+        ))
+
+        const initialProps = props
+        await props.pushHistory(action, () => nextState)
+
+        await props.resetHistory()
+        expect(props).toEqual(initialProps)
+    })
+})

--- a/app/src/editor/utils/autosave.js
+++ b/app/src/editor/utils/autosave.js
@@ -1,0 +1,74 @@
+import debounce from 'lodash/debounce'
+
+function unsavedUnloadWarning(event) {
+    const confirmationMessage = 'You have unsaved changes'
+    const evt = (event || window.event)
+    evt.returnValue = confirmationMessage // Gecko + IE
+    return confirmationMessage // Webkit, Safari, Chrome etc.
+}
+
+export default function Autosave(saveFn, opts) {
+    // keep returning the same promise until autosave fires
+    // resolve/reject autosave when debounce finally runs & save is complete
+    function autosave(canvas, ...args) {
+        function wait() {
+            const pending = new Promise((resolve, reject) => {
+                let canRun = true
+                window.addEventListener('beforeunload', unsavedUnloadWarning)
+
+                // warn user if changes not yet saved
+                function reset() {
+                    canRun = false
+                    // clear state for next run
+                    window.removeEventListener('beforeunload', unsavedUnloadWarning)
+                    Object.assign(autosave, {
+                        run: saveFn,
+                        cancel: Function.prototype,
+                        runLater: autosave,
+                        pending: undefined,
+                    })
+                }
+
+                async function cancel() {
+                    reset()
+                    console.info('Autosave cancelled', canvas.id) // eslint-disable-line no-console
+                    return Promise.resolve(false).then(resolve, reject)
+                }
+
+                // capture debounced function
+                async function run(canvas, ...args) {
+                    if (!canRun) { return } // noop if cancelled
+                    reset()
+                    try {
+                        const result = await saveFn(canvas, ...args)
+                        // TODO: temporary logs until notifications work again
+                        console.info('Autosaved', canvas.id) // eslint-disable-line no-console
+                        resolve(result)
+                    } catch (err) {
+                        console.warn('Autosave failed', canvas.id, err) // eslint-disable-line no-console
+                        reject(err)
+                    }
+                    return pending
+                }
+
+                Object.assign(autosave, {
+                    run,
+                    cancel,
+                    runLater: debounce(run, opts),
+                })
+            })
+            return pending
+        }
+
+        if (!autosave.pending) {
+            autosave.pending = wait()
+        }
+        autosave.runLater(canvas, ...args) // run debounced save with latest args
+        return autosave.pending
+    }
+    return Object.assign(autosave, {
+        run: saveFn,
+        runLater: autosave,
+        cancel: Function.prototype,
+    })
+}

--- a/app/src/shared/components/Toggle/index.jsx
+++ b/app/src/shared/components/Toggle/index.jsx
@@ -7,6 +7,7 @@ import styles from './toggle.pcss'
 
 type Props = {
     className?: string,
+    disabled?: boolean,
     onChange?: (checked: boolean) => void,
     value?: boolean,
 }
@@ -38,12 +39,17 @@ class Toggle extends Component<Props, State> {
     }
 
     render() {
-        const { className } = this.props
+        const { className, disabled } = this.props
         const { value } = this.state
         return (
             <div className={cx(className)}>
                 <label className={cx(styles.switch, styles.label)}>
-                    <input type="checkbox" onChange={this.onChange} checked={value} />
+                    <input
+                        type="checkbox"
+                        onChange={this.onChange}
+                        checked={value}
+                        disabled={disabled}
+                    />
                     <span className={cx(styles.slider)} />
                 </label>
             </div>

--- a/app/src/userpages/modules/canvas/actions.js
+++ b/app/src/userpages/modules/canvas/actions.js
@@ -78,6 +78,10 @@ export const getCanvases = () => (dispatch: Function) => {
             order: 'desc',
         },
     })
+        .then((data) => (
+            // filter out adhoc canvases which should be filtered by server
+            data.filter(({ adhoc }) => !adhoc)
+        ))
         .then(handleEntities(canvasesSchema, dispatch))
         .then((data) => {
             dispatch(getCanvasesSuccess(data))


### PR DESCRIPTION
* Enables Start/Stop buttons
* Enables historical "speed" settings
* Enables/disables "reset & start" functionality based on canvas "serialised" status.
* Disables editing & undo while canvas is running.
* Adds temporary swapping to historical canvases.
* Adds workaround for serverside `/canvases?adhoc=false` responding with `adhoc` canvases.
* Adds tests around undo/redo functionality.
* Automatically subscribes to streams for running canvas
* Automatically unsubscribes if running canvas ends.
* Automatically reverts to "parent" canvas if a historical canvas is ended.

To Test:

1. Open Any Canvas.
2. Create a new Canvas via the "…" menu  on the left of the canvas.
2. Add a clock & a table module.
2. Change the clock's unit to "hour" ("second" will flood the dev env with too many events and will require restarting build 👎).
2. Connect the modules via date or timestamp.
2. Switch to Realtime mode.
2. Click Start, see it's running. Editing & undo should be disabled. 
2. Click Stop. Editing & undo should be restored.
2. Switch to Historical mode.
2. Fill the `From` and `To` dates with a date formatted like: `2018-11-20`. The historical mode `From` & `To` fields need a date picker & default value. TODO. 
2. Click Start. Canvas should start then almost immediately end on its own. This is expected behaviour.

No data will display in the table module as I have no hooked up any custom modules like that yet. This is PR is just getting basic start/stop + subscriptions hooked up.