### PR TITLE
Quick fix for Dashboard route

### DIFF
--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -131,8 +131,8 @@ const UserpagesRouter = () => ([
 ])
 
 const EditorRouter = () => ([
-    <Route path={formatPath(editor.canvasEditor, ':id?')} component={CanvasEditorAuth} key="CanvasEditor" />,
-    <Route path={formatPath(editor.dashboardEditor, ':id?')} component={DashboardEditorAuth} key="DashboardEditor" />,
+    <Route exact path={formatPath(editor.canvasEditor, ':id?')} component={CanvasEditorAuth} key="CanvasEditor" />,
+    <Route exact path={formatPath(editor.dashboardEditor, ':id?')} component={DashboardEditorAuth} key="DashboardEditor" />,
 ])
 
 const MiscRouter = () => ([

--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -131,8 +131,8 @@ const UserpagesRouter = () => ([
 ])
 
 const EditorRouter = () => ([
-    <Route exact path={formatPath(editor.canvasEditor, ':id?')} component={CanvasEditorAuth} key="CanvasEditor" />,
-    <Route exact path={formatPath(editor.dashboardEditor, ':id')} component={DashboardEditorAuth} key="DashboardEditor" />,
+    <Route path={formatPath(editor.canvasEditor, ':id?')} component={CanvasEditorAuth} key="CanvasEditor" />,
+    <Route path={formatPath(editor.dashboardEditor, ':id?')} component={DashboardEditorAuth} key="DashboardEditor" />,
 ])
 
 const MiscRouter = () => ([


### PR DESCRIPTION
Route path fix to allow for base URL matching i.e. canvas/editor and dashboard/editor