### PR TITLE
Use I18n directly

### DIFF
--- a/app/src/marketplace/components/ActionBar/SearchInput/index.jsx
+++ b/app/src/marketplace/components/ActionBar/SearchInput/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { Container } from 'reactstrap'
+import { I18n } from 'react-redux-i18n'
 
 import type { SearchFilter } from '../../../flowtype/product-types'
 
@@ -13,15 +14,14 @@ import styles from './searchInput.pcss'
 type Props = {
     value: ?SearchFilter,
     onChange: (text: SearchFilter) => void,
-    translate: (key: string, options: any) => string,
 }
 
-const SearchInput = ({ value, onChange, translate }: Props) => (
+const SearchInput = ({ value, onChange }: Props) => (
     <div className={styles.searchInput}>
         <Container>
             <input
                 type="text"
-                placeholder={translate('actionBar.searchInput.placeholder')}
+                placeholder={I18n.t('actionBar.searchInput.placeholder')}
                 maxLength={searchCharMax}
                 value={value}
                 onChange={(e: SyntheticInputEvent<EventTarget>) => onChange(e.target.value)}

--- a/app/src/marketplace/components/ActionBar/index.jsx
+++ b/app/src/marketplace/components/ActionBar/index.jsx
@@ -5,7 +5,7 @@ import BN from 'bignumber.js'
 import { Link } from 'react-router-dom'
 import classNames from 'classnames'
 import { Container, Button } from 'reactstrap'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import links from '../../../links'
 import type { Filter, SearchFilter, CategoryFilter, SortByFilter } from '../../flowtype/product-types'
@@ -24,7 +24,6 @@ export type Props = {
     onCategoryChange: (filter: Filter) => void,
     onSortChange: (filter: Filter) => void,
     onSearchChange: (filter: Filter) => void,
-    translate: (key: string, options: any) => string,
 }
 
 class ActionBar extends Component<Props> {
@@ -78,7 +77,7 @@ class ActionBar extends Component<Props> {
             ActionBar.sortByOptions.find((o) => o === 'free') :
             ActionBar.sortByOptions.find((o) => o === this.props.filter.sortBy)
 
-        return opt ? this.props.translate(`actionBar.sortOptions.${opt}`) : null
+        return opt ? I18n.t(`actionBar.sortOptions.${opt}`) : null
     }
 
     render() {
@@ -91,7 +90,7 @@ class ActionBar extends Component<Props> {
                         <ul>
                             <li>
                                 <FilterSelector
-                                    title={this.props.translate('actionBar.category')}
+                                    title={I18n.t('actionBar.category')}
                                     selected={this.currentCategoryFilter()}
                                     onClear={() => this.onCategoryChange(null)}
                                     className={(category === null) ? '' : styles.activeFilter}
@@ -110,7 +109,7 @@ class ActionBar extends Component<Props> {
                             </li>
                             <li>
                                 <FilterSelector
-                                    title={this.props.translate('actionBar.sortBy')}
+                                    title={I18n.t('actionBar.sortBy')}
                                     selected={this.currentSortByFilter()}
                                     onClear={() => this.onSortByChange(null)}
                                     className={(sortBy === null && maxPrice === null) ? '' : styles.activeFilter}

--- a/app/src/marketplace/components/ImageUpload/index.jsx
+++ b/app/src/marketplace/components/ImageUpload/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react'
 import Dropzone from 'react-dropzone'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import { maxFileSizeForImageUpload } from '../../utils/constants'
 import withI18n from '../../containers/WithI18n'
@@ -19,7 +19,6 @@ type Props = {
     setImageToUpload?: (File) => void,
     onUploadError: OnUploadError,
     originalImage?: ?string,
-    translate: (key: string, options: any) => string,
 }
 
 type State = {
@@ -62,10 +61,10 @@ class ImageUpload extends Component<Props, State> {
     }
 
     onDropRejected = ([file]: any) => {
-        const { onUploadError, translate } = this.props
+        const { onUploadError } = this.props
 
         if (file.size > maxFileSizeForImageUpload) {
-            onUploadError(translate('imageUpload.fileSize.error', {
+            onUploadError(I18n.t('imageUpload.fileSize.error', {
                 limit: Math.floor(maxFileSizeForImageUpload / 1e6),
             }))
         }
@@ -93,7 +92,7 @@ class ImageUpload extends Component<Props, State> {
     }
 
     render() {
-        const { originalImage, translate } = this.props
+        const { originalImage } = this.props
         const { imageUploading, imageUploaded, hover } = this.state
         const srcImage = this.getPreviewImage() || originalImage
         return (
@@ -129,7 +128,7 @@ class ImageUpload extends Component<Props, State> {
                         <img
                             className={styles.previewImage}
                             src={srcImage}
-                            alt={translate('imageUpload.imageCaption')}
+                            alt={I18n.t('imageUpload.imageCaption')}
                         />
                     )}
                 </Dropzone>

--- a/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/TimeUnitSelector/index.jsx
+++ b/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/TimeUnitSelector/index.jsx
@@ -3,6 +3,7 @@
 import React, { Component, Fragment } from 'react'
 import classNames from 'classnames'
 import { Label } from 'reactstrap'
+import { I18n } from 'react-redux-i18n'
 
 import type { TimeUnit } from '../../../../flowtype/common-types'
 import withI18n from '../../../../containers/WithI18n'
@@ -12,7 +13,6 @@ import style from './timeUnitSelector.pcss'
 export type Props = {
     timeUnit: TimeUnit,
     onChange: (TimeUnit) => void,
-    translate: (key: string, options: any) => string,
 }
 
 type State = {
@@ -32,7 +32,7 @@ class TimeUnitSelector extends Component<Props, State> {
 
     render() {
         const timeUnits = ['hour', 'day', 'week', 'month']
-        const { timeUnit, onChange, translate } = this.props
+        const { timeUnit, onChange } = this.props
         return (
             <Fragment>
                 {timeUnits.map((unit) => (
@@ -53,7 +53,7 @@ class TimeUnitSelector extends Component<Props, State> {
                             value={this.props.timeUnit}
                             onChange={() => onChange(unit)}
                         />
-                        {translate(`modal.chooseAccessPeriod.${unit}`)}
+                        {I18n.t(`modal.chooseAccessPeriod.${unit}`)}
                     </Label>
                 ))}
             </Fragment>

--- a/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/index.jsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import BN from 'bignumber.js'
 import { Form, FormGroup } from 'reactstrap'
+import { I18n } from 'react-redux-i18n'
 
 import { toSeconds } from '../../../utils/time'
 import { dataToUsd, usdToData, formatDecimals } from '../../../utils/price'
@@ -20,7 +21,6 @@ export type Props = {
     contractProduct: SmartContractProduct,
     onNext: (time: NumberString, timeUnit: TimeUnit) => void,
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
 type State = {
@@ -48,13 +48,7 @@ export class ChooseAccessPeriodDialog extends React.Component<Props, State> {
     }
 
     render() {
-        const {
-            contractProduct,
-            onNext,
-            onCancel,
-            dataPerUsd,
-            translate,
-        } = this.props
+        const { contractProduct, onNext, onCancel, dataPerUsd } = this.props
         const { time, timeUnit } = this.state
         const { pricePerSecond, priceCurrency } = contractProduct
         if (!dataPerUsd) {
@@ -73,15 +67,15 @@ export class ChooseAccessPeriodDialog extends React.Component<Props, State> {
         return (
             <Dialog
                 onClose={onCancel}
-                title={translate('modal.chooseAccessPeriod.title')}
+                title={I18n.t('modal.chooseAccessPeriod.title')}
                 actions={{
                     cancel: {
-                        title: translate('modal.common.cancel'),
+                        title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
                         color: 'link',
                     },
                     next: {
-                        title: translate('modal.common.next'),
+                        title: I18n.t('modal.common.next'),
                         color: 'primary',
                         outline: true,
                         onClick: () => onNext(time, timeUnit),

--- a/app/src/marketplace/components/Modal/CompleteContractProductPublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompleteContractProductPublishDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Spinner from '$shared/components/Spinner'
 import CheckmarkIcon from '$mp/components/CheckmarkIcon'
@@ -17,24 +17,23 @@ import styles from '../CompletePublishDialog/completePublishDialog.pcss'
 export type Props = {
     publishState: ?TransactionState,
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const CompleteContractProductPublishDialog = ({ onCancel, publishState, translate }: Props) => {
+const CompleteContractProductPublishDialog = ({ onCancel, publishState }: Props) => {
     switch (publishState) {
         case transactionStates.STARTED:
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePublish.started.title')}
+                    title={I18n.t('modal.completePublish.started.title')}
                     actions={{
                         cancel: {
-                            title: translate('modal.common.cancel'),
+                            title: I18n.t('modal.common.cancel'),
                             onClick: onCancel,
                             color: 'link',
                         },
                         publish: {
-                            title: translate('modal.common.waiting'),
+                            title: I18n.t('modal.common.waiting'),
                             color: 'primary',
                             disabled: true,
                             spinner: true,
@@ -51,7 +50,7 @@ const CompleteContractProductPublishDialog = ({ onCancel, publishState, translat
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePublish.pending.title')}
+                    title={I18n.t('modal.completePublish.pending.title')}
                 >
                     <div>
                         <Spinner size="large" className={styles.icon} />
@@ -64,7 +63,7 @@ const CompleteContractProductPublishDialog = ({ onCancel, publishState, translat
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePublish.confirmed.title')}
+                    title={I18n.t('modal.completePublish.confirmed.title')}
                     autoClose
                 >
                     <div>
@@ -77,14 +76,14 @@ const CompleteContractProductPublishDialog = ({ onCancel, publishState, translat
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePublish.failed.title')}
+                    title={I18n.t('modal.completePublish.failed.title')}
                 >
                     <div>
                         <img
                             className={styles.icon}
                             src={TxFailedImage}
                             srcSet={`${TxFailedImage2x} 2x`}
-                            alt={translate('error.txFailed')}
+                            alt={I18n.t('error.txFailed')}
                         />
                         <p><Translate value="modal.completePublish.failed.message" dangerousHTML /></p>
                     </div>

--- a/app/src/marketplace/components/Modal/CompleteContractProductUnpublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompleteContractProductUnpublishDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Spinner from '$shared/components/Spinner'
 import CheckmarkIcon from '$mp/components/CheckmarkIcon'
@@ -17,24 +17,23 @@ import styles from '../CompleteUnpublishDialog/completeUnpublishDialog.pcss'
 export type Props = {
     publishState: ?TransactionState,
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const CompleteContractProductUnpublishDialog = ({ onCancel, publishState, translate }: Props) => {
+const CompleteContractProductUnpublishDialog = ({ onCancel, publishState }: Props) => {
     switch (publishState) {
         case transactionStates.STARTED:
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completeUnpublish.started.title')}
+                    title={I18n.t('modal.completeUnpublish.started.title')}
                     actions={{
                         cancel: {
-                            title: translate('modal.common.cancel'),
+                            title: I18n.t('modal.common.cancel'),
                             onClick: onCancel,
                             color: 'link',
                         },
                         publish: {
-                            title: translate('modal.common.waiting'),
+                            title: I18n.t('modal.common.waiting'),
                             color: 'primary',
                             disabled: true,
                             spinner: true,
@@ -51,7 +50,7 @@ const CompleteContractProductUnpublishDialog = ({ onCancel, publishState, transl
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completeUnpublish.pending.title')}
+                    title={I18n.t('modal.completeUnpublish.pending.title')}
                 >
                     <div>
                         <Spinner size="large" className={styles.icon} />
@@ -64,7 +63,7 @@ const CompleteContractProductUnpublishDialog = ({ onCancel, publishState, transl
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completeUnpublish.confirmed.title')}
+                    title={I18n.t('modal.completeUnpublish.confirmed.title')}
                     autoClose
                 >
                     <div>
@@ -77,14 +76,14 @@ const CompleteContractProductUnpublishDialog = ({ onCancel, publishState, transl
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completeUnpublish.failed.title')}
+                    title={I18n.t('modal.completeUnpublish.failed.title')}
                 >
                     <div>
                         <img
                             className={styles.icon}
                             src={TxFailedImage}
                             srcSet={`${TxFailedImage2x} 2x`}
-                            alt={translate('error.txFailed')}
+                            alt={I18n.t('error.txFailed')}
                         />
                         <p><Translate value="modal.completeUnpublish.failed.message" dangerousHTML /></p>
                     </div>

--- a/app/src/marketplace/components/Modal/CompletePublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompletePublishDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Spinner from '$shared/components/Spinner'
 import CheckmarkIcon from '$mp/components/CheckmarkIcon'
@@ -17,16 +17,15 @@ import styles from './completePublishDialog.pcss'
 export type Props = {
     publishState: ?TransactionState,
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const CompletePublishDialog = ({ onCancel, publishState, translate }: Props) => {
+const CompletePublishDialog = ({ onCancel, publishState }: Props) => {
     switch (publishState) {
         case transactionStates.STARTED:
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.readyToPublish.title')}
+                    title={I18n.t('modal.readyToPublish.title')}
                 >
                     <div>
                         <Spinner size="large" className={styles.icon} />
@@ -38,7 +37,7 @@ const CompletePublishDialog = ({ onCancel, publishState, translate }: Props) => 
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePublish.confirmed.title')}
+                    title={I18n.t('modal.completePublish.confirmed.title')}
                     autoClose
                 >
                     <div>
@@ -51,14 +50,14 @@ const CompletePublishDialog = ({ onCancel, publishState, translate }: Props) => 
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePublish.failed.title')}
+                    title={I18n.t('modal.completePublish.failed.title')}
                 >
                     <div>
                         <img
                             className={styles.icon}
                             src={TxFailedImage}
                             srcSet={`${TxFailedImage2x} 2x`}
-                            alt={translate('error.txFailed')}
+                            alt={I18n.t('error.txFailed')}
                         />
                         <p><Translate value="modal.completePublish.failed.message" dangerousHTML /></p>
                     </div>

--- a/app/src/marketplace/components/Modal/CompletePurchaseDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompletePurchaseDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Dialog from '../Dialog'
 import Spinner from '$shared/components/Spinner'
@@ -20,16 +20,15 @@ export type Props = {
     purchaseState: ?TransactionState,
     accountLinked: boolean,
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const CompletePurchaseDialog = ({ onCancel, purchaseState, accountLinked, translate }: Props) => {
+const CompletePurchaseDialog = ({ onCancel, purchaseState, accountLinked }: Props) => {
     switch (purchaseState) {
         case transactionStates.PENDING:
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePurchase.pending.title')}
+                    title={I18n.t('modal.completePurchase.pending.title')}
                 >
                     <Spinner size="large" className={styles.icon} />
                     <Translate
@@ -46,7 +45,7 @@ const CompletePurchaseDialog = ({ onCancel, purchaseState, accountLinked, transl
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePurchase.confirmed.title')}
+                    title={I18n.t('modal.completePurchase.confirmed.title')}
                 >
                     <CheckmarkIcon size="large" className={styles.icon} />
                     {!accountLinked && (
@@ -64,13 +63,13 @@ const CompletePurchaseDialog = ({ onCancel, purchaseState, accountLinked, transl
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completePurchase.failed.title')}
+                    title={I18n.t('modal.completePurchase.failed.title')}
                 >
                     <img
                         className={styles.icon}
                         src={TxFailedImage}
                         srcSet={`${TxFailedImage2x} 2x`}
-                        alt={translate('error.txFailed')}
+                        alt={I18n.t('error.txFailed')}
                     />
                     <Translate
                         tag="p"

--- a/app/src/marketplace/components/Modal/CompleteUnpublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompleteUnpublishDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Spinner from '$shared/components/Spinner'
 import CheckmarkIcon from '$mp/components/CheckmarkIcon'
@@ -17,16 +17,15 @@ import styles from './completeUnpublishDialog.pcss'
 export type Props = {
     publishState: ?TransactionState,
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const CompleteUnpublishDialog = ({ onCancel, publishState, translate }: Props) => {
+const CompleteUnpublishDialog = ({ onCancel, publishState }: Props) => {
     switch (publishState) {
         case transactionStates.STARTED:
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.readyToUnpublish.title')}
+                    title={I18n.t('modal.readyToUnpublish.title')}
                 >
                     <div>
                         <Spinner size="large" className={styles.icon} />
@@ -38,7 +37,7 @@ const CompleteUnpublishDialog = ({ onCancel, publishState, translate }: Props) =
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completeUnpublish.confirmed.title')}
+                    title={I18n.t('modal.completeUnpublish.confirmed.title')}
                     autoClose
                 >
                     <div>
@@ -51,14 +50,14 @@ const CompleteUnpublishDialog = ({ onCancel, publishState, translate }: Props) =
             return (
                 <Dialog
                     onClose={onCancel}
-                    title={translate('modal.completeUnpublish.failed.title')}
+                    title={I18n.t('modal.completeUnpublish.failed.title')}
                 >
                     <div>
                         <img
                             className={styles.icon}
                             src={TxFailedImage}
                             srcSet={`${TxFailedImage2x} 2x`}
-                            alt={translate('error.txFailed')}
+                            alt={I18n.t('error.txFailed')}
                         />
                         <p><Translate value="modal.completeUnpublish.failed.message" dangerousHTML /></p>
                     </div>

--- a/app/src/marketplace/components/Modal/ConfirmNoCoverImageDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ConfirmNoCoverImageDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import NoCoverPng from '../../../assets/no_cover.png'
 import NoCoverPng2x from '../../../assets/no_cover@2x.png'
@@ -14,22 +14,21 @@ export type Props = {
     closeOnContinue: boolean,
     onClose: () => void,
     onContinue: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const ConfirmNoCoverImageDialog = ({ closeOnContinue, onClose, onContinue, translate }: Props) => (
+const ConfirmNoCoverImageDialog = ({ closeOnContinue, onClose, onContinue }: Props) => (
     <Dialog
-        title={translate('modal.confirmNoCoverImage.title')}
+        title={I18n.t('modal.confirmNoCoverImage.title')}
         contentClassName={styles.content}
         onClose={onClose}
         actions={{
             cancel: {
-                title: translate('modal.common.cancel'),
+                title: I18n.t('modal.common.cancel'),
                 onClick: onClose,
                 color: 'link',
             },
             continue: {
-                title: translate('modal.common.continue'),
+                title: I18n.t('modal.common.continue'),
                 color: 'primary',
                 onClick: () => {
                     onContinue()
@@ -45,7 +44,7 @@ const ConfirmNoCoverImageDialog = ({ closeOnContinue, onClose, onContinue, trans
             className={styles.icon}
             src={NoCoverPng}
             srcSet={`${NoCoverPng2x} 2x`}
-            alt={translate('modal.confirmNoCoverImage.title')}
+            alt={I18n.t('modal.confirmNoCoverImage.title')}
         />
         <p><Translate value="modal.confirmNoCoverImage.message" dangerousHTML /></p>
     </Dialog>

--- a/app/src/marketplace/components/Modal/ErrorDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ErrorDialog/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { type Node } from 'react'
+import { I18n } from 'react-redux-i18n'
 
 import Dialog from '../Dialog'
 import withI18n from '../../../containers/WithI18n'
@@ -10,23 +11,16 @@ export type Props = {
     message?: Node,
     waiting?: boolean,
     onDismiss: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const ErrorDialog = ({
-    title,
-    message,
-    waiting,
-    onDismiss,
-    translate,
-}: Props) => (
+const ErrorDialog = ({ title, message, waiting, onDismiss }: Props) => (
     <Dialog
-        title={title || translate('modal.errorDialog.defaultTitle')}
+        title={title || I18n.t('modal.errorDialog.defaultTitle')}
         waiting={waiting}
         onClose={onDismiss}
         actions={{
             dismiss: {
-                title: translate('modal.common.ok'),
+                title: I18n.t('modal.common.ok'),
                 color: 'primary',
                 onClick: onDismiss,
             },

--- a/app/src/marketplace/components/Modal/GetCryptoDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/GetCryptoDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import WalletNoEthPng from '../../../assets/wallet_no_eth.png'
 import WalletNoEthPng2x from '../../../assets/wallet_no_eth@2x.png'
@@ -13,15 +13,14 @@ import styles from './getCryptoDialog.pcss'
 
 export type Props = {
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const GetCryptoDialog = ({ onCancel, translate }: Props) => (
+const GetCryptoDialog = ({ onCancel }: Props) => (
     <Dialog
-        title={translate('modal.getCryptoDialog.title')}
+        title={I18n.t('modal.getCryptoDialog.title')}
         onClose={onCancel}
     >
-        <img className={styles.icon} src={WalletNoEthPng} srcSet={`${WalletNoEthPng2x} 2x`} alt={translate('error.wallet')} />
+        <img className={styles.icon} src={WalletNoEthPng} srcSet={`${WalletNoEthPng2x} 2x`} alt={I18n.t('error.wallet')} />
         <Translate value="modal.getCryptoDialog.message" className={styles.message} />
 
         <div className={styles.buttonContainer}>

--- a/app/src/marketplace/components/Modal/GetDataTokensDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/GetDataTokensDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import NoDataPng from '../../../assets/wallet_no_data.png'
 import NoDataPng2x from '../../../assets/wallet_no_data@2x.png'
@@ -13,15 +13,14 @@ import styles from './getDataTokensDialog.pcss'
 
 export type Props = {
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const GetDataTokensDialog = ({ onCancel, translate }: Props) => (
+const GetDataTokensDialog = ({ onCancel }: Props) => (
     <Dialog
-        title={translate('modal.getDataTokensDialog.title')}
+        title={I18n.t('modal.getDataTokensDialog.title')}
         onClose={onCancel}
     >
-        <img className={styles.icon} src={NoDataPng} srcSet={`${NoDataPng2x} 2x`} alt={translate('error.wallet')} />
+        <img className={styles.icon} src={NoDataPng} srcSet={`${NoDataPng2x} 2x`} alt={I18n.t('error.wallet')} />
         <Translate value="modal.getDataTokensDialog.message" className={styles.message} />
 
         <div className={styles.buttonContainer}>

--- a/app/src/marketplace/components/Modal/InsufficientDataDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/InsufficientDataDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import WalletNoDataPng from '$mp/assets/wallet_no_data.png'
 import WalletNoDataPng2x from '$mp/assets/wallet_no_data@2x.png'
@@ -12,15 +12,14 @@ import styles from './insufficientDataDialog.pcss'
 
 export type Props = {
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const InsufficientDataDialog = ({ onCancel, translate }: Props) => (
+const InsufficientDataDialog = ({ onCancel }: Props) => (
     <Dialog
-        title={translate('modal.insufficientDataDialog.title')}
+        title={I18n.t('modal.insufficientDataDialog.title')}
         onClose={onCancel}
     >
-        <img className={styles.icon} src={WalletNoDataPng} srcSet={`${WalletNoDataPng2x} 2x`} alt={translate('error.wallet')} />
+        <img className={styles.icon} src={WalletNoDataPng} srcSet={`${WalletNoDataPng2x} 2x`} alt={I18n.t('error.wallet')} />
         <Translate value="modal.insufficientDataDialog.message" className={styles.message} />
     </Dialog>
 )

--- a/app/src/marketplace/components/Modal/NoStreamsWarningDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/NoStreamsWarningDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import NoCoverPng from '../../../assets/no_cover.png'
 import NoCoverPng2x from '../../../assets/no_cover@2x.png'
@@ -13,24 +13,23 @@ import styles from './noStreamsWarning.pcss'
 export type Props = {
     onClose: () => void,
     onContinue: () => void,
-    translate: (key: string, options: any) => string,
     waiting: boolean,
 }
 
-const NoStreamsWarningDialog = ({ onClose, onContinue, translate, waiting }: Props) => (
+const NoStreamsWarningDialog = ({ onClose, onContinue, waiting }: Props) => (
     <Dialog
-        title={translate('modal.noStreams.title')}
+        title={I18n.t('modal.noStreams.title')}
         contentClassName={styles.content}
         onClose={onClose}
         waiting={waiting}
         actions={{
             cancel: {
-                title: translate('modal.common.cancel'),
+                title: I18n.t('modal.common.cancel'),
                 onClick: onClose,
                 color: 'link',
             },
             continue: {
-                title: translate('editProductPage.edit'),
+                title: I18n.t('editProductPage.edit'),
                 color: 'primary',
                 onClick: onContinue,
             },
@@ -40,7 +39,7 @@ const NoStreamsWarningDialog = ({ onClose, onContinue, translate, waiting }: Pro
             className={styles.icon}
             src={NoCoverPng}
             srcSet={`${NoCoverPng2x} 2x`}
-            alt={translate('modal.noStreams.title')}
+            alt={I18n.t('modal.noStreams.title')}
         />
         <p><Translate value="modal.noStreams.message" dangerousHTML /></p>
     </Dialog>

--- a/app/src/marketplace/components/Modal/PurchaseSummaryDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/PurchaseSummaryDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Dialog from '../Dialog'
 import { toSeconds } from '../../../utils/time'
@@ -16,7 +16,6 @@ export type Props = {
     purchaseStarted: boolean,
     onCancel: () => void,
     onPay: () => void,
-    translate: (key: string, options: any) => string,
 }
 
 export const PurchaseSummaryDialog = ({
@@ -26,21 +25,20 @@ export const PurchaseSummaryDialog = ({
     purchaseStarted,
     onCancel,
     onPay,
-    translate,
 }: Props) => {
     if (purchaseStarted) {
         return (
             <Dialog
                 onClose={onCancel}
-                title={translate('modal.purchaseSummary.started.title')}
+                title={I18n.t('modal.purchaseSummary.started.title')}
                 actions={{
                     cancel: {
-                        title: translate('modal.common.cancel'),
+                        title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
                         color: 'link',
                     },
                     publish: {
-                        title: translate('modal.common.waiting'),
+                        title: I18n.t('modal.common.waiting'),
                         color: 'primary',
                         disabled: true,
                         spinner: true,
@@ -59,15 +57,15 @@ export const PurchaseSummaryDialog = ({
     return (
         <Dialog
             onClose={onCancel}
-            title={translate('modal.purchaseSummary.title')}
+            title={I18n.t('modal.purchaseSummary.title')}
             actions={{
                 cancel: {
-                    title: translate('modal.common.cancel'),
+                    title: I18n.t('modal.common.cancel'),
                     color: 'link',
                     onClick: onCancel,
                 },
                 next: {
-                    title: translate('modal.purchaseSummary.pay'),
+                    title: I18n.t('modal.purchaseSummary.pay'),
                     color: 'primary',
                     onClick: () => onPay(),
                 },
@@ -78,7 +76,7 @@ export const PurchaseSummaryDialog = ({
                 <Translate
                     value="modal.purchaseSummary.access"
                     time={purchase.time}
-                    timeUnit={translate(`common.timeUnit.${purchase.timeUnit}`)}
+                    timeUnit={I18n.t(`common.timeUnit.${purchase.timeUnit}`)}
                 />
             </p>
             <p>

--- a/app/src/marketplace/components/Modal/ReadyToPublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReadyToPublishDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { Component } from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 import { Label, FormGroup } from 'reactstrap'
 
 import Dialog from '../Dialog'
@@ -15,7 +15,6 @@ export type Props = {
     waiting?: boolean,
     onCancel: () => void,
     onPublish: () => void,
-    translate: (key: string, options: any) => string,
 }
 
 export type State = {
@@ -28,21 +27,21 @@ class ReadyToPublishDialog extends Component<Props, State> {
     }
 
     render = () => {
-        const { waiting, onPublish, onCancel, translate } = this.props
+        const { waiting, onPublish, onCancel } = this.props
 
         return (
             <Dialog
                 onClose={onCancel}
                 waiting={waiting}
-                title={translate('modal.readyToPublish.title')}
+                title={I18n.t('modal.readyToPublish.title')}
                 actions={{
                     cancel: {
-                        title: translate('modal.common.cancel'),
+                        title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
                         color: 'link',
                     },
                     publish: {
-                        title: translate('modal.readyToPublish.publish'),
+                        title: I18n.t('modal.readyToPublish.publish'),
                         color: 'primary',
                         onClick: onPublish,
                         disabled: !this.state.termsAccepted,

--- a/app/src/marketplace/components/Modal/ReadyToUnpublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReadyToUnpublishDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Dialog from '../Dialog'
 import withI18n from '$mp/containers/WithI18n'
@@ -9,21 +9,20 @@ import withI18n from '$mp/containers/WithI18n'
 export type Props = {
     onCancel: () => void,
     onUnpublish: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const ReadyToUnpublishDialog = ({ onCancel, onUnpublish, translate }: Props) => (
+const ReadyToUnpublishDialog = ({ onCancel, onUnpublish }: Props) => (
     <Dialog
         onClose={onCancel}
-        title={translate('modal.readyToUnpublish.title')}
+        title={I18n.t('modal.readyToUnpublish.title')}
         actions={{
             cancel: {
-                title: translate('modal.common.cancel'),
+                title: I18n.t('modal.common.cancel'),
                 onClick: onCancel,
                 color: 'link',
             },
             unpublish: {
-                title: translate('modal.readyToUnpublish.unpublish'),
+                title: I18n.t('modal.readyToUnpublish.unpublish'),
                 color: 'primary',
                 onClick: onUnpublish,
             },

--- a/app/src/marketplace/components/Modal/ReplaceAllowanceDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReplaceAllowanceDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Dialog from '../Dialog'
 import links from '../../../../links'
@@ -14,7 +14,6 @@ export type Props = {
     settingAllowance: boolean,
     onCancel: () => void,
     onSet: () => void,
-    translate: (key: string, options: any) => string,
 }
 
 const HelpText = () => (
@@ -23,26 +22,20 @@ const HelpText = () => (
     </p>
 )
 
-const ReplaceAllowanceDialog = ({
-    gettingAllowance,
-    settingAllowance,
-    onCancel,
-    onSet,
-    translate,
-}: Props) => {
+const ReplaceAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, onSet }: Props) => {
     if (settingAllowance) {
         return (
             <Dialog
                 onClose={onCancel}
-                title={translate('modal.setAllowance.started.title')}
+                title={I18n.t('modal.setAllowance.started.title')}
                 actions={{
                     cancel: {
-                        title: translate('modal.common.cancel'),
+                        title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
                         color: 'link',
                     },
                     publish: {
-                        title: translate('modal.common.waiting'),
+                        title: I18n.t('modal.common.waiting'),
                         color: 'primary',
                         disabled: true,
                         spinner: true,
@@ -59,17 +52,17 @@ const ReplaceAllowanceDialog = ({
     return (
         <Dialog
             onClose={onCancel}
-            title={translate('modal.setAllowance.title')}
+            title={I18n.t('modal.setAllowance.title')}
             waiting={gettingAllowance}
             helpText={<HelpText />}
             actions={{
                 cancel: {
-                    title: translate('modal.common.cancel'),
+                    title: I18n.t('modal.common.cancel'),
                     color: 'link',
                     onClick: onCancel,
                 },
                 next: {
-                    title: translate('modal.common.next'),
+                    title: I18n.t('modal.common.next'),
                     color: 'primary',
                     outline: true,
                     onClick: () => onSet(),

--- a/app/src/marketplace/components/Modal/SaveContractProductDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/SaveContractProductDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Spinner from '$shared/components/Spinner'
 import CheckmarkIcon from '$mp/components/CheckmarkIcon'
@@ -17,24 +17,23 @@ import styles from '../modal.pcss'
 export type Props = {
     transactionState: ?TransactionState,
     onClose: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const SaveContractProductDialog = ({ transactionState, onClose, translate }: Props) => {
+const SaveContractProductDialog = ({ transactionState, onClose }: Props) => {
     switch (transactionState) {
         case transactionStates.STARTED:
             return (
                 <Dialog
                     onClose={onClose}
-                    title={translate('modal.saveProduct.started.title')}
+                    title={I18n.t('modal.saveProduct.started.title')}
                     actions={{
                         cancel: {
-                            title: translate('modal.common.cancel'),
+                            title: I18n.t('modal.common.cancel'),
                             onClick: onClose,
                             outline: true,
                         },
                         publish: {
-                            title: translate('modal.common.waiting'),
+                            title: I18n.t('modal.common.waiting'),
                             color: 'primary',
                             disabled: true,
                             spinner: true,
@@ -51,7 +50,7 @@ const SaveContractProductDialog = ({ transactionState, onClose, translate }: Pro
             return (
                 <Dialog
                     onClose={onClose}
-                    title={translate('modal.saveProduct.pending.title')}
+                    title={I18n.t('modal.saveProduct.pending.title')}
                 >
                     <div>
                         <Spinner size="large" className={styles.icon} />
@@ -64,7 +63,7 @@ const SaveContractProductDialog = ({ transactionState, onClose, translate }: Pro
             return (
                 <Dialog
                     onClose={onClose}
-                    title={translate('modal.saveProduct.confirmed.title')}
+                    title={I18n.t('modal.saveProduct.confirmed.title')}
                 >
                     <div>
                         <CheckmarkIcon size="large" className={styles.icon} />
@@ -76,7 +75,7 @@ const SaveContractProductDialog = ({ transactionState, onClose, translate }: Pro
             return (
                 <Dialog
                     onClose={onClose}
-                    title={translate('modal.saveProduct.failed.title')}
+                    title={I18n.t('modal.saveProduct.failed.title')}
                 >
                     <div>
                         <WalletErrorIcon />

--- a/app/src/marketplace/components/Modal/SaveProductDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/SaveProductDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Dialog from '../Dialog'
 import Spinner from '$shared/components/Spinner'
@@ -16,16 +16,15 @@ import styles from '../modal.pcss'
 export type Props = {
     transactionState: ?TransactionState,
     onClose: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const SaveProductDialog = ({ transactionState, onClose, translate }: Props) => {
+const SaveProductDialog = ({ transactionState, onClose }: Props) => {
     switch (transactionState) {
         case transactionStates.STARTED:
             return (
                 <Dialog
                     onClose={onClose}
-                    title={translate('modal.saveProduct.started.title')}
+                    title={I18n.t('modal.saveProduct.started.title')}
                 >
                     <div>
                         <Spinner size="large" className={styles.icon} />
@@ -37,7 +36,7 @@ const SaveProductDialog = ({ transactionState, onClose, translate }: Props) => {
             return (
                 <Dialog
                     onClose={onClose}
-                    title={translate('modal.saveProduct.confirmed.title')}
+                    title={I18n.t('modal.saveProduct.confirmed.title')}
                 >
                     <div>
                         <CheckmarkIcon size="large" className={styles.icon} />
@@ -49,7 +48,7 @@ const SaveProductDialog = ({ transactionState, onClose, translate }: Props) => {
             return (
                 <Dialog
                     onClose={onClose}
-                    title={translate('modal.saveProduct.failed.title')}
+                    title={I18n.t('modal.saveProduct.failed.title')}
                 >
                     <div>
                         <WalletErrorIcon />

--- a/app/src/marketplace/components/Modal/SetAllowanceDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/SetAllowanceDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Dialog from '../Dialog'
 import links from '../../../../links'
@@ -14,7 +14,6 @@ export type Props = {
     settingAllowance: boolean,
     onCancel: () => void,
     onSet: () => void,
-    translate: (key: string, options: any) => string,
 }
 
 const HelpText = () => (
@@ -23,26 +22,20 @@ const HelpText = () => (
     </p>
 )
 
-const SetAllowanceDialog = ({
-    gettingAllowance,
-    settingAllowance,
-    onCancel,
-    onSet,
-    translate,
-}: Props) => {
+const SetAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, onSet }: Props) => {
     if (settingAllowance) {
         return (
             <Dialog
                 onClose={onCancel}
-                title={translate('modal.setAllowance.started.title')}
+                title={I18n.t('modal.setAllowance.started.title')}
                 actions={{
                     cancel: {
-                        title: translate('modal.common.cancel'),
+                        title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
                         color: 'link',
                     },
                     publish: {
-                        title: translate('modal.common.waiting'),
+                        title: I18n.t('modal.common.waiting'),
                         color: 'primary',
                         disabled: true,
                         spinner: true,
@@ -59,17 +52,17 @@ const SetAllowanceDialog = ({
     return (
         <Dialog
             onClose={onCancel}
-            title={translate('modal.setAllowance.title')}
+            title={I18n.t('modal.setAllowance.title')}
             waiting={gettingAllowance}
             helpText={<HelpText />}
             actions={{
                 cancel: {
-                    title: translate('modal.common.cancel'),
+                    title: I18n.t('modal.common.cancel'),
                     color: 'link',
                     onClick: onCancel,
                 },
                 next: {
-                    title: translate('modal.common.next'),
+                    title: I18n.t('modal.common.next'),
                     color: 'primary',
                     outline: true,
                     onClick: () => onSet(),

--- a/app/src/marketplace/components/Modal/SetPriceDialog/TimeUnitButton/index.jsx
+++ b/app/src/marketplace/components/Modal/SetPriceDialog/TimeUnitButton/index.jsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import { capital } from 'case'
+import { I18n } from 'react-redux-i18n'
 
 import type { TimeUnit } from '../../../../flowtype/common-types'
 import withI18n from '../../../../containers/WithI18n'
@@ -14,7 +15,6 @@ type Props = {
     className?: string,
     active: boolean,
     onClick: (TimeUnit) => void,
-    translate: (key: string, options: any) => string,
 }
 
 export class TimeUnitButton extends React.Component<Props> {
@@ -24,12 +24,12 @@ export class TimeUnitButton extends React.Component<Props> {
     }
 
     render() {
-        const { value, className, active, translate } = this.props
+        const { value, className, active } = this.props
 
         return (
             <div className={classNames(className, styles.root, active && styles.active)}>
                 <button type="button" onClick={this.onClick}>
-                    {capital(translate(`common.timeUnit.${value}`))}
+                    {capital(I18n.t(`common.timeUnit.${value}`))}
                 </button>
             </div>
         )

--- a/app/src/marketplace/components/Modal/SetPriceDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/SetPriceDialog/index.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import BN from 'bignumber.js'
 import omit from 'lodash/omit'
 import { Container, Col, Row } from 'reactstrap'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import ModalDialog from '$mp/components/ModalDialog'
 import Steps from '$mp/components/Steps'
@@ -41,7 +41,6 @@ type Props = PriceDialogProps & {
     onClose: () => void,
     onResult: (PriceDialogResult) => void,
     isFree?: boolean,
-    translate: (key: string, options: any) => string,
 }
 
 type State = {
@@ -73,7 +72,7 @@ class SetPriceDialog extends React.Component<Props, State> {
             amount,
             errors: {
                 ...this.state.errors,
-                price: isPriceValid(amount) ? '' : this.props.translate('validation.invalidPrice'),
+                price: isPriceValid(amount) ? '' : I18n.t('validation.invalidPrice'),
                 pricePerSecond: '',
             },
         })
@@ -130,7 +129,7 @@ class SetPriceDialog extends React.Component<Props, State> {
     isBNAmountValid = (BNAmount: any) => !BNAmount.isNaN() && BNAmount.isPositive()
 
     render() {
-        const { onClose, dataPerUsd, accountId, translate } = this.props
+        const { onClose, dataPerUsd, accountId } = this.props
         const { amount,
             timeUnit,
             beneficiaryAddress,
@@ -154,8 +153,8 @@ class SetPriceDialog extends React.Component<Props, State> {
                                 errors={this.getErrors()}
                             >
                                 <Step
-                                    title={translate('modal.setPrice.setPrice')}
-                                    nextButtonLabel={BNAmount.isEqualTo(0) ? translate('modal.setPrice.finish') : ''}
+                                    title={I18n.t('modal.setPrice.setPrice')}
+                                    nextButtonLabel={BNAmount.isEqualTo(0) ? I18n.t('modal.setPrice.finish') : ''}
                                 >
                                     <PaymentRate
                                         currency={priceCurrency}
@@ -176,18 +175,18 @@ class SetPriceDialog extends React.Component<Props, State> {
                                     />
                                 </Step>
                                 <Step
-                                    title={translate('modal.setPrice.setAddresses')}
+                                    title={I18n.t('modal.setPrice.setAddresses')}
                                     className={styles.addresses}
                                     disabled={BNAmount.isEqualTo(0)}
                                 >
                                     <EthAddressField
                                         id="ownerAddress"
-                                        label={translate('modal.setPrice.ownerAddress')}
+                                        label={I18n.t('modal.setPrice.ownerAddress')}
                                         value={accountId || ''}
                                     />
                                     <EthAddressField
                                         id="beneficiaryAddress"
-                                        label={translate('modal.setPrice.beneficiaryAddress')}
+                                        label={I18n.t('modal.setPrice.beneficiaryAddress')}
                                         value={beneficiaryAddress || ''}
                                         onChange={this.onBeneficiaryAddressChange}
                                         hasError={!!(this.state.errors && this.state.errors.beneficiaryAddress)}

--- a/app/src/marketplace/components/Modal/UnlockWalletDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/UnlockWalletDialog/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react'
+import { I18n } from 'react-redux-i18n'
 
 import WalletPng from '../../../assets/wallet.png'
 import WalletPng2x from '../../../assets/wallet@2x.png'
@@ -12,16 +13,15 @@ import styles from './unlockwalletdialog.pcss'
 export type Props = {
     onCancel: () => void,
     message?: string,
-    translate: (key: string, options: any) => string,
 }
 
 const UnlockWalletDialog = ({ onCancel, message, translate, ...props }: Props) => (
     <Dialog
         onClose={onCancel}
-        title={translate('modal.unlockWallet.title')}
+        title={I18n.t('modal.unlockWallet.title')}
         {...props}
     >
-        <img className={styles.walletIcon} src={WalletPng} srcSet={`${WalletPng2x} 2x`} alt={translate('error.wallet')} />
+        <img className={styles.walletIcon} src={WalletPng} srcSet={`${WalletPng2x} 2x`} alt={I18n.t('error.wallet')} />
         {message && (
             <p>{message}</p>
         )}

--- a/app/src/marketplace/components/Modal/Web3/InstallMetaMaskDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/Web3/InstallMetaMaskDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import WalletErrorPng from '../../../../assets/wallet_error.png'
 import WalletErrorPng2x from '../../../../assets/wallet_error@2x.png'
@@ -12,16 +12,15 @@ import styles from './installMetaMaskDialog.pcss'
 
 export type Props = {
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const InstallMetaMaskDialog = ({ onCancel, translate, ...props }: Props) => (
+const InstallMetaMaskDialog = ({ onCancel, ...props }: Props) => (
     <Dialog
         onClose={onCancel}
-        title={translate('modal.web3.installmetamask.title')}
+        title={I18n.t('modal.web3.installmetamask.title')}
         {...props}
     >
-        <img className={styles.icon} src={WalletErrorPng} srcSet={`${WalletErrorPng2x} 2x`} alt={translate('error.wallet')} />
+        <img className={styles.icon} src={WalletErrorPng} srcSet={`${WalletErrorPng2x} 2x`} alt={I18n.t('error.wallet')} />
         <p><Translate value="modal.web3.installmetamask.message" dangerousHTML /></p>
     </Dialog>
 )

--- a/app/src/marketplace/components/Modal/Web3/InstallMobileApplicationDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/Web3/InstallMobileApplicationDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Dialog from '../../Dialog'
 import withI18n from '../../../../containers/WithI18n'
@@ -11,13 +11,12 @@ import styles from './installMobileApplicationDialog.pcss'
 
 export type Props = {
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const InstallMobileApplicationDialog = ({ onCancel, translate, ...props }: Props) => (
+const InstallMobileApplicationDialog = ({ onCancel, ...props }: Props) => (
     <Dialog
         onClose={onCancel}
-        title={translate('modal.web3.installmobileapplication.title')}
+        title={I18n.t('modal.web3.installmobileapplication.title')}
         {...props}
     >
         <p><Translate value="modal.web3.installmobileapplication.message" dangerousHTML /></p>

--- a/app/src/marketplace/components/Modal/Web3/InstallSupportedBrowserDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/Web3/InstallSupportedBrowserDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import BrowserNotSupportedPng from '../../../../assets/browser_not_supported.png'
 import BrowserNotSupportedPng2x from '../../../../assets/browser_not_supported@2x.png'
@@ -13,20 +13,19 @@ import styles from './installSupportedBrowserDialog.pcss'
 
 export type Props = {
     onCancel: () => void,
-    translate: (key: string, options: any) => string,
 }
 
-const InstallSupportedBrowserDialog = ({ onCancel, translate, ...props }: Props) => (
+const InstallSupportedBrowserDialog = ({ onCancel, ...props }: Props) => (
     <Dialog
         onClose={onCancel}
-        title={translate('modal.web3.installsupportedbrowser.title')}
+        title={I18n.t('modal.web3.installsupportedbrowser.title')}
         {...props}
     >
         <img
             className={styles.icon}
             src={BrowserNotSupportedPng}
             srcSet={`${BrowserNotSupportedPng2x} 2x`}
-            alt={translate('modal.web3.installsupportedbrowser.imageCaption')}
+            alt={I18n.t('modal.web3.installsupportedbrowser.imageCaption')}
         />
         <p><Translate value="modal.web3.installsupportedbrowser.message" dangerousHTML /></p>
 

--- a/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import cx from 'classnames'
 import { Button } from 'reactstrap'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import Link from '$shared/components/Link'
 import { isPaidProduct } from '../../../utils/product'
@@ -18,30 +18,28 @@ type Props = {
     product: Product,
     isValidSubscription: boolean,
     onPurchase: () => void,
-    translate: (key: string, options: any) => string,
     setTruncateState: () => void,
     truncateState: boolean,
     truncationRequired: boolean,
     productDetailsRef: Object,
 }
 
-const buttonTitle = (product: Product, isValidSubscription: boolean, translate: (key: string, options: any) => string) => {
+const buttonTitle = (product: Product, isValidSubscription: boolean) => {
     if (isPaidProduct(product)) {
         return isValidSubscription ?
-            translate('productPage.productDetails.renew') :
-            translate('productPage.productDetails.purchase')
+            I18n.t('productPage.productDetails.renew') :
+            I18n.t('productPage.productDetails.purchase')
     }
 
     return isValidSubscription ?
-        translate('productPage.productDetails.saved') :
-        translate('productPage.productDetails.add')
+        I18n.t('productPage.productDetails.saved') :
+        I18n.t('productPage.productDetails.add')
 }
 
 const ProductDetails = ({
     product,
     isValidSubscription,
     onPurchase,
-    translate,
     truncateState,
     setTruncateState,
     truncationRequired,
@@ -60,7 +58,7 @@ const ProductDetails = ({
                 <span className={styles.productOwner}>by {product.owner}</span>
                 <span className={styles.separator} />
                 <div className={styles.paymentRate}>
-                    {product.isFree ? translate('productPage.productDetails.free') : (
+                    {product.isFree ? I18n.t('productPage.productDetails.free') : (
                         <PaymentRate
                             amount={product.pricePerSecond}
                             currency={product.priceCurrency}
@@ -80,7 +78,7 @@ const ProductDetails = ({
                 disabled={(!isPaidProduct(product) && isValidSubscription) || product.state !== productStates.DEPLOYED}
                 onClick={onPurchase}
             >
-                {buttonTitle(product, isValidSubscription, translate)}
+                {buttonTitle(product, isValidSubscription)}
             </Button>
         </div>
         <div className={styles.description}>

--- a/app/src/marketplace/components/ProductPage/index.jsx
+++ b/app/src/marketplace/components/ProductPage/index.jsx
@@ -5,6 +5,7 @@ import BN from 'bignumber.js'
 import MediaQuery from 'react-responsive'
 import breakpoints from '$app/scripts/breakpoints'
 import classNames from 'classnames'
+import { I18n } from 'react-redux-i18n'
 
 import Toolbar from '$shared/components/Toolbar'
 import Hero from '../Hero'
@@ -33,7 +34,6 @@ export type Props = {
     isLoggedIn?: boolean,
     isProductSubscriptionValid?: boolean,
     onPurchase?: () => void,
-    translate: (key: string, options: any) => string,
     truncateState: boolean,
     setTruncateState: () => void,
     truncationRequired: boolean,
@@ -59,7 +59,6 @@ class ProductPage extends Component<Props> {
             isLoggedIn,
             isProductSubscriptionValid,
             onPurchase,
-            translate,
             toolbarStatus,
             truncateState,
             setTruncateState,
@@ -108,7 +107,7 @@ class ProductPage extends Component<Props> {
                     <MediaQuery minDeviceWidth={md.max}>
                         {(matches) => (
                             <Products
-                                header={translate('productPage.relatedProducts')}
+                                header={I18n.t('productPage.relatedProducts')}
                                 products={matches ? relatedProducts : relatedProducts.slice(0, 2)}
                                 type="relatedProducts"
                             />

--- a/app/src/marketplace/components/ProductPageEditor/ProductDetailsEditor/index.jsx
+++ b/app/src/marketplace/components/ProductPageEditor/ProductDetailsEditor/index.jsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import BN from 'bignumber.js'
 import { Input } from 'reactstrap'
+import { I18n } from 'react-redux-i18n'
 
 import PaymentRate from '../../PaymentRate'
 import { DEFAULT_CURRENCY, timeUnits } from '../../../utils/constants'
@@ -28,7 +29,6 @@ type Props = {
     categories: CategoryList,
     isPriceEditable: boolean,
     user?: ?User,
-    translate: (key: string, options: any) => string,
 }
 
 type State = {
@@ -58,8 +58,8 @@ class ProductDetailsEditor extends React.Component<Props, State> {
         if (this.title) {
             const { title } = this
             title.select()
-            title.addEventListener('focus', () => this.onTitleFocus(title, this.props.translate))
-            title.addEventListener('click', () => this.onTitleFocus(title, this.props.translate))
+            title.addEventListener('focus', () => this.onTitleFocus(title))
+            title.addEventListener('click', () => this.onTitleFocus(title))
         }
     }
 
@@ -116,9 +116,9 @@ class ProductDetailsEditor extends React.Component<Props, State> {
         this.props.onEdit('category', category.id)
     }
 
-    onTitleFocus = (titleElement: HTMLInputElement, translate: (key: string, options: any) => string) => {
+    onTitleFocus = (titleElement: HTMLInputElement) => {
         const title = titleElement
-        if (title.value === translate('productDetailsEditor.name')) {
+        if (title.value === I18n.t('productDetailsEditor.name')) {
             title.value = ''
         }
     }
@@ -132,7 +132,6 @@ class ProductDetailsEditor extends React.Component<Props, State> {
             categories,
             isPriceEditable,
             user,
-            translate,
         } = this.props
         const { category, pricePerSecond, priceCurrency } = this.state
 
@@ -143,8 +142,8 @@ class ProductDetailsEditor extends React.Component<Props, State> {
                     type="text"
                     name="name"
                     id="name"
-                    placeholder={translate('productDetailsEditor.name')}
-                    defaultValue={product.name || translate('productDetailsEditor.name')}
+                    placeholder={I18n.t('productDetailsEditor.name')}
+                    defaultValue={product.name || I18n.t('productDetailsEditor.name')}
                     innerRef={(innerRef) => {
                         this.title = innerRef
                     }}
@@ -158,7 +157,7 @@ class ProductDetailsEditor extends React.Component<Props, State> {
                         <DropdownActions
                             className={styles.dropdown}
                             title={
-                                <span>{product.isFree ? translate('productDetailsEditor.free') : <PaymentRate
+                                <span>{product.isFree ? I18n.t('productDetailsEditor.free') : <PaymentRate
                                     className={styles.paymentRate}
                                     amount={pricePerSecond}
                                     currency={priceCurrency || DEFAULT_CURRENCY}
@@ -172,11 +171,11 @@ class ProductDetailsEditor extends React.Component<Props, State> {
                                 key="setPrice"
                                 onClick={(e) => this.onOpenPriceDialogClick(e)}
                             >
-                                {product.id ? translate('productDetailsEditor.editPrice') : translate('productDetailsEditor.setPrice')}
+                                {product.id ? I18n.t('productDetailsEditor.editPrice') : I18n.t('productDetailsEditor.setPrice')}
                             </DropdownActions.Item>
                         </DropdownActions>
                     ) : (
-                        <span>{product.isFree ? translate('productDetailsEditor.free') : <PaymentRate
+                        <span>{product.isFree ? I18n.t('productDetailsEditor.free') : <PaymentRate
                             className={styles.paymentRate}
                             amount={pricePerSecond}
                             currency={priceCurrency || DEFAULT_CURRENCY}
@@ -190,7 +189,7 @@ class ProductDetailsEditor extends React.Component<Props, State> {
                     className={styles.dropdown}
                     title={
                         <span>
-                            {category ? category.name : translate('productDetailsEditor.category')}
+                            {category ? category.name : I18n.t('productDetailsEditor.category')}
                         </span>
                     }
                 >
@@ -207,7 +206,7 @@ class ProductDetailsEditor extends React.Component<Props, State> {
                     type="textarea"
                     name="description"
                     id="description"
-                    placeholder={translate('productDetailsEditor.description')}
+                    placeholder={I18n.t('productDetailsEditor.description')}
                     className={styles.productDescription}
                     defaultValue={product.description}
                     onChange={(e: SyntheticInputEvent<EventTarget>) => onEdit('description', e.target.value)}

--- a/app/src/marketplace/components/ProductPageEditor/StreamSelector/index.jsx
+++ b/app/src/marketplace/components/ProductPageEditor/StreamSelector/index.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import uniq from 'lodash/uniq'
 import sortBy from 'lodash/sortBy'
 import { Container, Input, Button } from 'reactstrap'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import StreamListing from '../../ProductPage/StreamListing'
 import DropdownActions from '$shared/components/DropdownActions'
@@ -27,11 +27,8 @@ export type StateProps = {
     className?: string,
 }
 
-type OwnProps = {
-    translate: (key: string, options: any) => string,
+type Props = StateProps & {
 }
-
-type Props = OwnProps & StateProps
 
 type State = {
     isEditing: boolean,
@@ -193,7 +190,7 @@ export class StreamSelector extends React.Component<Props, State> {
     }
 
     render() {
-        const { availableStreams, fetchingStreams, className, translate } = this.props
+        const { availableStreams, fetchingStreams, className } = this.props
         const { search, isEditing, sort } = this.state
         const matchingStreams: StreamList = availableStreams.filter((stream) => (
             stream.name.toLowerCase().includes(search.toLowerCase())
@@ -241,7 +238,7 @@ export class StreamSelector extends React.Component<Props, State> {
                                 className={styles.input}
                                 onChange={this.onChange}
                                 value={this.state.search}
-                                placeholder={translate('streamSelector.typeToSearch')}
+                                placeholder={I18n.t('streamSelector.typeToSearch')}
                             />
                             <DropdownActions
                                 className={classNames(styles.sortDropdown, styles.dropdown)}
@@ -285,7 +282,7 @@ export class StreamSelector extends React.Component<Props, State> {
                                         <a
                                             className={styles.removeButton}
                                             href="#"
-                                            title={translate('streamSelector.remove')}
+                                            title={I18n.t('streamSelector.remove')}
                                             onClick={(event: SyntheticInputEvent<EventTarget>) => {
                                                 event.preventDefault()
                                                 event.stopPropagation()

--- a/app/src/marketplace/components/Steps/index.jsx
+++ b/app/src/marketplace/components/Steps/index.jsx
@@ -2,6 +2,7 @@
 
 import React, { Component, type Node, Fragment } from 'react'
 import classNames from 'classnames'
+import { I18n } from 'react-redux-i18n'
 
 import Buttons from '$shared/components/Buttons'
 import withI18n from '../../containers/WithI18n'
@@ -16,7 +17,6 @@ type Props = {
     tabClassName?: string,
     isDisabled: boolean,
     errors?: Array<string>,
-    translate: (key: string, options: any) => string,
 }
 
 type State = {
@@ -51,12 +51,12 @@ class Steps extends Component<Props, State> {
     }
 
     nextButtonLabel = () => {
-        const { children, translate } = this.props
+        const { children } = this.props
         const { currentIndex } = this.state
         const buttonLabels = this.nextButtonLabels()
         return buttonLabels[currentIndex] || (currentIndex === React.Children.count(children) - 1 ?
-            translate('steps.set') :
-            translate('modal.common.next')
+            I18n.t('steps.set') :
+            I18n.t('modal.common.next')
         )
     }
 
@@ -95,7 +95,7 @@ class Steps extends Component<Props, State> {
                 })}
                 actions={{
                     cancel: {
-                        title: this.props.translate('modal.common.cancel'),
+                        title: I18n.t('modal.common.cancel'),
                         color: 'link',
                         onClick: this.props.onCancel,
                     },

--- a/app/src/marketplace/containers/EditProductPage/index.jsx
+++ b/app/src/marketplace/containers/EditProductPage/index.jsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { push, replace } from 'react-router-redux'
 import type { Match } from 'react-router-dom'
+import { I18n } from 'react-redux-i18n'
 
 import type { StoreState } from '$shared/flowtype/store-state'
 import type { ProductId, EditProduct, SmartContractProduct, Product } from '../../flowtype/product-types'
@@ -64,7 +65,6 @@ import { showNotification as showNotificationAction } from '../../modules/notifi
 export type OwnProps = {
     match: Match,
     ownerAddress: ?Address,
-    translate: (key: string, options: any) => string,
 }
 
 export type StateProps = {
@@ -138,32 +138,28 @@ export class EditProductPage extends Component<Props> {
     }
 
     getUpdateButtonTitle = (product: EditProduct) => {
-        const { translate } = this.props
-
         if (product.state === productStates.NOT_DEPLOYED) {
-            return translate('editProductPage.save')
+            return I18n.t('editProductPage.save')
         }
 
         if (product.state === productStates.DEPLOYED && this.isWeb3Required()) {
-            return translate('editProductPage.republish')
+            return I18n.t('editProductPage.republish')
         }
 
-        return translate('editProductPage.update')
+        return I18n.t('editProductPage.update')
     }
 
     getPublishButtonTitle = (product: EditProduct) => {
-        const { translate } = this.props
-
         switch (product.state) {
             case productStates.DEPLOYED:
-                return translate('editProductPage.unpublish')
+                return I18n.t('editProductPage.unpublish')
             case productStates.DEPLOYING:
-                return translate('editProductPage.publishing')
+                return I18n.t('editProductPage.publishing')
             case productStates.UNDEPLOYING:
-                return translate('editProductPage.unpublishing')
+                return I18n.t('editProductPage.unpublishing')
             case productStates.NOT_DEPLOYED:
             default:
-                return translate('editProductPage.publish')
+                return I18n.t('editProductPage.publish')
         }
     }
 
@@ -192,14 +188,14 @@ export class EditProductPage extends Component<Props> {
         }
 
         // Creating a product, rather than editing an existing product:
-        const { onSaveAndExit, onPublish, translate } = this.props
+        const { onSaveAndExit, onPublish } = this.props
         return {
             saveAndExit: {
-                title: translate('editProductPage.save'),
+                title: I18n.t('editProductPage.save'),
                 onClick: () => this.validateProductBeforeSaving(onSaveAndExit),
             },
             publish: {
-                title: translate('editProductPage.publish'),
+                title: I18n.t('editProductPage.publish'),
                 color: 'primary',
                 onClick: () => this.validateProductBeforeSaving(onPublish),
                 className: 'd-none d-sm-block',

--- a/app/src/marketplace/containers/ProductPage/PurchaseDialog/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/PurchaseDialog/index.jsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { replace } from 'react-router-redux'
+import { I18n } from 'react-redux-i18n'
 
 import { selectStep, selectStepParams, selectProduct, selectPurchaseData } from '../../../modules/purchaseDialog/selectors'
 import { setAccessPeriod, setAllowance, initPurchase, approvePurchase } from '../../../modules/purchaseDialog/actions'
@@ -69,7 +70,6 @@ type DispatchProps = {
 
 export type OwnProps = {
     productId: ProductId,
-    translate: (key: string, options: any) => string,
 }
 
 type Props = WithContractProductProps & StateProps & DispatchProps & OwnProps
@@ -109,7 +109,6 @@ export class PurchaseDialog extends React.Component<Props> {
             settingAllowance,
             step,
             stepParams,
-            translate,
             web3Accounts,
             resettingAllowance,
             setAllowanceError,
@@ -132,7 +131,7 @@ export class PurchaseDialog extends React.Component<Props> {
                     if (resetAllowanceError) {
                         return (
                             <ErrorDialog
-                                title={translate('purchaseDialog.errorTitle')}
+                                title={I18n.t('purchaseDialog.errorTitle')}
                                 message={resetAllowanceError.message}
                                 onDismiss={onCancel}
                             />
@@ -153,7 +152,7 @@ export class PurchaseDialog extends React.Component<Props> {
                     if (setAllowanceError) {
                         return (
                             <ErrorDialog
-                                title={translate('purchaseDialog.errorTitle')}
+                                title={I18n.t('purchaseDialog.errorTitle')}
                                 message={setAllowanceError.message}
                                 onDismiss={onCancel}
                             />

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import type { Match } from 'react-router-dom'
 import { push, replace } from 'react-router-redux'
+import { I18n } from 'react-redux-i18n'
 
 import ProductPageComponent from '../../components/ProductPage'
 import Layout from '../../components/Layout'
@@ -42,7 +43,6 @@ export type OwnProps = {
     match: Match,
     overlayPurchaseDialog: boolean,
     overlayPublishDialog: boolean,
-    translate: (key: string, options: any) => string,
 }
 
 export type StateProps = {
@@ -146,18 +146,16 @@ export class ProductPage extends Component<Props, State> {
     )
 
     getPublishButtonTitle = (product: Product) => {
-        const { translate } = this.props
-
         switch (product.state) {
             case productStates.DEPLOYED:
-                return translate('editProductPage.unpublish')
+                return I18n.t('editProductPage.unpublish')
             case productStates.DEPLOYING:
-                return translate('editProductPage.publishing')
+                return I18n.t('editProductPage.publishing')
             case productStates.UNDEPLOYING:
-                return translate('editProductPage.unpublishing')
+                return I18n.t('editProductPage.unpublishing')
             case productStates.NOT_DEPLOYED:
             default:
-                return translate('editProductPage.publish')
+                return I18n.t('editProductPage.publish')
         }
     }
 
@@ -213,7 +211,6 @@ export class ProductPage extends Component<Props, State> {
             editPermission,
             onPurchase,
             relatedProducts,
-            translate,
             noHistoryRedirect,
             productError,
         } = this.props
@@ -229,7 +226,7 @@ export class ProductPage extends Component<Props, State> {
         const toolbarActions = {}
         if (product && editPermission) {
             toolbarActions.edit = {
-                title: translate('editProductPage.edit'),
+                title: I18n.t('editProductPage.edit'),
                 linkTo: formatPath(links.products, product.id || '', 'edit'),
             }
         }

--- a/app/src/marketplace/containers/WithI18n/index.jsx
+++ b/app/src/marketplace/containers/WithI18n/index.jsx
@@ -2,7 +2,6 @@
 
 import React, { type ComponentType } from 'react'
 import { connect } from 'react-redux'
-import { I18n } from 'react-redux-i18n'
 import { createSelector } from 'reselect'
 
 import type { StoreState, I18nState, Translations, Locale } from '../../flowtype/store-state'
@@ -46,14 +45,10 @@ export function withI18n(WrappedComponent: ComponentType<any>) {
         }
     }
 
-    const mapDispatchToProps = (): DispatchProps => ({
-        translate: (key, options) => I18n.t(key, options),
-    })
-
     const WithI18n = (props: Props) =>
         <WrappedComponent {...props} />
 
-    return connect(mapStateToProps, mapDispatchToProps)(WithI18n)
+    return connect(mapStateToProps)(WithI18n)
 }
 
 export default withI18n

--- a/app/test/unit/containers/EditProductPage/EditProductPage.test.jsx
+++ b/app/test/unit/containers/EditProductPage/EditProductPage.test.jsx
@@ -4,6 +4,7 @@ import sinon from 'sinon'
 import assert from 'assert-diff'
 import { productStates } from '$mp/utils/constants'
 import * as validators from '$mp/validators'
+import { I18n } from 'react-redux-i18n'
 
 import { EditProductPage, mapStateToProps, mapDispatchToProps } from '$mp/containers/EditProductPage'
 import ProductPageEditorComponent from '$mp/components/ProductPageEditor'
@@ -81,13 +82,13 @@ describe('EditProductPage', () => {
             setImageToUploadProp: sandbox.spy(),
             showSaveDialog: sandbox.spy(),
             streams: [],
-            translate: sandbox.stub().callsFake((str) => str),
             user: {
                 name: 'bob',
                 username: 'bobcat69',
                 timezone: 'HEL',
             },
         }
+        sandbox.stub(I18n, 't').callsFake(String)
     })
 
     afterEach(() => {

--- a/app/test/unit/containers/ProductPage/ProductPage.test.jsx
+++ b/app/test/unit/containers/ProductPage/ProductPage.test.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import assert from 'assert-diff'
+import { I18n } from 'react-redux-i18n'
 
 import { productStates } from '$mp/utils/constants'
 import { ProductPage, mapStateToProps, mapDispatchToProps } from '$mp/containers/ProductPage'
@@ -60,8 +61,8 @@ describe('ProductPage', () => {
                     id: product.id,
                 },
             },
-            translate: sandbox.stub().callsFake((str) => str),
         }
+        sandbox.stub(I18n, 't').callsFake(String)
     })
 
     afterEach(() => {

--- a/app/test/unit/containers/ProductPage/PurchaseDialog/PurchaseDialog.test.jsx
+++ b/app/test/unit/containers/ProductPage/PurchaseDialog/PurchaseDialog.test.jsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import assert from 'assert-diff'
 import { replace } from 'react-router-redux'
+import { I18n } from 'react-redux-i18n'
 
 import { mapStateToProps, mapDispatchToProps, PurchaseDialog } from '$mp/containers/ProductPage/PurchaseDialog'
 import ChooseAccessPeriodDialog from '$mp/containers/ProductPage/PurchaseDialog/ChooseAccessPeriodDialog'
@@ -45,9 +46,9 @@ describe('PurchaseDialog container', () => {
             gettingAllowance: false,
             settingAllowance: false,
             resettingAllowance: false,
-            translate: sandbox.stub().callsFake((a) => a),
             productId,
         }
+        sandbox.stub(I18n, 't').callsFake(String)
     })
 
     afterEach(() => {

--- a/app/test/unit/containers/WithI18n/WithI18n.test.jsx
+++ b/app/test/unit/containers/WithI18n/WithI18n.test.jsx
@@ -48,6 +48,5 @@ describe('WithI18n', () => {
         const innerComponent = wrapper.dive()
         expect(innerComponent.find(EmptyComponent).length).toEqual(1)
         expect(innerComponent.prop('locale')).toEqual('en')
-        expect(innerComponent.prop('translate')).toEqual(expect.any(Function))
     })
 })

--- a/app/test/unit/containers/WithI18n/WithI18n.test.jsx
+++ b/app/test/unit/containers/WithI18n/WithI18n.test.jsx
@@ -5,16 +5,13 @@ import sinon from 'sinon'
 import { withI18n } from '$mp/containers/WithI18n'
 import mockStore from '$testUtils/mockStoreProvider'
 
-/* eslint-disable */
+/* eslint-disable react/prefer-stateless-function */
 class EmptyComponent extends React.Component {
     render() {
-        return (
-            <div>
-            </div>
-        )
+        return <div />
     }
 }
-/* eslint-enable */
+/* eslint-enable react/prefer-stateless-function */
 
 describe('WithI18n', () => {
     let wrapper


### PR DESCRIPTION
In this PR I remove `translate` prop provided by `withI18n` HoC and use `I18n.t` directly (import it from `react-redux-i18n` everywhere it's needed).

Reason? Making the library easily replaceable (original idea for driving it via props) appears to not be important. And we messed it up by mixing `Translate` imported directly from `react-redux-i18n` with `translate` (I18n.t) takes from props.

I feel like the new way (everything via `import`) is more reasonable.

Let me know what you think.