### PR TITLE
[PLATFORM-109] Editor notification when autosave fails

### DIFF
--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -72,7 +72,7 @@ class CanvasModule extends React.PureComponent {
             // Check if reload is needed after the change
             const port = this.props.module.params.find((p) => p.id === portId)
 
-            if (!this.unmounted && port.updateOnChange && port && port.value === value) {
+            if (!this.unmounted && port && port.updateOnChange && port.value === value) {
                 this.props.api.loadNewDefinition(this.props.module.hash)
             }
         })

--- a/app/src/editor/canvas/components/ShareDialog.jsx
+++ b/app/src/editor/canvas/components/ShareDialog.jsx
@@ -4,27 +4,22 @@ import Modal from '$editor/shared/components/Modal'
 import UserPageShareDialog from '$userpages/components/ShareDialog'
 
 const ShareDialog = (props) => {
-    const { isOpen, modalApi, canvas } = props
-    if (!isOpen || !canvas) { return null }
+    const { modalApi, canvas } = props
+    if (!canvas) { return null }
     return (
-        <React.Fragment>
-            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-            <div hidden={!isOpen}>
-                <UserPageShareDialog
-                    resourceTitle={canvas.name}
-                    resourceType="CANVAS"
-                    resourceId={canvas.id}
-                    onClose={() => modalApi.close()}
-                />
-            </div>
-        </React.Fragment>
+        <UserPageShareDialog
+            resourceTitle={canvas.name}
+            resourceType="CANVAS"
+            resourceId={canvas.id}
+            onClose={() => modalApi.close()}
+        />
     )
 }
 
 export default (props) => (
     <Modal modalId="ShareDialog">
-        {({ api, value }) => (
-            <ShareDialog isOpen={value} modalApi={api} {...props} />
+        {({ api }) => (
+            <ShareDialog modalApi={api} {...props} />
         )}
     </Modal>
 )

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -13,8 +13,6 @@ import Subscription from '$editor/shared/components/Subscription'
 import { ClientProvider } from '$editor/shared/components/Client'
 import { ModalProvider } from '$editor/shared/components/Modal'
 import * as sharedServices from '$editor/shared/services'
-import Notification from '$shared/utils/Notification'
-import { NotificationIcon } from '$shared/utils/constants'
 
 import Canvas from './components/Canvas'
 import CanvasToolbar from './components/Toolbar'
@@ -117,10 +115,6 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
         const newCanvas = await services.autosave(canvas)
         if (this.unmounted) { return }
-        Notification.push({
-            title: 'Saved',
-            icon: NotificationIcon.CHECKMARK,
-        })
         // ignore new canvas, just extract updated time from it
         this.setState({ updated: setUpdated(newCanvas) }) // call setState to trigger rerender, but actual updated value comes from gDSFP
     }

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -13,6 +13,8 @@ import Subscription from '$editor/shared/components/Subscription'
 import { ClientProvider } from '$editor/shared/components/Client'
 import { ModalProvider } from '$editor/shared/components/Modal'
 import * as sharedServices from '$editor/shared/services'
+import Notification from '$shared/utils/Notification'
+import { NotificationIcon } from '$shared/utils/constants'
 
 import Canvas from './components/Canvas'
 import CanvasToolbar from './components/Toolbar'
@@ -115,6 +117,10 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
         const newCanvas = await services.autosave(canvas)
         if (this.unmounted) { return }
+        Notification.push({
+            title: 'Saved',
+            icon: NotificationIcon.CHECKMARK,
+        })
         // ignore new canvas, just extract updated time from it
         this.setState({ updated: setUpdated(newCanvas) }) // call setState to trigger rerender, but actual updated value comes from gDSFP
     }

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -33,7 +33,7 @@ function autoSaveWithNotification() {
 
     autosave.on('fail', () => {
         Notification.push({
-            title: 'Save failed',
+            title: 'Autosave failed.',
             icon: NotificationIcon.ERROR,
         })
     })
@@ -41,7 +41,7 @@ function autoSaveWithNotification() {
     return autosave
 }
 
-export const autosave = autoSaveWithNotification(save, AUTOSAVE_DELAY)
+export const autosave = autoSaveWithNotification()
 
 export async function saveNow(canvas, ...args) {
     if (autosave.pending) {

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -5,6 +5,8 @@
 import axios from 'axios'
 
 import Autosave from '$editor/shared/utils/autosave'
+import Notification from '$shared/utils/Notification'
+import { NotificationIcon } from '$shared/utils/constants'
 import { emptyCanvas } from './state'
 
 export const API = axios.create({
@@ -26,7 +28,20 @@ async function save(canvas) {
     return API.put(`${canvasesUrl}/${canvas.id}`, canvas).then(getData)
 }
 
-export const autosave = Autosave(save, AUTOSAVE_DELAY)
+function autoSaveWithNotification() {
+    const autosave = Autosave(save, AUTOSAVE_DELAY)
+
+    autosave.on('fail', () => {
+        Notification.push({
+            title: 'Save failed',
+            icon: NotificationIcon.ERROR,
+        })
+    })
+
+    return autosave
+}
+
+export const autosave = autoSaveWithNotification(save, AUTOSAVE_DELAY)
 
 export async function saveNow(canvas, ...args) {
     if (autosave.pending) {

--- a/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
+++ b/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
@@ -67,6 +67,11 @@ class DashboardModuleSearch extends React.PureComponent {
 
     componentDidMount() {
         this.load()
+
+        // focus input on open
+        if (this.input) {
+            this.input.focus()
+        }
     }
 
     componentWillUnmount() {
@@ -97,15 +102,6 @@ class DashboardModuleSearch extends React.PureComponent {
         this.input = el
     }
 
-    componentDidUpdate(prevProps) {
-        // focus input on open
-        if (this.props.isOpen && !prevProps.isOpen) {
-            if (this.input) {
-                this.input.focus()
-            }
-        }
-    }
-
     isOnDashboard = (...args) => (
         !!this.findDashboardItem(...args)
     )
@@ -121,13 +117,13 @@ class DashboardModuleSearch extends React.PureComponent {
     }
 
     render() {
-        const { isOpen, modalApi, dashboard } = this.props
+        const { modalApi, dashboard } = this.props
         if (!dashboard) { return null }
         const availableDashboardModules = groupBy(dashboardModuleSearch(this.state.canvases, this.state.search), 'canvasId')
         return (
             <React.Fragment>
                 {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-                <div className={styles.ModuleSearch} hidden={!isOpen}>
+                <div className={styles.ModuleSearch}>
                     <div className={styles.Header}>
                         <button onClick={() => modalApi.close()}>X</button>
                     </div>
@@ -157,8 +153,8 @@ class DashboardModuleSearch extends React.PureComponent {
 
 export default (props) => (
     <Modal modalId="DashboardModuleSearch">
-        {({ api, value }) => (
-            <DashboardModuleSearch isOpen={value} modalApi={api} {...props} />
+        {({ api }) => (
+            <DashboardModuleSearch modalApi={api} {...props} />
         )}
     </Modal>
 )

--- a/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
+++ b/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
@@ -65,8 +65,20 @@ class DashboardModuleSearch extends React.PureComponent {
         canvases: [],
     }
 
+    constructor(props) {
+        super(props)
+        this.input = React.createRef()
+    }
+
     componentDidMount() {
         this.load()
+        // focus input on open, timeout is needed because React cannot focus to the field
+        // if it's not visible (which it instantly isn't due to the modal loading logic).
+        setTimeout(() => {
+            if (this.input.current) {
+                this.input.current.focus()
+            }
+        }, 100)
     }
 
     componentWillUnmount() {
@@ -77,9 +89,6 @@ class DashboardModuleSearch extends React.PureComponent {
         const canvases = await getCanvases()
         if (this.unmounted) { return }
         this.setState({ canvases }, () => {
-            if (this.input) {
-                this.input.focus()
-            }
         })
     }
 
@@ -95,10 +104,6 @@ class DashboardModuleSearch extends React.PureComponent {
         } else {
             this.props.removeModule(dashboardItem)
         }
-    }
-
-    onInputRef = (el) => {
-        this.input = el
     }
 
     isOnDashboard = (...args) => (
@@ -127,7 +132,7 @@ class DashboardModuleSearch extends React.PureComponent {
                         <button onClick={() => modalApi.close()}>X</button>
                     </div>
                     <div className={styles.Input}>
-                        <input ref={this.onInputRef} placeholder="Search or select a module" value={this.state.search} onChange={this.onChange} />
+                        <input ref={this.input} placeholder="Search or select a module" value={this.state.search} onChange={this.onChange} />
                     </div>
                     <div className={styles.Content}>
                         {Object.entries(availableDashboardModules).map(([canvasId, modules]) => {

--- a/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
+++ b/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
@@ -67,11 +67,6 @@ class DashboardModuleSearch extends React.PureComponent {
 
     componentDidMount() {
         this.load()
-
-        // focus input on open
-        if (this.input) {
-            this.input.focus()
-        }
     }
 
     componentWillUnmount() {
@@ -81,7 +76,11 @@ class DashboardModuleSearch extends React.PureComponent {
     async load() {
         const canvases = await getCanvases()
         if (this.unmounted) { return }
-        this.setState({ canvases })
+        this.setState({ canvases }, () => {
+            if (this.input) {
+                this.input.focus()
+            }
+        })
     }
 
     onChange = (event) => {

--- a/app/src/editor/shared/components/Modal.jsx
+++ b/app/src/editor/shared/components/Modal.jsx
@@ -114,9 +114,13 @@ export class Modal extends React.Component {
         return (
             <ModalContainer modalId={modalId}>
                 {({ value, api, modalId }) => {
+                    const isOpen = !!value
+
+                    if (!isOpen) { return null }
+
                     const content = getContent({
                         children,
-                        isOpen: !!value,
+                        isOpen,
                         data: {
                             modalId,
                             value,
@@ -162,13 +166,17 @@ export default class ModalWithOverlay extends React.Component {
     render() {
         const { children, modalId, overlayClassName } = this.props
         return (
-            <Modal modalId={modalId}>
-                {({ value, api }) => {
+            <ModalContainer modalId={modalId}>
+                {({ value, api, modalId }) => {
                     this.api = api
                     this.value = value
+                    const isOpen = !!value
+
+                    if (!isOpen) { return null }
+
                     const content = getContent({
                         children,
-                        isOpen: !!value,
+                        isOpen,
                         data: {
                             modalId,
                             value,
@@ -180,11 +188,11 @@ export default class ModalWithOverlay extends React.Component {
                         <React.Fragment>
                             {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                             <div className={cx(styles.Overlay, overlayClassName)} onClick={api.close} hidden={!value} />
-                            {content}
+                            <StreamrModal>{content}</StreamrModal>
                         </React.Fragment>
                     )
                 }}
-            </Modal>
+            </ModalContainer>
         )
     }
 }

--- a/app/src/editor/shared/utils/autosave.js
+++ b/app/src/editor/shared/utils/autosave.js
@@ -44,7 +44,7 @@ export function CancellableDebounce(fn, waitTime) {
 
                     reset()
                     fn(...args).then((result) => {
-                        emitter.emit('end', result, ...args)
+                        emitter.emit('done', result, ...args)
                         return resolve(result)
                     }, (error) => {
                         // emits fail instead of error as we don't want unhandled error bubbling behaviour


### PR DESCRIPTION
Adds a notification when autosaving fails in editor. Not sure what else we should notify but maybe it'll give some indication that things start failing. Can be tested by blocking the autosave request in console.

I had to refactor the modal logic a bit since it's using the shared `Modal` component and notifications are not shown if a modal is open. Previously, the editor modals were always in the DOM, just hidden which meant they were always "open" internally.