### PR TITLE
[PLATFORM-424] Don't show own module port states when dragging connection

### DIFF
--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -67,8 +67,9 @@ class PortIcon extends React.PureComponent {
         const dragPortInProgress = (
             this.context.isDragging // something is dragging
             && this.context.data.portId != null // something has a port
-            && !arePortsOfSameModule(canvas, this.context.data.portId, port.id) // dragged port doesn't belong to same module as this
         )
+
+        const draggingFromSameModule = arePortsOfSameModule(canvas, this.context.data.portId, port.id)
 
         const from = this.context.data || {}
         const fromId = from.sourceId || from.portId
@@ -87,6 +88,7 @@ class PortIcon extends React.PureComponent {
                     [styles.noRepeat]: port.noRepeat,
                     [styles.dragPortInProgress]: dragPortInProgress,
                     [styles.canDrop]: canDrop,
+                    [styles.draggingFromSameModule]: draggingFromSameModule,
                 })}
             >
                 <div className={styles.portIconInner}>

--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -5,7 +5,7 @@ import startCase from 'lodash/startCase'
 
 import RenameInput from '$editor/shared/components/RenameInput'
 
-import { RunStates, canConnectPorts } from '../state'
+import { RunStates, canConnectPorts, arePortsOfSameModule } from '../state'
 
 import { DropTarget, DragSource } from './PortDragger'
 import { DragDropContext } from './DragDropContext'
@@ -64,7 +64,12 @@ class PortIcon extends React.PureComponent {
     render() {
         const { port, canvas, api } = this.props
         const isInput = !!port.acceptedTypes
-        const dragPortInProgress = this.context.isDragging && this.context.data.portId != null
+        const dragPortInProgress = (
+            this.context.isDragging // something is dragging
+            && this.context.data.portId != null // something has a port
+            && !arePortsOfSameModule(canvas, this.context.data.portId, port.id) // dragged port doesn't belong to same module as this
+        )
+
         const from = this.context.data || {}
         const fromId = from.sourceId || from.portId
         const canDrop = dragPortInProgress && canConnectPorts(this.props.canvas, fromId, this.props.port.id)
@@ -589,4 +594,3 @@ export default class Ports extends React.Component {
         )
     }
 }
-

--- a/app/src/editor/canvas/components/Ports.pcss
+++ b/app/src/editor/canvas/components/Ports.pcss
@@ -106,12 +106,12 @@
   border-color: var(--no-repeat-color);
 }
 
-.ports .PortIcon:not(.isDragging).dragPortInProgress .portIconGraphic {
+.ports .PortIcon:not(.isDragging):not(.draggingFromSameModule).dragPortInProgress .portIconGraphic {
   border-color: rgba(255, 255, 255, 0);
   background-color: #C90000;
 }
 
-.ports .PortIcon:not(.isDragging).dragPortInProgress.canDrop .portIconGraphic {
+.ports .PortIcon:not(.isDragging):not(.draggingFromSameModule).dragPortInProgress.canDrop .portIconGraphic {
   background-color: #00C900;
 }
 
@@ -123,7 +123,7 @@
   border-color: var(--connected-color);
 }
 
-.ports .PortIcon.dragPortInProgress .portDropTarget {
+.ports .PortIcon.dragPortInProgress:not(.draggingFromSameModule) .portDropTarget {
   z-index: 2;
 }
 
@@ -140,12 +140,12 @@
   opacity: 1;
 }
 
-.ports .PortIcon.connected.dragPortInProgress .portIconGraphic::after {
+.ports .PortIcon.connected.dragPortInProgress:not(.draggingFromSameModule) .portIconGraphic::after {
   opacity: 0;
 }
 
-.ports .PortIcon.dragPortInProgress.canDrop:hover .portDropTarget,
-.ports .PortIcon.dragPortInProgress.canDrop:hover .portIconGraphic {
+.ports .PortIcon.dragPortInProgress:not(.draggingFromSameModule).canDrop:hover .portDropTarget,
+.ports .PortIcon.dragPortInProgress:not(.draggingFromSameModule).canDrop:hover .portIconGraphic {
   transform: scale(1.5);
 }
 

--- a/app/src/editor/canvas/components/Ports.pcss
+++ b/app/src/editor/canvas/components/Ports.pcss
@@ -189,6 +189,10 @@
   pointer-events: none;
 }
 
+.ports .PortIcon.dragPortInProgress:not(.canDrop) .portDragger {
+  cursor: default;
+}
+
 /**
  * Port Options
  */

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -259,6 +259,13 @@ export function canConnectPorts(canvas, portIdA, portIdB) {
     return inputTypes.has(output.type)
 }
 
+export function arePortsOfSameModule(canvas, portIdA, portIdB) {
+    const moduleA = getModuleForPort(canvas, portIdA)
+    const moduleB = getModuleForPort(canvas, portIdB)
+    if (!moduleA || !moduleB) { return false }
+    return moduleA.hash === moduleB.hash
+}
+
 function hasVariadicPort(canvas, moduleHash, type) {
     if (!type) { throw new Error('type missing') }
     const canvasModule = getModule(canvas, moduleHash)


### PR DESCRIPTION
![no-style-own-ports](https://user-images.githubusercontent.com/43438/54104452-f4dd0d00-440a-11e9-8753-d4ecf6b71482.gif)

