### PR TITLE
[PLATFORM-299] Disable deleting API key if only one remains

### DIFF
--- a/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
+++ b/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
@@ -40,9 +40,16 @@ class KeyFieldEditor extends React.Component<Props, State> {
         })
     }
 
+    onSave = () => {
+        const { keyName, value } = this.state
+        const { onSave } = this.props
+
+        onSave(keyName, value)
+    }
+
     render = () => {
         const { keyName, value } = this.state
-        const { onSave, onCancel, createNew, editValue } = this.props
+        const { onCancel, createNew, editValue } = this.props
         const filled = !!keyName && (createNew || !!value)
         return (
             <div className={styles.editor}>
@@ -71,7 +78,7 @@ class KeyFieldEditor extends React.Component<Props, State> {
                         save: {
                             title: I18n.t(`userpages.keyFieldEditor.${createNew ? 'add' : 'save'}`),
                             color: 'primary',
-                            onClick: () => onSave(keyName, value),
+                            onClick: this.onSave,
                             disabled: !filled,
                         },
                         cancel: {

--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -20,6 +20,7 @@ type Props = {
     allowEdit?: boolean,
     onSave?: (?string, ?string) => void,
     allowDelete?: boolean,
+    disableDelete?: boolean,
     onDelete?: () => void,
 }
 
@@ -100,6 +101,7 @@ class KeyField extends React.Component<Props, State> {
             className,
             allowEdit,
             allowDelete,
+            disableDelete,
         } = this.props
         const { hidden, editing, menuOpen } = this.state
         return !editing ? (
@@ -129,7 +131,7 @@ class KeyField extends React.Component<Props, State> {
                             </DropdownActions.Item>
                         )}
                         {!!allowDelete && (
-                            <DropdownActions.Item onClick={this.onDelete}>
+                            <DropdownActions.Item onClick={this.onDelete} disabled={disableDelete}>
                                 <Translate value="userpages.keyField.delete" />
                             </DropdownActions.Item>
                         )}

--- a/app/src/userpages/components/ProfilePage/APICredentials/CredentialsControl/index.jsx
+++ b/app/src/userpages/components/ProfilePage/APICredentials/CredentialsControl/index.jsx
@@ -14,6 +14,7 @@ type Props = {
     keys: Array<Key>,
     addKey: (key: string) => void,
     removeKey: (id: $ElementType<Key, 'id'>) => void,
+    disableDelete?: boolean,
 }
 
 export default class CredentialsControl extends Component<Props> {
@@ -40,6 +41,7 @@ export default class CredentialsControl extends Component<Props> {
                                 alert('Editing is not supported yet!') // eslint-disable-line no-alert
                             }}
                             allowDelete
+                            disableDelete={this.props.disableDelete}
                             onDelete={() => this.props.removeKey(key.id)}
                         />
                     ))}

--- a/app/src/userpages/components/ProfilePage/APICredentials/index.jsx
+++ b/app/src/userpages/components/ProfilePage/APICredentials/index.jsx
@@ -34,6 +34,7 @@ export class APICredentials extends Component<Props> {
                 keys={keys}
                 addKey={addKey}
                 removeKey={removeKey}
+                disableDelete={keys.length <= 1}
                 permissionTypeVisible={false}
             />
         )

--- a/app/src/userpages/tests/components/KeyField/KeyField.test.jsx
+++ b/app/src/userpages/tests/components/KeyField/KeyField.test.jsx
@@ -1,0 +1,182 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import assert from 'assert-diff'
+import sinon from 'sinon'
+
+import KeyField from '$userpages/components/KeyField'
+import TextInput from '$shared/components/TextInput'
+import DropdownActions from '$shared/components/DropdownActions'
+import KeyFieldEditor from '$userpages/components/KeyField/KeyFieldEditor'
+
+describe('DashboardPage', () => {
+    let sandbox
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    describe('basic', () => {
+        it('It renders the component', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+            />)
+
+            assert(el.find(TextInput).prop('label') === 'myKey')
+            assert(el.find(TextInput).prop('value') === 'testValue')
+            assert(el.find(TextInput).prop('type') === 'text')
+        })
+
+        it('has a copy action', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+            />)
+
+            const actions = el.find(DropdownActions).children()
+            assert(actions.length === 1)
+            assert(actions.at(0).find('Translate').shallow().text() === 'copy')
+        })
+    })
+
+    describe('hide/reveal', () => {
+        it('hides the value', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                hideValue
+            />)
+
+            assert(el.find(TextInput).prop('type') === 'password')
+        })
+
+        it('has a menu option to reveal the value', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                hideValue
+            />)
+
+            assert(el.find(TextInput).prop('type') === 'password')
+
+            const action = el.find(DropdownActions).childAt(0)
+            assert(action.find('Translate').shallow().text() === 'reveal')
+            action.simulate('click')
+
+            assert(el.find(TextInput).prop('type') === 'text')
+        })
+
+        it('has a menu option to hide the value again if revealed', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                hideValue
+            />)
+            assert(el.find(TextInput).prop('type') === 'password')
+
+            const action = el.find(DropdownActions).childAt(0)
+            assert(action.find('Translate').shallow().text() === 'reveal')
+            action.simulate('click')
+
+            assert(el.find(TextInput).prop('type') === 'text')
+
+            action.simulate('click')
+            assert(el.find(TextInput).prop('type') === 'password')
+        })
+    })
+
+    describe('editing', () => {
+        it('has a menu option to edit value', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                allowEdit
+            />)
+
+            const action = el.find(DropdownActions).childAt(1)
+            assert(action.find('Translate').shallow().text() === 'edit')
+        })
+
+        it('changes to editor', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                allowEdit
+            />)
+
+            const action = el.find(DropdownActions).childAt(1)
+            action.simulate('click')
+
+            assert(el.find(TextInput).length === 0)
+            assert(el.find(KeyFieldEditor).length === 1)
+        })
+
+        it('calls onSave prop', () => {
+            const spy = sinon.spy()
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                allowEdit
+                onSave={spy}
+            />)
+
+            const action = el.find(DropdownActions).childAt(1)
+            action.simulate('click')
+
+            const editor = el.find(KeyFieldEditor).shallow().instance()
+            editor.setState({
+                keyName: 'newKey',
+                value: 'newName',
+            })
+            editor.onSave()
+
+            assert(spy.calledOnce)
+            assert(spy.calledWith('newKey', 'newName'))
+        })
+    })
+
+    describe('deleting', () => {
+        it('has a menu option to remove value', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                allowDelete
+            />)
+
+            const action = el.find(DropdownActions).childAt(1)
+            assert(action.find('Translate').shallow().text() === 'delete')
+            assert(action.prop('disabled') !== true)
+        })
+
+        it('disables the delete option', () => {
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                allowDelete
+                disableDelete
+            />)
+
+            const action = el.find(DropdownActions).childAt(1)
+            assert(action.prop('disabled') === true)
+        })
+
+        it('calls onDelete prop', () => {
+            const spy = sinon.spy()
+            const el = shallow(<KeyField
+                keyName="myKey"
+                value="testValue"
+                allowDelete
+                onDelete={spy}
+            />)
+
+            const action = el.find(DropdownActions).childAt(1)
+            action.simulate('click')
+
+            assert(spy.calledOnce)
+        })
+    })
+})

--- a/app/src/userpages/tests/components/KeyField/KeyField.test.jsx
+++ b/app/src/userpages/tests/components/KeyField/KeyField.test.jsx
@@ -8,7 +8,7 @@ import TextInput from '$shared/components/TextInput'
 import DropdownActions from '$shared/components/DropdownActions'
 import KeyFieldEditor from '$userpages/components/KeyField/KeyFieldEditor'
 
-describe('DashboardPage', () => {
+describe('KeyField', () => {
     let sandbox
 
     beforeEach(() => {


### PR DESCRIPTION
Small update, prevents deleting API key in user profile if there is only one remaining.

https://share.goabstract.com/5af550d2-4f42-47b0-988b-884348ca8c60
<img width="649" alt="screen shot 2019-01-16 at 13 52 16" src="https://user-images.githubusercontent.com/1064982/51247529-16cf8b80-1996-11e9-84cc-8fa1880ed565.png">
