### PR TITLE
[PLATFORM-353] Port toggle export

### DIFF
--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -148,6 +148,8 @@ class PortOptions extends React.PureComponent {
     render() {
         const { port, canvas } = this.props
         const isRunning = canvas.state === 'RUNNING'
+        const isOutput = !port.acceptedTypes
+
         return (
             <div className={styles.portOptions}>
                 {port.canToggleDrivingInput && (
@@ -172,6 +174,18 @@ class PortOptions extends React.PureComponent {
                         disabled={!!isRunning}
                     >
                         NR
+                    </button>
+                )}
+                {isOutput && (
+                    <button
+                        type="button"
+                        title={`Export: ${port.export ? 'On' : 'Off'}`}
+                        value={!!port.export}
+                        className={styles.export}
+                        onClick={this.getToggleOption('export')}
+                        disabled={!!isRunning}
+                    >
+                        EX
                     </button>
                 )}
             </div>

--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -148,7 +148,6 @@ class PortOptions extends React.PureComponent {
     render() {
         const { port, canvas } = this.props
         const isRunning = canvas.state === 'RUNNING'
-        const isOutput = !port.acceptedTypes
 
         return (
             <div className={styles.portOptions}>
@@ -176,18 +175,16 @@ class PortOptions extends React.PureComponent {
                         NR
                     </button>
                 )}
-                {isOutput && (
-                    <button
-                        type="button"
-                        title={`Export: ${port.export ? 'On' : 'Off'}`}
-                        value={!!port.export}
-                        className={styles.export}
-                        onClick={this.getToggleOption('export')}
-                        disabled={!!isRunning}
-                    >
-                        EX
-                    </button>
-                )}
+                <button
+                    type="button"
+                    title={`Export: ${port.export ? 'On' : 'Off'}`}
+                    value={!!port.export}
+                    className={styles.export}
+                    onClick={this.getToggleOption('export')}
+                    disabled={!!isRunning}
+                >
+                    EX
+                </button>
             </div>
         )
     }

--- a/app/src/editor/canvas/components/Ports.pcss
+++ b/app/src/editor/canvas/components/Ports.pcss
@@ -4,6 +4,7 @@
   --driving-input-color: #FF5C00;
   --no-repeat-color: #0324FF;
   --connected-color: #2AC437;
+  --export-color: #6240AF; /* invented in lieu of design */
   --port-size: 8px;
 }
 
@@ -226,6 +227,10 @@
   letter-spacing: 0;
   line-height: 10px;
   transition: background 0.25s;
+}
+
+.ports .PortIcon .portOptions > .export[value='true'] {
+  background-color: var(--export-color);
 }
 
 .ports .PortIcon .portOptions > .drivingInputOption[value='true'] {


### PR DESCRIPTION
As far as I can tell, there doesn't seem to be any way to toggle "export" for ports in the new designs.
i.e. 
![image](https://user-images.githubusercontent.com/43438/52697152-cd318b00-2fab-11e9-8004-5334e23754f1.png)

Upcoming work with canvas custom module needs this ability.

This PR adds a port export toggle using the same system for toggling driving input/no repeat:

![image](https://user-images.githubusercontent.com/43438/52697199-ed614a00-2fab-11e9-8b68-3b38393bc3c1.png)
![image](https://user-images.githubusercontent.com/43438/52697211-f520ee80-2fab-11e9-8abc-184653e66b1b.png)

Once @mattatgit returns perhaps he will have a better idea. Perhaps it was intended as a right click menu.
