### PR TITLE
[PLATFORM-257] View live data while Logged out

### DIFF
--- a/app/src/shared/modules/user/actions.js
+++ b/app/src/shared/modules/user/actions.js
@@ -133,7 +133,7 @@ export const fetchLinkedWeb3Accounts = () => (dispatch: Function) => {
 }
 
 // Fetch login keys, a token is saved to local storage and used when needed (eg. in StreamLivePreview)
-export const getApiKeys = () => (dispatch: Function) => {
+export const getApiKeys = () => (dispatch: Function, getState: Function) => {
     dispatch(apiKeysRequest())
 
     return services.getMyKeys()
@@ -143,7 +143,10 @@ export const getApiKeys = () => (dispatch: Function) => {
         }, (error) => {
             dispatch(apiKeysError(error))
             // Session was not found so logout from marketplace
-            dispatch(logout())
+            const user = selectUserData(getState())
+            if (user) {
+                dispatch(logout())
+            }
         })
 }
 

--- a/app/test/unit/modules/user/actions.test.js
+++ b/app/test/unit/modules/user/actions.test.js
@@ -6,6 +6,7 @@ import mockStore from '$testUtils/mockStoreProvider'
 import * as actions from '$shared/modules/user/actions'
 import * as constants from '$shared/modules/user/constants'
 import * as services from '$shared/modules/user/services'
+import * as selectors from '$shared/modules/user/selectors'
 
 describe('user - actions', () => {
     let sandbox
@@ -112,14 +113,42 @@ describe('user - actions', () => {
             assert.deepStrictEqual(store.getActions(), expectedActions)
         })
 
-        it('calls services.getMyKeys, logs out if there are errors', async () => {
+        it('calls services.getMyKeys, does nothing on error if user is not logged in', async () => {
             const error = new Error('error')
             const serviceStub = sandbox.stub(services, 'getMyKeys').callsFake(() => Promise.reject(error))
+            const selectorStub = sandbox.stub(selectors, 'selectUserData').callsFake(() => null)
+
+            const store = mockStore()
+            await store.dispatch(actions.getApiKeys())
+            assert(serviceStub.calledOnce)
+            assert(selectorStub.calledOnce)
+
+            const expectedActions = [
+                {
+                    type: constants.API_KEYS_REQUEST,
+                },
+                {
+                    type: constants.API_KEYS_FAILURE,
+                    error: true,
+                    payload: error,
+                },
+            ]
+
+            assert.deepStrictEqual(store.getActions(), expectedActions)
+        })
+
+        it('calls services.getMyKeys, logs out if there are errors and user is logged in', async () => {
+            const error = new Error('error')
+            const serviceStub = sandbox.stub(services, 'getMyKeys').callsFake(() => Promise.reject(error))
+            const selectorStub = sandbox.stub(selectors, 'selectUserData').callsFake(() => ({
+                id: 'user',
+            }))
             const windowReplaceStub = sandbox.stub(window.location, 'replace')
 
             const store = mockStore()
             await store.dispatch(actions.getApiKeys())
             assert(serviceStub.calledOnce)
+            assert(selectorStub.calledOnce)
 
             const expectedActions = [
                 {


### PR DESCRIPTION
The cause of this issue is that when Stream preview page was added as an actual page, there is a call to `getApiKeys` which will log the user out if it fails. I added a check that the logout only happens if a session already exists.