### PR TITLE
[PLATFORM-434] Add name for private network

### DIFF
--- a/app/src/shared/i18n/en.po
+++ b/app/src/shared/i18n/en.po
@@ -176,6 +176,9 @@ msgstr "Connecting..."
 msgid "shared##errors##unlockWallet"
 msgstr "Please unlock your wallet"
 
+msgid "shared##errors##networkName"
+msgstr "#%{networkId}"
+
 msgid "shared##errors##incorrectEthereumNetwork"
 msgstr ""
 "Please make sure your wallet is set to use Ethereum %{requiredNetworkName} "

--- a/app/src/shared/utils/web3.js
+++ b/app/src/shared/utils/web3.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { I18n } from 'react-redux-i18n'
+
 import { StreamrWeb3, getPublicWeb3 } from '$shared/web3/web3Provider'
 import getConfig from '$shared/web3/config'
 import { ethereumNetworks } from '$shared/utils/constants'
@@ -9,8 +11,12 @@ import type { Hash } from '$shared/flowtype/web3-types'
 export const checkEthereumNetworkIsCorrect = (web3Instance: StreamrWeb3): Promise<void> => web3Instance.getEthereumNetwork()
     .then((network) => {
         const { networkId: requiredNetwork } = getConfig()
-        const requiredNetworkName = ethereumNetworks[requiredNetwork]
-        const currentNetworkName = ethereumNetworks[network] || `#${network}`
+        const requiredNetworkName = ethereumNetworks[requiredNetwork] || I18n.t('shared.errors.networkName', {
+            networkId: requiredNetwork,
+        })
+        const currentNetworkName = ethereumNetworks[network] || I18n.t('shared.errors.networkName', {
+            networkId: network,
+        })
         if (network.toString() !== requiredNetwork.toString()) {
             throw new WrongNetworkSelectedError(requiredNetworkName, currentNetworkName)
         }


### PR DESCRIPTION
Small fix that adds a translation to unknown network name when e.g. trying to purchase a product in the wrong network. This comes up in staging where the network name is not part of the predefined `ethereumNetworks` constant.

Before:
<img width="544" alt="Screen Shot 2019-03-11 at 11 35 28" src="https://user-images.githubusercontent.com/1064982/54200567-5ddc8780-44d4-11e9-9722-b89f73af5830.png">

After:
<img width="543" alt="Screen Shot 2019-03-12 at 14 32 06" src="https://user-images.githubusercontent.com/1064982/54200593-6f259400-44d4-11e9-9320-97825f477cf5.png">
<img width="541" alt="Screen Shot 2019-03-12 at 14 30 05" src="https://user-images.githubusercontent.com/1064982/54200664-9aa87e80-44d4-11e9-8347-304ed11923a6.png">

