### PR TITLE
[PLATFORM-396] Don't show uiChannel streams in streams listing page

### DIFF
--- a/app/src/userpages/flowtype/common-types.js
+++ b/app/src/userpages/flowtype/common-types.js
@@ -21,6 +21,8 @@ export type Filter = {
     order?: ?SortOrder,
     key?: ?string,
     value?: ?string,
+    adhoc?: boolean,
+    uiChannel?: boolean,
 }
 
 export type SortOption = {

--- a/app/src/userpages/modules/canvas/actions.js
+++ b/app/src/userpages/modules/canvas/actions.js
@@ -85,6 +85,7 @@ export const getCanvases = () => (dispatch: Function, getState: () => StoreState
 
     const filter = selectFilter(getState())
     const params = getParamsForFilter(filter, {
+        adhoc: false,
         sortBy: 'lastUpdated',
     })
 

--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -260,6 +260,7 @@ export const getStreams = () => (dispatch: Function, getState: Function) => {
 
     const filter = selectFilter(getState())
     const params = getParamsForFilter(filter, {
+        uiChannel: false,
         sortBy: 'lastUpdated',
     })
 

--- a/app/src/userpages/utils/filters.js
+++ b/app/src/userpages/utils/filters.js
@@ -1,5 +1,6 @@
 // @flow
 
+import defaults from 'lodash/defaults'
 import type { Filter } from '$userpages/flowtype/common-types'
 
 type FilterDefaults = {
@@ -8,21 +9,14 @@ type FilterDefaults = {
     order?: string,
 }
 
-export const getParamsForFilter = (filter: ?Filter, defaultValues?: FilterDefaults) => {
-    const { sortBy: defaultSortBy, search: defaultSearch, order: defaultOrder } = defaultValues || {}
-    const {
-        sortBy,
-        search,
-        order,
-        key,
-        value,
-    } = filter || {}
+export const getParamsForFilter = (filter: ?Filter, defaultValues?: FilterDefaults = {}) => {
+    // special handling for key+value
+    const { key, value, ...filterOptions } = (filter || {})
+
+    const options = defaults({}, filterOptions, defaultValues, { order: 'desc' })
 
     return {
-        adhoc: false,
-        sortBy: sortBy || defaultSortBy || null,
-        search: search || defaultSearch || null,
-        order: order || defaultOrder || 'desc',
+        ...options,
         ...(key && value ? {
             [key]: value,
         } : {}),

--- a/app/test/unit/utils/filters.test.js
+++ b/app/test/unit/utils/filters.test.js
@@ -5,11 +5,11 @@ describe('getParamsForFilter', () => {
 
     describe('order', () => {
         it('is `desc` by out of the box', () => {
-            expect(f(null, null)).toHaveProperty('order', 'desc')
+            expect(f(undefined, undefined)).toHaveProperty('order', 'desc')
         })
 
         it('defaults to given default order', () => {
-            expect(f(null, {
+            expect(f(undefined, {
                 order: 'FOO',
             })).toHaveProperty('order', 'FOO')
 
@@ -18,7 +18,7 @@ describe('getParamsForFilter', () => {
             })).toHaveProperty('order', 'FOO')
 
             expect(f({
-                order: null,
+                order: undefined,
             }, {
                 order: 'FOO',
             })).toHaveProperty('order', 'FOO')
@@ -38,12 +38,12 @@ describe('getParamsForFilter', () => {
     })
 
     describe('search', () => {
-        it('is null by out of the box', () => {
-            expect(f(null, null)).toHaveProperty('search', null)
+        it('is empty out of the box', () => {
+            expect(f(undefined, undefined).search).toBeUndefined()
         })
 
         it('defaults to given default search', () => {
-            expect(f(null, {
+            expect(f(undefined, {
                 search: 'FOO',
             })).toHaveProperty('search', 'FOO')
 
@@ -52,7 +52,7 @@ describe('getParamsForFilter', () => {
             })).toHaveProperty('search', 'FOO')
 
             expect(f({
-                search: null,
+                search: undefined,
             }, {
                 search: 'FOO',
             })).toHaveProperty('search', 'FOO')
@@ -72,12 +72,12 @@ describe('getParamsForFilter', () => {
     })
 
     describe('sortBy', () => {
-        it('is null by out of the box', () => {
-            expect(f(null, null)).toHaveProperty('sortBy', null)
+        it('is empty out of the box', () => {
+            expect(f(undefined, undefined).sortBy).toBeUndefined()
         })
 
         it('defaults to given default sortBy', () => {
-            expect(f(null, {
+            expect(f(undefined, {
                 sortBy: 'FOO',
             })).toHaveProperty('sortBy', 'FOO')
 
@@ -86,7 +86,7 @@ describe('getParamsForFilter', () => {
             })).toHaveProperty('sortBy', 'FOO')
 
             expect(f({
-                sortBy: null,
+                sortBy: undefined,
             }, {
                 sortBy: 'FOO',
             })).toHaveProperty('sortBy', 'FOO')
@@ -107,43 +107,33 @@ describe('getParamsForFilter', () => {
 
     describe('[key]', () => {
         it('is skipped if either key or value are blank', () => {
-            expect(f(null)).toMatchObject({
+            expect(f(undefined)).toMatchObject({
                 order: 'desc',
-                search: null,
-                sortBy: null,
             })
 
             expect(f({})).toMatchObject({
                 order: 'desc',
-                search: null,
-                sortBy: null,
             })
 
             expect(f({
-                key: null,
-                value: null,
+                key: undefined,
+                value: undefined,
             })).toMatchObject({
                 order: 'desc',
-                search: null,
-                sortBy: null,
             })
 
             expect(f({
                 key: 'FOO',
-                value: null,
+                value: undefined,
             })).toMatchObject({
                 order: 'desc',
-                search: null,
-                sortBy: null,
             })
 
             expect(f({
-                key: null,
+                key: undefined,
                 value: 'FOO',
             })).toMatchObject({
                 order: 'desc',
-                search: null,
-                sortBy: null,
             })
         })
 


### PR DESCRIPTION
This filters uiChannel streams out of the userpages streams listing page.

# Before

Note lots of random streams for UI components:

![image](https://user-images.githubusercontent.com/43438/52894430-1704b600-31e4-11e9-8efa-4ad0e3571462.png)

# After

Note the much smaller list of streams after uiChannel streams are removed:

![image](https://user-images.githubusercontent.com/43438/52894613-5680d180-31e7-11e9-97c1-4c004f6746b4.png)


This is the same listing of streams shown in the old UI:

![image](https://user-images.githubusercontent.com/43438/52894556-5af8ba80-31e6-11e9-9aa5-e0e0e0cf31d0.png)
 
----

#### Also
* Now allows pages to define their own default filter parameters. e.g. before every filter query got `adhoc=false` even though it's only relevant to canvas requests.
* Should generally prefer using `undefined` over `null` as `null` prevents application of default value via destructuring or function args or when using utilities like `lodash/defaults`.