### PR TITLE
Add webpack-bundle-analyzer

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6402,6 +6402,17 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bfj": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.1.tgz",
+      "integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "check-types": "^7.3.0",
+        "hoopy": "^0.1.2",
+        "tryer": "^1.0.0"
+      }
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -6960,6 +6971,11 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
+    "check-types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
+      "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
     },
     "cheerio": {
       "version": "1.0.0-rc.2",
@@ -11251,6 +11267,11 @@
         "parse-passwd": "^1.0.0"
       }
     },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -15517,6 +15538,11 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "opener": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
     },
     "opn": {
       "version": "5.4.0",
@@ -27473,6 +27499,11 @@
         "glob": "^7.1.2"
       }
     },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -29260,6 +29291,35 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
           "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.3.tgz",
+      "integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
+      "requires": {
+        "acorn": "^5.7.3",
+        "bfj": "^6.1.1",
+        "chalk": "^2.4.1",
+        "commander": "^2.18.0",
+        "ejs": "^2.6.1",
+        "express": "^4.16.3",
+        "filesize": "^3.6.1",
+        "gzip-size": "^5.0.0",
+        "lodash": "^4.17.10",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.5.1",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+          "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },

--- a/app/package.json
+++ b/app/package.json
@@ -209,6 +209,7 @@
     "web3-fake-provider": "^0.1.0",
     "web3-utils": "1.0.0-beta.34",
     "webpack": "^4.12.0",
+    "webpack-bundle-analyzer": "^3.0.2",
     "webpack-cli": "^3.0.8",
     "webpack-dev-server": "^3.1.4",
     "webpack-notifier": "^1.6.0",

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -152,7 +152,10 @@ module.exports = {
         }),
         new webpack.EnvironmentPlugin(loadedDotenv),
         ...(analyze ? [
-            new BundleAnalyzerPlugin(),
+            new BundleAnalyzerPlugin({
+                analyzerMode: 'static',
+                openAnalyzer: false,
+            }),
         ] : []),
     ].concat(isProduction() ? [
         // Production plugins

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -11,14 +11,11 @@ const StyleLintPlugin = require('stylelint-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 const { UnusedFilesWebpackPlugin } = require('unused-files-webpack-plugin')
 const cssProcessor = require('cssnano')
-
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const GitRevisionPlugin = require('git-revision-webpack-plugin')
+const dotenv = require('./scripts/dotenv')
 
-let dotenv = []
-if (!process.env.NO_DOTENV) {
-    dotenv = require('./scripts/dotenv.js')()
-}
+const loadedDotenv = !process.env.NO_DOTENV ? dotenv() : []
 
 const isProduction = require('./scripts/isProduction')
 
@@ -151,7 +148,7 @@ module.exports = {
                 'src/**/*.(p|s)css',
             ],
         }),
-        new webpack.EnvironmentPlugin(dotenv),
+        new webpack.EnvironmentPlugin(loadedDotenv),
     ].concat(isProduction() ? [
         // Production plugins
         new webpack.optimize.OccurrenceOrderPlugin(),

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -11,11 +11,13 @@ const StyleLintPlugin = require('stylelint-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 const { UnusedFilesWebpackPlugin } = require('unused-files-webpack-plugin')
 const cssProcessor = require('cssnano')
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const GitRevisionPlugin = require('git-revision-webpack-plugin')
 const dotenv = require('./scripts/dotenv')
 
 const loadedDotenv = !process.env.NO_DOTENV ? dotenv() : []
+const analyze = !!process.env.ANALYZE
 
 const isProduction = require('./scripts/isProduction')
 
@@ -149,6 +151,9 @@ module.exports = {
             ],
         }),
         new webpack.EnvironmentPlugin(loadedDotenv),
+        ...(analyze ? [
+            new BundleAnalyzerPlugin(),
+        ] : []),
     ].concat(isProduction() ? [
         // Production plugins
         new webpack.optimize.OccurrenceOrderPlugin(),


### PR DESCRIPTION
I'm working on async `zxcvbn` loading. It's going pretty well. 💃 I'd like to merge this little puppy first tho. I saw @fonty1 using it long time ago, thought it's kinda cool; why don't we use it?

It is useful to analyze both production and development bundles that's why it's included for both envs. You have to explicitly request it when running `npm run build` (via the optional `ANALYZE` env variable).

Example:
```
ANALYZE=1 NODE_ENV=production node --max_old_space_size=4096 ./node_modules/.bin/webpack
```

<img width="1873" alt="screenshot 2018-11-23 12 47 25" src="https://user-images.githubusercontent.com/320066/48942323-47a7bd00-ef1f-11e8-8779-c0ee253c64a8.png">

Thoughts?