### PR TITLE
[PLATFORM-416] Ensure canvas background is focusable.

### DIFF
--- a/app/src/editor/canvas/components/Canvas.pcss
+++ b/app/src/editor/canvas/components/Canvas.pcss
@@ -18,6 +18,7 @@
   top: 0;
   left: 0;
   bottom: 0;
+  right: 0;
   margin-bottom: 20px;
   margin-right: 20px;
 }


### PR DESCRIPTION
Fixes both click to deselect PLATFORM-416 & click to close sidebar drawer PLATFORM-417 issues.

Also I cannot reproduce PLATFORM-418: scrollbars on sidebar open but I recall this being an issue in the past. Perhaps @mattatgit is looking at an older version and PLATFORM-418 is already fixed?

