### PR TITLE
[editor canvas] Create new canvas when canvas url has no id.

### DIFF
--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -375,7 +375,15 @@ const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class Canv
         this.unmounted = true
     }
 
-    init() {
+    async init() {
+        if (!this.props.match.params.id) {
+            // if no id, create new
+            const newCanvas = await services.create()
+            if (this.unmounted) { return }
+            this.props.history.replace(`${links.editor.canvasEditor}/${newCanvas.id}`)
+            return
+        }
+
         const canvas = this.context.state
         const currentId = canvas && canvas.id
         const canvasId = currentId || this.props.match.params.id


### PR DESCRIPTION
Simply creates a new canvas if user navigates to `/canvas/editor/` without any canvas id.

Also fixes "New Canvas" button in nav dropdown + "Create Canvas" button on userpages canvases view i.e.

![image](https://user-images.githubusercontent.com/43438/54339167-f7d83780-466e-11e9-8dd6-5bb46486cf5f.png)

Ideally it would use a fake canvas until user the edits something, but we've discussed this in the past and this solution will do for now.