### PR TITLE
Add jsconfig.json for vscode

### DIFF
--- a/app/jsconfig.json
+++ b/app/jsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "allowSyntheticDefaultImports": false,
+    "baseUrl": ".",
+    "paths": {
+      "$app/**/*": ["./**/*"],
+      "$auth/**/*": ["src/auth/**/*"],
+      "$mp/**/*": ["src/marketplace/**/*"],
+      "$userpages/**/*": ["src/userpages/**/*"],
+      "$routes**/*": ["src/routes/**/*"],
+      "$shared/**/*": ["src/shared/**/*"],
+      "$testUtils/**/*": ["src/test/test-utils/**/*"],
+      "$utils/**/*": ["src/utils/**/*"],
+    }
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
I'd like to add jsconfig.json to the project root so that vscode will know how to follow path aliases. With this addition `Go to definition (F12)` works with path aliases.