### PR TITLE
[PLATFORM-209] Smooth drag/drop

### DIFF
--- a/app/src/editor/components/Cables.jsx
+++ b/app/src/editor/components/Cables.jsx
@@ -129,10 +129,13 @@ export default class Cables extends React.Component {
         ]
     }
 
-    render() {
-        const cables = this.getCables()
+    componentDidUpdate() {
         const { monitor } = this.props
         this.dragger.update(monitor.getItem() || monitor.didDrop(), monitor)
+    }
+
+    render() {
+        const cables = this.getCables()
 
         return (
             <svg

--- a/app/src/editor/components/Cables.jsx
+++ b/app/src/editor/components/Cables.jsx
@@ -18,8 +18,8 @@ export default class Cables extends React.Component {
 
     state = {}
 
-    componentDidUpdate({ itemType }) {
-        if (itemType) {
+    componentDidUpdate({ monitor }) {
+        if (monitor.getItem() && !monitor.didDrop()) {
             this.followDragStart()
         } else {
             this.followDragStop()
@@ -47,6 +47,7 @@ export default class Cables extends React.Component {
      */
 
     followDragStop() {
+        if (!this.followingDrag) { return }
         this.followingDrag = false
         if (this.state.diff) {
             this.setState({ diff: undefined })
@@ -59,9 +60,17 @@ export default class Cables extends React.Component {
 
     followDrag = () => {
         if (!this.followingDrag) { return }
-        const diff = this.props.monitor.getDifferenceFromInitialOffset()
-        if (!diff || !this.el.current) { return }
-        const { scrollLeft, scrollTop } = this.el.current.parentElement
+        const { monitor } = this.props
+        const { current } = this.el
+
+        if (!monitor.getItem() || monitor.didDrop()) {
+            this.followDragStop()
+            return
+        }
+
+        const diff = monitor.getDifferenceFromInitialOffset()
+        if (!diff || !current) { return }
+        const { scrollLeft, scrollTop } = current.parentElement
         const scrollOffset = {
             x: scrollLeft - this.initialScroll.x,
             y: scrollTop - this.initialScroll.y,

--- a/app/src/editor/components/Canvas.jsx
+++ b/app/src/editor/components/Canvas.jsx
@@ -14,7 +14,7 @@ import styles from './Canvas.pcss'
 
 const { DragTypes } = CanvasState
 
-export default DragDropContext(HTML5Backend)(class Canvas extends React.Component {
+export default DragDropContext(HTML5Backend)(class Canvas extends React.PureComponent {
     onDropModule = (props, monitor) => {
         const { moduleHash, component } = monitor.getItem()
         const { diff } = component.dragger

--- a/app/src/editor/components/Canvas.jsx
+++ b/app/src/editor/components/Canvas.jsx
@@ -16,15 +16,21 @@ const { DragTypes } = CanvasState
 
 export default DragDropContext(HTML5Backend)(class Canvas extends React.Component {
     onDropModule = (props, monitor) => {
-        const { moduleHash } = monitor.getItem()
-        const diff = monitor.getDifferenceFromInitialOffset()
+        const { moduleHash, component } = monitor.getItem()
+        // have to stop module dragging before updating canvas
+        // otherwise position flickers
+        component.followDragStop()
 
+        const diff = monitor.getDifferenceFromInitialOffset()
         this.props.setCanvas({ type: 'Move Module' }, (canvas) => (
             CanvasState.updateModulePosition(canvas, moduleHash, diff)
         ))
     }
 
-    onDragModule = (props) => ({ moduleHash: props.module.hash })
+    onDragModule = (props, monitor, component) => ({
+        moduleHash: props.module.hash,
+        component,
+    })
 
     onCanDropPort = (props, monitor) => {
         const from = monitor.getItem()

--- a/app/src/editor/components/Canvas.jsx
+++ b/app/src/editor/components/Canvas.jsx
@@ -17,11 +17,8 @@ const { DragTypes } = CanvasState
 export default DragDropContext(HTML5Backend)(class Canvas extends React.Component {
     onDropModule = (props, monitor) => {
         const { moduleHash, component } = monitor.getItem()
-        // have to stop module dragging before updating canvas
-        // otherwise position flickers
-        component.followDragStop()
-
-        const diff = monitor.getDifferenceFromInitialOffset()
+        const { diff } = component.dragger
+        component.dragger.stop()
         this.props.setCanvas({ type: 'Move Module' }, (canvas) => (
             CanvasState.updateModulePosition(canvas, moduleHash, diff)
         ))

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -17,7 +17,7 @@ import Ports from './Ports'
 
 import styles from './Module.pcss'
 
-class CanvasModule extends React.Component {
+class CanvasModule extends React.PureComponent {
     state = {
         isDraggable: true,
         isResizing: false,

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -6,7 +6,7 @@ import cx from 'classnames'
 import withErrorBoundary from '$shared/utils/withErrorBoundary'
 import { Translate } from 'react-redux-i18n'
 
-import { DragSource } from '../utils/dnd'
+import { DragSource, emptyImage } from '../utils/dnd'
 import Dragger from '../utils/Dragger'
 
 import { DragTypes, RunStates } from '../state'
@@ -107,7 +107,7 @@ class CanvasModule extends React.PureComponent {
             monitor,
             canvas,
             connectDragSource,
-            connectEmptyPreview,
+            connectDragPreview,
         } = this.props
 
         this.dragger.update(monitor.isDragging(), monitor)
@@ -116,7 +116,8 @@ class CanvasModule extends React.PureComponent {
 
         const isSelected = module.hash === this.props.selectedModuleHash
 
-        connectEmptyPreview()
+        connectDragPreview(emptyImage)
+
         const maybeConnectDragging = (el) => (
             isDraggable ? connectDragSource(el) : el
         )

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -100,17 +100,19 @@ class CanvasModule extends React.PureComponent {
         this.props.api.renameModule(this.props.module.hash, value)
     )
 
+    componentDidUpdate() {
+        const { monitor } = this.props
+        this.dragger.update(monitor.isDragging(), monitor)
+    }
+
     render() {
         const {
             api,
             module,
-            monitor,
             canvas,
             connectDragSource,
             connectDragPreview,
         } = this.props
-
-        this.dragger.update(monitor.isDragging(), monitor)
 
         const { isDraggable, layout } = this.state
 

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -36,7 +36,13 @@ class CanvasModule extends React.Component {
      */
 
     el = React.createRef()
-    dragger = new Dragger(this.el)
+
+    dragger = new Dragger(this.el, (diff) => {
+        this.el.current.style.transform = `translate3d(${diff.x}px, ${diff.y}px, 0)`
+    }, () => {
+        this.el.current.style.transform = ''
+    })
+
     onRef = (el) => {
         // manually set ref as react-dnd chokes on React.createRef()
         // https://github.com/react-dnd/react-dnd/issues/998

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -110,7 +110,7 @@ class CanvasModule extends React.Component {
             connectEmptyPreview,
         } = this.props
 
-        this.dragger.update(monitor)
+        this.dragger.update(monitor.isDragging(), monitor)
 
         const { isDraggable, layout } = this.state
 

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 import cx from 'classnames'
-import { getEmptyImage } from 'react-dnd-html5-backend'
 
 import withErrorBoundary from '$shared/utils/withErrorBoundary'
 import { Translate } from 'react-redux-i18n'
@@ -108,7 +107,7 @@ class CanvasModule extends React.Component {
             monitor,
             canvas,
             connectDragSource,
-            connectDragPreview,
+            connectEmptyPreview,
         } = this.props
 
         this.dragger.update(monitor)
@@ -117,7 +116,7 @@ class CanvasModule extends React.Component {
 
         const isSelected = module.hash === this.props.selectedModuleHash
 
-        connectDragPreview(getEmptyImage())
+        connectEmptyPreview()
         const maybeConnectDragging = (el) => (
             isDraggable ? connectDragSource(el) : el
         )

--- a/app/src/editor/components/Module.pcss
+++ b/app/src/editor/components/Module.pcss
@@ -28,6 +28,11 @@
   box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.1);
 }
 
+.isSelected,
+.Module:focus {
+  z-index: 2;
+}
+
 .moduleHeader {
   border-bottom: 1px solid #EFEFEF;
   padding: 10px;

--- a/app/src/editor/components/Ports.jsx
+++ b/app/src/editor/components/Ports.jsx
@@ -64,8 +64,8 @@ const Port = PortDrag(PortDrop(class Port extends React.PureComponent {
             >
                 {port.displayName || startCase(port.name)}
             </div>,
-            <div key={`${port.id}.icon`} className={styles.portIconContainer} role="gridcell">
-                {props.connectDragSource(props.connectDropTarget((
+            props.connectDragSource(props.connectDropTarget((
+                <div key={`${port.id}.icon`} className={styles.portIconContainer} role="gridcell">
                     <div
                         ref={this.onRef}
                         title={port.id}
@@ -86,8 +86,8 @@ const Port = PortDrag(PortDrop(class Port extends React.PureComponent {
                     >
                         <PortOptions port={port} canvas={canvas} setPortOptions={this.props.setPortOptions} />
                     </div>
-                )))}
-            </div>,
+                </div>
+            ))),
         ]
 
         if (isInput) {

--- a/app/src/editor/components/Ports.jsx
+++ b/app/src/editor/components/Ports.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import cx from 'classnames'
 import startCase from 'lodash/startCase'
 
-import { DragSource, DropTarget } from '../utils/dnd'
+import { DragSource, DropTarget, emptyImage } from '../utils/dnd'
 import { DragTypes, RunStates } from '../state'
 
 import styles from './Ports.pcss'
@@ -47,10 +47,10 @@ const PortIcon = PortDrag(PortDrop(class PortIcon extends React.PureComponent {
     }
 
     render() {
-        const { port, canvas, connectEmptyPreview, ...props } = this.props
+        const { port, canvas, connectDragPreview, ...props } = this.props
         const isInput = !!port.acceptedTypes
 
-        connectEmptyPreview()
+        connectDragPreview(emptyImage)
         return props.connectDragSource(props.connectDropTarget((
             <div className={styles.portIconContainer} role="gridcell">
                 <div

--- a/app/src/editor/components/Ports.jsx
+++ b/app/src/editor/components/Ports.jsx
@@ -47,10 +47,11 @@ const Port = PortDrag(PortDrop(class Port extends React.PureComponent {
     }
 
     render() {
-        const { port, canvas, ...props } = this.props
+        const { port, canvas, connectEmptyPreview, ...props } = this.props
         const isInput = !!port.acceptedTypes
         const isParam = 'defaultValue' in port
         const hasInputField = isParam || port.canHaveInitialValue
+        connectEmptyPreview()
 
         const portContent = [
             <div

--- a/app/src/editor/components/Ports.pcss
+++ b/app/src/editor/components/Ports.pcss
@@ -60,7 +60,7 @@
   height: 8px;
   background: #FFFFFF;
   border-radius: 100%;
-  transition: box-shadow 0.2s;
+  transition: box-shadow 0.2s, transform 0.2s;
   transform-origin: center center;
   position: relative;
   box-shadow: 0 0 0 2px rgba(255, 255, 255, 0);
@@ -113,8 +113,8 @@
   opacity: 0;
 }
 
-.ports .portIcon.isOver {
-  transform: scale(2);
+.ports .portIcon.canDrop.isOver {
+  transform: scale(1.5);
 }
 
 .ports .portIcon .portOptions {
@@ -125,6 +125,7 @@
   grid-column-gap: 2px;
   opacity: 0;
   transition: opacity 0.25s;
+  pointer-events: none;
 }
 
 .ports .portIcon.isInput .portOptions {
@@ -142,6 +143,7 @@
 }
 
 .ports .portIcon:not(.dragPortInProgress):hover .portOptions {
+  pointer-events: all;
   opacity: 1;
 }
 

--- a/app/src/editor/components/Ports.pcss
+++ b/app/src/editor/components/Ports.pcss
@@ -124,7 +124,7 @@
   grid-template-columns: auto auto auto;
   grid-column-gap: 2px;
   opacity: 0;
-  transition: opacity 0.25s;
+  transition: opacity 0.25s 0.5s;
   pointer-events: none;
 }
 

--- a/app/src/editor/components/Status.jsx
+++ b/app/src/editor/components/Status.jsx
@@ -81,10 +81,10 @@ export default class Status extends React.Component {
     }
 
     render() {
-        const { canvas } = this.props
+        const { updated } = this.props
         return (
-            <div className={styles.status} title={new Date(canvas.updated).toLocaleTimeString()}>
-                Updated {ago(new Date(canvas.updated))}
+            <div className={styles.status} title={new Date(updated).toLocaleTimeString()}>
+                Updated {ago(new Date(updated))}
             </div>
         )
     }

--- a/app/src/editor/state.js
+++ b/app/src/editor/state.js
@@ -228,6 +228,11 @@ export function canConnectPorts(canvas, portIdA, portIdB) {
         return false
     }
 
+    const moduleA = getModuleForPort(canvas, portIdA)
+    const moduleB = getModuleForPort(canvas, portIdB)
+    // cannot connect module to self
+    if (moduleA.hash === moduleB.hash) { return false }
+
     const [output, input] = getOutputInputPorts(canvas, portIdA, portIdB)
 
     if (!input.canConnect || !output.canConnect) { return false }

--- a/app/src/editor/utils/Dragger.js
+++ b/app/src/editor/utils/Dragger.js
@@ -25,9 +25,9 @@ export default class Dragger {
         if (!current) { return }
         if (this.started) { return }
         this.el = current
-        current.addEventListener('dragend', this.stop, true)
+        this.el.addEventListener('dragend', this.stop, true)
         this.started = true
-        this.step()
+        raf(this.step)
     }
 
     stop = () => {
@@ -48,14 +48,12 @@ export default class Dragger {
             return
         }
 
-        const { current } = this.ref
         const diff = this.monitor.getDifferenceFromInitialOffset()
-        if (!diff || !current) { return }
+        if (!diff) { return }
 
         this.diff = diff
 
         this.onStep(this.diff)
-
         raf(this.step) // loop
     }
 }

--- a/app/src/editor/utils/Dragger.js
+++ b/app/src/editor/utils/Dragger.js
@@ -1,0 +1,65 @@
+import raf from 'raf'
+
+export default class Dragger {
+    constructor(ref) {
+        this.ref = ref
+        this.isDragging = false
+    }
+
+    update(monitor) {
+        const isDragging = monitor.isDragging()
+        if (this.isDragging === isDragging) { return }
+        this.isDragging = isDragging
+        this.monitor = monitor
+
+        if (isDragging) {
+            this.start()
+        } else {
+            this.stop()
+        }
+    }
+
+    start() {
+        const { current } = this.ref
+        if (!current) { return }
+        if (this.started) { return }
+        // save initial scroll offset
+        this.initialScroll = {
+            x: current.parentElement.scrollLeft,
+            y: current.parentElement.scrollTop,
+        }
+        this.started = true
+        this.step()
+    }
+
+    stop() {
+        const { current } = this.ref
+        current.style.transform = ''
+        this.started = false
+    }
+
+    /**
+     * Update position diff in RAF loop
+     */
+
+    step = () => {
+        if (!this.started || !this.monitor.isDragging()) { return }
+        const { current } = this.ref
+        const diff = this.monitor.getDifferenceFromInitialOffset()
+        if (!diff || !current) { return }
+        const { scrollLeft, scrollTop } = current.parentElement
+        const scrollOffset = {
+            x: scrollLeft - this.initialScroll.x,
+            y: scrollTop - this.initialScroll.y,
+        }
+
+        this.diff = {
+            x: diff.x + scrollOffset.x,
+            y: diff.y + scrollOffset.y,
+        }
+
+        current.style.transform = `translate3d(${this.diff.x}px, ${this.diff.y}px, 0)`
+
+        raf(this.step) // loop
+    }
+}

--- a/app/src/editor/utils/Dragger.js
+++ b/app/src/editor/utils/Dragger.js
@@ -8,8 +8,7 @@ export default class Dragger {
         this.onStop = onStop
     }
 
-    update(monitor) {
-        const isDragging = monitor.isDragging()
+    update(isDragging, monitor) {
         if (this.isDragging === isDragging) { return }
         this.isDragging = isDragging
         this.monitor = monitor
@@ -49,7 +48,7 @@ export default class Dragger {
 
     step = () => {
         if (!this.started) { return }
-        if (!this.monitor.isDragging() || this.monitor.didDrop()) {
+        if (this.monitor.didDrop()) {
             this.stop()
             return
         }

--- a/app/src/editor/utils/Dragger.js
+++ b/app/src/editor/utils/Dragger.js
@@ -1,9 +1,11 @@
 import raf from 'raf'
 
 export default class Dragger {
-    constructor(ref) {
+    constructor(ref, onStep, onStop) {
         this.ref = ref
         this.isDragging = false
+        this.onStep = onStep
+        this.onStop = onStop
     }
 
     update(monitor) {
@@ -33,8 +35,7 @@ export default class Dragger {
     }
 
     stop() {
-        const { current } = this.ref
-        current.style.transform = ''
+        this.onStop(this.diff)
         this.started = false
     }
 
@@ -58,7 +59,7 @@ export default class Dragger {
             y: diff.y + scrollOffset.y,
         }
 
-        current.style.transform = `translate3d(${this.diff.x}px, ${this.diff.y}px, 0)`
+        this.updater(this.diff)
 
         raf(this.step) // loop
     }

--- a/app/src/editor/utils/Dragger.js
+++ b/app/src/editor/utils/Dragger.js
@@ -25,16 +25,14 @@ export default class Dragger {
         if (!current) { return }
         if (this.started) { return }
         this.el = current
-        this.el.addEventListener('dragend', this.stop, true)
         this.started = true
         raf(this.step)
     }
 
     stop = () => {
         if (!this.started) { return }
-        this.el.removeEventListener('dragend', this.stop)
-        this.onStop(this.diff)
         this.started = false
+        this.onStop(this.diff)
     }
 
     /**

--- a/app/src/editor/utils/Dragger.js
+++ b/app/src/editor/utils/Dragger.js
@@ -26,11 +26,6 @@ export default class Dragger {
         if (this.started) { return }
         this.el = current
         current.addEventListener('dragend', this.stop, true)
-        // save initial scroll offset
-        this.initialScroll = {
-            x: current.parentElement.scrollLeft,
-            y: current.parentElement.scrollTop,
-        }
         this.started = true
         this.step()
     }
@@ -56,16 +51,8 @@ export default class Dragger {
         const { current } = this.ref
         const diff = this.monitor.getDifferenceFromInitialOffset()
         if (!diff || !current) { return }
-        const { scrollLeft, scrollTop } = current.parentElement
-        const scrollOffset = {
-            x: scrollLeft - this.initialScroll.x,
-            y: scrollTop - this.initialScroll.y,
-        }
 
-        this.diff = {
-            x: diff.x + scrollOffset.x,
-            y: diff.y + scrollOffset.y,
-        }
+        this.diff = diff
 
         this.onStep(this.diff)
 

--- a/app/src/editor/utils/Dragger.js
+++ b/app/src/editor/utils/Dragger.js
@@ -21,10 +21,12 @@ export default class Dragger {
         }
     }
 
-    start() {
+    start = () => {
         const { current } = this.ref
         if (!current) { return }
         if (this.started) { return }
+        this.el = current
+        current.addEventListener('dragend', this.stop, true)
         // save initial scroll offset
         this.initialScroll = {
             x: current.parentElement.scrollLeft,
@@ -34,7 +36,9 @@ export default class Dragger {
         this.step()
     }
 
-    stop() {
+    stop = () => {
+        if (!this.started) { return }
+        this.el.removeEventListener('dragend', this.stop)
         this.onStop(this.diff)
         this.started = false
     }
@@ -44,7 +48,12 @@ export default class Dragger {
      */
 
     step = () => {
-        if (!this.started || !this.monitor.isDragging()) { return }
+        if (!this.started) { return }
+        if (!this.monitor.isDragging() || this.monitor.didDrop()) {
+            this.stop()
+            return
+        }
+
         const { current } = this.ref
         const diff = this.monitor.getDifferenceFromInitialOffset()
         if (!diff || !current) { return }
@@ -59,7 +68,7 @@ export default class Dragger {
             y: diff.y + scrollOffset.y,
         }
 
-        this.updater(this.diff)
+        this.onStep(this.diff)
 
         raf(this.step) // loop
     }

--- a/app/src/editor/utils/dnd.js
+++ b/app/src/editor/utils/dnd.js
@@ -18,7 +18,9 @@ const DragSourceProps = (type) => DragSource(type, {
 }, (connect, monitor) => ({
     monitor,
     connectDragSource: connect.dragSource(),
+    connectDragPreview: connect.dragPreview(),
     isDragging: monitor.isDragging(),
+    didDrop: monitor.didDrop(),
 }))
 
 const DropTargetProps = (type) => DropTarget(type, {

--- a/app/src/editor/utils/dnd.js
+++ b/app/src/editor/utils/dnd.js
@@ -5,11 +5,11 @@
 
 import { DragSource, DropTarget } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
+import memoize from 'lodash/memoize'
 
 // create upfront, prevents flickering of wrong icon on drag
 export const emptyImage = getEmptyImage()
-
-const DragSourceProps = (type) => DragSource(type, {
+const DragSourceProps = memoize((type) => DragSource(type, {
     beginDrag(props, ...args) {
         return props.onDrag && props.onDrag(props, ...args)
     },
@@ -23,14 +23,11 @@ const DragSourceProps = (type) => DragSource(type, {
     monitor,
     connectDragSource: connect.dragSource(),
     connectDragPreview: connect.dragPreview(),
-    connectEmptyPreview() {
-        return connect.dragPreview()(emptyImage)
-    },
     isDragging: monitor.isDragging(),
     didDrop: monitor.didDrop(),
-}))
+})))
 
-const DropTargetProps = (type) => DropTarget(type, {
+const DropTargetProps = memoize((type) => DropTarget(type, {
     drop(props, ...args) {
         return props.onDrop && props.onDrop(props, ...args)
     },
@@ -46,7 +43,7 @@ const DropTargetProps = (type) => DropTarget(type, {
     }),
     canDrop: monitor.canDrop(),
     itemType: monitor.getItemType(),
-}))
+})))
 
 export {
     DragSourceProps as DragSource,

--- a/app/src/editor/utils/dnd.js
+++ b/app/src/editor/utils/dnd.js
@@ -4,6 +4,10 @@
  */
 
 import { DragSource, DropTarget } from 'react-dnd'
+import { getEmptyImage } from 'react-dnd-html5-backend'
+
+// create upfront, prevents flickering of wrong icon on drag
+export const emptyImage = getEmptyImage()
 
 const DragSourceProps = (type) => DragSource(type, {
     beginDrag(props, ...args) {
@@ -19,6 +23,9 @@ const DragSourceProps = (type) => DragSource(type, {
     monitor,
     connectDragSource: connect.dragSource(),
     connectDragPreview: connect.dragPreview(),
+    connectEmptyPreview() {
+        return connect.dragPreview()(emptyImage)
+    },
     isDragging: monitor.isDragging(),
     didDrop: monitor.didDrop(),
 }))
@@ -45,3 +52,4 @@ export {
     DragSourceProps as DragSource,
     DropTargetProps as DropTarget,
 }
+

--- a/app/src/editor/utils/dnd.js
+++ b/app/src/editor/utils/dnd.js
@@ -24,7 +24,6 @@ const DragSourceProps = memoize((type) => DragSource(type, {
     connectDragSource: connect.dragSource(),
     connectDragPreview: connect.dragPreview(),
     isDragging: monitor.isDragging(),
-    didDrop: monitor.didDrop(),
 })))
 
 const DropTargetProps = memoize((type) => DropTarget(type, {


### PR DESCRIPTION
This was a real PITA, but we got there. The primary issues were resolvable with reasonable performance without removing react-dnd by working around some react-dnd perf gotchas. There's still a small delay when you start dragging, but when React is running in production mode, this delay becomes unnoticeable. 

* Dragging modules actually drags the module element, rather than an image of the module. Without this, the dragged module appears translucent, scales weirdly, and captures weird images when things like port options are open. Switching from dragging images to dragging DOM elements in a performant manner is really the primary purpose of this PR.
* Port no longer shows weird preview when being dragged.
* Fixed cable/module flickering after drag/drop.
* Reduced the delay between starting drag and seeing drag occur.
* Reduced amount of weird icon flicker when first starting drag.
* Consolidated port and module raf diff/drag logic in `utils/Dragger`.
* Fixed an issue where dragging a module too fast would produce weird cable offset values.
* Fixed dragging and scrolling the page resulting in weird offset issues.

I opted for keeping react-dnd rather than the home grown solution I was working on last week as this requires fewer overall changes, plus it's probably best to wait for React hooks to land before changing these APIs up too much, hooks will enable a vastly different but much better organisation than is currently possible.

To test, drag and drop some modules and cables. Cables in particular should feel a lot smoother than the previous version.

Also:

* The Selected/focussed module now appears on top of other modules.
* Prevented hidden port options buttons influencing port drop target size.
* Ports can no longer connect to the same module.
* Port styles updated.