### PR TITLE
[PLATFORM-277] User Profile - Stream settings

### DIFF
--- a/app/src/shared/components/FormControl/formControl.pcss
+++ b/app/src/shared/components/FormControl/formControl.pcss
@@ -6,14 +6,14 @@
 
   label {
     color: var(--greyDark);
-    font-size: 0.75em;
+    font-size: 0.75rem;
     left: 0;
-    line-height: 1em;
+    line-height: 1rem;
     margin: 0;
     pointer-events: none;
     position: absolute;
-    top: -1em;
-    transform: translate(0, 1.75em) scale(1);
+    top: -1rem;
+    transform: translate(0, 1.75rem) scale(1);
     transform-origin: top left;
     transition: 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
     transition-property: color, transform;
@@ -54,11 +54,11 @@
 }
 
 .withLabelSpace {
-  margin-top: 1em;
+  margin-top: 1rem;
 }
 
 @media (--md-up) {
   .root label {
-    font-size: 1em;
+    font-size: 1rem;
   }
 }

--- a/app/src/shared/components/TextField/textField.pcss
+++ b/app/src/shared/components/TextField/textField.pcss
@@ -19,11 +19,11 @@
   box-sizing: content-box;
   color: var(--greyDark);
   display: block;
-  font-size: 0.75em;
-  height: 1em;
-  line-height: 1em;
+  font-size: 0.75rem;
+  height: 1rem;
+  line-height: 1rem;
   outline: 0;
-  padding: 0.75em 0;
+  padding: 0.75rem 0;
   width: 100%;
   background-color: inherit;
 }
@@ -50,6 +50,6 @@
 
 @media (--md-up) {
   .root {
-    font-size: 1em;
+    font-size: 1rem;
   }
 }

--- a/app/src/userpages/components/ProfilePage/StreamSettings/index.jsx
+++ b/app/src/userpages/components/ProfilePage/StreamSettings/index.jsx
@@ -1,0 +1,62 @@
+// @flow
+
+import React from 'react'
+import { Translate, I18n } from 'react-redux-i18n'
+
+import ToggleField from '$userpages/components/ToggleField'
+import TextInput from '$shared/components/TextInput'
+
+import styles from './streamSettings.pcss'
+
+type Props = {}
+type State = {
+    requireSignedMessages: boolean,
+    historicalStoragePeriod: string,
+}
+
+class StreamSettings extends React.Component<Props, State> {
+    state = {
+        requireSignedMessages: false,
+        historicalStoragePeriod: '365',
+    }
+
+    onToggleChange = (checked: boolean) => {
+        this.setState({
+            requireSignedMessages: checked,
+        })
+    }
+
+    onValueChange = (e: SyntheticInputEvent<EventTarget>) => {
+        this.setState({
+            historicalStoragePeriod: e.target.value,
+        })
+    }
+
+    render() {
+        const { requireSignedMessages, historicalStoragePeriod } = this.state
+
+        return (
+            <div>
+                <ToggleField
+                    label={I18n.t('userpages.profilePage.streams.requireSignedMessages')}
+                    value={requireSignedMessages}
+                    onChange={this.onToggleChange}
+                />
+                <div className={styles.historicalStoragePeriod}>
+                    <Translate value="userpages.profilePage.streams.historicalStoragePeriod.description" />
+                </div>
+                <div className={styles.input}>
+                    <TextInput
+                        type="number"
+                        label={I18n.t('userpages.profilePage.streams.historicalStoragePeriod.label')}
+                        value={historicalStoragePeriod}
+                        onChange={this.onValueChange}
+                        preserveLabelSpace
+                    />
+                </div>
+            </div>
+        )
+    }
+}
+
+export default StreamSettings

--- a/app/src/userpages/components/ProfilePage/StreamSettings/streamSettings.pcss
+++ b/app/src/userpages/components/ProfilePage/StreamSettings/streamSettings.pcss
@@ -1,0 +1,7 @@
+.historicalStoragePeriod {
+  margin-top: 2.5rem;
+}
+
+.input {
+  margin-top: 2.25rem;
+}

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -5,6 +5,7 @@ import { I18n } from 'react-redux-i18n'
 
 import Layout from '../Layout'
 import ProfileSettings from './ProfileSettings'
+import StreamSettings from './StreamSettings'
 import APICredentials from './APICredentials'
 import IntegrationKeyHandler from './IntegrationKeyHandler'
 import IdentityHandler from './IdentityHandler/index'
@@ -32,6 +33,9 @@ export default class ProfilePage extends Component<{}> {
                         <TOCPage title={I18n.t('userpages.profilePage.pageTitle')}>
                             <TOCPage.Section id="profile" title={I18n.t('userpages.profilePage.profile.title')}>
                                 <ProfileSettings />
+                            </TOCPage.Section>
+                            <TOCPage.Section id="stream-settings" title={I18n.t('userpages.profilePage.streams.title')}>
+                                <StreamSettings />
                             </TOCPage.Section>
                             <TOCPage.Section
                                 id="api-keys"

--- a/app/src/userpages/components/ProfilePage/profilePage.pcss
+++ b/app/src/userpages/components/ProfilePage/profilePage.pcss
@@ -7,6 +7,7 @@
   z-index: 11;
   top: -4em;
   position: relative;
+  font-size: 14px;
 
   @media (--md-up) {
     top: -5em;

--- a/app/src/userpages/components/ToggleField/index.jsx
+++ b/app/src/userpages/components/ToggleField/index.jsx
@@ -1,0 +1,26 @@
+// @flow
+
+import React from 'react'
+import { Row, Col } from 'reactstrap'
+
+import Toggle from '$shared/components/Toggle'
+import styles from './toggleField.pcss'
+
+type Props = {
+    label: string,
+    value: boolean,
+    onChange: (checked: boolean) => void,
+}
+
+const ToggleField = ({ label, value, onChange }: Props) => (
+    <Row>
+        <Col xs={10} className={styles.label}>
+            {label}
+        </Col>
+        <Col xs={2} className={styles.toggle}>
+            <Toggle value={value} onChange={onChange} />
+        </Col>
+    </Row>
+)
+
+export default ToggleField

--- a/app/src/userpages/components/ToggleField/toggleField.pcss
+++ b/app/src/userpages/components/ToggleField/toggleField.pcss
@@ -1,0 +1,9 @@
+.label {
+  font-size: 1rem;
+  line-height: 1rem;
+}
+
+.toggle {
+  text-align: right;
+  line-height: 1rem;
+}

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -188,6 +188,18 @@ msgstr "Settings"
 msgid "userpages##profilePage##profile##title"
 msgstr "Profile"
 
+msgid "userpages##profilePage##streams##title"
+msgstr "Stream settings"
+
+msgid "userpages##profilePage##streams##requireSignedMessages"
+msgstr "Require all messages in this stream to be signed"
+
+msgid "userpages##profilePage##streams##historicalStoragePeriod##description"
+msgstr "Please select how long your historical data is retained before it is automatically removed from the system."
+
+msgid "userpages##profilePage##streams##historicalStoragePeriod##label"
+msgstr "Historical data storage period (days)"
+
 msgid "userpages##profilePage##apiCredentials##title"
 msgstr "API Credentials"
 


### PR DESCRIPTION
Small update, adding the new Stream Settings section from designs. There is no API for this so nothing is saved.

Design:
<img width="564" alt="screen shot 2018-12-13 at 11 50 38" src="https://user-images.githubusercontent.com/1064982/49930676-c1ebb180-fecd-11e8-9a20-424045803ac4.png">

Actual:
<img width="695" alt="screen shot 2018-12-13 at 11 50 04" src="https://user-images.githubusercontent.com/1064982/49930691-c87a2900-fecd-11e8-8438-af5b777850aa.png">

@mondoreale I updated the `TextField` and `FormControl` font sizes  from `em` to `rem`. Hopefully it doesn't break anything 🙄 