### PR TITLE
Add Switcher, Button, TextField, Label modules.

### DIFF
--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -120,6 +120,7 @@ class CanvasModule extends React.PureComponent {
                     </button>
                 </div>
                 <Ports
+                    className={styles.ports}
                     api={api}
                     module={module}
                     canvas={canvas}

--- a/app/src/editor/canvas/components/Module.pcss
+++ b/app/src/editor/canvas/components/Module.pcss
@@ -7,8 +7,6 @@
 .CanvasModule {
   margin: 20px;
   position: absolute;
-  min-width: 100px;
-  min-height: 80px;
   will-change: transform;
 }
 

--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -483,7 +483,14 @@ export default class Ports extends React.Component {
     }
 
     render() {
-        const { api, module, canvas, onPort } = this.props
+        const {
+            api,
+            module,
+            canvas,
+            onPort,
+            className,
+        } = this.props
+
         const { outputs } = module
 
         const inputs = module.params.concat(module.inputs)
@@ -501,7 +508,7 @@ export default class Ports extends React.Component {
         ), Math.max(4, this.state.minPortSize)), 40)
 
         return (
-            <div className={styles.ports}>
+            <div className={cx(className, styles.ports)}>
                 {rows.map((ports) => (
                     <div key={ports.map((p) => p && p.id).join(',')} className={styles.portRow} role="row">
                         {ports.map((port, index) => (

--- a/app/src/editor/canvas/components/Ports.pcss
+++ b/app/src/editor/canvas/components/Ports.pcss
@@ -14,7 +14,6 @@
   font-family: 'IBM Plex Mono', sans-serif;
   border-spacing: 4px;
   padding: 8px 2px;
-  flex: 1;
 }
 
 .ports:empty {

--- a/app/src/editor/canvas/components/Ports.pcss
+++ b/app/src/editor/canvas/components/Ports.pcss
@@ -28,6 +28,7 @@
 .ports .portRow > * {
   display: table-cell;
   padding: 0 2px;
+  vertical-align: middle;
 }
 
 .ports .portName {

--- a/app/src/editor/canvas/components/Resizer.jsx
+++ b/app/src/editor/canvas/components/Resizer.jsx
@@ -11,10 +11,11 @@ const RESIZABLE_MODULES = [
     'GaugeModule',
     'HeatmapModule',
     'MapModule',
+    'StreamrTextField',
 ]
 
 export function isModuleResizable(module) {
-    return RESIZABLE_MODULES.includes(module.jsModule)
+    return RESIZABLE_MODULES.includes(module.jsModule) || RESIZABLE_MODULES.includes(module.widget)
 }
 
 export class Resizer extends React.Component {

--- a/app/src/editor/canvas/components/Resizer.jsx
+++ b/app/src/editor/canvas/components/Resizer.jsx
@@ -12,6 +12,7 @@ const RESIZABLE_MODULES = [
     'HeatmapModule',
     'MapModule',
     'LabelModule',
+    'TableModule',
     'StreamrTextField',
 ]
 

--- a/app/src/editor/canvas/components/Resizer.jsx
+++ b/app/src/editor/canvas/components/Resizer.jsx
@@ -11,6 +11,7 @@ const RESIZABLE_MODULES = [
     'GaugeModule',
     'HeatmapModule',
     'MapModule',
+    'LabelModule',
     'StreamrTextField',
 ]
 

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -9,7 +9,8 @@ import ErrorComponentView from '$shared/components/ErrorComponentView'
 import links from '../../links'
 
 import UndoContainer, { UndoControls } from '$editor/shared/components/UndoContainer'
-import Subscription, { Provider as ClientProvider } from '$editor/shared/components/Subscription'
+import Subscription from '$editor/shared/components/Subscription'
+import { ClientProvider } from '$editor/shared/components/Client'
 import { ModalProvider } from '$editor/shared/components/Modal'
 
 import Canvas from './components/Canvas'

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -1,3 +1,7 @@
+/**
+ * Canvas-specific API call wrappers
+ */
+
 import axios from 'axios'
 
 import Autosave from '$editor/shared/utils/autosave'

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -33,6 +33,15 @@ export function emptyCanvas() {
     }
 }
 
+const DEFAULT_MODULE_LAYOUT = {
+    position: {
+        top: 0,
+        left: 0,
+    },
+    width: '250px',
+    height: '150px',
+}
+
 /**
  * Module hash -> path to module in canvas
  */
@@ -444,17 +453,19 @@ export function removeModule(canvas, moduleHash) {
     }
 }
 
+/**
+ * Create new module from data
+ */
+
 export function addModule(canvas, moduleData) {
-    const canvasModule = { ...moduleData }
-    canvasModule.hash = Date.now()
-    canvasModule.layout = {
-        position: {
-            top: 0,
-            left: 0,
+    const canvasModule = {
+        ...moduleData,
+        hash: Date.now(), // TODO: better ids
+        layout: {
+            ...DEFAULT_MODULE_LAYOUT, // TODO: read position from mouse
         },
-        width: '250px',
-        height: '150px',
     }
+
     return {
         ...canvas,
         modules: canvas.modules.concat(canvasModule),
@@ -488,6 +499,10 @@ export function setPortUserValue(canvas, portId, value) {
     })
 }
 
+/**
+ * Update properties on port.
+ */
+
 export function setPortOptions(canvas, portId, options = {}) {
     const port = getPort(canvas, portId)
     if (Object.entries(options).every(([key, value]) => port[key] === value)) {
@@ -500,6 +515,11 @@ export function setPortOptions(canvas, portId, options = {}) {
         ...options,
     }))
 }
+
+/**
+ * Convert object of key/value pairs to:
+ * modules[moduleHash].options[key].value = value
+ */
 
 export function setModuleOptions(canvas, moduleHash, newOptions = {}) {
     const { modules } = getIndex(canvas)

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -452,8 +452,8 @@ export function addModule(canvas, moduleData) {
             top: 0,
             left: 0,
         },
-        width: '100px',
-        height: '100px',
+        width: '250px',
+        height: '150px',
     }
     return {
         ...canvas,

--- a/app/src/editor/dashboard/components/Background.js
+++ b/app/src/editor/dashboard/components/Background.js
@@ -1,3 +1,12 @@
+/**
+ * Generates Grid Background
+ */
+
+/**
+ * Set attributes on elem
+ * Object key/value -> attributes
+ */
+
 function setAttrs(elem, attrs) {
     if (!attrs) { return elem }
     Object.keys(attrs).forEach((key) => {
@@ -6,8 +15,10 @@ function setAttrs(elem, attrs) {
     })
     return elem
 }
+
 /**
- * Create SVG element
+ * Create an SVG element with attributes
+ * e.g. SVG('rect', { width, height })
  */
 
 function SVG(name, attrs) {
@@ -20,6 +31,10 @@ function SVG(name, attrs) {
     setAttrs(elem, attrs)
     return elem
 }
+
+/**
+ * Convert SVG element to string so can be used as background
+ */
 
 function SVGEncode(svgElement) {
     const div = document.createElement('div')

--- a/app/src/editor/dashboard/components/Dashboard.jsx
+++ b/app/src/editor/dashboard/components/Dashboard.jsx
@@ -85,12 +85,11 @@ class DashboardItem extends React.Component {
 
     render() {
         const { item, disabled, selectItem, isSelected } = this.props
-        const moduleSpecificStyles = [ModuleStyles[module.jsModule], ModuleStyles[module.widget]]
         return (
             /* eslint-disable-next-line max-len */
             /* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-tabindex */
             <div
-                className={cx(styles.dashboardItem, ModuleStyles.ModuleBase, ...moduleSpecificStyles, {
+                className={cx(styles.dashboardItem, ModuleStyles.ModuleBase, {
                     [styles.isSelected]: isSelected,
                     [styles.isInactive]: !!this.state.error,
                 })}

--- a/app/src/editor/dashboard/components/Dashboard.jsx
+++ b/app/src/editor/dashboard/components/Dashboard.jsx
@@ -53,6 +53,10 @@ const normalizeLayout = (targetLayout) => dashboardConfig.layout.sizes.reduce((o
     })
 ), {})
 
+/**
+ * Each module on a dashboard is a DashboardItem
+ */
+
 class DashboardItem extends React.Component {
     state = {}
     renameItem = (title) => {
@@ -178,6 +182,7 @@ export default WidthProvider(class DashboardEditor extends React.Component {
     }
 
     onFullscreenToggle = (value) => {
+        // TODO: this is not currently hooked up
         this.setState(({ isFullscreen }) => ({
             isFullscreen: value !== undefined ? value : !isFullscreen,
         }))
@@ -204,8 +209,10 @@ export default WidthProvider(class DashboardEditor extends React.Component {
 
     render() {
         const { className, dashboard, editorLocked } = this.props
-        const select = this.context
         if (!dashboard) { return null }
+
+        const select = this.context
+
         const layout = dashboard && dashboard.items && this.generateLayout()
         const items = dashboard && dashboard.items ? sortBy(dashboard.items, ['canvas', 'module']) : []
         const locked = editorLocked || this.state.isFullscreen
@@ -217,6 +224,7 @@ export default WidthProvider(class DashboardEditor extends React.Component {
         const cols = dashboardConfig.layout.cols[breakpoint]
         const gridSize = Math.floor(this.props.width / (cols - 4))
         const cellSize = (gridSize + 10) / 4
+
         return (
             <div className={cx(className, CanvasStyles.Canvas)}>
                 <div

--- a/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
+++ b/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
@@ -1,12 +1,17 @@
+/**
+ * Popup canvas/module searcher for adding new items to a dashboard.
+ */
+
 import React from 'react'
 import startCase from 'lodash/startCase'
 import groupBy from 'lodash/groupBy'
 import cx from 'classnames'
 
+import Modal from '$editor/shared/components/Modal'
+
 import { getCanvases } from '../services'
 import { dashboardModuleSearch } from '../state'
 
-import Modal from '$editor/shared/components/Modal'
 import styles from './DashboardModuleSearch.pcss'
 
 class DashboardModuleSearchItem extends React.PureComponent {

--- a/app/src/editor/dashboard/components/Selection.jsx
+++ b/app/src/editor/dashboard/components/Selection.jsx
@@ -1,7 +1,12 @@
-/* eslint-disable react/no-unused-state */
+/**
+ * Manages current selection.
+ * Selected item is an id.
+ * Can add/remove from selection, select all or select none.
+ */
 
 import React from 'react'
 
+/* eslint-disable react/no-unused-state */
 const SelectionContext = React.createContext({})
 const { Consumer } = SelectionContext
 

--- a/app/src/editor/dashboard/components/Toolbar.jsx
+++ b/app/src/editor/dashboard/components/Toolbar.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unused-state */
 import React from 'react'
 import * as R from 'reactstrap'
 import cx from 'classnames'
@@ -13,6 +12,8 @@ import { ModalContainer } from '$editor/shared/components/Modal'
 import DashboardModuleSearch from './DashboardModuleSearch'
 
 import styles from '$editor/canvas/components/Toolbar.pcss'
+
+/* eslint-disable react/no-unused-state */
 
 export default withErrorBoundary(ErrorComponentView)(class DashboardToolbar extends React.PureComponent {
     onRenameRef = (el) => {

--- a/app/src/editor/dashboard/config.js
+++ b/app/src/editor/dashboard/config.js
@@ -1,3 +1,7 @@
+/**
+ * Adapted from engine-and-editor.
+ */
+
 import zipObject from 'lodash/zipObject'
 
 const sizes = ['lg', 'md', 'sm', 'xs']
@@ -49,6 +53,7 @@ const overridesByModule = {
         h: 6,
     },
 }
+
 const overridesBySizeAndModule = {}
 
 export default {

--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -6,7 +6,7 @@ import Layout from '$mp/components/Layout'
 import withErrorBoundary from '$shared/utils/withErrorBoundary'
 import ErrorComponentView from '$shared/components/ErrorComponentView'
 import UndoContainer, { UndoControls } from '$editor/shared/components/UndoContainer'
-import { Provider as ClientProvider } from '$editor/shared/components/Subscription'
+import { ClientProvider } from '$editor/shared/components/Client'
 
 import links from '../../links'
 

--- a/app/src/editor/dashboard/services.js
+++ b/app/src/editor/dashboard/services.js
@@ -1,3 +1,7 @@
+/**
+ * Dashboard-specific API call wrappers
+ */
+
 import axios from 'axios'
 
 import Autosave from '$editor/shared/utils/autosave'

--- a/app/src/editor/dashboard/state.js
+++ b/app/src/editor/dashboard/state.js
@@ -46,6 +46,10 @@ export function updateModule(dashboard, id, fn) {
     }
 }
 
+/**
+ * Find all modules in canvases matching search
+ */
+
 export function dashboardModuleSearch(canvases, search) {
     const canvasModules = canvases.map((canvas) => (
         canvas.modules

--- a/app/src/editor/shared/components/Client.jsx
+++ b/app/src/editor/shared/components/Client.jsx
@@ -1,0 +1,82 @@
+/**
+ * Provides a shared streamr-client instance.
+ */
+
+/* eslint-disable react/no-unused-state */
+
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import t from 'prop-types'
+import StreamrClient from 'streamr-client'
+import { selectAuthApiKeyId } from '$shared/modules/resourceKey/selectors'
+
+import * as services from '../services'
+
+export const ClientContext = React.createContext()
+
+class ClientProviderComponent extends Component {
+    static propTypes = {
+        authKey: t.string,
+    }
+
+    componentDidMount() {
+        this.setup()
+    }
+
+    componentDidUpdate() {
+        this.setup()
+    }
+
+    componentWillUnmount() {
+        this.teardown()
+    }
+
+    setup() {
+        const { authKey } = this.props
+        if (!authKey || this.state.client) { return }
+        this.setState({
+            client: new StreamrClient({
+                url: process.env.STREAMR_WS_URL,
+                authKey,
+                autoConnect: true,
+                autoDisconnect: true,
+            }),
+        })
+    }
+
+    teardown() {
+        const { client } = this.state
+        if (client && client.connection) {
+            client.disconnect()
+        }
+    }
+
+    send = async (rest) => (
+        services.send({
+            authKey: this.props.authKey,
+            ...rest,
+        })
+    )
+
+    state = {
+        client: undefined,
+        send: this.send,
+    }
+
+    render() {
+        return (
+            <ClientContext.Provider value={this.state}>
+                {this.props.children || null}
+            </ClientContext.Provider>
+        )
+    }
+}
+
+export const withAuthKey = connect((state) => ({
+    authKey: selectAuthApiKeyId(state),
+}))
+
+export const ClientProvider = withAuthKey((props) => (
+    // new client if authKey changes
+    <ClientProviderComponent key={props.authKey} {...props} />
+))

--- a/app/src/editor/shared/components/Module.pcss
+++ b/app/src/editor/shared/components/Module.pcss
@@ -1,5 +1,9 @@
 @import './variables.pcss';
 
+/**
+ * Module styles shared between canvas/dashboard.
+ */
+
 .ModuleBase {
   border-radius: 4px;
   background: white;

--- a/app/src/editor/shared/components/Module.pcss
+++ b/app/src/editor/shared/components/Module.pcss
@@ -60,3 +60,9 @@
     display: none;
   }
 }
+
+.ModuleBase.StreamrTextField {
+  .ports {
+    flex: initial;
+  }
+}

--- a/app/src/editor/shared/components/ModuleLoader.jsx
+++ b/app/src/editor/shared/components/ModuleLoader.jsx
@@ -1,0 +1,69 @@
+/* eslint-disable react/no-unused-state */
+
+import React from 'react'
+
+import { ClientContext } from './Subscription'
+
+export default class ModuleLoader extends React.PureComponent {
+    static contextType = ClientContext
+    state = {}
+
+    componentDidMount() {
+        if (this.props.isActive) {
+            this.load()
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (!prevProps.isActive && this.props.isActive) {
+            // always load when switching from inactive to active
+            this.load()
+        }
+
+        if (prevProps.isActive && !this.props.isActive) {
+            this.unload()
+        }
+    }
+
+    unload = () => {
+        this.setState({
+            module: undefined,
+        })
+    }
+
+    load = async () => {
+        const { canvasId, dashboardId, moduleHash } = this.props
+
+        const data = {
+            type: 'json',
+        }
+
+        const res = await this.context.send({
+            data,
+            canvasId,
+            dashboardId,
+            moduleHash,
+        })
+
+        if (this.unmounted) { return }
+
+        this.setState({
+            module: res.json,
+        })
+    }
+
+    componentWillUnmount() {
+        this.unmounted = true
+    }
+
+    render() {
+        const { children, ...props } = this.props
+        const module = this.state.module || this.props.module
+        return (
+            children({
+                ...props,
+                module,
+            })
+        )
+    }
+}

--- a/app/src/editor/shared/components/ModuleLoader.jsx
+++ b/app/src/editor/shared/components/ModuleLoader.jsx
@@ -1,11 +1,25 @@
+/**
+ * When isActive, loads module's runtime state from server.
+ * Exposes a renderProp API.
+ */
+
 /* eslint-disable react/no-unused-state */
 
+import t from 'prop-types'
 import React from 'react'
 
-import { ClientContext } from './Subscription'
+import { ClientContext } from './Client'
 
 export default class ModuleLoader extends React.PureComponent {
+    static propTypes = {
+        isActive: t.bool.isRequired,
+        canvasId: t.string,
+        dashboardId: t.string,
+        moduleHash: t.number.isRequired,
+    }
+
     static contextType = ClientContext
+
     state = {}
 
     componentDidMount() {

--- a/app/src/editor/shared/components/ModuleSubscription.jsx
+++ b/app/src/editor/shared/components/ModuleSubscription.jsx
@@ -2,7 +2,8 @@
 
 import React from 'react'
 
-import Subscription, { ClientContext } from './Subscription'
+import Subscription from './Subscription'
+import { ClientContext } from './Client'
 
 export default class ModuleSubscription extends React.PureComponent {
     static contextType = ClientContext

--- a/app/src/editor/shared/components/ModuleSubscription.jsx
+++ b/app/src/editor/shared/components/ModuleSubscription.jsx
@@ -2,75 +2,24 @@
 
 import React from 'react'
 
-import * as services from '../services'
+import Subscription, { ClientContext } from './Subscription'
 
-import Subscription, { withAuthKey } from './Subscription'
+export default class ModuleSubscription extends React.PureComponent {
+    static contextType = ClientContext
 
-const ModuleContext = React.createContext()
-
-const ModuleLoader = withAuthKey(class ModuleLoader extends React.PureComponent {
-    static Context = ModuleContext
-
-    componentDidMount() {
-        this.loadIfNeeded()
+    static loadGetState = {
+        type: 'getState',
     }
 
-    componentDidUpdate(prevProps) {
-        if (!prevProps.isActive && this.props.isActive) {
-            // always load when switching from inactive to active
-            this.load()
-        } else {
-            this.loadIfNeeded()
-        }
-    }
-
-    async loadIfNeeded() {
-        if (!this.props.isActive) { return } // do nothing if not active
-        if (this.state.module) { return } // do nothing if already loaded
-        if (this.state.error) { return } // do nothing if errored
-        if (this.state.loading) { return } // do nothing if already loading
-        return this.load()
-    }
-
-    async load() {
-        this.setState(({ loading }) => ({
-            loading: loading + 1, // start loading
-        }))
-
-        let res
-        try {
-            res = await this.send({ type: 'json' })
-        } catch (error) {
-            if (this.unmounted) { return }
-            this.setState(({ loading }) => ({
-                error,
-                loading: Math.max(0, loading - 1), // end loading
-            }))
-            if (!this.props.onError) {
-                throw error
-            }
-            this.props.onError(error)
-            return
-        }
-
-        if (this.unmounted) { return }
-
-        this.setState(({ loading }) => ({
-            loading: Math.max(0, loading - 1), // end loading
-            error: undefined,
-            module: res.json,
-        }))
-
-        if (this.props.onLoad) {
-            this.props.onLoad(res.json)
-        }
+    static loadJSON = {
+        type: 'json',
     }
 
     send = async (data) => {
+        if (this.unmounted) { return }
         if (!this.props.isActive) { return } // do nothing if not active
-        const { canvasId, dashboardId, moduleHash, authKey } = this.props
-        return services.send({
-            authKey,
+        const { canvasId, dashboardId, moduleHash } = this.props
+        return this.context.send({
             data,
             canvasId,
             dashboardId,
@@ -78,33 +27,51 @@ const ModuleLoader = withAuthKey(class ModuleLoader extends React.PureComponent 
         })
     }
 
+    componentDidUpdate(prevProps) {
+        if (!prevProps.isActive && this.props.isActive) {
+            // always load when switching from inactive to active
+            this.load()
+            if (this.props.onActiveChange) {
+                return this.props.onActiveChange(true)
+            }
+        }
+
+        if (prevProps.isActive && !this.props.isActive) {
+            if (this.props.onActiveChange) {
+                return this.props.onActiveChange(false)
+            }
+        }
+    }
+
+    async load() {
+        if (this.props.isActive && this.props.loadOptions) {
+            let res
+            try {
+                res = await this.send(this.props.loadOptions)
+                if (this.unmounted) { return }
+            } catch (error) {
+                if (this.unmounted) { return }
+                if (this.props.onError) {
+                    return this.props.onError(error)
+                }
+                throw error
+            }
+            if (this.props.onLoad) {
+                return this.props.onLoad(res)
+            }
+        }
+    }
+
+    componentDidMount() {
+        this.load()
+    }
+
     componentWillUnmount() {
         this.unmounted = true
     }
 
-    state = {
-        error: undefined,
-        loading: 0,
-        module: undefined,
-        send: this.send,
-    }
-
     render() {
-        return (
-            <ModuleContext.Provider value={this.state}>
-                {this.props.children || null}
-            </ModuleContext.Provider>
-        )
-    }
-})
-
-export { ModuleLoader }
-
-export default class ModuleSubscription extends React.PureComponent {
-    static contextType = ModuleContext
-
-    render() {
-        const { module } = this.context
+        const { module } = this.props
         if (!module) { return null }
         const { options = {} } = module
         return (

--- a/app/src/editor/shared/components/ModuleSubscription.jsx
+++ b/app/src/editor/shared/components/ModuleSubscription.jsx
@@ -8,14 +8,6 @@ import { ClientContext } from './Client'
 export default class ModuleSubscription extends React.PureComponent {
     static contextType = ClientContext
 
-    static loadGetState = {
-        type: 'getState',
-    }
-
-    static loadJSON = {
-        type: 'json',
-    }
-
     send = async (data) => {
         if (this.unmounted) { return }
         if (!this.props.isActive) { return } // do nothing if not active

--- a/app/src/editor/shared/components/ModuleSubscription.jsx
+++ b/app/src/editor/shared/components/ModuleSubscription.jsx
@@ -102,6 +102,7 @@ export { ModuleLoader }
 
 export default class ModuleSubscription extends React.PureComponent {
     static contextType = ModuleContext
+
     render() {
         const { module } = this.context
         if (!module) { return null }

--- a/app/src/editor/shared/components/ModuleUI.jsx
+++ b/app/src/editor/shared/components/ModuleUI.jsx
@@ -1,3 +1,7 @@
+/**
+ * Maps module jsModule/widget to UI components.
+ */
+
 import React from 'react'
 
 import TableModule from './modules/Table'
@@ -9,6 +13,7 @@ import LabelModule from './modules/Label'
 import StreamrSwitcher from './modules/Switcher'
 import ModuleLoader from './ModuleLoader'
 
+// Set by module.jsModule
 const Modules = {
     TableModule,
     ChartModule,
@@ -16,6 +21,7 @@ const Modules = {
     LabelModule,
 }
 
+// Set by module.widget
 const Widgets = {
     StreamrButton,
     StreamrTextField,

--- a/app/src/editor/shared/components/ModuleUI.jsx
+++ b/app/src/editor/shared/components/ModuleUI.jsx
@@ -6,8 +6,6 @@ import Button from './modules/Button'
 import CommentModule from './modules/Comment'
 import TextField from './modules/TextField'
 
-import { ModuleLoader } from './ModuleSubscription'
-
 const Modules = {
     TableModule: Table,
     ChartModule: Chart,
@@ -19,24 +17,13 @@ const Widgets = {
     StreamrTextField: TextField,
 }
 
-class ModuleUI extends React.Component {
-    static contextType = ModuleLoader.Context
+export default (props) => {
+    const { module } = props
+    if (!module) { return null }
+    const Module = module.widget ? Widgets[module.widget] : Modules[module.jsModule]
+    if (!Module) { return null }
 
-    render() {
-        const { send } = this.context
-        const module = this.context.module || this.props.module
-        if (!module) { return null }
-        const Module = module.widget ? Widgets[module.widget] : Modules[module.jsModule]
-        if (!Module) { return null }
-
-        return (
-            <Module {...this.props} module={module} send={send} />
-        )
-    }
+    return (
+        <Module {...props} />
+    )
 }
-
-export default (props) => (
-    <ModuleLoader {...props}>
-        <ModuleUI {...props} />
-    </ModuleLoader>
-)

--- a/app/src/editor/shared/components/ModuleUI.jsx
+++ b/app/src/editor/shared/components/ModuleUI.jsx
@@ -4,6 +4,7 @@ import Table from './modules/Table'
 import Chart from './modules/Chart'
 import Button from './modules/Button'
 import CommentModule from './modules/Comment'
+import TextField from './modules/TextField'
 
 import { ModuleLoader } from './ModuleSubscription'
 
@@ -15,6 +16,7 @@ const Modules = {
 
 const Widgets = {
     StreamrButton: Button,
+    StreamrTextField: TextField,
 }
 
 class ModuleUI extends React.Component {
@@ -22,7 +24,7 @@ class ModuleUI extends React.Component {
 
     render() {
         const { send } = this.context
-        const module = this.props.module || this.context.module
+        const module = this.context.module || this.props.module
         if (!module) { return null }
         const Module = module.widget ? Widgets[module.widget] : Modules[module.jsModule]
         if (!Module) { return null }

--- a/app/src/editor/shared/components/ModuleUI.jsx
+++ b/app/src/editor/shared/components/ModuleUI.jsx
@@ -7,6 +7,7 @@ import CommentModule from './modules/Comment'
 import StreamrTextField from './modules/TextField'
 import LabelModule from './modules/Label'
 import StreamrSwitcher from './modules/Switcher'
+import ModuleLoader from './ModuleLoader'
 
 const Modules = {
     TableModule,
@@ -21,13 +22,14 @@ const Widgets = {
     StreamrSwitcher,
 }
 
-export default (props) => {
-    const { module } = props
-    if (!module) { return null }
-    const Module = module.widget ? Widgets[module.widget] : Modules[module.jsModule]
-    if (!Module) { return null }
-
-    return (
-        <Module {...props} />
-    )
-}
+export default (props) => (
+    <ModuleLoader {...props}>
+        {(props) => {
+            const { module } = props
+            if (!module) { return null }
+            const Module = module.widget ? Widgets[module.widget] : Modules[module.jsModule]
+            if (!Module) { return null }
+            return <Module {...props} />
+        }}
+    </ModuleLoader>
+)

--- a/app/src/editor/shared/components/ModuleUI.jsx
+++ b/app/src/editor/shared/components/ModuleUI.jsx
@@ -6,6 +6,7 @@ import StreamrButton from './modules/Button'
 import CommentModule from './modules/Comment'
 import StreamrTextField from './modules/TextField'
 import LabelModule from './modules/Label'
+import StreamrSwitcher from './modules/Switcher'
 
 const Modules = {
     TableModule,
@@ -17,6 +18,7 @@ const Modules = {
 const Widgets = {
     StreamrButton,
     StreamrTextField,
+    StreamrSwitcher,
 }
 
 export default (props) => {

--- a/app/src/editor/shared/components/ModuleUI.jsx
+++ b/app/src/editor/shared/components/ModuleUI.jsx
@@ -1,20 +1,22 @@
 import React from 'react'
 
-import Table from './modules/Table'
-import Chart from './modules/Chart'
-import Button from './modules/Button'
+import TableModule from './modules/Table'
+import ChartModule from './modules/Chart'
+import StreamrButton from './modules/Button'
 import CommentModule from './modules/Comment'
-import TextField from './modules/TextField'
+import StreamrTextField from './modules/TextField'
+import LabelModule from './modules/Label'
 
 const Modules = {
-    TableModule: Table,
-    ChartModule: Chart,
+    TableModule,
+    ChartModule,
     CommentModule,
+    LabelModule,
 }
 
 const Widgets = {
-    StreamrButton: Button,
-    StreamrTextField: TextField,
+    StreamrButton,
+    StreamrTextField,
 }
 
 export default (props) => {

--- a/app/src/editor/shared/components/RenameInput.jsx
+++ b/app/src/editor/shared/components/RenameInput.jsx
@@ -1,9 +1,15 @@
-/* eslint-disable react/no-unused-state */
+/**
+ *  Double-click to edit text value.
+ */
+
 import React from 'react'
 import * as R from 'reactstrap'
 import cx from 'classnames'
+
 import TextInput from './TextInput'
 import styles from './RenameInput.pcss'
+
+/* eslint-disable react/no-unused-state */
 
 export default class RenameInput extends React.PureComponent {
     onInnerRef = (el) => {
@@ -15,6 +21,7 @@ export default class RenameInput extends React.PureComponent {
 
     render() {
         const { className, inputClassName, ...props } = this.props
+        const PADDING = 2 // add some padding to ensure text isn't cut off :/
         return (
             <div className={cx(styles.RenameInputContainer, className)} onDoubleClick={() => this.el.focus()}>
                 <TextInput {...props} innerRef={this.onInnerRef}>
@@ -22,7 +29,7 @@ export default class RenameInput extends React.PureComponent {
                         <R.Input
                             {...props}
                             className={cx(styles.RenameInput, inputClassName)}
-                            size={props.value.length ? String(props.value.length + 2) : undefined}
+                            size={props.value.length ? String(props.value.length + PADDING) : undefined}
                         />
                     )}
                 </TextInput>

--- a/app/src/editor/shared/components/RenameInput.jsx
+++ b/app/src/editor/shared/components/RenameInput.jsx
@@ -22,7 +22,7 @@ export default class RenameInput extends React.PureComponent {
                         <R.Input
                             {...props}
                             className={cx(styles.RenameInput, inputClassName)}
-                            size={props.value.length ? String(props.value.length) : undefined}
+                            size={props.value.length ? String(props.value.length + 2) : undefined}
                         />
                     )}
                 </TextInput>

--- a/app/src/editor/shared/components/RenameInput.jsx
+++ b/app/src/editor/shared/components/RenameInput.jsx
@@ -25,9 +25,10 @@ export default class RenameInput extends React.PureComponent {
         return (
             <div className={cx(styles.RenameInputContainer, className)} onDoubleClick={() => this.el.focus()}>
                 <TextInput {...props} innerRef={this.onInnerRef}>
-                    {(props) => (
+                    {(props, { hasFocus }) => (
                         <R.Input
                             {...props}
+                            key={hasFocus}
                             className={cx(styles.RenameInput, inputClassName)}
                             size={props.value.length ? String(props.value.length + PADDING) : undefined}
                         />

--- a/app/src/editor/shared/components/Subscription.jsx
+++ b/app/src/editor/shared/components/Subscription.jsx
@@ -1,80 +1,19 @@
+/**
+ * Manages a subscription.
+ */
+
 /* eslint-disable react/no-unused-state */
 
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 import t from 'prop-types'
-import StreamrClient from 'streamr-client'
-import { selectAuthApiKeyId } from '$shared/modules/resourceKey/selectors'
 
-import * as services from '../services'
+import { ClientContext } from './Client'
 
 const MessageTypes = {
     Done: 'D',
     Error: 'E',
     Notification: 'N',
     ModuleWarning: 'MW',
-}
-
-const ClientContext = React.createContext()
-
-export { ClientContext }
-
-class ClientProvider extends Component {
-    static propTypes = {
-        authKey: t.string,
-    }
-
-    componentDidMount() {
-        this.setup()
-    }
-
-    componentDidUpdate() {
-        this.setup()
-    }
-
-    componentWillUnmount() {
-        this.teardown()
-    }
-
-    setup() {
-        const { authKey } = this.props
-        if (!authKey || this.state.client) { return }
-        this.setState({
-            client: new StreamrClient({
-                url: process.env.STREAMR_WS_URL,
-                authKey,
-                autoConnect: true,
-                autoDisconnect: true,
-            }),
-        })
-    }
-
-    teardown() {
-        const { client } = this.state
-        if (client && client.connection) {
-            client.disconnect()
-        }
-    }
-
-    send = async (rest) => (
-        services.send({
-            authKey: this.props.authKey,
-            ...rest,
-        })
-    )
-
-    state = {
-        client: undefined,
-        send: this.send,
-    }
-
-    render() {
-        return (
-            <ClientContext.Provider value={this.state}>
-                {this.props.children || null}
-            </ClientContext.Provider>
-        )
-    }
 }
 
 class Subscription extends Component {
@@ -206,12 +145,3 @@ export default (props) => {
         <Subscription key={subscriptionKey} {...props} />
     )
 }
-
-export const withAuthKey = connect((state) => ({
-    authKey: selectAuthApiKeyId(state),
-}))
-
-export const Provider = withAuthKey((props) => (
-    // new client if authKey changes
-    <ClientProvider key={props.authKey} {...props} />
-))

--- a/app/src/editor/shared/components/Subscription.jsx
+++ b/app/src/editor/shared/components/Subscription.jsx
@@ -1,8 +1,12 @@
+/* eslint-disable react/no-unused-state */
+
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import t from 'prop-types'
 import StreamrClient from 'streamr-client'
 import { selectAuthApiKeyId } from '$shared/modules/resourceKey/selectors'
+
+import * as services from '../services'
 
 const MessageTypes = {
     Done: 'D',
@@ -13,13 +17,11 @@ const MessageTypes = {
 
 const ClientContext = React.createContext()
 
+export { ClientContext }
+
 class ClientProvider extends Component {
     static propTypes = {
         authKey: t.string,
-    }
-
-    state = {
-        client: undefined,
     }
 
     componentDidMount() {
@@ -52,6 +54,18 @@ class ClientProvider extends Component {
         if (client && client.connection) {
             client.disconnect()
         }
+    }
+
+    send = async (rest) => (
+        services.send({
+            authKey: this.props.authKey,
+            ...rest,
+        })
+    )
+
+    state = {
+        client: undefined,
+        send: this.send,
     }
 
     render() {

--- a/app/src/editor/shared/components/TextInput.jsx
+++ b/app/src/editor/shared/components/TextInput.jsx
@@ -122,7 +122,7 @@ export default class TextInput extends React.PureComponent {
                 onBlur: this.onBlur,
                 onChange: this.onChange,
                 onKeyDown: this.onKeyDown,
-            })
+            }, this.state)
         )
     }
 }

--- a/app/src/editor/shared/components/modules/Button.jsx
+++ b/app/src/editor/shared/components/modules/Button.jsx
@@ -7,27 +7,20 @@ import ButtonStyles from '$shared/components/Button/button.pcss'
 import styles from './Button.pcss'
 
 export default class ButtonModule extends React.Component {
+    subscription = React.createRef()
+
     state = {
-        buttonName: 'Button',
+        value: 'Button',
     }
 
-    componentDidMount() {
-        if (this.props.isActive) {
-            this.load()
-        }
-    }
-
-    load = async () => {
-        const { state } = await this.props.send({
-            type: 'getState',
-        })
+    onLoad = async ({ state }) => {
         this.setName(state)
     }
 
     setName = (buttonName = '') => {
         if (buttonName == null) { return }
         this.setState({
-            buttonName: buttonName || '',
+            value: buttonName || '',
         })
     }
 
@@ -36,7 +29,7 @@ export default class ButtonModule extends React.Component {
     }
 
     onClick = async () => {
-        this.props.send({
+        this.subscription.current.send({
             type: 'uiEvent',
             value: '',
         })
@@ -45,9 +38,14 @@ export default class ButtonModule extends React.Component {
     render() {
         return (
             <div className={cx(this.props.className, styles.Button)}>
-                <ModuleSubscription isActive={this.props.isActive} onMessage={this.onMessage} />
+                <ModuleSubscription
+                    {...this.props}
+                    onLoad={this.onLoad}
+                    loadOptions={ModuleSubscription.getState}
+                    ref={this.subscription}
+                />
                 <button className={cx(styles.button, ButtonStyles.btn, ButtonStyles.btnPrimary)} onClick={this.onClick}>
-                    {this.state.buttonName}
+                    {this.state.value}
                 </button>
             </div>
         )

--- a/app/src/editor/shared/components/modules/Button.jsx
+++ b/app/src/editor/shared/components/modules/Button.jsx
@@ -13,10 +13,6 @@ export default class ButtonModule extends React.Component {
         value: 'Button',
     }
 
-    onLoad = async ({ state }) => {
-        this.setName(state)
-    }
-
     setName = (buttonName = '') => {
         if (buttonName == null) { return }
         this.setState({
@@ -40,9 +36,8 @@ export default class ButtonModule extends React.Component {
             <div className={cx(this.props.className, styles.Button)}>
                 <ModuleSubscription
                     {...this.props}
-                    onLoad={this.onLoad}
-                    loadOptions={ModuleSubscription.loadGetState}
                     ref={this.subscription}
+                    onMessage={this.onMessage}
                 />
                 <button className={cx(styles.button, ButtonStyles.btn, ButtonStyles.btnPrimary)} onClick={this.onClick}>
                     {this.state.value}

--- a/app/src/editor/shared/components/modules/Button.jsx
+++ b/app/src/editor/shared/components/modules/Button.jsx
@@ -6,11 +6,16 @@ import ModuleSubscription from '../ModuleSubscription'
 import ButtonStyles from '$shared/components/Button/button.pcss'
 import styles from './Button.pcss'
 
+function getModuleButtonName(module) {
+    const param = module.params.find((p) => p.name === 'buttonName')
+    return param.value || param.defaultValue
+}
+
 export default class ButtonModule extends React.Component {
     subscription = React.createRef()
 
     state = {
-        value: 'Button',
+        value: undefined,
     }
 
     onLoad = async ({ state }) => {
@@ -35,6 +40,24 @@ export default class ButtonModule extends React.Component {
         })
     }
 
+    getValue = () => {
+        let { value } = this.state
+        if (value == null) {
+            // use module value unless state set
+            value = getModuleButtonName(this.props.module)
+        }
+
+        return value
+    }
+
+    onActiveChange = (isActive) => {
+        if (!isActive) {
+            this.setState({
+                value: undefined,
+            })
+        }
+    }
+
     render() {
         return (
             <div className={cx(this.props.className, styles.Button)}>
@@ -43,10 +66,11 @@ export default class ButtonModule extends React.Component {
                     onLoad={this.onLoad}
                     loadOptions={{ type: 'getState' }}
                     onMessage={this.onMessage}
+                    onActiveChange={this.onActiveChange}
                     ref={this.subscription}
                 />
                 <button className={cx(styles.button, ButtonStyles.btn, ButtonStyles.btnPrimary)} onClick={this.onClick}>
-                    {this.state.value}
+                    {this.getValue()}
                 </button>
             </div>
         )

--- a/app/src/editor/shared/components/modules/Button.jsx
+++ b/app/src/editor/shared/components/modules/Button.jsx
@@ -13,6 +13,10 @@ export default class ButtonModule extends React.Component {
         value: 'Button',
     }
 
+    onLoad = async ({ state }) => {
+        this.setName(state)
+    }
+
     setName = (buttonName = '') => {
         if (buttonName == null) { return }
         this.setState({
@@ -36,8 +40,10 @@ export default class ButtonModule extends React.Component {
             <div className={cx(this.props.className, styles.Button)}>
                 <ModuleSubscription
                     {...this.props}
-                    ref={this.subscription}
+                    onLoad={this.onLoad}
+                    loadOptions={{ type: 'getState' }}
                     onMessage={this.onMessage}
+                    ref={this.subscription}
                 />
                 <button className={cx(styles.button, ButtonStyles.btn, ButtonStyles.btnPrimary)} onClick={this.onClick}>
                     {this.state.value}

--- a/app/src/editor/shared/components/modules/Button.jsx
+++ b/app/src/editor/shared/components/modules/Button.jsx
@@ -41,7 +41,7 @@ export default class ButtonModule extends React.Component {
                 <ModuleSubscription
                     {...this.props}
                     onLoad={this.onLoad}
-                    loadOptions={ModuleSubscription.getState}
+                    loadOptions={ModuleSubscription.loadGetState}
                     ref={this.subscription}
                 />
                 <button className={cx(styles.button, ButtonStyles.btn, ButtonStyles.btnPrimary)} onClick={this.onClick}>

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -262,15 +262,8 @@ export default class ChartModule extends React.Component {
         }
     }
 
-    onLoad = (res) => {
-        this.setState({
-            module: res.json,
-        })
-    }
-
     render() {
-        const { className } = this.props
-        const module = this.state.module || this.props.module
+        const { className, module } = this.props
         const { options = {} } = module
         const { title } = this.state
         const seriesData = this.getSeriesData(this.state.datapoints)
@@ -278,11 +271,9 @@ export default class ChartModule extends React.Component {
         return (
             <div className={cx(styles.Chart, className)}>
                 <ModuleSubscription
-                    ref={this.subscription}
                     {...this.props}
+                    ref={this.subscription}
                     onMessage={this.onMessage}
-                    onLoad={this.onLoad}
-                    loadOptions={ModuleSubscription.loadJSON}
                 />
                 {!!(options.displayTitle && options.displayTitle.value && title) && (
                     <h4>{title}</h4>

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -112,6 +112,8 @@ class MinMax {
 }
 
 export default class ChartModule extends React.Component {
+    subscription = React.createRef()
+
     queuedDatapoints = []
     state = {
         title: 'My Chart',
@@ -224,7 +226,7 @@ export default class ChartModule extends React.Component {
     }, 10)
 
     load = async () => {
-        const { initRequest } = await this.props.send({
+        const { initRequest } = await this.subscription.current.send({
             type: 'initRequest',
         })
         this.setState(initRequest)
@@ -260,15 +262,28 @@ export default class ChartModule extends React.Component {
         }
     }
 
+    onLoad = (res) => {
+        this.setState({
+            module: res.json,
+        })
+    }
+
     render() {
-        const { module, isActive, className } = this.props
+        const { className } = this.props
+        const module = this.state.module || this.props.module
         const { options = {} } = module
         const { title } = this.state
         const seriesData = this.getSeriesData(this.state.datapoints)
 
         return (
             <div className={cx(styles.Chart, className)}>
-                <ModuleSubscription isActive={isActive} onMessage={this.onMessage} />
+                <ModuleSubscription
+                    ref={this.subscription}
+                    {...this.props}
+                    onMessage={this.onMessage}
+                    onLoad={this.onLoad}
+                    loadOptions={ModuleSubscription.loadJSON}
+                />
                 {!!(options.displayTitle && options.displayTitle.value && title) && (
                     <h4>{title}</h4>
                 )}

--- a/app/src/editor/shared/components/modules/Comment.jsx
+++ b/app/src/editor/shared/components/modules/Comment.jsx
@@ -4,17 +4,45 @@ import cx from 'classnames'
 import TextInput from '../TextInput'
 import styles from './Comment.pcss'
 
-export default class CommentModule extends React.Component {
+export default class CommentModule extends React.PureComponent {
+    state = {}
     onChange = (text) => {
-        this.props.api.updateModule(this.props.moduleHash, { text })
+        if (!this.props.isActive) {
+            this.props.api.updateModule(this.props.moduleHash, { text })
+        } else {
+            this.setState({
+                value: text,
+            })
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.isActive && !this.props.isActive) {
+            this.clear()
+        }
+    }
+
+    clear() {
+        this.setState({
+            value: undefined,
+        })
+    }
+
+    getValue = () => {
+        let { value } = this.state
+        if (value == null) {
+            // use module value unless state set
+            const { module } = this.props
+            value = module.text
+        }
+        return value
     }
 
     render() {
-        const { module } = this.props
         return (
             <div className={cx(this.props.className, styles.Comment)}>
                 <TextInput
-                    value={module.text}
+                    value={this.getValue()}
                     placeholder="Enter comment here"
                     onChange={this.onChange}
                     selectOnFocus={false}

--- a/app/src/editor/shared/components/modules/Comment.jsx
+++ b/app/src/editor/shared/components/modules/Comment.jsx
@@ -48,8 +48,12 @@ export default class CommentModule extends React.PureComponent {
                     selectOnFocus={false}
                     blurOnEnterKey={false}
                 >
-                    {({ innerRef, ...props }) => (
-                        <textarea ref={innerRef} {...props} />
+                    {({ innerRef, ...props }, { hasFocus }) => (
+                        <textarea
+                            key={hasFocus}
+                            ref={innerRef}
+                            {...props}
+                        />
                     )}
                 </TextInput>
             </div>

--- a/app/src/editor/shared/components/modules/Label.jsx
+++ b/app/src/editor/shared/components/modules/Label.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import cx from 'classnames'
+
+import ModuleSubscription from '../ModuleSubscription'
+import styles from './Label.pcss'
+
+export default class CommentModule extends React.Component {
+    state = {
+        value: '',
+    }
+
+    onMessage = ({ value }) => {
+        this.setState({
+            value,
+        })
+    }
+
+    render() {
+        return (
+            <div className={cx(this.props.className, styles.Label)}>
+                <ModuleSubscription
+                    {...this.props}
+                    onMessage={this.onMessage}
+                    ref={this.subscription}
+                    loadOptions={ModuleSubscription.loadJSON}
+                />
+                {this.state.value}
+            </div>
+        )
+    }
+}

--- a/app/src/editor/shared/components/modules/Label.jsx
+++ b/app/src/editor/shared/components/modules/Label.jsx
@@ -16,13 +16,23 @@ export default class CommentModule extends React.Component {
     }
 
     render() {
+        let { module } = this.props
+        module = Object.assign({}, module, {
+            options: {
+                ...module.options,
+                uiResendLast: {
+                    value: 1,
+                },
+            },
+        })
+
         return (
             <div className={cx(this.props.className, styles.Label)}>
                 <ModuleSubscription
                     {...this.props}
-                    onMessage={this.onMessage}
                     ref={this.subscription}
-                    loadOptions={ModuleSubscription.loadJSON}
+                    module={module}
+                    onMessage={this.onMessage}
                 />
                 {this.state.value}
             </div>

--- a/app/src/editor/shared/components/modules/Label.pcss
+++ b/app/src/editor/shared/components/modules/Label.pcss
@@ -1,0 +1,10 @@
+.Label {
+  padding: 0.8rem 1.4rem;
+  color: #525252;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 16px;
+  min-height: 3em;
+}

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -45,6 +45,10 @@ export default class SwitcherModule extends React.Component {
                 type: 'uiEvent',
                 value: this.getValue(),
             })
+        } else {
+            this.setState({
+                value: undefined,
+            })
         }
     }
 

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -62,8 +62,6 @@ export default class SwitcherModule extends React.Component {
                 <ModuleSubscription
                     {...this.props}
                     ref={this.subscription}
-                    onLoad={this.onLoad}
-                    loadOptions={ModuleSubscription.loadGetState}
                     onMessage={this.onMessage}
                     onActiveChange={this.onActiveChange}
                 />

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -29,11 +29,15 @@ export default class SwitcherModule extends React.Component {
     onChange = async (value) => {
         if (this.props.isActive) {
             this.sendValue(value)
-        }
 
-        this.props.api.updateModule(this.props.moduleHash, {
-            switcherValue: value,
-        })
+            this.setState({
+                value,
+            })
+        } else {
+            this.props.api.updateModule(this.props.moduleHash, {
+                switcherValue: value,
+            })
+        }
     }
 
     sendValue(value) {

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -68,6 +68,7 @@ export default class SwitcherModule extends React.Component {
                     onActiveChange={this.onActiveChange}
                 />
                 <Toggle
+                    className={styles.Toggle}
                     key={this.props.module.switcherValue}
                     value={value}
                     onChange={this.onChange}

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -14,7 +14,7 @@ export default class SwitcherModule extends React.Component {
         let { value } = this.state
         if (value == null) {
             // use module value unless state set
-            const module = this.state.module || this.props.module
+            const { module } = this.props
             value = module.switcherValue
         }
         return value
@@ -28,10 +28,7 @@ export default class SwitcherModule extends React.Component {
 
     onChange = async (value) => {
         if (this.props.isActive) {
-            this.subscription.current.send({
-                type: 'uiEvent',
-                value,
-            })
+            this.sendValue(value)
         }
 
         this.props.api.updateModule(this.props.moduleHash, {
@@ -39,12 +36,16 @@ export default class SwitcherModule extends React.Component {
         })
     }
 
+    sendValue(value) {
+        return this.subscription.current.send({
+            type: 'uiEvent',
+            value,
+        })
+    }
+
     onActiveChange = (isActive) => {
         if (isActive) {
-            this.subscription.current.send({
-                type: 'uiEvent',
-                value: this.getValue(),
-            })
+            this.sendValue(this.getValue())
         } else {
             this.setState({
                 value: undefined,
@@ -60,9 +61,10 @@ export default class SwitcherModule extends React.Component {
             <div className={cx(styles.Switcher, className)}>
                 <ModuleSubscription
                     {...this.props}
-                    onMessage={this.onMessage}
                     ref={this.subscription}
-                    loadOptions={ModuleSubscription.getState}
+                    onLoad={this.onLoad}
+                    loadOptions={ModuleSubscription.loadGetState}
+                    onMessage={this.onMessage}
                     onActiveChange={this.onActiveChange}
                 />
                 <Toggle

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -20,7 +20,7 @@ export default class SwitcherModule extends React.Component {
         return value
     }
 
-    onMessage = ({ value }) => {
+    onMessage = ({ switcherValue: value }) => {
         this.setState({
             value,
         })
@@ -69,7 +69,6 @@ export default class SwitcherModule extends React.Component {
                 />
                 <Toggle
                     className={styles.Toggle}
-                    key={this.props.module.switcherValue}
                     value={value}
                     onChange={this.onChange}
                 />

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import cx from 'classnames'
+
+import Toggle from '$shared/components/Toggle'
+import ModuleSubscription from '../ModuleSubscription'
+import styles from './Switcher.pcss'
+
+export default class SwitcherModule extends React.Component {
+    subscription = React.createRef()
+
+    state = {}
+
+    getValue = () => {
+        let { value } = this.state
+        if (value == null) {
+            // use module value unless state set
+            const module = this.state.module || this.props.module
+            value = module.switcherValue
+        }
+        return value
+    }
+
+    onMessage = ({ value }) => {
+        this.setState({
+            value,
+        })
+    }
+
+    onChange = async (value) => {
+        if (this.props.isActive) {
+            this.subscription.current.send({
+                type: 'uiEvent',
+                value,
+            })
+        }
+
+        this.props.api.updateModule(this.props.moduleHash, {
+            switcherValue: value,
+        })
+    }
+
+    onActiveChange = (isActive) => {
+        if (isActive) {
+            this.subscription.current.send({
+                type: 'uiEvent',
+                value: this.getValue(),
+            })
+        }
+    }
+
+    render() {
+        const { className } = this.props
+        const value = this.getValue()
+
+        return (
+            <div className={cx(styles.Switcher, className)}>
+                <ModuleSubscription
+                    {...this.props}
+                    onMessage={this.onMessage}
+                    ref={this.subscription}
+                    loadOptions={ModuleSubscription.getState}
+                    onActiveChange={this.onActiveChange}
+                />
+                <Toggle
+                    key={this.props.module.switcherValue}
+                    value={value}
+                    onChange={this.onChange}
+                />
+            </div>
+        )
+    }
+}

--- a/app/src/editor/shared/components/modules/Switcher.pcss
+++ b/app/src/editor/shared/components/modules/Switcher.pcss
@@ -1,0 +1,6 @@
+.Switcher {
+  padding: 0.8rem 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/app/src/editor/shared/components/modules/Switcher.pcss
+++ b/app/src/editor/shared/components/modules/Switcher.pcss
@@ -4,3 +4,9 @@
   align-items: center;
   justify-content: center;
 }
+
+.Toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -96,15 +96,8 @@ export default class TableModule extends React.Component {
         this.setState(parseMessage(d, options))
     }
 
-    onLoad = (res) => {
-        this.setState({
-            module: res.json,
-        })
-    }
-
     render() {
-        const { className } = this.props
-        const module = this.state.module || this.props.module
+        const { className, module } = this.props
         const { options = {} } = module
         const { title, headers, rows } = this.state
 
@@ -113,8 +106,6 @@ export default class TableModule extends React.Component {
                 <ModuleSubscription
                     {...this.props}
                     onMessage={this.onMessage}
-                    onLoad={this.onLoad}
-                    loadOptions={ModuleSubscription.loadJSON}
                 />
                 {!!(options.displayTitle && options.displayTitle.value && title) && (
                     <h4>{title}</h4>

--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -87,19 +87,35 @@ export default class TableModule extends React.Component {
         ...(this.props.module.tableConfig || {}),
     }
 
+    componentWillUnmount() {
+        this.unmounted = true
+    }
+
     onMessage = (d) => {
         const { options = {} } = this.props.module
         this.setState(parseMessage(d, options))
     }
 
+    onLoad = (res) => {
+        this.setState({
+            module: res.json,
+        })
+    }
+
     render() {
-        const { module, isActive, className } = this.props
+        const { className } = this.props
+        const module = this.state.module || this.props.module
         const { options = {} } = module
         const { title, headers, rows } = this.state
 
         return (
             <div className={cx(styles.tableModule, className)}>
-                <ModuleSubscription isActive={isActive} onMessage={this.onMessage} />
+                <ModuleSubscription
+                    {...this.props}
+                    onMessage={this.onMessage}
+                    onLoad={this.onLoad}
+                    loadOptions={ModuleSubscription.loadJSON}
+                />
                 {!!(options.displayTitle && options.displayTitle.value && title) && (
                     <h4>{title}</h4>
                 )}

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -74,8 +74,12 @@ export default class TextFieldModule extends React.Component {
                     selectOnFocus={false}
                     blurOnEnterKey={false}
                 >
-                    {({ innerRef, ...props }) => (
-                        <textarea ref={innerRef} {...props} />
+                    {({ innerRef, ...props }, { hasFocus }) => (
+                        <textarea
+                            key={hasFocus}
+                            ref={innerRef}
+                            {...props}
+                        />
                     )}
                 </TextInput>
                 <button type="button" className={styles.button} onClick={this.onClick} disabled={!isActive}>

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -14,18 +14,20 @@ export default class TextFieldModule extends React.Component {
     subscription = React.createRef()
 
     onChange = (textFieldValue) => {
-        this.props.api.updateModule(this.props.moduleHash, { textFieldValue })
+        if (this.props.isActive) {
+            this.setState({
+                value: textFieldValue,
+            })
+        } else {
+            this.props.api.updateModule(this.props.moduleHash, {
+                textFieldValue,
+            })
+        }
     }
 
     onMessage = ({ state: textFieldValue }) => {
         this.setState({
             value: textFieldValue,
-        })
-    }
-
-    onLoad = (res) => {
-        this.setState({
-            module: res.json,
         })
     }
 
@@ -40,19 +42,14 @@ export default class TextFieldModule extends React.Component {
         let { value } = this.state
         if (value == null) {
             // use module value unless state set
-            const module = this.state.module || this.props.module
+            const { module } = this.props
             value = module.textFieldValue
         }
         return value
     }
 
     onActiveChange = (isActive) => {
-        if (isActive) {
-            this.subscription.current.send({
-                type: 'uiEvent',
-                value: this.getValue(),
-            })
-        } else {
+        if (!isActive) {
             this.setState({
                 value: undefined,
             })
@@ -66,10 +63,8 @@ export default class TextFieldModule extends React.Component {
             <div className={cx(this.props.className, styles.TextField)}>
                 <ModuleSubscription
                     {...this.props}
-                    onMessage={this.onMessage}
-                    onLoad={this.onLoad}
-                    loadOptions={ModuleSubscription.loadJSON}
                     ref={this.subscription}
+                    onMessage={this.onMessage}
                     onActiveChange={this.onActiveChange}
                 />
                 <TextInput

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -15,9 +15,6 @@ export default class TextFieldModule extends React.Component {
 
     onChange = (textFieldValue) => {
         this.props.api.updateModule(this.props.moduleHash, { textFieldValue })
-        this.setState({
-            value: textFieldValue,
-        })
     }
 
     onMessage = ({ state: textFieldValue }) => {
@@ -49,6 +46,19 @@ export default class TextFieldModule extends React.Component {
         return value
     }
 
+    onActiveChange = (isActive) => {
+        if (isActive) {
+            this.subscription.current.send({
+                type: 'uiEvent',
+                value: this.getValue(),
+            })
+        } else {
+            this.setState({
+                value: undefined,
+            })
+        }
+    }
+
     render() {
         const { isActive } = this.props
         const value = this.getValue()
@@ -60,6 +70,7 @@ export default class TextFieldModule extends React.Component {
                     onLoad={this.onLoad}
                     loadOptions={ModuleSubscription.loadJSON}
                     ref={this.subscription}
+                    onActiveChange={this.onActiveChange}
                 />
                 <TextInput
                     value={value}

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -25,9 +25,9 @@ export default class TextFieldModule extends React.Component {
         }
     }
 
-    onMessage = ({ state: textFieldValue }) => {
+    onMessage = ({ textFieldValue: value }) => {
         this.setState({
-            value: textFieldValue,
+            value,
         })
     }
 

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import cx from 'classnames'
+
+import ModuleSubscription from '../ModuleSubscription'
+
+import TextInput from '../TextInput'
+import styles from './TextField.pcss'
+
+export default class TextFieldModule extends React.Component {
+    state = {}
+
+    static getDerivedStateFromProps(props) {
+        if (props.isActive) { return null }
+        return {
+            value: props.module.textFieldValue,
+        }
+    }
+
+    onChange = (textFieldValue) => {
+        this.props.api.updateModule(this.props.moduleHash, { textFieldValue })
+        this.setState({
+            value: textFieldValue,
+        })
+    }
+
+    onMessage = ({ state: textFieldValue }) => {
+        this.setState({
+            value: textFieldValue,
+        })
+    }
+
+    componentDidMount() {
+        if (this.props.isActive) {
+            this.load()
+        }
+    }
+
+    load = async () => {
+        const { state } = await this.props.send({
+            type: 'getState',
+        })
+
+        this.setState({
+            value: state,
+        })
+    }
+
+    onClick = async () => {
+        this.props.send({
+            type: 'uiEvent',
+            value: this.state.value,
+        })
+    }
+
+    render() {
+        const { value } = this.state
+        return (
+            <div className={cx(this.props.className, styles.TextField)}>
+                <ModuleSubscription isActive={this.props.isActive} onMessage={this.onMessage} />
+                <TextInput
+                    value={value}
+                    placeholder="Enter your text here"
+                    onChange={this.onChange}
+                    selectOnFocus={false}
+                    blurOnEnterKey={false}
+                >
+                    {({ innerRef, ...props }) => (
+                        <textarea ref={innerRef} {...props} />
+                    )}
+                </TextInput>
+                <button className={styles.button} onClick={this.onClick}>
+                    Send
+                </button>
+            </div>
+        )
+    }
+}

--- a/app/src/editor/shared/components/modules/TextField.pcss
+++ b/app/src/editor/shared/components/modules/TextField.pcss
@@ -1,19 +1,17 @@
-body .Comment {
+body .TextField {
   position: relative;
   flex: 1;
-  border: none;
+  min-height: 3em;
+  display: flex;
+  flex-direction: column;
 
   textarea {
     resize: none;
     width: 100%;
     height: 100%;
+    flex: 1;
     border: none;
     background: transparent;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    top: 0;
     padding: 0.8rem 1.4rem;
     color: #525252;
     font-family: 'IBM Plex Sans', sans-serif;
@@ -21,7 +19,7 @@ body .Comment {
     font-weight: 500;
     letter-spacing: 0;
     line-height: 16px;
-    min-height: 3em;
+    border-bottom: 1px solid #EFEFEF;
   }
 
   textarea::placeholder {
@@ -34,6 +32,23 @@ body .Comment {
   }
 
   textarea:focus {
+    outline: none;
+  }
+
+  .button {
+    border: 1px solid #EFEFEF;
+    border-radius: 2px;
+    background: white;
+    color: #525252;
+    font-size: 10px;
+    font-weight: 500;
+    text-align: center;
+    letter-spacing: 0;
+    line-height: 16px;
+    margin: 8px auto;
+  }
+
+  .button:focus {
     outline: none;
   }
 }

--- a/app/src/editor/shared/services.js
+++ b/app/src/editor/shared/services.js
@@ -9,6 +9,10 @@ const API = axios.create({
 
 const getData = ({ data }) => data
 
+export const LOAD_JSON_REQ = {
+    type: 'json',
+}
+
 export async function send({
     authKey,
     data = {},
@@ -20,7 +24,7 @@ export async function send({
     const modulePath = `/canvases/${canvasId}/modules/${moduleHash}`
     const url = `${process.env.STREAMR_API_URL}${dashboardPath}${modulePath}/request`
     return API.post(url, {
-        type: 'json',
+        ...LOAD_JSON_REQ,
         ...data,
     }, {
         Authorization: `Token ${authKey}`,

--- a/app/src/editor/shared/tests/ModuleLoader.test.jsx
+++ b/app/src/editor/shared/tests/ModuleLoader.test.jsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { ModuleLoader } from '../components/ModuleLoader'
+
+function wait(delay) {
+    return new Promise((resolve) => setTimeout(resolve, delay))
+}
+
+describe('ModuleLoader', () => {
+    it('loads on active mount', async () => {
+        const moduleResult = {
+            moduleHash: 1,
+        }
+
+        const loadModule = jest.fn().mockResolvedValueOnce(moduleResult)
+        const render = jest.fn().mockReturnValue(null)
+
+        mount((
+            <ModuleLoader isActive loadModule={loadModule}>
+                {render}
+            </ModuleLoader>
+        ))
+
+        expect(render).toHaveBeenCalled()
+
+        expect(render.mock.calls[render.mock.calls.length - 1][0]).toMatchObject({
+            module: undefined,
+        })
+
+        await wait(100) // wait for load module to flush
+
+        expect(render.mock.calls[render.mock.calls.length - 1][0]).toMatchObject({
+            module: moduleResult,
+        })
+    })
+
+    it('forwards module, does not load if inactive', async () => {
+        const originalModule = {
+            isOriginal: true,
+            moduleHash: 1,
+        }
+
+        const loadModule = jest.fn()
+        const render = jest.fn().mockReturnValue(null)
+
+        mount((
+            <ModuleLoader isActive={false} module={originalModule} loadModule={loadModule}>
+                {render}
+            </ModuleLoader>
+        ))
+
+        expect(render.mock.calls[render.mock.calls.length - 1][0]).toMatchObject({
+            module: originalModule,
+        })
+
+        expect(loadModule).not.toHaveBeenCalled()
+    })
+
+    it('loads on active, unloads on not active', async () => {
+        const originalModule = {
+            isOriginal: true,
+            moduleHash: 1,
+        }
+
+        const moduleResult = {
+            isOriginal: false,
+            moduleHash: 1,
+        }
+
+        const loadModule = jest.fn().mockResolvedValueOnce(moduleResult)
+        const render = jest.fn().mockReturnValue(null)
+
+        const wrapper = mount((
+            <ModuleLoader isActive={false} module={originalModule} loadModule={loadModule}>
+                {render}
+            </ModuleLoader>
+        ))
+
+        expect(loadModule).not.toHaveBeenCalled()
+
+        expect(render.mock.calls[0][0]).toMatchObject({
+            module: originalModule, // forwards original
+        })
+
+        wrapper.setProps({ isActive: true })
+        expect(loadModule).toHaveBeenCalledTimes(1)
+
+        await wait(100) // wait for load module to flush
+
+        expect(render.mock.calls[render.mock.calls.length - 1][0]).toMatchObject({
+            module: moduleResult, // should have loaded new module
+        })
+
+        wrapper.setProps({ isActive: false })
+
+        expect(loadModule).toHaveBeenCalledTimes(1) // didn't call load again
+
+        expect(render.mock.calls[render.mock.calls.length - 1][0]).toMatchObject({
+            module: originalModule, // module is now original module
+        })
+    })
+})

--- a/app/src/editor/shared/utils/autosave.js
+++ b/app/src/editor/shared/utils/autosave.js
@@ -7,6 +7,10 @@ function unsavedUnloadWarning(event) {
     return confirmationMessage // Webkit, Safari, Chrome etc.
 }
 
+/**
+ * Autosave is basically a cancellable debounce with a beforeunload handler.
+ */
+
 export default function Autosave(saveFn, opts) {
     // keep returning the same promise until autosave fires
     // resolve/reject autosave when debounce finally runs & save is complete

--- a/app/src/shared/components/Toggle/index.jsx
+++ b/app/src/shared/components/Toggle/index.jsx
@@ -12,28 +12,14 @@ type Props = {
     value?: boolean,
 }
 
-type State = {
-    value: boolean,
-}
+type State = {}
 
-class Toggle extends Component<Props, State> {
-    constructor(props: Props) {
-        super(props)
-
-        this.state = {
-            value: !!props.value,
-        }
-    }
-
+class ControlledToggle extends Component<Props, State> {
     onChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
         const value = e.target.checked
         const { onChange } = this.props
 
-        this.setState({
-            value,
-        })
-
-        if (onChange) {
+        if (typeof onChange === 'function') {
             onChange(value)
         }
     }
@@ -46,14 +32,13 @@ class Toggle extends Component<Props, State> {
             onChange,
             ...rest
         } = this.props
-        const { value: stateValue } = this.state
         return (
             <div className={cx(className)}>
                 <label className={cx(styles.switch, styles.label)}>
                     <input
                         type="checkbox"
                         onChange={this.onChange}
-                        checked={stateValue}
+                        checked={value}
                         disabled={disabled}
                         {...rest}
                     />
@@ -64,4 +49,4 @@ class Toggle extends Component<Props, State> {
     }
 }
 
-export default Toggle
+export default ControlledToggle

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -49,8 +49,29 @@ const story = (name) => storiesOf(`Shared/${name}`, module)
     }))
     .addDecorator(withKnobs)
 
+class ToggleContainer extends React.Component {
+    state = {
+        value: false,
+    }
+
+    render() {
+        return (
+            <Toggle
+                value={this.state.value}
+                onChange={(value) => {
+                    this.setState({
+                        value,
+                    })
+                    action('onChange')(value)
+                }}
+            />
+        )
+    }
+}
 story('Toggle')
-    .addWithJSX('basic', () => <Toggle onChange={action('onChange')} />)
+    .addWithJSX('changeable', () => <ToggleContainer />)
+    .addWithJSX('off', () => <Toggle value={boolean('value', false)} onChange={action('onChange')} />)
+    .addWithJSX('on', () => <Toggle value={boolean('value', true)} onChange={action('onChange')} />)
 
 story('Popover actions')
     .addWithJSX('basic', () => (


### PR DESCRIPTION
Adds Switcher, Button, TextField, Label modules.

For testing Switcher & Label:
* Connect a Switcher to a Label.
* Toggle Switch, try undo/redo.
* Start canvas, note Label shows a value.
* Toggle Switch, note Label value updates.
* Stop canvas. Note switch reverts to value used at canvas start.
* Open same canvas in another tab.
* Start canvas.
* Toggle switch.
* Note switch & label value is replicated to other tab.

For testing Button & TextField:

* Add a Button.
* Change the button value param. Note button value changes.
* Add a TextField.
* Edit TextField content.
* Content is saved on blur. Try undo/redo.
* Connect TextField's out to Button's name.
* Start canvas
* Note actual button value changes.
* Edit TextField content.
* Press send button.
* Note actual button value changes with new textfield content.
* Stop Canvas.
* Note value changes are reverted.

Also note that Textfield & Comment content changes won't replicate across tabs at runtime, the changed values currently don't get sent over the subscription.

Also: 
* Improves API for doing subscriptions & sending data.
* Fixes undo/redo for comment module. Need to create wipe DOM nodes for undo-managed text inputs on blur otherwise in-browser undo gets confused with the app's undo.
* Updates Button name value from button's `buttonName` param.
* Adjusts default module sizes.
* Makes Table resizable.
* Adds a bunch of explanatory comments in the code.

Closes PLATFORM-255 (switcher), PLATFORM-256 (textfield), PLATFORM-247 (label), PLATFORM-331 (remove getState)