### PR TITLE
Tests for basic canvas operations

### DIFF
--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -113,7 +113,7 @@ class Cables extends React.PureComponent {
         return [
             ...cables,
             this.getDragCable(), // append dragging cable
-        ]
+        ].filter(Boolean)
     }
 
     getDragCable() {

--- a/app/src/editor/canvas/components/ModuleSidebar.jsx
+++ b/app/src/editor/canvas/components/ModuleSidebar.jsx
@@ -14,6 +14,7 @@ import ModuleHelp from './ModuleHelp'
 
 export default withErrorBoundary(ErrorComponentView)(class ModuleSidebar extends React.PureComponent {
     onChange = (name) => (_value) => {
+        if (this.props.selectedModuleHash == null) { return }
         const module = CanvasState.getModule(this.props.canvas, this.props.selectedModuleHash)
         const option = module.options[name]
 
@@ -46,10 +47,11 @@ export default withErrorBoundary(ErrorComponentView)(class ModuleSidebar extends
 
     render() {
         const { canvas, selectedModuleHash, isOpen, open } = this.props
-        const module = CanvasState.getModule(canvas, selectedModuleHash)
+        const module = CanvasState.getModuleIfExists(canvas, selectedModuleHash)
         if (!module) {
             return <div className={cx(styles.sidebar)} hidden={!isOpen} />
         }
+
         const optionsKeys = Object.keys(module.options || {})
         const isRunning = canvas.state === CanvasState.RunStates.Running
         return (

--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -5,7 +5,7 @@ import startCase from 'lodash/startCase'
 
 import RenameInput from '$editor/shared/components/RenameInput'
 
-import { RunStates, canConnectPorts, arePortsOfSameModule } from '../state'
+import { RunStates, canConnectPorts, arePortsOfSameModule, hasPort } from '../state'
 
 import { DropTarget, DragSource } from './PortDragger'
 import { DragDropContext } from './DragDropContext'
@@ -69,7 +69,8 @@ class PortIcon extends React.PureComponent {
             && this.context.data.portId != null // something has a port
         )
 
-        const draggingFromSameModule = dragPortInProgress && arePortsOfSameModule(canvas, this.context.data.portId, port.id)
+        const sourcePort = dragPortInProgress && (this.context.data.sourceId || this.context.data.portId)
+        const draggingFromSameModule = dragPortInProgress && hasPort(canvas, sourcePort) && arePortsOfSameModule(canvas, sourcePort, port.id)
 
         const from = this.context.data || {}
         const fromId = from.sourceId || from.portId

--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -69,7 +69,7 @@ class PortIcon extends React.PureComponent {
             && this.context.data.portId != null // something has a port
         )
 
-        const draggingFromSameModule = arePortsOfSameModule(canvas, this.context.data.portId, port.id)
+        const draggingFromSameModule = dragPortInProgress && arePortsOfSameModule(canvas, this.context.data.portId, port.id)
 
         const from = this.context.data || {}
         const fromId = from.sourceId || from.portId

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -177,7 +177,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         const newModule = await sharedServices.getModule(module)
 
         if (!this.unmounted) {
-            replace(() => CanvasState.updateModule(this.props.canvas, hash, () => newModule))
+            replace(() => CanvasState.updateCanvas(CanvasState.updateModule(this.props.canvas, hash, () => newModule)))
         }
     }
 
@@ -274,7 +274,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
             }
         }
         if (!newCanvas) { return this.loadParent() }
-        replace(() => newCanvas)
+        replace(() => CanvasState.updateCanvas(newCanvas))
     }
 
     loadParent = async () => {
@@ -282,7 +282,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         const nextId = canvas.settings.parentCanvasId || canvas.id
         const newCanvas = await services.loadCanvas({ id: nextId })
         if (this.unmounted) { return }
-        replace(() => newCanvas)
+        replace(() => CanvasState.updateCanvas(newCanvas))
     }
 
     render() {

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -36,6 +36,14 @@ function setUpdated(canvas) {
     return updated
 }
 
+function canvasUpdater(fn) {
+    return (canvas) => {
+        const nextCanvas = fn(canvas)
+        if (nextCanvas === null || nextCanvas === canvas) { return null }
+        return CanvasState.updateCanvas(nextCanvas)
+    }
+}
+
 const CanvasEditComponent = class CanvasEdit extends Component {
     state = {
         isWaiting: false,
@@ -51,11 +59,12 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     setCanvas = (action, fn, done) => {
         if (this.unmounted) { return }
-        this.props.push(action, (canvas) => {
-            const nextCanvas = fn(canvas)
-            if (nextCanvas === null || nextCanvas === canvas) { return null }
-            return CanvasState.updateCanvas(nextCanvas)
-        }, done)
+        this.props.push(action, canvasUpdater(fn), done)
+    }
+
+    replaceCanvas = (fn, done) => {
+        if (this.unmounted) { return }
+        this.props.replace(canvasUpdater(fn), done)
     }
 
     moduleSearchOpen = (show = true) => {
@@ -172,13 +181,12 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 
     loadNewDefinition = async (hash) => {
-        const { replace } = this.props
         const module = CanvasState.getModule(this.props.canvas, hash)
         const newModule = await sharedServices.getModule(module)
 
-        if (!this.unmounted) {
-            replace(() => CanvasState.updateCanvas(CanvasState.updateModule(this.props.canvas, hash, () => newModule)))
-        }
+        this.replaceCanvas((canvas) => (
+            CanvasState.updateModule(canvas, hash, () => newModule)
+        ))
     }
 
     renameModule = (hash, displayName) => {
@@ -258,7 +266,6 @@ const CanvasEditComponent = class CanvasEdit extends Component {
      * Loads parent canvas on failure/no canvas response
      */
     getNewCanvas = async (fn) => {
-        const { replace } = this.props
         this.setState({ isWaiting: true })
         let newCanvas
         try {
@@ -274,15 +281,15 @@ const CanvasEditComponent = class CanvasEdit extends Component {
             }
         }
         if (!newCanvas) { return this.loadParent() }
-        replace(() => CanvasState.updateCanvas(newCanvas))
+        this.replaceCanvas(() => newCanvas)
     }
 
     loadParent = async () => {
-        const { canvas, replace } = this.props
+        const { canvas } = this.props
         const nextId = canvas.settings.parentCanvasId || canvas.id
         const newCanvas = await services.loadCanvas({ id: nextId })
         if (this.unmounted) { return }
-        replace(() => CanvasState.updateCanvas(newCanvas))
+        this.replaceCanvas(() => newCanvas)
     }
 
     render() {


### PR DESCRIPTION
@juhah I checked out your branch and worked on top of it to add a lot more tests around basic canvas state operations.

Also noticed that the disconnection on subcanvas change wasn't happening in the UI, turns out updateCanvas wasn't being called in a few locations so it wasn't sanitising the canvas data. This is fixed with this PR.

One change to note is the canvas state now throws for a lot more cases when it can't find modules/ports. The idea is to try to surface missing module/port issues closer to the source of the problem, rather than waiting for an undefined value to propagate.