### PR TITLE
[PLATFORM-298] Add saving to profile

### DIFF
--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -25,6 +25,7 @@
     "signUp": "/signup",
     "streamPreview": "/products/:id/streamPreview/:streamId",
     "terms": "https://s3.amazonaws.com/streamr-public/streamr-terms-of-use.pdf",
+    "userPages": "/u",
     "userPageStreamListing": "/u/streams",
     "privacy": "https://s3.amazonaws.com/streamr-public/streamr-privacy-policy.pdf",
     "whitepaper": "<landingPage>/whitepaper"

--- a/app/src/shared/modules/user/actions.js
+++ b/app/src/shared/modules/user/actions.js
@@ -173,7 +173,7 @@ export const updateCurrentUserImage = (image: ?string) => (dispatch: Function, g
         })
 }
 
-export const saveCurrentUser = () => (dispatch: Function, getState: Function) => {
+export const saveCurrentUser = () => async (dispatch: Function, getState: Function) => {
     dispatch(saveCurrentUserRequest())
 
     const user = selectUserData(getState())

--- a/app/src/shared/modules/user/actions.js
+++ b/app/src/shared/modules/user/actions.js
@@ -173,12 +173,15 @@ export const updateCurrentUserImage = (image: ?string) => (dispatch: Function, g
         })
 }
 
-export const saveCurrentUser = (user: User) => (dispatch: Function) => {
+export const saveCurrentUser = () => (dispatch: Function, getState: Function) => {
     dispatch(saveCurrentUserRequest())
-    const form = new FormData()
-    Object.keys(user).forEach((key: string) => {
-        form.append(key, user[key])
-    })
+
+    const user = selectUserData(getState())
+
+    if (!user) {
+        throw new Error('Invalid user data')
+    }
+
     return services.postUser(user)
         .then((data) => {
             dispatch(saveCurrentUserSuccess(data))

--- a/app/src/shared/test/modules/user/actions.test.js
+++ b/app/src/shared/test/modules/user/actions.test.js
@@ -302,7 +302,7 @@ describe('user - actions', () => {
                 },
             }]
 
-            await store.dispatch(actions.saveCurrentUser(user, true))
+            await store.dispatch(actions.saveCurrentUser())
             assert(serviceStub.calledOnce)
 
             assert.deepStrictEqual(store.getActions(), expectedActions)
@@ -352,7 +352,7 @@ describe('user - actions', () => {
             }]
 
             try {
-                await store.dispatch(actions.saveCurrentUser(user, true))
+                await store.dispatch(actions.saveCurrentUser())
             } catch (e) {
                 assert(serviceStub.calledOnce)
                 assert.deepStrictEqual(store.getActions(), expectedActions)

--- a/app/src/userpages/components/ProfilePage/ProfileSettings/index.jsx
+++ b/app/src/userpages/components/ProfilePage/ProfileSettings/index.jsx
@@ -3,13 +3,11 @@
 import React, { Fragment, Component } from 'react'
 import { connect } from 'react-redux'
 import moment from 'moment-timezone'
-import { Form } from 'reactstrap'
 
 import TextInput from '$shared/components/TextInput'
 import SelectInput from '$shared/components/SelectInput'
 
 import {
-    saveCurrentUser,
     updateCurrentUserName,
     updateCurrentUserTimezone,
     updateCurrentUserImage,
@@ -33,7 +31,6 @@ type DispatchProps = {
     updateCurrentUserName: (name: $ElementType<User, 'name'>) => void,
     updateCurrentUserTimezone: (timezone: $ElementType<User, 'timezone'>) => void,
     updateCurrentUserImage: (image: ?string) => Promise<void>,
-    saveCurrentUser: (user: User) => void
 }
 
 type Props = StateProps & DispatchProps
@@ -61,13 +58,6 @@ export class ProfileSettings extends Component<Props> {
         this.props.updateCurrentUserImage(image)
     )
 
-    onSubmit = (e: Event) => {
-        e.preventDefault()
-        if (this.props.user) {
-            this.props.saveCurrentUser(this.props.user)
-        }
-    }
-
     render() {
         const user = this.props.user || {
             email: '',
@@ -77,41 +67,39 @@ export class ProfileSettings extends Component<Props> {
         }
         return (
             <Fragment>
-                <Form onSubmit={this.onSubmit}>
-                    <Avatar
-                        className={styles.avatar}
-                        editable
-                        // $FlowFixMe
-                        user={user}
-                        onImageChange={this.onImageChange}
+                <Avatar
+                    className={styles.avatar}
+                    editable
+                    // $FlowFixMe
+                    user={user}
+                    onImageChange={this.onImageChange}
+                />
+                <div className={styles.fullname}>
+                    <TextInput
+                        label="Your name"
+                        name="name"
+                        value={user.name || ''}
+                        onChange={this.onNameChange}
+                        required
+                        preserveLabelSpace
                     />
-                    <div className={styles.fullname}>
-                        <TextInput
-                            label="Your name"
-                            name="name"
-                            value={user.name || ''}
-                            onChange={this.onNameChange}
-                            required
-                            preserveLabelSpace
-                        />
-                    </div>
-                    <div className={styles.email}>
-                        <TextInput label="Email" value={user.username || ''} readOnly />
-                    </div>
-                    <div className={styles.password}>
-                        <ChangePassword.Button />
-                    </div>
-                    <div className={styles.timezone}>
-                        <SelectInput
-                            label="Timezone"
-                            name="name"
-                            options={options}
-                            value={options.find(({ value }) => user.timezone === value)}
-                            onChange={this.onTimezoneChange}
-                            required
-                        />
-                    </div>
-                </Form>
+                </div>
+                <div className={styles.email}>
+                    <TextInput label="Email" value={user.username || ''} readOnly />
+                </div>
+                <div className={styles.password}>
+                    <ChangePassword.Button />
+                </div>
+                <div className={styles.timezone}>
+                    <SelectInput
+                        label="Timezone"
+                        name="name"
+                        options={options}
+                        value={options.find(({ value }) => user.timezone === value)}
+                        onChange={this.onTimezoneChange}
+                        required
+                    />
+                </div>
             </Fragment>
         )
     }
@@ -133,9 +121,6 @@ export const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
     },
     updateCurrentUserImage(image: ?string) {
         return dispatch(updateCurrentUserImage(image))
-    },
-    saveCurrentUser(user: User) {
-        dispatch(saveCurrentUser(user))
     },
 })
 

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -1,7 +1,12 @@
 // @flow
 
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
 import { I18n } from 'react-redux-i18n'
+
+import { saveCurrentUser } from '$shared/modules/user/actions'
+import Toolbar from '$shared/components/Toolbar'
+import TOCPage from '$userpages/components/TOCPage'
 
 import Layout from '../Layout'
 import ProfileSettings from './ProfileSettings'
@@ -9,13 +14,54 @@ import APICredentials from './APICredentials'
 import IntegrationKeyHandler from './IntegrationKeyHandler'
 import IdentityHandler from './IdentityHandler/index'
 import DeleteAccount from './DeleteAccount'
-
-import Toolbar from '$shared/components/Toolbar'
-import TOCPage from '$userpages/components/TOCPage'
 import styles from './profilePage.pcss'
 
-export default class ProfilePage extends Component<{}> {
+type StateProps = {
+}
+
+type DispatchProps = {
+    saveCurrentUser: () => Promise<void>,
+}
+
+type Props = StateProps & DispatchProps
+
+type State = {
+    saving: boolean,
+}
+
+export class ProfilePage extends Component<Props, State> {
+    state = {
+        saving: false,
+    }
+
+    unmounted: boolean = false
+
+    componentWillUnmount() {
+        this.unmounted = true
+    }
+
+    onSave = () => {
+        this.setState({
+            saving: true,
+        }, () => {
+            this.props.saveCurrentUser()
+                .then(() => {
+                    if (!this.unmounted) {
+                        this.setState({
+                            saving: false,
+                        })
+                    }
+                }, () => {
+                    if (!this.unmounted) {
+                        this.setState({
+                            saving: false,
+                        })
+                    }
+                })
+        })
+    }
     render() {
+        const { saving } = this.state
         return (
             <Layout noHeader>
                 <div className={styles.profilePage}>
@@ -28,6 +74,9 @@ export default class ProfilePage extends Component<{}> {
                         saveChanges: {
                             title: I18n.t('userpages.profilePage.toolbar.saveChanges'),
                             color: 'primary',
+                            onClick: this.onSave,
+                            disabled: saving,
+                            spinner: saving,
                         },
                     }}
                     />
@@ -71,3 +120,11 @@ export default class ProfilePage extends Component<{}> {
         )
     }
 }
+
+const mapStateToProps = (): StateProps => ({})
+
+const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
+    saveCurrentUser: () => dispatch(saveCurrentUser()),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProfilePage)

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -47,30 +47,23 @@ export class ProfilePage extends Component<Props, State> {
         const { saveCurrentUser, redirectToUserPages } = this.props
         this.setState({
             saving: true,
-        }, () => {
+        }, async () => {
             try {
-                saveCurrentUser()
-                    .then(() => {
-                        if (!this.unmounted) {
-                            this.setState({
-                                saving: false,
-                            }, redirectToUserPages)
-                        }
-                    }, (e) => {
-                        console.warn(e)
+                await saveCurrentUser()
 
-                        if (!this.unmounted) {
-                            this.setState({
-                                saving: false,
-                            })
-                        }
-                    })
+                if (!this.unmounted) {
+                    this.setState({
+                        saving: false,
+                    }, redirectToUserPages)
+                }
             } catch (e) {
                 console.warn(e)
 
-                this.setState({
-                    saving: false,
-                })
+                if (!this.unmounted) {
+                    this.setState({
+                        saving: false,
+                    })
+                }
             }
         })
     }

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -3,6 +3,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { I18n } from 'react-redux-i18n'
+import { push } from 'react-router-redux'
 
 import { saveCurrentUser } from '$shared/modules/user/actions'
 import Toolbar from '$shared/components/Toolbar'
@@ -15,12 +16,14 @@ import IntegrationKeyHandler from './IntegrationKeyHandler'
 import IdentityHandler from './IdentityHandler/index'
 import DeleteAccount from './DeleteAccount'
 import styles from './profilePage.pcss'
+import routes from '$routes'
 
 type StateProps = {
 }
 
 type DispatchProps = {
     saveCurrentUser: () => Promise<void>,
+    redirectToUserPages: () => void,
 }
 
 type Props = StateProps & DispatchProps
@@ -41,23 +44,34 @@ export class ProfilePage extends Component<Props, State> {
     }
 
     onSave = () => {
+        const { saveCurrentUser, redirectToUserPages } = this.props
         this.setState({
             saving: true,
         }, () => {
-            this.props.saveCurrentUser()
-                .then(() => {
-                    if (!this.unmounted) {
-                        this.setState({
-                            saving: false,
-                        })
-                    }
-                }, () => {
-                    if (!this.unmounted) {
-                        this.setState({
-                            saving: false,
-                        })
-                    }
+            try {
+                saveCurrentUser()
+                    .then(() => {
+                        if (!this.unmounted) {
+                            this.setState({
+                                saving: false,
+                            }, redirectToUserPages)
+                        }
+                    }, (e) => {
+                        console.warn(e)
+
+                        if (!this.unmounted) {
+                            this.setState({
+                                saving: false,
+                            })
+                        }
+                    })
+            } catch (e) {
+                console.warn(e)
+
+                this.setState({
+                    saving: false,
                 })
+            }
         })
     }
     render() {
@@ -125,6 +139,7 @@ const mapStateToProps = (): StateProps => ({})
 
 const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
     saveCurrentUser: () => dispatch(saveCurrentUser()),
+    redirectToUserPages: () => dispatch(push(routes.userPages())),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProfilePage)

--- a/app/src/userpages/tests/components/ProfilePage/ProfileSettings/profileSettings.test.jsx
+++ b/app/src/userpages/tests/components/ProfilePage/ProfileSettings/profileSettings.test.jsx
@@ -73,57 +73,6 @@ describe('ProfileSettings', () => {
         })
     })
 
-    describe('onSubmit', () => {
-        it('must call e.preventDefault', () => {
-            const spy = sinon.spy()
-            const el = shallow(<ProfileSettings
-                user={{}}
-                getCurrentUser={() => {}}
-                updateCurrentUserName={() => {}}
-                updateCurrentUserTimezone={() => {}}
-                saveCurrentUser={() => {}}
-            />)
-            el.instance().onSubmit({
-                preventDefault: spy,
-                target: {},
-            })
-            assert(spy.calledOnce)
-        })
-        it('must call props.saveCurrentUser with the value', () => {
-            const spy = sinon.spy()
-            const user = {
-                moi: 'hei',
-            }
-            const el = shallow(<ProfileSettings
-                user={user}
-                getCurrentUser={() => {}}
-                updateCurrentUserName={() => {}}
-                updateCurrentUserTimezone={() => {}}
-                saveCurrentUser={spy}
-            />)
-            el.instance().onSubmit({
-                preventDefault: () => {},
-                target: {},
-            })
-            assert(spy.calledOnce)
-            assert(spy.calledWith(user))
-        })
-    })
-
-    describe('render', () => {
-        it('must have a Form with correct onSubmit as a child', () => {
-            const el = shallow(<ProfileSettings
-                user={{}}
-                getCurrentUser={() => {}}
-                updateCurrentUserName={() => {}}
-                updateCurrentUserTimezone={() => {}}
-                saveCurrentUser={() => {}}
-            />)
-            const form = el.find('Form')
-            assert.equal(form.props().onSubmit, el.instance().onSubmit)
-        })
-    })
-
     describe('mapStateToProps', () => {
         it('must return right kind of object', () => {
             const user = {
@@ -145,7 +94,6 @@ describe('ProfileSettings', () => {
             assert.equal(typeof mapDispatchToProps().getCurrentUser, 'function')
             assert.equal(typeof mapDispatchToProps().updateCurrentUserName, 'function')
             assert.equal(typeof mapDispatchToProps().updateCurrentUserTimezone, 'function')
-            assert.equal(typeof mapDispatchToProps().saveCurrentUser, 'function')
         })
 
         describe('getCurrentUser', () => {

--- a/app/src/userpages/tests/components/ProfilePage/profilePage.test.jsx
+++ b/app/src/userpages/tests/components/ProfilePage/profilePage.test.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import assert from 'assert-diff'
 
-import ProfilePage from '../../../components/ProfilePage'
+import { ProfilePage } from '../../../components/ProfilePage'
 
 describe('ProfilePageHandler', () => {
     describe('render', () => {


### PR DESCRIPTION
Add saving to user profile top bar button. Saving doesn't actually work because the API endpoint `/profile/update` is outside the `/api/v1` namespace (same problem happens with changing the password). But that should be changed in the backend so left it as it is for now.