### PR TITLE
[PLATFORM-394] Docs Tables

### DIFF
--- a/app/src/docs/components/ApiPage/Content.mdx
+++ b/app/src/docs/components/ApiPage/Content.mdx
@@ -1,7 +1,4 @@
 import ScrollableAnchor from 'react-scrollable-anchor'
-import { Table } from 'reactstrap'
-
-import styles from '../DocsLayout/docsLayout.pcss'
 
 # Streamr APIs
 Streamr provides a set of APIs for easy integration with other systems. The APIs cover authentication, data input, data output, and managing various resources within Streamr (such as Streams, Canvases, Products, and Dashboards).
@@ -28,43 +25,17 @@ If you'd like to contribute a client library and get it listed here, please get 
 ## Authentication
 A session token is required to make requests to the REST API endpoints or over the websocket protocol. You can obtain a session token by authenticating either using an API key or by signing a cryptographic challenge using an Ethereum private key.
 
-Once you get a <span className={styles.inlineHighlight}>session token</span> using one of the below methods, see the section on using it.
+Once you get a <kbd>session token</kbd> using one of the below methods, see the section on using it.
 
 ### Response code
 
-<Table>
-    <thead>
-        <tr>
-            <th>code</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <th>200</th>
-            <td>Success (the response is empty)</td>
-        </tr>
-        <tr>
-            <th>400</th>
-            <td>Invalid request</td>
-        </tr>
-        <tr>
-            <th>401</th>
-            <td>Permission denied</td>
-        </tr>
-        <tr>
-            <th>403</th>
-            <td>Authentication failed</td>
-        </tr>
-        <tr>
-            <th>404</th>
-            <td>Stream not found</td>
-        </tr>        
-        <tr>
-            <th>500</th>
-            <td>Unexpected error</td>
-        </tr>            
-    </tbody>
-</Table>
+code | Description
+:--- | :---:
+200 | Success (the response is empty)
+400 | Invalid request
+401 | Permission denied
+403 | Authentication failed
+404 | Stream not found
+500 | Unexpected error
 
 </div></ScrollableAnchor>

--- a/app/src/docs/components/ApiPage/Content.mdx
+++ b/app/src/docs/components/ApiPage/Content.mdx
@@ -29,7 +29,7 @@ Once you get a <kbd>session token</kbd> using one of the below methods, see the 
 
 ### Response code
 
-code | Description
+Code | Description
 :--- | :---:
 200 | Success (the response is empty)
 400 | Invalid request

--- a/app/src/docs/components/ApiPage/Content.mdx
+++ b/app/src/docs/components/ApiPage/Content.mdx
@@ -1,4 +1,7 @@
 import ScrollableAnchor from 'react-scrollable-anchor'
+import { Table } from 'reactstrap'
+
+import styles from '../DocsLayout/docsLayout.pcss'
 
 # Streamr APIs
 Streamr provides a set of APIs for easy integration with other systems. The APIs cover authentication, data input, data output, and managing various resources within Streamr (such as Streams, Canvases, Products, and Dashboards).
@@ -25,5 +28,43 @@ If you'd like to contribute a client library and get it listed here, please get 
 ## Authentication
 A session token is required to make requests to the REST API endpoints or over the websocket protocol. You can obtain a session token by authenticating either using an API key or by signing a cryptographic challenge using an Ethereum private key.
 
-Once you get a session token using one of the below methods, see the section on using it.
+Once you get a <span className={styles.inlineHighlight}>session token</span> using one of the below methods, see the section on using it.
+
+### Response code
+
+<Table>
+    <thead>
+        <tr>
+            <th>code</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>200</th>
+            <td>Success (the response is empty)</td>
+        </tr>
+        <tr>
+            <th>400</th>
+            <td>Invalid request</td>
+        </tr>
+        <tr>
+            <th>401</th>
+            <td>Permission denied</td>
+        </tr>
+        <tr>
+            <th>403</th>
+            <td>Authentication failed</td>
+        </tr>
+        <tr>
+            <th>404</th>
+            <td>Stream not found</td>
+        </tr>        
+        <tr>
+            <th>500</th>
+            <td>Unexpected error</td>
+        </tr>            
+    </tbody>
+</Table>
+
 </div></ScrollableAnchor>

--- a/app/src/docs/components/DocsLayout/docsLayout.pcss
+++ b/app/src/docs/components/DocsLayout/docsLayout.pcss
@@ -112,21 +112,27 @@
     font-weight: var(--medium);
   }
 
-  .inlineHighlight {
+  kbd {
+    color: #323232;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 12px;
     background-color: #EFEFEF;
     padding: 2px 4px;
     border-radius: 2px;
   }
 
   table {
+    width: 100%;
     border: 1px solid #E7E7E7;
+    margin: 2em 0;
 
     th,
     td {
+      text-align: left;
       font-size: 14px;
       line-height: 24px;
       font-weight: var(--regular);
-      border-left: 1px solid #E7E7E7;
+      border: 1px solid #E7E7E7;
       padding: 1em 1.5em;
     }
 

--- a/app/src/docs/components/DocsLayout/docsLayout.pcss
+++ b/app/src/docs/components/DocsLayout/docsLayout.pcss
@@ -111,6 +111,36 @@
   strong {
     font-weight: var(--medium);
   }
+
+  .inlineHighlight {
+    background-color: #EFEFEF;
+    padding: 2px 4px;
+    border-radius: 2px;
+  }
+
+  table {
+    border: 1px solid #E7E7E7;
+
+    th,
+    td {
+      font-size: 14px;
+      line-height: 24px;
+      font-weight: var(--regular);
+      border-left: 1px solid #E7E7E7;
+      padding: 1em 1.5em;
+    }
+
+    thead {
+      background-color: #F8F8F8;
+      color: #BABABA;
+
+      th {
+        line-height: 28px;
+        border: none;
+        border-left: 1px solid #E7E7E7;
+      }
+    }
+  }
 }
 
 @media (--md-down) {


### PR DESCRIPTION
Small PR for styling for table usage inside the Docs. ~Ended up with the vanilla reactstrap implementation because we don't need much from it:~
Update: Decided on using the native implementation of table. 

<img width="688" alt="screenshot 2019-02-19 at 11 04 42" src="https://user-images.githubusercontent.com/1593398/53002781-31ce6900-3436-11e9-8e63-3135efaaefec.png">

~And, also added the inline highlighting of keywords:~
Update: Decided on using the native implementation of 'KBD' for inline highlighting.
 
<img width="677" alt="screenshot 2019-02-19 at 11 05 22" src="https://user-images.githubusercontent.com/1593398/53002850-5de9ea00-3436-11e9-9831-2e00a7d77d1e.png">

Designs:
https://share.goabstract.com/73496436-3d33-45af-b79d-afc7f696bc30

