### PR TITLE
Enable git information via streamr.info for prod builds.

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -166,6 +166,8 @@ module.exports = {
         new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.EnvironmentPlugin({
             NODE_ENV: 'production',
+            GIT_VERSION: gitRevisionPlugin.version(),
+            GIT_BRANCH: gitRevisionPlugin.branch(),
         }),
         new UglifyJsPlugin({
             uglifyOptions: {


### PR DESCRIPTION
Git information currently missing from 'production' deployments e.g. staging.

![image](https://user-images.githubusercontent.com/43438/54181892-f6760600-44da-11e9-98a6-a2cde091b2ec.png)