### PR TITLE
Suppress repeat web3 warnings

### DIFF
--- a/app/src/shared/web3/web3Poller/web3Poller.js
+++ b/app/src/shared/web3/web3Poller/web3Poller.js
@@ -27,6 +27,17 @@ const WEB3_POLL_INTERVAL = 1000 // 1s
 const NETWORK_POLL_INTERVAL = 1000 // 1s
 const PENDING_TX_POLL_INTERVAL = 1000 * 5 // 5s
 
+let lastWarning = ''
+
+function warnOnce(error) {
+    // do not print warning if same as last warning
+    if (error.message) {
+        if (lastWarning === error.message) { return }
+        lastWarning = error.message
+    }
+    console.warn(error)
+}
+
 export default class Web3Poller {
     web3PollTimeout: ?TimeoutID = null
     ethereumNetworkPollTimeout: ?TimeoutID = null
@@ -59,7 +70,7 @@ export default class Web3Poller {
     pollWeb3 = () => (
         this.fetchWeb3Account()
             .then(this.startWeb3Poll, (error) => {
-                console.warn(error)
+                warnOnce(error)
                 this.startWeb3Poll()
             })
     )
@@ -72,7 +83,7 @@ export default class Web3Poller {
     pollEthereumNetwork = () => (
         this.fetchChosenEthereumNetwork()
             .then(this.startEthereumNetworkPoll, (error) => {
-                console.warn(error)
+                warnOnce(error)
                 this.startEthereumNetworkPoll()
             })
     )
@@ -137,7 +148,7 @@ export default class Web3Poller {
                         if (this.account) {
                             this.emitter.emit(events.NETWORK_ERROR, err)
                         } else {
-                            console.warn(err)
+                            warnOnce(err)
                         }
                     })
             })
@@ -161,7 +172,7 @@ export default class Web3Poller {
     pollPendingTransactions = () => (
         this.handlePendingTransactions()
             .then(this.startPendingTransactionsPoll, (error) => {
-                console.warn(error)
+                warnOnce(error)
                 this.startPendingTransactionsPoll()
             })
     )
@@ -176,7 +187,7 @@ export default class Web3Poller {
                 completed = await hasTransactionCompleted(txHash)
                 receipt = !!completed && await web3.eth.getTransactionReceipt(txHash)
             } catch (err) {
-                console.warn(err) // log unexpected errors
+                warnOnce(err)
                 return // bail out
             }
 


### PR DESCRIPTION
Prevents repeated web3 poller warnings from appearing. 

i.e. prevents this:

![image](https://user-images.githubusercontent.com/43438/51521844-c018f480-1e62-11e9-910e-b812ffee2e24.png)

If the same warning would be logged twice in a row, the second one will be ignored.
This allows new warnings to be shown.

Alternatively this could suppress any warning that had already been seen, however this runs the risk of suppressing too much.

Another alternative would be to specifically suppress the repeated "Provider not set or invalid" messages.

Also, perhaps this should only be enabled in development.