### PR TITLE
[PLATFORM-170] Input initial value

### DIFF
--- a/app/src/editor/components/Canvas.jsx
+++ b/app/src/editor/components/Canvas.jsx
@@ -61,9 +61,9 @@ export default DragDropContext(HTML5Backend)(class Canvas extends React.Componen
         })
     }
 
-    setPortValue = (portId, value) => {
+    setPortUserValue = (portId, value) => {
         this.props.setCanvas({ type: 'Set Port Value' }, (canvas) => (
-            CanvasState.setPortValue(canvas, portId, value)
+            CanvasState.setPortUserValue(canvas, portId, value)
         ))
     }
 
@@ -106,7 +106,7 @@ export default DragDropContext(HTML5Backend)(class Canvas extends React.Componen
             onCanDrop: this.onCanDropPort,
             onDragEnd: this.onDragEndPort,
             onCanDrag: this.onCanDrag,
-            onChange: this.setPortValue,
+            onChange: this.setPortUserValue,
             setPortOptions: this.setPortOptions,
         },
     }

--- a/app/src/editor/components/Canvas.pcss
+++ b/app/src/editor/components/Canvas.pcss
@@ -21,6 +21,10 @@
   right: 0;
 }
 
+.Modules:focus {
+  outline: none;
+}
+
 .Cables {
   z-index: 0;
   fill: none;

--- a/app/src/editor/components/Ports.jsx
+++ b/app/src/editor/components/Ports.jsx
@@ -361,7 +361,9 @@ class PortValue extends React.Component {
     }
 
     onBlur = () => {
-        this.props.onChange(this.props.port.id, this.state.value)
+        let { value } = this.state
+        if (value === '') { value = null }
+        this.props.onChange(this.props.port.id, value)
         this.setState({
             hasFocus: false,
         })
@@ -389,7 +391,10 @@ class PortValue extends React.Component {
             (!port.canHaveInitialValue && port.connected)
         )
 
-        const { value = '' } = this.state
+        let { value } = this.state
+        if (value == null) {
+            value = '' // prevent uncontrolled/controlled switching
+        }
 
         const portSize = size + 2 // add some padding
 

--- a/app/src/editor/components/Ports.jsx
+++ b/app/src/editor/components/Ports.jsx
@@ -220,12 +220,14 @@ class MapParam extends React.Component {
     )
 
     getOnFocus = (type, index) => (event) => {
-        event.target.select() // select all input text on focus
+        if (event.target.select) {
+            event.target.select() // select all input text on focus
+        }
         // set field to single space to trigger new empty row
         // user will not see the space
         const kv = this.state.values[index] || ['', '']
-        this.onChange(type, index, kv[type === 'key' ? 0 : 1])
         this.props.onFocus(event)
+        this.onChange(type, index, kv[type === 'key' ? 0 : 1])
     }
 
     getRemoveRow = (index) => () => {
@@ -354,7 +356,10 @@ class PortValue extends React.Component {
     }
 
     onFocus = (event) => {
-        event.target.select()
+        if (event.target.select) {
+            event.target.select() // select all input text on focus
+        }
+
         this.setState({
             hasFocus: true,
         })
@@ -412,7 +417,7 @@ class PortValue extends React.Component {
                         ...props,
                     }}
                     disabled={disabled}
-                    onChange={onChange}
+                    onChange={this.onChange}
                     onBlur={this.onBlur}
                     onFocus={this.onFocus}
                 />

--- a/app/src/editor/components/Ports.jsx
+++ b/app/src/editor/components/Ports.jsx
@@ -42,44 +42,17 @@ const PortDrag = DragSource(DragTypes.Port)
 const PortDrop = DropTarget(DragTypes.Port)
 
 const Port = PortDrag(PortDrop(class Port extends React.PureComponent {
-    state = {
-        hasFocus: false,
-    }
-
-    static getDerivedStateFromProps({ port }, { hasFocus }) {
-        if (hasFocus) { return null }
-        let value = port.value || port.defaultValue
-        if (value == null) { value = '' } // react isn't happy if input value is undefined/null
-        return { value }
-    }
-
     onRef = (el) => {
         this.props.onPort(this.props.port.id, el)
-    }
-
-    onChange = (value, done) => {
-        this.props.adjustMinPortSize(String(value).length)
-        this.setState({ value }, done)
-    }
-
-    onFocus = () => {
-        this.setState({
-            hasFocus: true,
-        })
-    }
-
-    onBlur = () => {
-        this.props.onChange(this.props.port.id, this.state.value)
-        this.setState({
-            hasFocus: false,
-        })
     }
 
     render() {
         const { port, canvas, ...props } = this.props
         const isInput = !!port.acceptedTypes
         const isParam = 'defaultValue' in port
+        const hasInputField = isParam || port.canHaveInitialValue
         const isRunning = canvas.state === RunStates.Running
+
         const portContent = [
             <div
                 role="gridcell"
@@ -122,21 +95,20 @@ const Port = PortDrag(PortDrop(class Port extends React.PureComponent {
             portContent.reverse()
         }
 
-        if (isParam) {
-            /* add input for params */
+        if (hasInputField) {
+            /* add input for params/inputs with initial value */
             portContent.push((
                 <div key={`${port.id}.value`} className={cx(styles.portValueContainer)} role="gridcell">
-                    <PortParam
+                    {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}
+                    <PortValue
                         className={styles.portValue}
                         port={port}
                         size={this.props.size}
-                        value={this.state.value}
-                        onChange={this.onChange}
+                        adjustMinPortSize={this.props.adjustMinPortSize}
+                        onChange={this.props.onChange}
                         disabled={!!port.connected || !!isRunning}
                         onMouseOver={() => this.props.setIsDraggable(false)}
                         onMouseOut={() => this.props.setIsDraggable(true)}
-                        onBlur={this.onBlur}
-                        onFocus={this.onFocus}
                     />
                 </div>
             ))
@@ -178,18 +150,6 @@ class PortOptions extends React.PureComponent {
                         disabled={!!isRunning}
                     >
                         DI
-                    </button>
-                )}
-                {port.canHaveInitialValue && (
-                    <button
-                        type="button"
-                        title={`Initial Value: ${port.initialValue !== '' ? port.initialValue : '(None)'}`}
-                        value={port.initialValue !== ''}
-                        className={styles.initialValueOption}
-                        onClick={this.getToggleOption('initialValue')}
-                        disabled={!!isRunning}
-                    >
-                        IV
                     </button>
                 )}
                 {port.canBeNoRepeat && (
@@ -376,43 +336,98 @@ class MapParam extends React.Component {
  * Render appropriate control based on port.type
  */
 
-function PortParam({ port, size, onChange, ...props }) {
-    // normalize onChange to always return new value rather than an event
-    const onChangeEvent = (event) => onChange(event.target.value)
-
-    const portSize = size + 2 // add some padding
-
-    const style = {
-        minWidth: `${portSize}ch`, // setting minWidth allows size transition
+class PortValue extends React.Component {
+    state = {
+        hasFocus: false,
+        value: '',
     }
 
-    if (port.type === 'Map') {
+    static getDerivedStateFromProps({ port }, { hasFocus }) {
+        if (hasFocus) { return null }
+        let value = port.value || port.defaultValue
+        if (value == null) { value = '' } // react isn't happy if input value is undefined/null
+        return { value }
+    }
+
+    onRef = (el) => {
+        this.props.onPort(this.props.port.id, el)
+    }
+
+    onChange = (value, done) => {
+        this.props.adjustMinPortSize(String(value).length)
+        this.setState({ value }, done)
+    }
+
+    onFocus = () => {
+        this.setState({
+            hasFocus: true,
+        })
+    }
+
+    onBlur = () => {
+        this.props.onChange(this.props.port.id, this.state.value)
+        this.setState({
+            hasFocus: false,
+        })
+    }
+
+    // normalize onChange to always return new value rather than an event
+    onChangeEvent = (event) => {
+        this.props.onChange(this.props.port.id, event.target.value)
+    }
+
+    render() {
+        const {
+            port,
+            size,
+            onChange,
+            adjustMinPortSize,
+            ...props
+        } = this.props
+
+        const { value } = this.state
+
+        const portSize = size + 2 // add some padding
+
+        const style = {
+            minWidth: `${portSize}ch`, // setting minWidth allows size transition
+        }
+
+        if (port.type === 'Map') {
+            return (
+                <MapParam
+                    {...{
+                        port,
+                        size,
+                        value,
+                        ...props,
+                    }}
+                    onChange={onChange}
+                />
+            )
+        }
+
+        /* Select */
+        if (port.possibleValues) {
+            return (
+                <select {...props} value={value} onChange={this.onChangeEvent} style={style}>
+                    {port.possibleValues.map(({ name, value }) => (
+                        <option key={value} value={value}>{name}</option>
+                    ))}
+                </select>
+            )
+        }
+
         return (
-            <MapParam
-                {...{
-                    port,
-                    size,
-                    ...props,
-                }}
-                onChange={onChange}
+            <input
+                {...props}
+                placeholder={port.displayName || port.name}
+                value={value}
+                onChange={this.onChangeEvent}
+                style={style}
             />
         )
     }
-
-    /* Select */
-    if (port.possibleValues) {
-        return (
-            <select {...props} onChange={onChangeEvent} style={style}>
-                {port.possibleValues.map(({ name, value }) => (
-                    <option key={value} value={value}>{name}</option>
-                ))}
-            </select>
-        )
-    }
-
-    return (
-        <input {...props} onChange={onChangeEvent} style={style} />
-    )
 }
 
 // this is the `display: table` equivalent of `<td colspan="3" />`. For alignment.

--- a/app/src/editor/components/Ports.pcss
+++ b/app/src/editor/components/Ports.pcss
@@ -1,5 +1,11 @@
 @import './variables.pcss';
 
+:root {
+  --driving-input-color: #FF5C00;
+  --no-repeat-color: #0324FF;
+  --connected-color: #2AC437;
+}
+
 /* stylelint-disable no-descending-specificity */
 
 .ports {
@@ -65,11 +71,11 @@
 }
 
 .ports .portIcon.drivingInput {
-  border-color: #FF5C00;
+  border-color: var(--driving-input-color);
 }
 
 .ports .portIcon.noRepeat {
-  border-color: #0324FF;
+  border-color: var(--no-repeat-color);
 }
 
 .ports .portIcon:not(.isDragging).dragPortInProgress {
@@ -86,7 +92,7 @@
 }
 
 .ports .portIcon.connected {
-  border-color: #2AC437;
+  border-color: var(--connected-color);
 }
 
 .ports .portIcon.connected::after {
@@ -98,7 +104,7 @@
   transform: translate(-50%, -50%);
   width: 2px;
   height: 2px;
-  background: #2AC437;
+  background: var(--connected-color);
   opacity: 1;
 }
 
@@ -154,15 +160,11 @@
 }
 
 .ports .portIcon .portOptions > .drivingInputOption[value='true'] {
-  background-color: #FF5C00;
-}
-
-.ports .portIcon .portOptions > .initialValueOption[value='true'] {
-  background-color: #BF9595;
+  background-color: var(--driving-input-color);
 }
 
 .ports .portIcon .portOptions > .noRepeatOption[value='true'] {
-  background-color: #0324FF;
+  background-color: var(--no-repeat-color);
 }
 
 /**

--- a/app/src/editor/components/Ports.pcss
+++ b/app/src/editor/components/Ports.pcss
@@ -70,7 +70,8 @@
   border-radius: 0;
 }
 
-.ports .portIcon.drivingInput {
+.ports .portIcon.drivingInput,
+.ports .portIcon.connected.drivingInput {
   border-color: var(--driving-input-color);
 }
 

--- a/app/src/editor/state.js
+++ b/app/src/editor/state.js
@@ -19,6 +19,12 @@ export const RunTabs = {
     historical: '#tab-historical',
 }
 
+export const PortTypes = {
+    input: 'input',
+    output: 'output',
+    param: 'param',
+}
+
 export function emptyCanvas() {
     return {
         name: 'Untitled Canvas',
@@ -117,12 +123,12 @@ function getPortModulePath(canvas, portId) {
 }
 
 /**
- * True if port is an output port
+ * True iff port is an output port
  */
 
 function getIsOutput(canvas, portId) {
     const type = getPortType(canvas, portId)
-    return type === 'output'
+    return type === PortTypes.output
 }
 
 /**
@@ -446,16 +452,29 @@ export function addModule(canvas, moduleData) {
     }
 }
 
-export function setPortValue(canvas, portId, value) {
-    if (JSON.stringify(getPort(canvas, portId).value) === JSON.stringify(value)) {
+/**
+ * Sets initialValue for inputs
+ * Sets value for output/params
+ */
+
+export function setPortUserValue(canvas, portId, value) {
+    const portType = getPortType(canvas, portId)
+    const key = {
+        [PortTypes.input]: 'initialValue',
+        [PortTypes.param]: 'value',
+        [PortTypes.output]: 'value', // not really user-configurable but whatever
+    }[portType]
+
+    if (JSON.stringify(getPort(canvas, portId)[key]) === JSON.stringify(value)) {
         // noop if no change
         return canvas
     }
+
     return updatePort(canvas, portId, (port) => {
-        if (port.value === value) { return port }
+        if (port[key] === value) { return port }
         return {
             ...port,
-            value,
+            [key]: value,
         }
     })
 }


### PR DESCRIPTION
To test:

* Add the `Multiply` module to a canvas
* Note the A & B ports have inputs. These inputs allow setting the initial value.
* Note that unlike params, initial value inputs are not disabled when connected.

Also
* All ports with inputs now have placeholder text.
* Input text is selected when input gets focus
