### PR TITLE
Editor API tests

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26883,9 +26883,9 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "streamr-client": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-0.12.2.tgz",
-      "integrity": "sha512-5DS5Cf1i1EgvH3lE+vdy33umYWioBADmyTOy5JvmnE6ZlwAiHECZCaoiXbFXc+IIxyyD4VMMFCErnIyIhQ0o5A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-1.0.0.tgz",
+      "integrity": "sha512-KiZPLwvv3NA8zIwi3OnI5hPCe8LJgzzYM2ZCbGD6/eGz+dRaMiYimkUKdzlpItGKPj60xNChzqPDiHdXFr6XIQ==",
       "requires": {
         "babel-plugin-transform-builtin-extend": "^1.1.2",
         "babel-runtime": "^6.26.0",
@@ -26893,6 +26893,8 @@
         "eventemitter3": "^3.0.1",
         "node-fetch": "^2.1.2",
         "querystring": "^0.2.0",
+        "streamr-client-protocol": "^1.1.0",
+        "web3": "^1.0.0-beta.36",
         "webpack-node-externals": "^1.7.2",
         "ws": "^5.1.0"
       },
@@ -26902,6 +26904,16 @@
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
           "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
         }
+      }
+    },
+    "streamr-client-protocol": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-1.2.0.tgz",
+      "integrity": "sha512-2SbUtJWsHjvqT3O0PEsV+rEBdJYWDTZ3khFdPKbVAeWfgfUodoPi4gXn8DSKdBv2wPoXVPIEsBnqzs9rqDhElA==",
+      "requires": {
+        "babel-plugin-transform-builtin-extend": "^1.1.2",
+        "babel-runtime": "^6.26.0",
+        "debug": "^3.1.0"
       }
     },
     "strict-uri-encode": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6566,6 +6566,22 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
+    "bindings": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.4.0.tgz",
+      "integrity": "sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -8714,6 +8730,16 @@
         }
       }
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "dreamopt": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
@@ -10213,6 +10239,11 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -13746,6 +13777,17 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
       "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
     },
+    "keccak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "keccakjs": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
@@ -13759,6 +13801,26 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
       "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+    },
+    "keythereum": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/keythereum/-/keythereum-1.0.4.tgz",
+      "integrity": "sha512-c3gWM0nQ6x5TKAzTOA1yIqn73S8sP9+lR7mc7QS6t509g7C0/CukykxGA6+B+aXI6BIrlSwVh5muPv/I1lD9LA==",
+      "requires": {
+        "crypto-browserify": "3.12.0",
+        "keccak": "1.4.0",
+        "scrypt": "6.0.3",
+        "secp256k1": "3.5.0",
+        "sjcl": "1.0.6",
+        "uuid": "3.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
+          "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
+        }
+      }
     },
     "killable": {
       "version": "1.0.1",
@@ -26016,6 +26078,21 @@
         }
       }
     },
+    "secp256k1": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "seed-random": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
@@ -26397,6 +26474,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
       "integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g=="
+    },
+    "sjcl": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.6.tgz",
+      "integrity": "sha1-ZBVGKmPMDUIVxJuuydP6DBtTUg8="
     },
     "slash": {
       "version": "1.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -137,6 +137,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.1.0",
     "jest-localstorage-mock": "^2.1.0",
+    "keythereum": "^1.0.4",
     "lint-staged": "^8.0.3",
     "lodash": "^4.17.5",
     "mini-css-extract-plugin": "^0.4.0",

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "start": "webpack-dev-server --hot",
     "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack",
     "test": "jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/*",
+    "test-local": "jest ./src/editor/canvas/tests --collectCoverage=false",
     "flow": "flow",
     "flow-stop": "flow stop",
     "eslint": "eslint .",

--- a/app/package.json
+++ b/app/package.json
@@ -208,7 +208,7 @@
     "storybook-addon-jsx": "^5.4.0",
     "storybook-chromatic": "^1.2.0",
     "storybook-react-router": "^1.0.1",
-    "streamr-client": "^0.12.2",
+    "streamr-client": "^1.0.0",
     "stringify-object": "^3.2.2",
     "style-loader": "^0.21.0",
     "stylelint": "^9.2.1",

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -7,7 +7,7 @@ import axios from 'axios'
 import Autosave from '$editor/shared/utils/autosave'
 import { emptyCanvas } from './state'
 
-const API = axios.create({
+export const API = axios.create({
     headers: {
         'Content-Type': 'application/json',
     },
@@ -53,7 +53,7 @@ export async function duplicateCanvas(canvas) {
     return createCanvas(savedCanvas)
 }
 
-export async function deleteCanvas({ id }) {
+export async function deleteCanvas({ id } = {}) {
     await autosave.cancel()
     return API.delete(`${canvasesUrl}/${id}`).then(getData)
 }
@@ -62,14 +62,18 @@ export async function getModuleTree() {
     return API.get(getModuleTreeURL).then(getData)
 }
 
-export async function addModule({ id }) {
+export async function addModule({ id } = {}) {
     const form = new FormData()
     form.append('id', id)
     return API.post(getModuleURL, form).then(getData)
 }
 
-export async function loadCanvas({ id }) {
+export async function loadCanvas({ id } = {}) {
     return API.get(`${canvasesUrl}/${id}`).then(getData)
+}
+
+export async function loadCanvases() {
+    return API.get(canvasesUrl).then(getData)
 }
 
 async function startCanvas(canvas, { clearState }) {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -556,7 +556,7 @@ export function updateCanvas(canvas, path, fn) {
     return limitLayout(updateVariadic(update(path, fn, canvas)))
 }
 
-function moduleTreeIndex(modules = [], path = [], index = []) {
+export function moduleTreeIndex(modules = [], path = [], index = []) {
     modules.forEach((m) => {
         if (m.metadata.canAdd) {
             index.push({

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -174,6 +174,11 @@ export function getModulePorts(canvas, moduleHash) {
     return ports
 }
 
+export function findModulePort(canvas, moduleHash, matchFn) {
+    const ports = getModulePorts(canvas, moduleHash)
+    return Object.values(ports).find(matchFn)
+}
+
 export function getConnectedPortIds(canvas, portId) {
     const port = getPort(canvas, portId)
     if (!getIsOutput(canvas, portId)) {
@@ -254,53 +259,58 @@ export function canConnectPorts(canvas, portIdA, portIdB) {
     return inputTypes.has(output.type)
 }
 
-function hasVariadicPort(canvas, moduleHash) {
+function hasVariadicPort(canvas, moduleHash, type) {
+    if (!type) { throw new Error('type missing') }
     const canvasModule = getModule(canvas, moduleHash)
-    return canvasModule.inputs.some(({ variadic }) => variadic)
+    return canvasModule[type].some(({ variadic }) => variadic)
 }
 
-function getVariadicPorts(canvas, moduleHash) {
+function getVariadicPorts(canvas, moduleHash, type) {
+    if (!type) { throw new Error('type missing') }
     const canvasModule = getModule(canvas, moduleHash)
-    return canvasModule.inputs.filter(({ variadic }) => variadic)
+    return canvasModule[type].filter(({ variadic }) => variadic)
 }
 
-function findLastVariadicPort(canvas, moduleHash) {
-    const variadics = getVariadicPorts(canvas, moduleHash)
+function findLastVariadicPort(canvas, moduleHash, type) {
+    if (!type) { throw new Error('type missing') }
+    const variadics = getVariadicPorts(canvas, moduleHash, type)
     return variadics.find(({ variadic }) => (
         variadic.isLast
     )) || variadics[variadics.length - 1]
 }
 
-function findPreviousLastVariadicPort(canvas, moduleHash) {
-    const variadics = getVariadicPorts(canvas, moduleHash)
-    const last = findLastVariadicPort(canvas, moduleHash)
+function findPreviousLastVariadicPort(canvas, moduleHash, type) {
+    const variadics = getVariadicPorts(canvas, moduleHash, type)
+    const last = findLastVariadicPort(canvas, moduleHash, type)
     const index = variadics.indexOf(last)
     return variadics[index - 1]
 }
 
-function addVariadic(canvas, moduleHash) {
-    const port = findLastVariadicPort(canvas, moduleHash)
+function addVariadic(canvas, moduleHash, type) {
+    if (!type) { throw new Error('type missing') }
+    const port = findLastVariadicPort(canvas, moduleHash, type)
+    const canvasModule = getModule(canvas, moduleHash)
+    if (canvasModule.moduleClosed) { return canvas } // do nothing if module closed
+    if (type === 'outputs' && port.variadic.disableGrow) { return canvas } // do nothing if grow disabled
 
     // update current last port
     const nextCanvas = updatePort(canvas, port.id, (port) => ({
         ...port,
-        variadic: {
+        variadic: Object.assign({
             ...port.variadic,
             isLast: false,
-            requiresConnection: true,
-        },
+        }, type === 'inputs' ? { requiresConnection: false } : {}),
     }))
 
     const index = port.variadic.index + 1
     const id = uuid.v4()
-    const newPort = Object.assign(cloneDeep(port), {
+
+    let resetMask = {
         id,
         // reset port info
         longName: undefined,
         sourceId: undefined,
         name: `endpoint-${id}`,
-        displayName: `in${index}`,
-        requiresConnection: false,
         connected: false,
         export: false,
         variadic: {
@@ -308,55 +318,76 @@ function addVariadic(canvas, moduleHash) {
             isLast: true,
             index,
         },
-    })
+    }
+
+    if (type === 'inputs') {
+        resetMask = {
+            ...resetMask,
+            sourceId: undefined,
+            name: `endpoint-${id}`,
+            displayName: `in${index}`,
+            requiresConnection: false,
+        }
+    } else {
+        resetMask = {
+            ...resetMask,
+            displayName: `out${index}`,
+        }
+    }
+
+    const newPort = Object.assign(cloneDeep(port), resetMask)
 
     // append new last port
     return updateModule(nextCanvas, moduleHash, (canvasModule) => ({
         ...canvasModule,
-        inputs: canvasModule.inputs.concat(newPort),
+        [type]: canvasModule[type].concat(newPort),
     }))
 }
 
-function removeVariadic(canvas, moduleHash) {
-    const lastVariadicPort = findLastVariadicPort(canvas, moduleHash)
+function removeVariadic(canvas, moduleHash, type) {
+    if (!type) { throw new Error('type missing') }
+    const lastVariadicPort = findLastVariadicPort(canvas, moduleHash, type)
     if (!lastVariadicPort) { return canvas }
-    const prevVariadicPort = findPreviousLastVariadicPort(canvas, moduleHash)
+    const prevVariadicPort = findPreviousLastVariadicPort(canvas, moduleHash, type)
     let nextCanvas = canvas
     if (prevVariadicPort) {
         // make second-last variadic port the last
         nextCanvas = updatePort(canvas, prevVariadicPort.id, (port) => ({
             ...port,
-            variadic: {
+            variadic: Object.assign({
                 ...port.variadic,
                 isLast: true,
-                requiresConnection: false,
-            },
+            }, type === 'inputs' ? { requiresConnection: false } : {}),
         }))
     }
 
     // remove last variadic port
     return updateModule(nextCanvas, moduleHash, (canvasModule) => ({
         ...canvasModule,
-        inputs: canvasModule.inputs.filter(({ id }) => id !== lastVariadicPort.id),
+        [type]: canvasModule[type].filter(({ id }) => id !== lastVariadicPort.id),
     }))
 }
 
-export function updateVariadicModule(canvas, moduleHash) {
-    if (!hasVariadicPort(canvas, moduleHash)) {
+function updateVariadicModuleForType(canvas, moduleHash, type) {
+    if (!type) { throw new Error('type missing') }
+    if (!hasVariadicPort(canvas, moduleHash, type)) {
         return canvas // ignore if no variadic ports
     }
 
-    const lastVariadicPort = findLastVariadicPort(canvas, moduleHash)
+    const canvasModule = getModule(canvas, moduleHash)
+    if (canvasModule.moduleClosed) { return canvas } // do nothing if module closed
+
+    const lastVariadicPort = findLastVariadicPort(canvas, moduleHash, type)
     if (!lastVariadicPort) {
         throw new Error('no last variadic port') // should not happen
     }
 
     if (isPortConnected(canvas, lastVariadicPort.id)) {
         // add new port if last variadic port is connected
-        return addVariadic(canvas, moduleHash)
+        return addVariadic(canvas, moduleHash, type)
     }
 
-    const variadics = getVariadicPorts(canvas, moduleHash)
+    const variadics = getVariadicPorts(canvas, moduleHash, type)
     const lastConnected = variadics.slice().reverse().find(({ id }) => (
         isPortConnected(canvas, id)
     ))
@@ -368,13 +399,18 @@ export function updateVariadicModule(canvas, moduleHash) {
         // TODO: remove all in one go
         let newCanvas = canvas
         variadicsToRemove.forEach(() => {
-            newCanvas = removeVariadic(newCanvas, moduleHash)
+            newCanvas = removeVariadic(newCanvas, moduleHash, type)
         })
         return newCanvas
     }
 
     // otherwise ignore
     return canvas
+}
+
+export function updateVariadicModule(canvas, moduleHash) {
+    const newCanvas = updateVariadicModuleForType(canvas, moduleHash, 'inputs')
+    return updateVariadicModuleForType(newCanvas, moduleHash, 'outputs')
 }
 
 export function updateVariadic(canvas) {
@@ -454,6 +490,31 @@ export function removeModule(canvas, moduleHash) {
     }
 }
 
+let ID = 0
+
+function getHash(canvas, iterations = 0) {
+    if (iterations >= 100) {
+        // bail out if seriously can't find a hash
+        throw new Error(`could not find unique hash after ${iterations} attempts`)
+    }
+
+    ID += 1
+    const hash = Number((
+        String(Date.now() + ID)
+            .slice(-10) // 32 bits
+            .split('')
+            .reverse() // in order (for debugging)
+            .join('')
+    ))
+
+    if (canvas.modules.find((m) => m.hash === hash)) {
+        // double-check doesn't exist
+        return getHash(canvas, iterations + 1)
+    }
+
+    return hash
+}
+
 /**
  * Create new module from data
  */
@@ -461,7 +522,7 @@ export function removeModule(canvas, moduleHash) {
 export function addModule(canvas, moduleData) {
     const canvasModule = {
         ...moduleData,
-        hash: Date.now(), // TODO: better ids
+        hash: getHash(canvas), // TODO: better IDs
         layout: {
             ...DEFAULT_MODULE_LAYOUT, // TODO: read position from mouse
         },

--- a/app/src/editor/canvas/tests/__snapshots__/services.test.js.snap
+++ b/app/src/editor/canvas/tests/__snapshots__/services.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Canvas Services create can create canvases 1`] = `
+Object {
+  "adhoc": false,
+  "created": Any<String>,
+  "hasExports": false,
+  "id": Any<String>,
+  "modules": Array [],
+  "name": "Untitled Canvas",
+  "serialized": false,
+  "settings": Object {},
+  "startedById": null,
+  "state": "STOPPED",
+  "uiChannel": ObjectContaining {
+    "id": Any<String>,
+  },
+  "updated": Any<String>,
+}
+`;

--- a/app/src/editor/canvas/tests/__snapshots__/state.test.js.snap
+++ b/app/src/editor/canvas/tests/__snapshots__/state.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Canvas State emptyCanvas creates an empty canvas 1`] = `
+Object {
+  "modules": Array [],
+  "name": "Untitled Canvas",
+  "settings": Object {},
+}
+`;

--- a/app/src/editor/canvas/tests/mocks.js
+++ b/app/src/editor/canvas/tests/mocks.js
@@ -1,0 +1,182 @@
+import uuid from 'uuid'
+
+function remapIds(items) {
+    return items.map((item) => ({
+        ...item,
+        id: uuid(),
+    }))
+}
+
+function createMockModuleFactory(data) {
+    return () => {
+        const newData = { ...data }
+        if (newData.inputs) { newData.inputs = remapIds(newData.inputs) }
+        if (newData.outputs) { newData.outputs = remapIds(newData.outputs) }
+        if (newData.params) { newData.params = remapIds(newData.params) }
+        return newData
+    }
+}
+
+export const Table = createMockModuleFactory({
+    params: [],
+    inputs: [
+        {
+            id: 'ep_PgkxVnrySK69f9ldq5Fqsg',
+            name: 'endpoint-1550217129217',
+            longName: 'Table.in1',
+            type: 'Object',
+            connected: false,
+            canConnect: true,
+            export: false,
+            displayName: 'in1',
+            jsClass: 'VariadicInput',
+            variadic: {
+                isLast: true, index: 1,
+            },
+            drivingInput: true,
+            canToggleDrivingInput: false,
+            acceptedTypes: ['Object'],
+            requiresConnection: false,
+        },
+    ],
+    outputs: [],
+    id: 527,
+    jsModule: 'TableModule',
+    type: 'module event-table-module',
+    name: 'Table',
+    canClearState: true,
+    canRefresh: false,
+    uiChannel: {
+        webcomponent: 'streamr-table',
+        name: 'Table',
+        id: 'ofBRIwV4QRe5aiyheC94UA',
+    },
+    options: {
+        uiResendAll: {
+            value: false, type: 'boolean',
+        },
+        uiResendLast: {
+            value: 20, type: 'int',
+        },
+        maxRows: {
+            value: 20, type: 'int',
+        },
+        showOnlyNewValues: {
+            value: true, type: 'boolean',
+        },
+    },
+    tableConfig: {
+        headers: ['timestamp'], title: 'Table',
+    },
+})
+
+export const Clock = createMockModuleFactory({
+    params: [
+        {
+            id: 'ep_zRT5amaGTEiCP-ZoSG0oLA',
+            name: 'timezone',
+            longName: 'Clock.timezone',
+            type: 'String',
+            connected: false,
+            canConnect: true,
+            export: false,
+            value: 'UTC',
+            drivingInput: false,
+            canToggleDrivingInput: true,
+            acceptedTypes: ['String'],
+            requiresConnection: false,
+            defaultValue: 'UTC',
+        },
+        {
+            id: 'ep_N6nuE4q0T7yHRlWqB8D8lw',
+            name: 'format',
+            longName: 'Clock.format',
+            type: 'String',
+            connected: false,
+            canConnect: true,
+            export: false,
+            value: 'yyyy-MM-dd HH:mm:ss z',
+            drivingInput: false,
+            canToggleDrivingInput: false,
+            acceptedTypes: ['String'],
+            requiresConnection: false,
+            defaultValue: 'yyyy-MM-dd HH:mm:ss z',
+            isTextArea: false,
+        },
+        {
+            id: 'ep_iMatJKzSRniXU4KDsaesKQ',
+            name: 'rate',
+            longName: 'Clock.rate',
+            type: 'Double',
+            connected: false,
+            canConnect: true,
+            export: false,
+            value: 1,
+            drivingInput: false,
+            canToggleDrivingInput: false,
+            acceptedTypes: ['Double'],
+            requiresConnection: false,
+            defaultValue: 1,
+        },
+        {
+            id: 'ep_OZuffq_VQ1ioH_zmJxB5xw',
+            name: 'unit',
+            longName: 'Clock.unit',
+            type: 'String',
+            connected: false,
+            canConnect: true,
+            export: false,
+            value: 'SECOND',
+            drivingInput: false,
+            canToggleDrivingInput: false,
+            acceptedTypes: ['String'],
+            requiresConnection: false,
+            possibleValues: [
+                {
+                    name: 'second', value: 'SECOND',
+                },
+                {
+                    name: 'minute', value: 'MINUTE',
+                },
+                {
+                    name: 'hour', value: 'HOUR',
+                },
+                {
+                    name: 'day', value: 'DAY',
+                },
+            ],
+            defaultValue: 'SECOND',
+        },
+    ],
+    inputs: [],
+    outputs: [
+        {
+            id: 'ep_4lL-7RilToeOzECsEshtzg',
+            name: 'date',
+            longName: 'Clock.date',
+            type: 'String',
+            connected: false,
+            canConnect: true,
+            export: false,
+            noRepeat: false,
+            canBeNoRepeat: true,
+        },
+        {
+            id: 'ep__KUxRdB0Tyq-THqIP9Q-Ew',
+            name: 'timestamp',
+            longName: 'Clock.timestamp',
+            type: 'Double',
+            connected: false,
+            canConnect: true,
+            export: false,
+            noRepeat: false,
+            canBeNoRepeat: true,
+        },
+    ],
+    id: 209,
+    jsModule: 'GenericModule',
+    type: 'module',
+    name: 'Clock',
+    canClearState: true,
+    canRefresh: false,
+})

--- a/app/src/editor/canvas/tests/services.test.js
+++ b/app/src/editor/canvas/tests/services.test.js
@@ -1,0 +1,154 @@
+import * as Services from '../services'
+import * as State from '../state'
+
+import { setup } from './utils'
+
+const canvasMatcher = {
+    id: expect.any(String),
+    created: expect.any(String),
+    updated: expect.any(String),
+    uiChannel: expect.objectContaining({
+        id: expect.any(String),
+    }),
+}
+
+describe('Canvas Services', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setup(Services.API)
+    })
+
+    afterAll(async () => {
+        await teardown()
+    })
+
+    describe('create', () => {
+        it('can create canvases', async () => {
+            const canvases = await Services.loadCanvases()
+            expect(canvases.length).toBe(0)
+            const canvas = await Services.create()
+            expect(canvas).toMatchSnapshot(canvasMatcher)
+
+            expect(canvas).toHaveProperty('id')
+            expect(canvas.modules.length).toBe(0)
+            const canvasesAfterCreate = await Services.loadCanvases()
+            expect(canvasesAfterCreate.length).toBe(1)
+            expect(canvasesAfterCreate).toContainEqual({
+                ...canvas,
+                created: canvasMatcher.created,
+                updated: canvasMatcher.updated,
+            })
+        })
+    })
+
+    describe('loadCanvas', () => {
+        it('errors if no canvas', () => {
+            expect(Services.loadCanvas({
+                id: 'invalid',
+            })).rejects.toThrow()
+        })
+
+        it('can load a canvas', async () => {
+            const canvas = await Services.create()
+            const { id } = canvas
+            const loadedCanvas = await Services.loadCanvas({ id })
+            expect(loadedCanvas).toMatchObject({
+                ...canvas,
+                // loading canvas gives different created/updated time than create ???
+                created: canvasMatcher.created,
+                updated: canvasMatcher.updated,
+            })
+        })
+    })
+
+    describe('deleteCanvas', () => {
+        it('errors if no canvas', () => {
+            expect(Services.deleteCanvas({
+                id: 'invalid',
+            })).rejects.toThrow()
+        })
+
+        it('can delete a canvas', async () => {
+            const canvas = await Services.create()
+            const { id } = canvas
+            await Services.deleteCanvas({ id })
+            await expect(Services.loadCanvas({ id })).rejects.toThrow()
+        })
+    })
+
+    describe('duplicateCanvas', () => {
+        it('errors if no canvas', () => {
+            expect(Services.duplicateCanvas({
+                id: 'invalid',
+            })).rejects.toThrow()
+        })
+
+        it('can duplicate a canvas', async () => {
+            const canvas = await Services.create()
+            const duplicateCanvas = await Services.duplicateCanvas(canvas)
+            expect(duplicateCanvas.id).not.toEqual(canvas.id)
+            expect(duplicateCanvas).toMatchObject({
+                ...canvas,
+                ...canvasMatcher,
+            })
+        })
+    })
+
+    describe('start/stop canvas', () => {
+        it('errors if no canvas', () => {
+            expect(Services.start({
+                id: 'invalid',
+            })).rejects.toThrow()
+            expect(Services.stop({
+                id: 'invalid',
+            })).rejects.toThrow()
+        })
+
+        it('can start & stop a canvas', async () => {
+            const canvas = await Services.create()
+            const startedCanvas = await Services.start(canvas)
+            expect(startedCanvas).toMatchObject({
+                ...canvas,
+                ...canvasMatcher,
+                id: canvas.id,
+                state: State.RunStates.Running,
+                startedById: expect.any(Number),
+            })
+
+            // can't start a running canvas
+            await expect(Services.start(canvas)).rejects.toThrow()
+
+            const stoppedCanvas = await Services.stop(canvas)
+            expect(stoppedCanvas).toMatchObject({
+                ...startedCanvas,
+                ...canvasMatcher,
+                id: canvas.id,
+                state: State.RunStates.Stopped,
+                startedById: expect.any(Number),
+            })
+
+            // can't stop a stopped canvas
+            await expect(Services.stop(canvas)).rejects.toThrow()
+        })
+
+        it('can start adhoc canvases', async () => {
+            const canvas = await Services.create()
+            const startedAdhocCanvas = await Services.start(canvas, { adhoc: true })
+            expect(startedAdhocCanvas.id).not.toEqual(canvas.id)
+            expect(startedAdhocCanvas).toMatchObject({
+                ...canvas,
+                ...canvasMatcher,
+                adhoc: true,
+                state: State.RunStates.Running,
+                startedById: expect.any(Number),
+                settings: expect.objectContaining({
+                    parentCanvasId: canvas.id, // captures parent canvas id
+                }),
+            })
+
+            // adhoc canvas will immediately stop, so this should throw
+            await expect(Services.stop(startedAdhocCanvas)).rejects.toThrow()
+        })
+    })
+})

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -1,0 +1,11 @@
+import * as State from '../state'
+
+describe('Canvas State', () => {
+    describe('emptyCanvas', () => {
+        it('creates an empty canvas', () => {
+            expect(State.emptyCanvas()).toMatchSnapshot({
+                modules: [],
+            })
+        })
+    })
+})

--- a/app/src/editor/canvas/tests/utils.js
+++ b/app/src/editor/canvas/tests/utils.js
@@ -24,7 +24,7 @@ function createNewUserClient() {
 }
 
 /**
- * Add session tok
+ * Add session token
  */
 
 export async function setup(API) {

--- a/app/src/editor/canvas/tests/utils.js
+++ b/app/src/editor/canvas/tests/utils.js
@@ -1,0 +1,53 @@
+import keythereum from 'keythereum'
+import StreamrClient from 'streamr-client'
+import * as Services from '../services'
+
+/**
+ * Creates a client for a new, generated user.
+ */
+
+function createNewUserClient() {
+    const generatedKey = keythereum.create()
+    const privateKey = `0x${generatedKey.privateKey.toString('hex')}`
+
+    const client = new StreamrClient({
+        auth: {
+            privateKey,
+        },
+        url: process.env.STREAMR_WS_URL,
+        restUrl: process.env.STREAMR_API_URL,
+        autoConnect: false,
+        autoDisconnect: false,
+    })
+
+    return client
+}
+
+/**
+ * Add session tok
+ */
+
+export async function setup(API) {
+    const client = await createNewUserClient()
+    await client.connect()
+    const sessionToken = await client.session.getSessionToken() // returns a Promise that resolves with session token
+
+    const previousAuthHeader = API.defaults.headers.common.Authorization
+    // warning: mutates API's headers
+    API.defaults.headers.common.Authorization = `Bearer ${sessionToken}`
+
+    return async () => {
+        // try do some clean up so we don't fill the server with cruft
+        const canvases = await Services.loadCanvases()
+        await Promise.all(canvases.map((canvas) => (
+            Services.deleteCanvas(canvas)
+        )))
+
+        // restore previous auth header
+        API.defaults.headers.common.Authorization = previousAuthHeader
+
+        if (client && client.connection) {
+            await client.disconnect()
+        }
+    }
+}

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -1,0 +1,27 @@
+import * as State from '../state'
+import * as Mocks from './mocks'
+
+describe('Variadic Port Handling', () => {
+    it('can add/connect modules', () => {
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, Mocks.Clock())
+        canvas = State.addModule(canvas, Mocks.Table())
+        const clock = canvas.modules.find((m) => m.name === 'Clock')
+        const table = canvas.modules.find((m) => m.name === 'Table')
+        expect(clock).toBeTruthy()
+        expect(table).toBeTruthy()
+        expect(clock.hash).not.toEqual(table.hash)
+        const fromPort = State.findModulePort(canvas, clock.hash, (p) => p.name === 'timestamp')
+        const toPort = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 1)
+        expect(fromPort).toBeTruthy()
+        expect(toPort).toBeTruthy()
+
+        canvas = State.updateCanvas(State.connectPorts(canvas, fromPort.id, toPort.id))
+        expect(State.isPortConnected(canvas, fromPort.id)).toBeTruthy()
+        expect(State.isPortConnected(canvas, toPort.id)).toBeTruthy()
+
+        const newVariadicInput = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 2)
+        expect(newVariadicInput).toBeTruthy()
+        expect(newVariadicInput.variadic.isLast).toBeTruthy()
+    })
+})

--- a/app/src/editor/dashboard/services.js
+++ b/app/src/editor/dashboard/services.js
@@ -54,14 +54,14 @@ export async function duplicateDashboard(dashboard) {
     return createDashboard(savedDashboard)
 }
 
-export async function getModuleData({ authKey, dashboard, item: { canvas, module: itemModule } }) {
+export async function getModuleData({ apiKey, dashboard, item: { canvas, module: itemModule } }) {
     // If the db is new the user must have the ownership of the canvas so use url /api/v1/canvases/<canvasId>/modules/<module>
     // Else use the url /api/v1/dashboards/<dashboardId>/canvases/<canvasId>/modules/<module>
     const dashboardPath = (dashboard && !dashboard.new) ? `/dashboards/${dashboard.id}` : ''
     const modulePath = `/canvases/${canvas}/modules/${itemModule}`
     const url = `${process.env.STREAMR_API_URL}${dashboardPath}${modulePath}/request`
     return API.post(url, { type: 'json' }, {
-        Authorization: `Token ${authKey}`,
+        Authorization: `Token ${apiKey}`,
     }).then(getData).then(({ json }) => json)
 }
 

--- a/app/src/editor/shared/components/Client.jsx
+++ b/app/src/editor/shared/components/Client.jsx
@@ -17,7 +17,7 @@ export const ClientContext = React.createContext()
 
 class ClientProviderComponent extends Component {
     static propTypes = {
-        authKey: t.string,
+        apiKey: t.string,
     }
 
     componentDidMount() {
@@ -33,12 +33,15 @@ class ClientProviderComponent extends Component {
     }
 
     setup() {
-        const { authKey } = this.props
-        if (!authKey || this.state.client) { return }
+        const { apiKey } = this.props
+        if (!apiKey || this.state.client) { return }
         this.setState({
             client: new StreamrClient({
                 url: process.env.STREAMR_WS_URL,
-                authKey,
+                restUrl: process.env.STREAMR_API_URL,
+                auth: {
+                    apiKey,
+                },
                 autoConnect: true,
                 autoDisconnect: true,
             }),
@@ -54,7 +57,7 @@ class ClientProviderComponent extends Component {
 
     send = async (rest) => (
         services.send({
-            authKey: this.props.authKey,
+            apiKey: this.props.apiKey,
             ...rest,
         })
     )
@@ -73,19 +76,19 @@ class ClientProviderComponent extends Component {
     }
 }
 
-export const withAuthKey = connect((state) => ({
-    authKey: selectAuthApiKeyId(state),
+const withAuthApiKey = connect((state) => ({
+    apiKey: selectAuthApiKeyId(state),
 }), {
     loadKeys: getMyResourceKeys,
 })
 
-export const ClientProvider = withAuthKey(class ClientProvider extends React.Component {
+export const ClientProvider = withAuthApiKey(class ClientProvider extends React.Component {
     state = {
         isLoading: false,
     }
 
     async loadIfNoKey() {
-        if (this.state.isLoading || this.props.authKey) { return }
+        if (this.state.isLoading || this.props.apiKey) { return }
         this.setState({ isLoading: true })
         try {
             await this.props.loadKeys()
@@ -104,10 +107,10 @@ export const ClientProvider = withAuthKey(class ClientProvider extends React.Com
 
     render() {
         const { loadKey, ...props } = this.props
-        if (!props.authKey) { return null }
-        // new client if authKey changes
+        if (!props.apiKey) { return null }
+        // new client if apiKey changes
         return (
-            <ClientProviderComponent key={props.authKey} {...props} />
+            <ClientProviderComponent key={props.apiKey} {...props} />
         )
     }
 })

--- a/app/src/editor/shared/services.js
+++ b/app/src/editor/shared/services.js
@@ -16,7 +16,7 @@ export const LOAD_JSON_REQ = {
 }
 
 export async function send({
-    authKey,
+    apiKey,
     data = {},
     dashboardId,
     canvasId,
@@ -29,7 +29,7 @@ export async function send({
         ...LOAD_JSON_REQ,
         ...data,
     }, {
-        Authorization: `Token ${authKey}`,
+        Authorization: `Token ${apiKey}`,
     }).then(getData)
 }
 

--- a/app/src/editor/shared/tests/autosave.test.jsx
+++ b/app/src/editor/shared/tests/autosave.test.jsx
@@ -1,0 +1,61 @@
+import Autosave from '../utils/autosave'
+
+function delay(delay) {
+    return new Promise((resolve) => setTimeout(resolve, delay))
+}
+
+describe('autosave', () => {
+    it('runs saveFn after waiting', async () => {
+        const saveFn = jest.fn().mockImplementation(async (input) => input)
+        const wait = 1000
+        const autosave = Autosave(saveFn, wait)
+
+        const value = { value: true }
+        const startedAt = Date.now()
+        expect(await autosave(value)).toBe(value)
+        // at least wait ms elapsed
+        expect(Date.now() - startedAt).toBeGreaterThan(wait)
+        expect(saveFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('runs saveFn at most once after waiting', async () => {
+        const saveFn = jest.fn().mockImplementation(async (input) => input)
+        const wait = 100
+        const autosave = Autosave(saveFn, wait)
+
+        const value1 = { value: 1 }
+        const value2 = { value: 2 }
+
+        expect(autosave.pending).toBeFalsy()
+
+        const task1 = autosave(value1)
+        expect(autosave.pending).toBeTruthy()
+        await delay(50)
+        expect(autosave.pending).toBeTruthy()
+        const task2 = autosave(value2)
+        expect(autosave.pending).toBeTruthy()
+
+        expect(await task1).toBe(value2)
+        expect(await task2).toBe(value2)
+        expect(autosave.pending).toBeFalsy()
+
+        expect(saveFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('can cancel pending', async () => {
+        const saveFn = jest.fn().mockImplementation(async (input) => input)
+        const wait = 500
+        const autosave = Autosave(saveFn, wait)
+
+        const value = { value: 1 }
+
+        const task = autosave(value)
+        expect(autosave.pending).toBeTruthy()
+        const cancelTask = autosave.cancel()
+        expect(autosave.pending).toBeFalsy()
+        expect(await task).toBe(false)
+        expect(await cancelTask).toBeFalsy()
+
+        expect(saveFn).not.toHaveBeenCalled()
+    })
+})

--- a/app/src/editor/shared/tests/autosave.test.jsx
+++ b/app/src/editor/shared/tests/autosave.test.jsx
@@ -1,58 +1,72 @@
-import Autosave from '../utils/autosave'
+import { CancellableDebounce } from '../utils/autosave'
 
 function delay(delay) {
     return new Promise((resolve) => setTimeout(resolve, delay))
 }
 
-describe('autosave', () => {
+describe('CancellableDebounce', () => {
+    it('can handle rejections', async () => {
+        const rejection = new Error('expected rejection')
+        const saveFn = jest.fn().mockRejectedValue(rejection)
+        const wait = 100
+        const debouncedFn = CancellableDebounce(saveFn, wait)
+
+        const value = { value: true }
+        await expect(debouncedFn(value)).rejects.toBe(rejection)
+        expect(saveFn).toHaveBeenCalledTimes(1)
+        expect(saveFn).toHaveBeenCalledWith(value)
+    })
+
     it('runs saveFn after waiting', async () => {
         const saveFn = jest.fn().mockImplementation(async (input) => input)
         const wait = 1000
-        const autosave = Autosave(saveFn, wait)
+        const debouncedFn = CancellableDebounce(saveFn, wait)
 
         const value = { value: true }
         const startedAt = Date.now()
-        expect(await autosave(value)).toBe(value)
+        expect(await debouncedFn(value)).toBe(value)
         // at least wait ms elapsed
         expect(Date.now() - startedAt).toBeGreaterThan(wait)
         expect(saveFn).toHaveBeenCalledTimes(1)
+        expect(saveFn).toHaveBeenCalledWith(value)
     })
 
     it('runs saveFn at most once after waiting', async () => {
         const saveFn = jest.fn().mockImplementation(async (input) => input)
         const wait = 100
-        const autosave = Autosave(saveFn, wait)
+        const debouncedFn = CancellableDebounce(saveFn, wait)
 
         const value1 = { value: 1 }
         const value2 = { value: 2 }
 
-        expect(autosave.pending).toBeFalsy()
+        expect(debouncedFn.pending).toBeFalsy()
 
-        const task1 = autosave(value1)
-        expect(autosave.pending).toBeTruthy()
+        const task1 = debouncedFn(value1)
+        expect(debouncedFn.pending).toBeTruthy()
         await delay(50)
-        expect(autosave.pending).toBeTruthy()
-        const task2 = autosave(value2)
-        expect(autosave.pending).toBeTruthy()
+        expect(debouncedFn.pending).toBeTruthy()
+        const task2 = debouncedFn(value2)
+        expect(debouncedFn.pending).toBeTruthy()
 
         expect(await task1).toBe(value2)
         expect(await task2).toBe(value2)
-        expect(autosave.pending).toBeFalsy()
+        expect(debouncedFn.pending).toBeFalsy()
 
         expect(saveFn).toHaveBeenCalledTimes(1)
+        expect(saveFn).toHaveBeenCalledWith(value2)
     })
 
     it('can cancel pending', async () => {
         const saveFn = jest.fn().mockImplementation(async (input) => input)
         const wait = 500
-        const autosave = Autosave(saveFn, wait)
+        const debouncedFn = CancellableDebounce(saveFn, wait)
 
         const value = { value: 1 }
 
-        const task = autosave(value)
-        expect(autosave.pending).toBeTruthy()
-        const cancelTask = autosave.cancel()
-        expect(autosave.pending).toBeFalsy()
+        const task = debouncedFn(value)
+        expect(debouncedFn.pending).toBeTruthy()
+        const cancelTask = debouncedFn.cancel()
+        expect(debouncedFn.pending).toBeFalsy()
         expect(await task).toBe(false)
         expect(await cancelTask).toBeFalsy()
 

--- a/app/src/editor/shared/utils/autosave.js
+++ b/app/src/editor/shared/utils/autosave.js
@@ -11,7 +11,7 @@ function unsavedUnloadWarning(event) {
  * Autosave is basically a cancellable debounce with a beforeunload handler.
  */
 
-export default function Autosave(saveFn, opts) {
+export default function Autosave(saveFn, ...opts) {
     // keep returning the same promise until autosave fires
     // resolve/reject autosave when debounce finally runs & save is complete
     function autosave(canvas, ...args) {
@@ -58,7 +58,7 @@ export default function Autosave(saveFn, opts) {
                 Object.assign(autosave, {
                     run,
                     cancel,
-                    runLater: debounce(run, opts),
+                    runLater: debounce(run, ...opts),
                 })
             })
             return pending

--- a/app/src/editor/shared/utils/autosave.js
+++ b/app/src/editor/shared/utils/autosave.js
@@ -1,3 +1,4 @@
+import Emitter from 'events'
 import debounce from 'lodash/debounce'
 
 function unsavedUnloadWarning(event) {
@@ -7,26 +8,24 @@ function unsavedUnloadWarning(event) {
     return confirmationMessage // Webkit, Safari, Chrome etc.
 }
 
-/**
- * Autosave is basically a cancellable debounce with a beforeunload handler.
- */
+export function CancellableDebounce(fn, waitTime) {
+    const emitter = new Emitter()
 
-export default function Autosave(saveFn, ...opts) {
     // keep returning the same promise until autosave fires
     // resolve/reject autosave when debounce finally runs & save is complete
-    function autosave(canvas, ...args) {
+    function autosave(...args) {
         function wait() {
             const pending = new Promise((resolve, reject) => {
                 let canRun = true
-                window.addEventListener('beforeunload', unsavedUnloadWarning)
+                emitter.emit('start', ...args)
 
                 // warn user if changes not yet saved
                 function reset() {
                     canRun = false
                     // clear state for next run
-                    window.removeEventListener('beforeunload', unsavedUnloadWarning)
+                    emitter.emit('reset', undefined, ...args)
                     Object.assign(autosave, {
-                        run: saveFn,
+                        run: fn,
                         cancel: Function.prototype,
                         runLater: autosave,
                         pending: undefined,
@@ -35,30 +34,30 @@ export default function Autosave(saveFn, ...opts) {
 
                 async function cancel() {
                     reset()
-                    console.info('Autosave cancelled', canvas.id) // eslint-disable-line no-console
+                    emitter.emit('cancel', undefined, ...args)
                     return Promise.resolve(false).then(resolve, reject)
                 }
 
                 // capture debounced function
-                async function run(canvas, ...args) {
+                function run(...args) {
                     if (!canRun) { return } // noop if cancelled
+
                     reset()
-                    try {
-                        const result = await saveFn(canvas, ...args)
-                        // TODO: temporary logs until notifications work again
-                        console.info('Autosaved', canvas.id) // eslint-disable-line no-console
-                        resolve(result)
-                    } catch (err) {
-                        console.warn('Autosave failed', canvas.id, err) // eslint-disable-line no-console
-                        reject(err)
-                    }
+                    fn(...args).then((result) => {
+                        emitter.emit('end', result, ...args)
+                        return resolve(result)
+                    }, (error) => {
+                        // emits fail instead of error as we don't want unhandled error bubbling behaviour
+                        emitter.emit('fail', error, ...args)
+                        return reject(error)
+                    })
                     return pending
                 }
 
                 Object.assign(autosave, {
                     run,
                     cancel,
-                    runLater: debounce(run, ...opts),
+                    runLater: debounce(run, waitTime),
                 })
             })
             return pending
@@ -67,12 +66,42 @@ export default function Autosave(saveFn, ...opts) {
         if (!autosave.pending) {
             autosave.pending = wait()
         }
-        autosave.runLater(canvas, ...args) // run debounced save with latest args
+        autosave.runLater(...args) // run debounced save with latest args
         return autosave.pending
     }
+
     return Object.assign(autosave, {
-        run: saveFn,
+        run: fn,
         runLater: autosave,
         cancel: Function.prototype,
+        emitter,
+        on: emitter.on.bind(emitter),
+        off: emitter.on.bind(emitter),
+        once: emitter.on.bind(emitter),
     })
+}
+
+/**
+ * Autosave is basically a cancellable debounce with a beforeunload handler.
+ */
+
+export default function Autosave(saveFn, waitTime) {
+    const debounced = CancellableDebounce(saveFn, waitTime)
+    debounced
+        .on('done', (_, canvas = {}) => {
+            console.info('Autosaved', canvas.id) // eslint-disable-line no-console
+        })
+        .on('cancel', (_, canvas = {}) => {
+            console.info('Autosave cancelled', canvas.id) // eslint-disable-line no-console
+        })
+        .on('fail', (err, canvas = {}) => {
+            console.warn('Autosave failed', canvas.id, err) // eslint-disable-line no-console
+        })
+        .on('start', () => {
+            window.addEventListener('beforeunload', unsavedUnloadWarning)
+        })
+        .on('reset', () => {
+            window.removeEventListener('beforeunload', unsavedUnloadWarning)
+        })
+    return debounced
 }

--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -97,7 +97,10 @@ export class StreamLivePreview extends Component<Props, State> {
         if (!cachedClient || (authApiKeyId && cachedClient.options.apiKey !== authApiKeyId)) {
             cachedClient = new StreamrClient({
                 url: process.env.STREAMR_WS_URL,
-                apiKey: authApiKeyId || undefined,
+                restUrl: process.env.STREAMR_API_URL,
+                auth: {
+                    apiKey: authApiKeyId || undefined,
+                },
                 autoConnect: true,
                 autoDisconnect: false,
             })

--- a/app/src/userpages/components/StreamrClientProvider/index.jsx
+++ b/app/src/userpages/components/StreamrClientProvider/index.jsx
@@ -52,6 +52,7 @@ function initClient(keyId: ?string) {
 
     return new StreamrClient({
         url: process.env.STREAMR_WS_URL,
+        restUrl: process.env.STREAMR_API_URL,
         auth: {
             apiKey: keyId,
         },

--- a/app/src/userpages/components/WebComponents/StreamrWidget/index.jsx
+++ b/app/src/userpages/components/WebComponents/StreamrWidget/index.jsx
@@ -62,8 +62,8 @@ export default class StreamrWidget extends Component<Props> {
         }
     }
 
-    getHeaders = () => (this.client.options.authKey ? {
-        Authorization: `Token ${this.client.options.authKey}`,
+    getHeaders = () => (this.client.options.auth.apiKey ? {
+        Authorization: `Token ${this.client.options.auth.apiKey}`,
     } : {})
 
     setup() {
@@ -96,7 +96,7 @@ export default class StreamrWidget extends Component<Props> {
             if (this.stream && !this.subscription) {
                 this.subscription = this.client.subscribe({
                     stream: this.stream,
-                    authKey: subscriptionOptions.authKey,
+                    apiKey: subscriptionOptions.apiKey,
                     partition: subscriptionOptions.partition,
                     resend_all: !!(subscriptionOptions.resend_all || (options.uiResendAll && options.uiResendAll.value)),
                     resend_last: subscriptionOptions.resend_last || (options.uiResendLast && options.uiResendLast.value),

--- a/app/src/userpages/flowtype/streamr-client-types.js
+++ b/app/src/userpages/flowtype/streamr-client-types.js
@@ -20,7 +20,7 @@ export type StreamId = string
 
 export type SubscriptionOptions = {
     stream?: StreamId,
-    authKey?: string,
+    apiKey?: string,
     partition?: number,
     resend_all?: boolean,
     resend_last?: number,
@@ -46,7 +46,10 @@ export type StreamrClient = {
 
 export type StreamrClientOptions = {
     url: string,
-    authKey?: ?string,
+    restUrl: string,
+    auth: {
+        apiKey?: ?string,
+    },
     autoConnect: boolean,
     autoDisconnect: boolean
 }

--- a/app/test/test-utils/setupTests.js
+++ b/app/test/test-utils/setupTests.js
@@ -1,6 +1,9 @@
 import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import moxios from 'moxios'
+import dotenv from '../../scripts/dotenv'
+
+dotenv()
 
 moxios.promiseWait = () => new Promise((resolve) => moxios.wait(resolve))
 


### PR DESCRIPTION
* Adds some tests for editor apis.
* Hits locally running server, thus these tests currently won't run in CI.
* Note method for creating throwaway user in `editor/canvas/test/util.js`.
* Added tests for most service calls, but none around module apis since they're not accessed via /api/v1/ and thus don't work with the bearer auth.
* Update: also added some tests around the autosave functionality.

Invoke the api tests with `npm run test-local`

Could possibly look into using something like https://netflix.github.io/pollyjs/ so tests can run in CI.