### PR TITLE
[PLATFORM-318] Fixes Non-logged 401 error on the StreamPreview Page

### DIFF
--- a/app/src/marketplace/components/StreamPreviewPage/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/index.jsx
@@ -61,7 +61,11 @@ class StreamPreviewPage extends React.Component<Props, State> {
     }
 
     componentDidMount() {
-        this.props.getApiKeys()
+        const { currentUser } = this.props
+
+        if (currentUser) {
+            this.props.getApiKeys()
+        }
         this.props.getStreams()
     }
 


### PR DESCRIPTION
Stops `users/me/keys` endpoint being requested if the user is not logged in.