### PR TITLE
[PLATFORM-301] Fix canvas tile menu, add menu to user product listing

### DIFF
--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -44,6 +44,9 @@ msgstr "Publish"
 msgid "actionsDropdown##unpublish"
 msgstr "Unpublish"
 
+msgid "actionsDropdown##copyUrl"
+msgstr "Copy URL"
+
 msgid "general##backToMarketplace"
 msgstr "Back to Marketplace"
 

--- a/app/src/shared/components/Tile/index.jsx
+++ b/app/src/shared/components/Tile/index.jsx
@@ -27,17 +27,17 @@ const Tile = ({
     dropdownActions,
 }: Props) => (
     <Link className={styles.tile} to={link}>
+        {isHovered && dropdownActions &&
+            <DropdownActions
+                className={styles.menu}
+                title={<Meatball alt="Select" white />}
+                noCaret
+            >
+                {dropdownActions}
+            </DropdownActions>
+        }
         <div className={styles.image}>
             <FallbackImage src={imageUrl || ''} alt="Tile" className={styles.image} />
-            {isHovered && dropdownActions &&
-                <DropdownActions
-                    className={styles.menu}
-                    title={<Meatball alt="Select" white />}
-                    noCaret
-                >
-                    {dropdownActions}
-                </DropdownActions>
-            }
         </div>
         <div className={styles.content}>
             {children}

--- a/app/src/shared/components/Tile/tile.pcss
+++ b/app/src/shared/components/Tile/tile.pcss
@@ -1,6 +1,7 @@
 @import 'variables.pcss';
 
 .tile {
+  position: relative;
   display: block;
   margin: 1em auto 0;
   border-radius: 2px;
@@ -30,6 +31,7 @@
     right: 0;
     margin-right: 1.5em;
     margin-top: 1.5em;
+    z-index: 1;
   }
 }
 


### PR DESCRIPTION
Small fix for canvas tile menu. I also sneaked in the product tile menu in the user pages Products section which was missing.