### PR TITLE
[PLATFORM-224] Add search and filtering capabilities to dashboard listing

### DIFF
--- a/app/src/shared/components/Search/index.jsx
+++ b/app/src/shared/components/Search/index.jsx
@@ -23,12 +23,19 @@ type State = {
 class Search extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
-        this.debouncedOnChange = debounce(props.onChange, 500)
 
         this.state = {
             isOpen: this.props.value !== '',
             text: this.props.value || '',
         }
+    }
+
+    componentDidMount() {
+        this.mounted = true
+    }
+
+    componentWillUnmount() {
+        this.mounted = false
     }
 
     onTextChange = (e: SyntheticInputEvent<EventTarget>) => {
@@ -38,13 +45,18 @@ class Search extends React.Component<Props, State> {
             text: value,
         })
 
-        if (this.debouncedOnChange) {
-            this.debouncedOnChange(value)
-        }
+        this.debouncedOnChange(value)
     }
 
+    debouncedOnChange = debounce((text: string) => {
+        if (!this.mounted) {
+            return
+        }
+        this.props.onChange(text)
+    }, 500)
+
+    mounted = false
     inputRef = React.createRef()
-    debouncedOnChange: (string) => void
 
     handleClick = () => {
         const { current } = this.inputRef

--- a/app/src/shared/components/Search/index.jsx
+++ b/app/src/shared/components/Search/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import cx from 'classnames'
+import debounce from 'lodash/debounce'
 
 import SearchIcon from '$shared/components/SearchIcon'
 import ClearIcon from '$shared/components/ClearIcon'
@@ -20,20 +21,30 @@ type State = {
 }
 
 class Search extends React.Component<Props, State> {
-    state = {
-        isOpen: this.props.value !== '',
-        text: this.props.value || '',
+    constructor(props: Props) {
+        super(props)
+        this.debouncedOnChange = debounce(props.onChange, 500)
+
+        this.state = {
+            isOpen: this.props.value !== '',
+            text: this.props.value || '',
+        }
     }
 
     onTextChange = (e: SyntheticInputEvent<EventTarget>) => {
         const { value } = e.target
-        this.props.onChange(value)
+
         this.setState({
             text: value,
         })
+
+        if (this.debouncedOnChange) {
+            this.debouncedOnChange(value)
+        }
     }
 
     inputRef = React.createRef()
+    debouncedOnChange: (string) => void
 
     handleClick = () => {
         const { current } = this.inputRef

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -4,25 +4,31 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { Container, Row, Col, Button } from 'reactstrap'
 import { Link } from 'react-router-dom'
-import { Translate } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import links from '$userpages/../links'
-import { getDashboards } from '$userpages/modules/dashboard/actions'
-import { selectDashboards, selectFetching } from '$userpages/modules/dashboard/selectors'
+import { getDashboards, updateFilter } from '$userpages/modules/dashboard/actions'
+import { selectDashboards, selectFetching, selectFilter } from '$userpages/modules/dashboard/selectors'
 import type { StoreState } from '$userpages/flowtype/states/store-state'
 import type { DashboardList as DashboardListType } from '$userpages/flowtype/dashboard-types'
+import type { Filter } from '$userpages/flowtype/common-types'
 import Layout from '$userpages/components/Layout'
-import { defaultColumns } from '$userpages/utils/constants'
+import { defaultColumns, getDefaultSortOptions } from '$userpages/utils/constants'
 import Tile from '$shared/components/Tile'
+import Search from '$shared/components/Search'
+import Dropdown from '$shared/components/Dropdown'
+
 import NoDashboardsView from './NoDashboards'
 
 type StateProps = {
     dashboards: DashboardListType,
     fetching: boolean,
+    filter: ?Filter,
 }
 
 type DispatchProps = {
     getDashboards: () => void,
+    updateFilter: (filter: Filter) => void,
 }
 
 type Props = StateProps & DispatchProps
@@ -36,16 +42,66 @@ const CreateDashboardButton = () => (
 )
 
 class DashboardList extends Component<Props> {
+    defaultFilter = getDefaultSortOptions()[0].filter
+
     componentDidMount() {
+        // Set default filter if not selected
+        if (!this.props.filter) {
+            this.props.updateFilter(this.defaultFilter)
+        }
         this.props.getDashboards()
     }
 
+    onSearchChange = (value: string) => {
+        const { filter, updateFilter, getDashboards } = this.props
+        const newFilter = {
+            ...filter,
+            search: value,
+        }
+        updateFilter(newFilter)
+        getDashboards()
+    }
+
+    onSortChange = (sortOptionId) => {
+        const { filter, updateFilter, getDashboards } = this.props
+        const sortOption = getDefaultSortOptions().find((opt) => opt.filter.id === sortOptionId)
+
+        if (sortOption) {
+            const newFilter = {
+                search: filter && filter.search,
+                ...sortOption.filter,
+            }
+            updateFilter(newFilter)
+            getDashboards()
+        }
+    }
+
     render() {
-        const { fetching, dashboards } = this.props
+        const { fetching, dashboards, filter } = this.props
 
         return (
             <Layout
                 headerAdditionalComponent={<CreateDashboardButton />}
+                headerSearchComponent={
+                    <Search
+                        placeholder={I18n.t('userpages.canvases.filterCanvases')}
+                        value={(filter && filter.search) || ''}
+                        onChange={this.onSearchChange}
+                    />
+                }
+                headerFilterComponent={
+                    <Dropdown
+                        title={I18n.t('userpages.canvases.sortBy')}
+                        onChange={this.onSortChange}
+                        defaultSelectedItem={(filter && filter.id) || this.defaultFilter.id}
+                    >
+                        {getDefaultSortOptions().map((s) => (
+                            <Dropdown.Item key={s.filter.id} value={s.filter.id}>
+                                {s.displayName}
+                            </Dropdown.Item>
+                        ))}
+                    </Dropdown>
+                }
             >
                 <Container>
                     {!fetching && dashboards && dashboards.length <= 0 && (
@@ -71,10 +127,12 @@ class DashboardList extends Component<Props> {
 const mapStateToProps = (state: StoreState): StateProps => ({
     dashboards: selectDashboards(state),
     fetching: selectFetching(state),
+    filter: selectFilter(state),
 })
 
 const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
     getDashboards: () => dispatch(getDashboards()),
+    updateFilter: (filter) => dispatch(updateFilter(filter)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(DashboardList)

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -11,9 +11,9 @@ import { getDashboards, updateFilter } from '$userpages/modules/dashboard/action
 import { selectDashboards, selectFetching, selectFilter } from '$userpages/modules/dashboard/selectors'
 import type { StoreState } from '$userpages/flowtype/states/store-state'
 import type { DashboardList as DashboardListType } from '$userpages/flowtype/dashboard-types'
-import type { Filter } from '$userpages/flowtype/common-types'
+import type { Filter, SortOption } from '$userpages/flowtype/common-types'
 import Layout from '$userpages/components/Layout'
-import { defaultColumns, getDefaultSortOptions } from '$userpages/utils/constants'
+import { defaultColumns } from '$userpages/utils/constants'
 import Tile from '$shared/components/Tile'
 import Search from '$shared/components/Search'
 import Dropdown from '$shared/components/Dropdown'
@@ -33,6 +33,43 @@ type DispatchProps = {
 
 type Props = StateProps & DispatchProps
 
+export const getSortOptions = (): Array<SortOption> => [
+    {
+        displayName: I18n.t('userpages.filter.az'),
+        filter: {
+            id: 'az',
+            sortBy: 'name',
+            order: 'asc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.za'),
+        filter: {
+            id: 'za',
+            sortBy: 'name',
+            order: 'desc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.shared'),
+        filter: {
+            id: 'shared',
+            key: 'operation',
+            value: 'SHARE',
+            order: 'desc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.mine'),
+        filter: {
+            id: 'mine',
+            key: 'operation',
+            value: 'WRITE',
+            order: 'desc',
+        },
+    },
+]
+
 const CreateDashboardButton = () => (
     <Button>
         <Link to={links.userpages.dashboardEditor}>
@@ -42,7 +79,7 @@ const CreateDashboardButton = () => (
 )
 
 class DashboardList extends Component<Props> {
-    defaultFilter = getDefaultSortOptions()[0].filter
+    defaultFilter = getSortOptions()[0].filter
 
     componentDidMount() {
         // Set default filter if not selected
@@ -64,7 +101,7 @@ class DashboardList extends Component<Props> {
 
     onSortChange = (sortOptionId) => {
         const { filter, updateFilter, getDashboards } = this.props
-        const sortOption = getDefaultSortOptions().find((opt) => opt.filter.id === sortOptionId)
+        const sortOption = getSortOptions().find((opt) => opt.filter.id === sortOptionId)
 
         if (sortOption) {
             const newFilter = {
@@ -95,7 +132,7 @@ class DashboardList extends Component<Props> {
                         onChange={this.onSortChange}
                         defaultSelectedItem={(filter && filter.id) || this.defaultFilter.id}
                     >
-                        {getDefaultSortOptions().map((s) => (
+                        {getSortOptions().map((s) => (
                             <Dropdown.Item key={s.filter.id} value={s.filter.id}>
                                 {s.displayName}
                             </Dropdown.Item>
@@ -107,7 +144,7 @@ class DashboardList extends Component<Props> {
                     {!fetching && dashboards && dashboards.length <= 0 && (
                         <NoDashboardsView />
                     )}
-                    {!fetching && dashboards && dashboards.length > 0 && (
+                    {dashboards && dashboards.length > 0 && (
                         <Row>
                             {dashboards.map((dashboard) => (
                                 <Col {...defaultColumns} key={dashboard.id}>

--- a/app/src/userpages/flowtype/common-types.js
+++ b/app/src/userpages/flowtype/common-types.js
@@ -22,3 +22,8 @@ export type Filter = {
     key?: ?string,
     value?: ?string,
 }
+
+export type SortOption = {
+    displayName: string,
+    filter: Filter,
+}

--- a/app/src/userpages/flowtype/states/dashboard-state.js
+++ b/app/src/userpages/flowtype/states/dashboard-state.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { DashboardId, DashboardIdList } from '../dashboard-types'
+import type { Filter } from '../common-types'
 import type { ErrorInUi } from '$shared/flowtype/common-types'
 
 export type DashboardState = {
@@ -10,5 +11,6 @@ export type DashboardState = {
         isFullScreen: boolean
     },
     error: ?ErrorInUi,
-    fetching: boolean
+    fetching: boolean,
+    filter: ?Filter,
 }

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -14,27 +14,6 @@ msgstr "Create canvas"
 msgid "userpages##canvases##filterCanvases"
 msgstr "Filter canvases"
 
-msgid "userpages##canvases##filter##recent"
-msgstr "Recent"
-
-msgid "userpages##canvases##filter##running"
-msgstr "Running"
-
-msgid "userpages##canvases##filter##stopped"
-msgstr "Stopped"
-
-msgid "userpages##canvases##filter##shared"
-msgstr "Shared"
-
-msgid "userpages##canvases##filter##mine"
-msgstr "Mine"
-
-msgid "userpages##canvases##filter##az"
-msgstr "A to Z"
-
-msgid "userpages##canvases##filter##za"
-msgstr "Z to A"
-
 msgid "userpages##canvases##sortBy"
 msgstr "Sort by"
 
@@ -58,6 +37,27 @@ msgstr "Copy URL"
 
 msgid "userpages##canvases##menu##share"
 msgstr "Share"
+
+msgid "userpages##filter##recent"
+msgstr "Recent"
+
+msgid "userpages##filter##running"
+msgstr "Running"
+
+msgid "userpages##filter##stopped"
+msgstr "Stopped"
+
+msgid "userpages##filter##shared"
+msgstr "Shared"
+
+msgid "userpages##filter##mine"
+msgstr "Mine"
+
+msgid "userpages##filter##az"
+msgstr "A to Z"
+
+msgid "userpages##filter##za"
+msgstr "Z to A"
 
 msgid "userpages##header##canvases"
 msgstr "Canvases"

--- a/app/src/userpages/modules/canvas/actions.js
+++ b/app/src/userpages/modules/canvas/actions.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { error as errorNotification } from 'react-notification-system-redux'
-import debounce from 'lodash/debounce'
 
 import type { ErrorInUi } from '$shared/flowtype/common-types'
 import type { Filter } from '../../flowtype/common-types'
@@ -14,17 +13,17 @@ import { handleEntities } from '$shared/utils/entities'
 
 const apiUrl = `${process.env.STREAMR_API_URL}/canvases`
 
-export const GET_CANVASES_REQUEST = 'GET_CANVASES_REQUEST'
-export const GET_CANVASES_SUCCESS = 'GET_CANVASES_SUCCESS'
-export const GET_CANVASES_FAILURE = 'GET_CANVASES_FAILURE'
-export const GET_CANVAS_REQUEST = 'GET_CANVAS_REQUEST'
-export const GET_CANVAS_SUCCESS = 'GET_CANVAS_SUCCESS'
-export const GET_CANVAS_FAILURE = 'GET_CANVAS_FAILURE'
-export const DELETE_CANVAS_REQUEST = 'DELETE_CANVAS_REQUEST'
-export const DELETE_CANVAS_SUCCESS = 'DELETE_CANVAS_SUCCESS'
-export const DELETE_CANVAS_FAILURE = 'DELETE_CANVAS_FAILURE'
-export const OPEN_CANVAS = 'OPEN_CANVAS'
-export const UPDATE_FILTER = 'UPDATE_FILTER'
+export const GET_CANVASES_REQUEST = 'userpages/canvas/GET_CANVASES_REQUEST'
+export const GET_CANVASES_SUCCESS = 'userpages/canvas/GET_CANVASES_SUCCESS'
+export const GET_CANVASES_FAILURE = 'userpages/canvas/GET_CANVASES_FAILURE'
+export const GET_CANVAS_REQUEST = 'userpages/canvas/GET_CANVAS_REQUEST'
+export const GET_CANVAS_SUCCESS = 'userpages/canvas/GET_CANVAS_SUCCESS'
+export const GET_CANVAS_FAILURE = 'userpages/canvas/GET_CANVAS_FAILURE'
+export const DELETE_CANVAS_REQUEST = 'userpages/canvas/DELETE_CANVAS_REQUEST'
+export const DELETE_CANVAS_SUCCESS = 'userpages/canvas/DELETE_CANVAS_SUCCESS'
+export const DELETE_CANVAS_FAILURE = 'userpages/canvas/DELETE_CANVAS_FAILURE'
+export const OPEN_CANVAS = 'userpages/canvas/OPEN_CANVAS'
+export const UPDATE_FILTER = 'userpages/canvas/UPDATE_FILTER'
 
 const getCanvasesRequest = () => ({
     type: GET_CANVASES_REQUEST,
@@ -112,9 +111,6 @@ export const getCanvases = () => (dispatch: Function, getState: () => StoreState
             throw e
         })
 }
-
-const getCanvasesDebouncedInternal = debounce(getCanvases(), 500)
-export const getCanvasesDebounced = () => getCanvasesDebouncedInternal.bind(null)
 
 export const getCanvas = (id: CanvasId) => (dispatch: Function) => {
     dispatch(getCanvasRequest(id))

--- a/app/src/userpages/modules/dashboard/actions.js
+++ b/app/src/userpages/modules/dashboard/actions.js
@@ -4,39 +4,42 @@ import _ from 'lodash'
 
 import { success as successNotification, error as errorNotification } from 'react-notification-system-redux'
 import type { ErrorInUi } from '$shared/flowtype/common-types'
+import type { Filter } from '../../flowtype/common-types'
+import type { StoreState } from '../../flowtype/states/store-state'
 import type { DashboardId, DashboardIdList, Dashboard, DashboardItem, Layout, LayoutItem } from '../../flowtype/dashboard-types'
 import { selectUserData } from '$shared/modules/user/selectors'
 import { dashboardsSchema, dashboardSchema } from '$shared/modules/entities/schema'
 import { handleEntities } from '$shared/utils/entities'
 import { selectEntities } from '$shared/modules/entities/selectors'
+import type { StoreState as MPStoreState } from '$mp/flowtype/store-state'
 
-import type { StoreState } from '$mp/flowtype/store-state'
 import * as services from './services'
-import { selectOpenDashboard } from './selectors'
+import { selectOpenDashboard, selectFilter } from './selectors'
 
-export const OPEN_DASHBOARD = 'OPEN_DASHBOARD'
+export const OPEN_DASHBOARD = 'userpages/dashboard/OPEN_DASHBOARD'
 
-export const UPDATE_AND_SAVE_DASHBOARD_REQUEST = 'UPDATE_AND_SAVE_DASHBOARD_REQUEST'
-export const UPDATE_AND_SAVE_DASHBOARD_SUCCESS = 'UPDATE_AND_SAVE_DASHBOARD_SUCCESS'
-export const UPDATE_AND_SAVE_DASHBOARD_FAILURE = 'UPDATE_AND_SAVE_DASHBOARD_FAILURE'
+export const UPDATE_AND_SAVE_DASHBOARD_REQUEST = 'userpages/dashboard/UPDATE_AND_SAVE_DASHBOARD_REQUEST'
+export const UPDATE_AND_SAVE_DASHBOARD_SUCCESS = 'userpages/dashboard/UPDATE_AND_SAVE_DASHBOARD_SUCCESS'
+export const UPDATE_AND_SAVE_DASHBOARD_FAILURE = 'userpages/dashboard/UPDATE_AND_SAVE_DASHBOARD_FAILURE'
 
-export const GET_DASHBOARDS_REQUEST = 'GET_DASHBOARDS_REQUEST'
-export const GET_DASHBOARDS_SUCCESS = 'GET_DASHBOARDS_SUCCESS'
-export const GET_DASHBOARDS_FAILURE = 'GET_DASHBOARDS_FAILURE'
+export const GET_DASHBOARDS_REQUEST = 'userpages/dashboard/GET_DASHBOARDS_REQUEST'
+export const GET_DASHBOARDS_SUCCESS = 'userpages/dashboard/GET_DASHBOARDS_SUCCESS'
+export const GET_DASHBOARDS_FAILURE = 'userpages/dashboard/GET_DASHBOARDS_FAILURE'
 
-export const GET_DASHBOARD_REQUEST = 'GET_DASHBOARD_REQUEST'
-export const GET_DASHBOARD_SUCCESS = 'GET_DASHBOARD_SUCCESS'
-export const GET_DASHBOARD_FAILURE = 'GET_DASHBOARD_FAILURE'
+export const GET_DASHBOARD_REQUEST = 'userpages/dashboard/GET_DASHBOARD_REQUEST'
+export const GET_DASHBOARD_SUCCESS = 'userpages/dashboard/GET_DASHBOARD_SUCCESS'
+export const GET_DASHBOARD_FAILURE = 'userpages/dashboard/GET_DASHBOARD_FAILURE'
 
-export const DELETE_DASHBOARD_REQUEST = 'DELETE_DASHBOARD_REQUEST'
-export const DELETE_DASHBOARD_SUCCESS = 'DELETE_DASHBOARD_SUCCESS'
-export const DELETE_DASHBOARD_FAILURE = 'DELETE_DASHBOARD_FAILURE'
+export const DELETE_DASHBOARD_REQUEST = 'userpages/dashboard/DELETE_DASHBOARD_REQUEST'
+export const DELETE_DASHBOARD_SUCCESS = 'userpages/dashboard/DELETE_DASHBOARD_SUCCESS'
+export const DELETE_DASHBOARD_FAILURE = 'userpages/dashboard/DELETE_DASHBOARD_FAILURE'
 
-export const GET_MY_DASHBOARD_PERMISSIONS_REQUEST = 'GET_MY_DASHBOARD_PERMISSIONS_REQUEST'
-export const GET_MY_DASHBOARD_PERMISSIONS_SUCCESS = 'GET_MY_DASHBOARD_PERMISSIONS_SUCCESS'
-export const GET_MY_DASHBOARD_PERMISSIONS_FAILURE = 'GET_MY_DASHBOARD_PERMISSIONS_FAILURE'
+export const GET_MY_DASHBOARD_PERMISSIONS_REQUEST = 'userpages/dashboard/GET_MY_DASHBOARD_PERMISSIONS_REQUEST'
+export const GET_MY_DASHBOARD_PERMISSIONS_SUCCESS = 'userpages/dashboard/GET_MY_DASHBOARD_PERMISSIONS_SUCCESS'
+export const GET_MY_DASHBOARD_PERMISSIONS_FAILURE = 'userpages/dashboard/GET_MY_DASHBOARD_PERMISSIONS_FAILURE'
 
-export const CHANGE_DASHBOARD_ID = 'CHANGE_DASHBOARD_ID'
+export const CHANGE_DASHBOARD_ID = 'userpages/dashboard/CHANGE_DASHBOARD_ID'
+export const UPDATE_FILTER = 'userpages/dashboard/UPDATE_FILTER'
 
 const dashboardConfig = require('../../components/DashboardPage/dashboardConfig')
 
@@ -138,7 +141,7 @@ export const unlockDashboardEditing = (id: DashboardId) => (dispatch: Function) 
     })
 }
 
-const changeDashboardId = (oldId: DashboardId, newId: DashboardId) => (dispatch: Function, getState: () => StoreState) => {
+const changeDashboardId = (oldId: DashboardId, newId: DashboardId) => (dispatch: Function, getState: () => MPStoreState) => {
     const entities = selectEntities(getState())
 
     handleEntities(dashboardSchema, dispatch)({
@@ -225,9 +228,30 @@ const getMyDashboardPermissionsFailure = (id: DashboardId, error: ErrorInUi) => 
     error,
 })
 
-export const getDashboards = () => (dispatch: Function) => {
+const updateFilterAction = (filter: Filter) => ({
+    type: UPDATE_FILTER,
+    filter,
+})
+
+export const getDashboards = () => (dispatch: Function, getState: () => StoreState) => {
     dispatch(getDashboardsRequest())
-    return services.getDashboards()
+
+    const filter = selectFilter(getState())
+    let params = {
+        adhoc: false,
+        sortBy: (filter && filter.sortBy) || 'lastUpdated',
+        search: (filter && filter.search) || null,
+        order: (filter && filter.order) || 'desc',
+    }
+
+    if (filter && filter.key && filter.value) {
+        params = {
+            ...params,
+            [filter.key]: filter.value,
+        }
+    }
+
+    return services.getDashboards(params)
         .then(handleEntities(dashboardsSchema, dispatch))
         .then((data) => {
             dispatch(getDashboardsSuccess(data))
@@ -358,3 +382,7 @@ export const updateDashboardChanges = (id: DashboardId, changes: {}) => (dispatc
         }))
     }
 }
+
+export const updateFilter = (filter: Filter) => (dispatch: Function) => (
+    dispatch(updateFilterAction(filter))
+)

--- a/app/src/userpages/modules/dashboard/actions.js
+++ b/app/src/userpages/modules/dashboard/actions.js
@@ -5,13 +5,12 @@ import _ from 'lodash'
 import { success as successNotification, error as errorNotification } from 'react-notification-system-redux'
 import type { ErrorInUi } from '$shared/flowtype/common-types'
 import type { Filter } from '../../flowtype/common-types'
-import type { StoreState } from '../../flowtype/states/store-state'
+import type { StoreState } from '$shared/flowtype/store-state'
 import type { DashboardId, DashboardIdList, Dashboard, DashboardItem, Layout, LayoutItem } from '../../flowtype/dashboard-types'
 import { selectUserData } from '$shared/modules/user/selectors'
 import { dashboardsSchema, dashboardSchema } from '$shared/modules/entities/schema'
 import { handleEntities } from '$shared/utils/entities'
 import { selectEntities } from '$shared/modules/entities/selectors'
-import type { StoreState as MPStoreState } from '$mp/flowtype/store-state'
 
 import * as services from './services'
 import { selectOpenDashboard, selectFilter } from './selectors'
@@ -141,7 +140,7 @@ export const unlockDashboardEditing = (id: DashboardId) => (dispatch: Function) 
     })
 }
 
-const changeDashboardId = (oldId: DashboardId, newId: DashboardId) => (dispatch: Function, getState: () => MPStoreState) => {
+const changeDashboardId = (oldId: DashboardId, newId: DashboardId) => (dispatch: Function, getState: () => StoreState) => {
     const entities = selectEntities(getState())
 
     handleEntities(dashboardSchema, dispatch)({
@@ -239,7 +238,7 @@ export const getDashboards = () => (dispatch: Function, getState: () => StoreSta
     const filter = selectFilter(getState())
     let params = {
         adhoc: false,
-        sortBy: (filter && filter.sortBy) || 'lastUpdated',
+        sortBy: (filter && filter.sortBy) || 'name',
         search: (filter && filter.search) || null,
         order: (filter && filter.order) || 'desc',
     }

--- a/app/src/userpages/modules/dashboard/reducer.js
+++ b/app/src/userpages/modules/dashboard/reducer.js
@@ -21,6 +21,7 @@ import {
     GET_MY_DASHBOARD_PERMISSIONS_FAILURE,
     OPEN_DASHBOARD,
     CHANGE_DASHBOARD_ID,
+    UPDATE_FILTER,
 } from './actions'
 
 const initialState = {
@@ -31,6 +32,7 @@ const initialState = {
     },
     error: null,
     fetching: false,
+    filter: null,
 }
 
 const dashboard = function dashboard(state: DashboardState = initialState, action: DashboardAction): DashboardState {
@@ -114,6 +116,11 @@ const dashboard = function dashboard(state: DashboardState = initialState, actio
                 },
             }
         }
+        case UPDATE_FILTER:
+            return {
+                ...state,
+                filter: action.filter,
+            }
 
         default:
             return state

--- a/app/src/userpages/modules/dashboard/selectors.js
+++ b/app/src/userpages/modules/dashboard/selectors.js
@@ -7,6 +7,7 @@ import type { EntitiesState } from '$shared/flowtype/store-state'
 import type { StoreState } from '$userpages/flowtype/states/store-state'
 import type { DashboardState } from '$userpages/flowtype/states/dashboard-state'
 import type { DashboardId, DashboardIdList, Dashboard, DashboardList } from '$userpages/flowtype/dashboard-types'
+import type { Filter } from '$userpages/flowtype/common-types'
 
 import { selectEntities } from '$shared/modules/entities/selectors'
 import { dashboardsSchema, dashboardSchema } from '$shared/modules/entities/schema'
@@ -38,4 +39,9 @@ export const selectOpenDashboard: (StoreState) => ?Dashboard = createSelector(
 export const selectFetching: (StoreState) => boolean = createSelector(
     selectUserPageDashboardState,
     (subState: DashboardState): boolean => subState.fetching,
+)
+
+export const selectFilter: (StoreState) => ?Filter = createSelector(
+    selectUserPageDashboardState,
+    (subState: DashboardState): ?Filter => subState.filter,
 )

--- a/app/src/userpages/modules/dashboard/services.js
+++ b/app/src/userpages/modules/dashboard/services.js
@@ -6,7 +6,7 @@ import type { ApiResult } from '$shared/flowtype/common-types'
 import type { DashboardId, Dashboard, DashboardList } from '$userpages/flowtype/dashboard-types'
 import type { Permission } from '$userpages/flowtype/permission-types'
 
-export const getDashboards = (): ApiResult<DashboardList> => get(formatApiUrl('dashboards'))
+export const getDashboards = (params: any): ApiResult<DashboardList> => get(formatApiUrl('dashboards'), { params })
 
 export const getDashboard = (id: DashboardId): ApiResult<Dashboard> => get(formatApiUrl('dashboards', id))
 

--- a/app/src/userpages/tests/modules/dashboard/actions.test.js
+++ b/app/src/userpages/tests/modules/dashboard/actions.test.js
@@ -49,7 +49,7 @@ describe('Dashboard actions', () => {
 
     describe('getDashboards', () => {
         it('creates GET_DASHBOARDS_SUCCESS when fetching dashboards has succeeded', async () => {
-            moxios.stubRequest(`${process.env.STREAMR_API_URL}/dashboards`, {
+            moxios.stubRequest(new RegExp(`${process.env.STREAMR_API_URL}/dashboards` + '*'), {
                 status: 200,
                 response: [{
                     id: 'test',
@@ -75,7 +75,7 @@ describe('Dashboard actions', () => {
             assert.deepStrictEqual(store.getActions(), expectedActions)
         })
         it('creates GET_ALL_INTEGRATION_KEYS_FAILURE when fetching integration keys has failed', async (done) => {
-            moxios.stubRequest(`${process.env.STREAMR_API_URL}/dashboards`, {
+            moxios.stubRequest(new RegExp(`${process.env.STREAMR_API_URL}/dashboards` + '*'), {
                 status: 500,
                 response: {
                     message: 'test',
@@ -133,7 +133,7 @@ describe('Dashboard actions', () => {
         })
 
         it('creates GET_ALL_INTEGRATION_KEYS_FAILURE when fetching integration keys has failed', async (done) => {
-            moxios.stubRequest(`${process.env.STREAMR_API_URL}/dashboards`, {
+            moxios.stubRequest(new RegExp(`${process.env.STREAMR_API_URL}/dashboards` + '*'), {
                 status: 500,
                 response: {
                     message: 'test',

--- a/app/src/userpages/tests/modules/dashboard/reducer.test.js
+++ b/app/src/userpages/tests/modules/dashboard/reducer.test.js
@@ -11,6 +11,7 @@ describe('Dashboard reducer', () => {
         },
         error: null,
         fetching: false,
+        filter: null,
     }
 
     it('should return the initial state', () => {

--- a/app/src/userpages/utils/constants.js
+++ b/app/src/userpages/utils/constants.js
@@ -1,6 +1,74 @@
+// @flow
+
+import { I18n } from 'react-redux-i18n'
+import type { SortOption } from '$userpages/flowtype/common-types'
+
 export const defaultColumns = {
     xs: 12,
     sm: 6,
     md: 6,
     lg: 3,
 }
+
+export const getDefaultSortOptions = (): Array<SortOption> => [
+    {
+        displayName: I18n.t('userpages.filter.recent'),
+        filter: {
+            id: 'recent',
+            sortBy: 'lastUpdated',
+            order: 'desc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.running'),
+        filter: {
+            id: 'running',
+            key: 'state',
+            value: 'RUNNING',
+            order: 'desc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.stopped'),
+        filter: {
+            id: 'stopped',
+            key: 'state',
+            value: 'STOPPED',
+            order: 'desc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.shared'),
+        filter: {
+            id: 'shared',
+            key: 'operation',
+            value: 'SHARE',
+            order: 'desc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.mine'),
+        filter: {
+            id: 'mine',
+            key: 'operation',
+            value: 'WRITE',
+            order: 'desc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.az'),
+        filter: {
+            id: 'az',
+            sortBy: 'name',
+            order: 'asc',
+        },
+    },
+    {
+        displayName: I18n.t('userpages.filter.za'),
+        filter: {
+            id: 'za',
+            sortBy: 'name',
+            order: 'desc',
+        },
+    },
+]


### PR DESCRIPTION
Added search and filtering for dashboard listing. Also made default filters constant since canvases, dashboards and streams will use the same filters.

PS. I modified Search component to do debouncing so we don't have to make debounced versions of the redux actions