### PR TITLE
[PLATFORM-327] Rollback changes for streamr-client apikey init

### DIFF
--- a/app/src/editor/index.jsx
+++ b/app/src/editor/index.jsx
@@ -272,9 +272,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         const { id } = canvas.uiChannel
         this.client = new StreamrClient({
             url: process.env.STREAMR_WS_URL,
-            auth: {
-                apiKey: this.props.keyId,
-            },
+            apiKey: this.props.keyId,
             autoConnect: true,
             autoDisconnect: true,
         })

--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -97,9 +97,7 @@ export class StreamLivePreview extends Component<Props, State> {
         if (!cachedClient || (authApiKeyId && cachedClient.options.apiKey !== authApiKeyId)) {
             cachedClient = new StreamrClient({
                 url: process.env.STREAMR_WS_URL,
-                auth: {
-                    apiKey: authApiKeyId || undefined,
-                },
+                apiKey: authApiKeyId || undefined,
                 autoConnect: true,
                 autoDisconnect: false,
             })


### PR DESCRIPTION
Paid product streams not working because the `authKey` was not sent but the `stream-client`.