### PR TITLE
Prevent login redirect occurring before auth has been checked

### DIFF
--- a/app/src/marketplace/utils/auth.js
+++ b/app/src/marketplace/utils/auth.js
@@ -20,7 +20,7 @@ export const userIsAuthenticated = connectedReduxRedirect({
     authenticatingSelector: isAuthenticating,
     // If selector is true, wrapper will not redirect
     // For example let's check that state contains user data
-    authenticatedSelector: (state) => selectUserData(state),
+    authenticatedSelector: (state) => !!selectUserData(state),
     // A nice display name for this check
     wrapperDisplayName: 'UserIsAuthenticated',
     redirectAction: (newLoc) => (dispatch) => {

--- a/app/src/marketplace/utils/auth.js
+++ b/app/src/marketplace/utils/auth.js
@@ -4,7 +4,7 @@ import { connectedRouterRedirect, connectedReduxRedirect } from 'redux-auth-wrap
 import locationHelperBuilder from 'redux-auth-wrapper/history4/locationHelper'
 import queryString from 'query-string'
 
-import { selectUserData, selectFetchingExternalLogin, selectFetchingUserData } from '$shared/modules/user/selectors'
+import { selectUserData, isAuthenticating } from '$shared/modules/user/selectors'
 import { startExternalLogin } from '$shared/modules/user/actions'
 
 import { getLoginUrl } from './login'
@@ -17,10 +17,10 @@ export const doExternalLogin = (accessedPath: string) => {
 
 export const userIsAuthenticated = connectedReduxRedirect({
     redirectPath: 'NOT_USED_BUT_MUST_PROVIDE',
-    authenticatingSelector: (state) => selectFetchingUserData(state) || selectFetchingExternalLogin(state),
+    authenticatingSelector: isAuthenticating,
     // If selector is true, wrapper will not redirect
     // For example let's check that state contains user data
-    authenticatedSelector: (state) => selectUserData(state) !== null,
+    authenticatedSelector: (state) => selectUserData(state),
     // A nice display name for this check
     wrapperDisplayName: 'UserIsAuthenticated',
     redirectAction: (newLoc) => (dispatch) => {
@@ -33,6 +33,7 @@ export const userIsAuthenticated = connectedReduxRedirect({
 const locationHelper = locationHelperBuilder({})
 
 export const userIsNotAuthenticated = connectedRouterRedirect({
+    authenticatingSelector: isAuthenticating,
     // This sends the user either to the query param route if we have one, or to
     // the landing page if none is specified and the user is already logged in
     redirectPath: (state, ownProps) => locationHelper.getRedirectQueryParam(ownProps) || '/',
@@ -40,7 +41,7 @@ export const userIsNotAuthenticated = connectedRouterRedirect({
     allowRedirectBack: false,
     // If selector is true, wrapper will not redirect
     // So if there is no user data, then we show the page
-    authenticatedSelector: (state) => selectUserData(state) === null,
+    authenticatedSelector: (state) => !selectUserData(state),
     // A nice display name for this check
     wrapperDisplayName: 'UserIsNotAuthenticated',
 })

--- a/app/src/shared/modules/user/reducer.js
+++ b/app/src/shared/modules/user/reducer.js
@@ -49,6 +49,7 @@ const reducer: (UserState) => UserState = handleActions({
         ...state,
         fetchingUserData: false,
         user: action.payload.user,
+        userDataError: null,
     }),
 
     [USER_DATA_FAILURE]: (state: UserState, action: UserErrorAction) => ({

--- a/app/src/shared/modules/user/selectors.js
+++ b/app/src/shared/modules/user/selectors.js
@@ -28,6 +28,11 @@ export const selectLogoutError: (StoreState) => ?ErrorInUi = createSelector(
     (subState: UserState): ?ErrorInUi => subState.logoutError,
 )
 
+export const selectUserDataError: (StoreState) => ?ErrorInUi = createSelector(
+    selectUserState,
+    (subState: UserState): ?ErrorInUi => subState.userDataError,
+)
+
 export const selectDeletingUserAccount: (StoreState) => boolean = createSelector(
     selectUserState,
     (subState: UserState): boolean => subState.deletingUserAccount,
@@ -36,4 +41,17 @@ export const selectDeletingUserAccount: (StoreState) => boolean = createSelector
 export const selectDeleteUserAccountError: (StoreState) => ?ErrorInUi = createSelector(
     selectUserState,
     (subState: UserState): ?ErrorInUi => subState.deleteUserAccountError,
+)
+
+export const isAuthenticating: (StoreState) => boolean = createSelector(
+    selectFetchingUserData,
+    selectFetchingExternalLogin,
+    selectUserData,
+    selectUserDataError,
+    (isFetchingUserData, isFetchingExternalLogin, userData, userDataError) => {
+        // should not redirect until fetching of user data succeeds or fails
+        const isFetching = isFetchingUserData || isFetchingExternalLogin
+        const didFetch = userData || userDataError
+        return !!(isFetching || !didFetch)
+    },
 )

--- a/app/src/shared/test/modules/user/selectors.test.js
+++ b/app/src/shared/test/modules/user/selectors.test.js
@@ -1,7 +1,8 @@
 import assert from 'assert-diff'
 import BN from 'bignumber.js'
-
+import set from 'lodash/fp/set'
 import * as all from '$shared/modules/user/selectors'
+import { initialState } from '$shared/modules/user/reducer'
 
 const state = {
     test: true,
@@ -67,6 +68,13 @@ const state = {
 }
 
 describe('user - selectors', () => {
+    it('selects user data error', () => {
+        assert.deepStrictEqual(all.selectUserDataError(state), null)
+        const err = new Error()
+        const errorState = set('user.userDataError', err, state)
+        assert.strictEqual(all.selectUserDataError(errorState), err)
+    })
+
     it('selects user data fetching status', () => {
         assert.deepStrictEqual(all.selectFetchingUserData(state), false)
     })
@@ -81,5 +89,20 @@ describe('user - selectors', () => {
 
     it('selects logout error', () => {
         assert.deepStrictEqual(all.selectLogoutError(state), null)
+    })
+
+    it('isAuthenticating', () => {
+        // initial state should be considered authenticating
+        assert.deepStrictEqual(all.isAuthenticating({
+            user: initialState,
+        }), true)
+
+        // success state should NOT be considered authenticating
+        assert.deepStrictEqual(all.isAuthenticating(state), false)
+
+        // fail state should NOT be considered authenticating
+        let errorState = set('user.user', null, state)
+        errorState = set('user.userDataError', new Error(), errorState)
+        assert.deepStrictEqual(all.isAuthenticating(errorState), false)
     })
 })


### PR DESCRIPTION
Not sure where this behaviour change was introduced (???!) but for some reason the app now seems to want to re-authenticate on every page refresh.


This issue is that the `redux-auth-wrapper`'s `authenticatingSelector` does a check for the `user.isFetchingUserData` flag to determine whether authentication is in progress:

https://github.com/streamr-dev/streamr-platform/blob/c9bbd6fed56d486951690a7ad3d1f0bbe613dbab/app/src/marketplace/utils/auth.js#L20-L23

And `pollLogin` calls `getUserData` which sets the `user.isFetchingUserData` flag, however *it doesn't get executed until `onComponentDidMount`*:

https://github.com/streamr-dev/streamr-platform/blob/c9bbd6fed56d486951690a7ad3d1f0bbe613dbab/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx#L57-L70

This occurs *after* the `authenticatingSelector`/`authenticatedSelector` checks have already detected that there's no user and there's no user loading, thus issuing the redirect 💥

----

The fix is to treat the lack of both `userData` and `userDataError` as "authenticating" i.e. don't consider redirecting until *after* either `userData` or `userDataError` exist.

I'm actually most confused as to why this "worked" before.