### PR TITLE
Use router links for editor menu

### DIFF
--- a/app/src/marketplace/components/Nav/index.jsx
+++ b/app/src/marketplace/components/Nav/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Link, withRouter, type Location } from 'react-router-dom'
+import { NavLink as Link, withRouter, type Location } from 'react-router-dom'
 import { I18n, Translate } from 'react-redux-i18n'
 import FrameNav, { NavLink, NavDivider, NavLabel, NavDropdown } from '$shared/components/Nav'
 

--- a/app/src/marketplace/components/Nav/index.jsx
+++ b/app/src/marketplace/components/Nav/index.jsx
@@ -54,18 +54,18 @@ class Nav extends React.Component<Props> {
                     <Translate value="general.browse" />
                 </NavLink>
                 <NavDropdown align="center" label={I18n.t('general.editor')}>
-                    <a href={links.editor.canvasEditor}>
+                    <Link to={formatPath(links.editor.canvasEditor)}>
                         <Translate value="general.newCanvas" />
-                    </a>
-                    <a href={links.userpages.canvases}>
+                    </Link>
+                    <Link to={formatPath(links.userpages.canvases)}>
                         <Translate value="general.canvases" />
-                    </a>
-                    <a href={links.userpages.dashboards}>
+                    </Link>
+                    <Link to={formatPath(links.userpages.dashboards)}>
                         <Translate value="general.dashboards" />
-                    </a>
-                    <a href={links.userpages.streams}>
+                    </Link>
+                    <Link to={formatPath(links.userpages.streams)}>
                         <Translate value="general.streams" />
-                    </a>
+                    </Link>
                 </NavDropdown>
                 <NavDivider />
                 <NavLink mobile to={formatPath(links.userpages.purchases)}>

--- a/app/src/shared/components/Nav/NavDropdown/navDropdown.pcss
+++ b/app/src/shared/components/Nav/NavDropdown/navDropdown.pcss
@@ -92,6 +92,10 @@
       color: #0324FF;
       transition-duration: 50ms;
     }
+
+    &.active {
+      cursor: default;
+    }
   }
 }
 


### PR DESCRIPTION
Prevents page reload when using the current editor nav menu:

![image](https://user-images.githubusercontent.com/43438/54340586-a92c9c80-4672-11e9-8230-4c3ce6adb0c1.png)

This menu needs redoing shortly but this is a quick fix so the menu works more normally today.