### PR TITLE
[PLATFORM-189] Show relative canvas updated time.

### DIFF
--- a/app/src/editor/components/Canvas.jsx
+++ b/app/src/editor/components/Canvas.jsx
@@ -112,7 +112,13 @@ export default DragDropContext(HTML5Backend)(class Canvas extends React.Componen
     }
 
     render() {
-        const { className, canvas, selectedModuleHash, moduleSidebarIsOpen } = this.props
+        const {
+            className,
+            canvas,
+            selectedModuleHash,
+            moduleSidebarIsOpen,
+            children,
+        } = this.props
 
         return (
             <div className={cx(styles.Canvas, className)}>
@@ -124,6 +130,7 @@ export default DragDropContext(HTML5Backend)(class Canvas extends React.Componen
                     moduleSidebarIsOpen={moduleSidebarIsOpen}
                     {...this.api.module}
                 />
+                {children}
             </div>
         )
     }

--- a/app/src/editor/components/Status.jsx
+++ b/app/src/editor/components/Status.jsx
@@ -1,0 +1,91 @@
+import React from 'react'
+
+import styles from './Status.pcss'
+
+function format(diff, divisor, unit, prev) {
+    const val = Math.round(diff / divisor)
+    return val <= 1 ? prev : `${val} ${unit}s ago`
+}
+
+const units = [
+    {
+        max: 2760000,
+        value: 60000,
+        name: 'minute',
+        prev: 'a minute ago',
+    },
+    {
+        max: 72000000,
+        value: 3600000,
+        name: 'hour',
+        prev: 'an hour ago',
+    },
+    {
+        max: 518400000,
+        value: 86400000,
+        name: 'day',
+        prev: 'yesterday',
+    },
+    {
+        max: 2419200000,
+        value: 604800000,
+        name: 'week',
+        prev: 'last week',
+    },
+    {
+        max: 28512000000,
+        value: 2592000000,
+        name: 'month',
+        prev: 'last month',
+    }, // max: 11 months
+]
+
+function ago(date) {
+    const diff = Math.abs(Date.now() - date.getTime())
+    // less than a minute
+    if (diff < 60000) {
+        return 'just now'
+    }
+
+    for (let i = 0; i < units.length; i += 1) {
+        if (diff < units[i].max) {
+            return format(diff, units[i].value, units[i].name, units[i].prev)
+        }
+    }
+    // `year` is the final unit.
+    // same as:
+    //  {
+    //    max: Infinity,
+    //    value: 31536000000,
+    //    name: 'year',
+    //    prev: 'last year'
+    //  }
+    return format(diff, 31536000000, 'year', 'last year')
+}
+
+export default class Status extends React.Component {
+    componentDidMount() {
+        this.periodicUpdate()
+    }
+
+    componentWillUnmount() {
+        clearTimeout(this.period)
+    }
+
+    periodicUpdate() {
+        clearTimeout(this.period)
+        this.period = setTimeout(() => (
+            this.periodicUpdate()
+        ), 10000 + Math.random())
+        this.forceUpdate()
+    }
+
+    render() {
+        const { canvas } = this.props
+        return (
+            <div className={styles.status} title={new Date(canvas.updated).toLocaleTimeString()}>
+                Updated {ago(new Date(canvas.updated))}
+            </div>
+        )
+    }
+}

--- a/app/src/editor/components/Status.pcss
+++ b/app/src/editor/components/Status.pcss
@@ -1,0 +1,11 @@
+.status {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  color: #CDCDCD;
+  font-size: 12px;
+  text-align: right;
+  letter-spacing: 0;
+  z-index: 12;
+  margin: 13px 40px;
+}

--- a/app/src/editor/components/Status.pcss
+++ b/app/src/editor/components/Status.pcss
@@ -8,4 +8,5 @@
   letter-spacing: 0;
   z-index: 12;
   margin: 13px 40px;
+  user-select: none;
 }

--- a/app/src/editor/index.jsx
+++ b/app/src/editor/index.jsx
@@ -106,7 +106,9 @@ const CanvasEditComponent = class CanvasEdit extends Component {
             // do not autosave running/adhoc canvases
             return
         }
+        const doReplace = !!services.autosave.pending
         const newCanvas = await services.autosave(canvas)
+        if (!doReplace) { return } // prevent double replacing
         replace((currentCanvas) => {
             if (currentCanvas !== canvas) { return null }
             const nextCanvas = CanvasState.updateCanvas(newCanvas)


### PR DESCRIPTION
Shows relative "updated" time in bottom right corner of editor. Updates every ~10s.

It'd be possible to do this relative time setup with `moment` but that's a massive dependency and we should be phasing it out in favour of `date-fns` or `luxon`.