### PR TITLE
[PLATFORM-431, PLATFORM-412] Toolbar styling & Tooltips

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -24555,6 +24555,15 @@
       "resolved": "https://registry.npmjs.org/react-toggle-switch/-/react-toggle-switch-3.0.4.tgz",
       "integrity": "sha512-eM2Izl0qNrdFZlmRwpXPpUjaYVISHVy8dxCN9l6eRZ7KpmrDsIGInDpoSRU2QPs596+Al+udOArdXX5wCRg0Gg=="
     },
+    "react-tooltip": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.10.0.tgz",
+      "integrity": "sha512-GGdxJvM1zSFztkTP7gCQbLTstWr1OOoMpJ5WZUGhimj0nhRY+MPz+92MpEnKmj0cftJ9Pd/M6FfSl0sfzmZWkg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-transition-group": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -24555,15 +24555,6 @@
       "resolved": "https://registry.npmjs.org/react-toggle-switch/-/react-toggle-switch-3.0.4.tgz",
       "integrity": "sha512-eM2Izl0qNrdFZlmRwpXPpUjaYVISHVy8dxCN9l6eRZ7KpmrDsIGInDpoSRU2QPs596+Al+udOArdXX5wCRg0Gg=="
     },
-    "react-tooltip": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.10.0.tgz",
-      "integrity": "sha512-GGdxJvM1zSFztkTP7gCQbLTstWr1OOoMpJ5WZUGhimj0nhRY+MPz+92MpEnKmj0cftJ9Pd/M6FfSl0sfzmZWkg==",
-      "requires": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.0"
-      }
-    },
     "react-transition-group": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --hot",
     "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack",
-    "test": "jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/* ./src/editor/canvas/tests/*",
+    "test": "jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/*",
     "flow": "flow",
     "flow-stop": "flow stop",
     "eslint": "eslint .",
@@ -37,9 +37,6 @@
     "coverageThreshold": {
       "global": {
         "lines": 38
-      },
-      "./src/editor/": {
-        "lines": 10
       },
       "./src/userpages/": {
         "lines": 10

--- a/app/package.json
+++ b/app/package.json
@@ -199,6 +199,7 @@
     "react-switcher": "^1.0.2",
     "react-syntax-highlighter": "^10.1.2",
     "react-toggle-switch": "^3.0.4",
+    "react-tooltip": "^3.10.0",
     "react-transition-group": "^2.2.1",
     "reactstrap": "^6.5.0",
     "redux": "^4.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -199,7 +199,6 @@
     "react-switcher": "^1.0.2",
     "react-syntax-highlighter": "^10.1.2",
     "react-toggle-switch": "^3.0.4",
-    "react-tooltip": "^3.10.0",
     "react-transition-group": "^2.2.1",
     "reactstrap": "^6.5.0",
     "redux": "^4.0.0",

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -7,6 +7,9 @@ import Toggle from '$shared/components/Toggle'
 import withErrorBoundary from '$shared/utils/withErrorBoundary'
 import ErrorComponentView from '$shared/components/ErrorComponentView'
 import { ModalContainer } from '$editor/shared/components/Modal'
+import SvgIcon from '$shared/components/SvgIcon'
+import StatusIcon from '$shared/components/StatusIcon'
+import DropdownActions from '$shared/components/DropdownActions'
 import { RunTabs, RunStates } from '../state'
 
 import RenameInput from '$editor/shared/components/RenameInput'
@@ -80,168 +83,168 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
         const { editorState = {} } = settings
         return (
             <div className={cx(className, styles.CanvasToolbar)}>
-                <R.ButtonGroup className={cx(styles.Hollow, styles.CanvasNameContainer)}>
-                    <RenameInput
-                        value={canvas.name}
-                        onChange={renameCanvas}
-                        innerRef={this.onRenameRef}
-                        disabled={!canEdit}
-                        required
-                    />
-                    <R.UncontrolledDropdown>
-                        <R.DropdownToggle className={styles.Hollow}>
-                            <Meatball />
-                        </R.DropdownToggle>
-                        <R.DropdownMenu>
-                            <R.DropdownItem onClick={newCanvas}>New Canvas</R.DropdownItem>
-                            <R.DropdownItem>Share</R.DropdownItem>
-                            <R.DropdownItem onClick={this.onRename} disabled={!canEdit}>Rename</R.DropdownItem>
-                            <R.DropdownItem onClick={() => duplicateCanvas()}>Duplicate</R.DropdownItem>
-                            <R.DropdownItem onClick={() => deleteCanvas()} disabled={!canEdit}>Delete</R.DropdownItem>
-                        </R.DropdownMenu>
-                    </R.UncontrolledDropdown>
-                </R.ButtonGroup>
-                <R.ButtonGroup style={{ position: 'relative' }}>
-                    <R.Button onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}>Open</R.Button>
-                    <CanvasSearch
-                        isOpen={this.state.canvasSearchIsOpen}
-                        open={this.canvasSearchOpen}
-                    />
-                </R.ButtonGroup>
-                <R.Button
-                    onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
-                    disabled={!canEdit}
-                >
-                    +
-                </R.Button>
-                <div>
-                    <R.Button
-                        color="success"
-                        disabled={isWaiting}
-                        onClick={() => (isRunning ? canvasStop() : canvasStart())}
-                    >
-                        {isRunning ? 'Stop' : 'Start'}
-                    </R.Button>
-                    {editorState.runTab !== RunTabs.realtime ? (
-                        <R.UncontrolledDropdown>
-                            <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
-                            <R.DropdownMenu>
-                                <R.DropdownItem
-                                    onClick={() => setSpeed('0')}
-                                    active={!settings.speed || settings.speed === '0'}
-                                >
-                                    Full
-                                </R.DropdownItem>
-                                <R.DropdownItem
-                                    onClick={() => setSpeed('1')}
-                                    active={settings.speed === '1'}
-                                >
-                                    1x
-                                </R.DropdownItem>
-                                <R.DropdownItem
-                                    onClick={() => setSpeed('10')}
-                                    active={settings.speed === '10'}
-                                >
-                                    10x
-                                </R.DropdownItem>
-                                <R.DropdownItem
-                                    onClick={() => setSpeed('100')}
-                                    active={settings.speed === '100'}
-                                >
-                                    100x
-                                </R.DropdownItem>
-                                <R.DropdownItem
-                                    onClick={() => setSpeed('1000')}
-                                    active={settings.speed === '1000'}
-                                >
-                                    1000x
-                                </R.DropdownItem>
-                            </R.DropdownMenu>
-                        </R.UncontrolledDropdown>
-                    ) : (
-                        <R.UncontrolledDropdown>
-                            <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
-                            <R.DropdownMenu>
-                                <R.DropdownItem
-                                    onClick={() => canvasStart({ clearState: true })}
-                                    disabled={!canvas.serialized || !canEdit}
-                                >
-                                    Reset &amp; Start
-                                </R.DropdownItem>
-                            </R.DropdownMenu>
-                        </R.UncontrolledDropdown>
-                    )}
-                </div>
-                <R.ButtonGroup className={styles.runTabToggle}>
-                    <R.Button
-                        active={editorState.runTab === RunTabs.realtime}
-                        onClick={() => setRunTab(RunTabs.realtime)}
-                        disabled={!canEdit}
-                    >
-                        Realtime
-                    </R.Button>
-                    <R.Button
-                        active={editorState.runTab !== RunTabs.realtime}
-                        onClick={() => setRunTab(RunTabs.historical)}
-                        disabled={!canEdit}
-                    >
-                        Historical
-                    </R.Button>
-                </R.ButtonGroup>
-                {editorState.runTab !== RunTabs.realtime ? (
-                    <div className={styles.runTabInputs}>
-                        <TextInput
-                            placeholder="From"
-                            onChange={this.getOnChangeHistorical('beginDate')}
-                            value={settings.beginDate}
-                            disabled={!canEdit}
-                            required
-                        />
-                        <TextInput
-                            placeholder="To"
-                            onChange={this.getOnChangeHistorical('endDate')}
-                            value={settings.endDate}
-                            disabled={!canEdit}
-                            required
-                        />
-                    </div>
-                ) : (
-                    <div className={styles.saveStateToggleSection}>
-                        {/* eslint-disable react/no-unknown-property */}
-                        <R.Label
-                            for="saveStateToggle"
-                            className={styles.saveStateToggleLabel}
-                        >
-                            Save state
-                        </R.Label>
-                        {/* eslint-enable react/no-unknown-property */}
-                        <Toggle
-                            id="saveStateToggle"
-                            className={styles.saveStateToggle}
-                            value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
-                            onChange={(value) => setSaveState(value)}
-                            disabled={!canEdit}
-                        />
-                    </div>
-                )}
                 <ModalContainer modalId="ShareDialog">
-                    {({ api }) => (
-                        <R.Button
-                            className={cx(styles.ShareButton, styles.Hollow)}
-                            onClick={() => api.open()}
-                        >
-                            <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" height="1em" width="1em" viewBox="0 0 40 40">
-                                <g fill="none" fillRule="evenodd">
-                                    <rect width="40" height="40" fill="#FFF" rx="4" />
-                                    <g stroke="#CDCDCD" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5">
-                                        <path d="M28.788 14.375h-7.013c-1.408 0-2.55 1.12-2.55 2.5V20" />
-                                        <path d="M24.963 18.125l3.825-3.75-3.825-3.75M26.238 21.875v6.25c0 .69-.571 1.25-1.275 1.25H13.486c-.704
-                                            0-1.275-.56-1.275-1.25v-10c0-.69.571-1.25 1.275-1.25H15.4"
+                    {({ api: shareDialog }) => (
+                        <React.Fragment>
+                            <div className={styles.CanvasNameContainer}>
+                                <StatusIcon status={isRunning && StatusIcon.OK} className={styles.status} />
+                                <RenameInput
+                                    inputClassName={styles.canvasName}
+                                    title={canvas.name}
+                                    value={canvas.name}
+                                    onChange={renameCanvas}
+                                    innerRef={this.onRenameRef}
+                                    disabled={!canEdit}
+                                    required
+                                />
+                                <DropdownActions
+                                    title={<Meatball alt="Select" />}
+                                    noCaret
+                                    className={styles.DropdownMenu}
+                                >
+                                    <DropdownActions.Item onClick={newCanvas}>New Canvas</DropdownActions.Item>
+                                    <DropdownActions.Item onClick={() => shareDialog.open()}>Share</DropdownActions.Item>
+                                    <DropdownActions.Item onClick={this.onRename} disabled={!canEdit}>Rename</DropdownActions.Item>
+                                    <DropdownActions.Item onClick={() => duplicateCanvas()}>Duplicate</DropdownActions.Item>
+                                    <DropdownActions.Item onClick={() => deleteCanvas()} disabled={!canEdit}>Delete</DropdownActions.Item>
+                                </DropdownActions>
+                            </div>
+                            <div>
+                                <R.ButtonGroup className={styles.OpenCanvasButton}>
+                                    <R.Button onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}>Open</R.Button>
+                                    <CanvasSearch
+                                        isOpen={this.state.canvasSearchIsOpen}
+                                        open={this.canvasSearchOpen}
+                                    />
+                                </R.ButtonGroup>
+                                <R.Button
+                                    onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
+                                    disabled={!canEdit}
+                                >
+                                    <SvgIcon name="plus" className={styles.icon} />
+                                </R.Button>
+                            </div>
+                            <div>
+                                <R.Button
+                                    color="success"
+                                    disabled={isWaiting}
+                                    onClick={() => (isRunning ? canvasStop() : canvasStart())}
+                                >
+                                    {isRunning ? 'Stop' : 'Start'}
+                                </R.Button>
+                                {editorState.runTab !== RunTabs.realtime ? (
+                                    <R.UncontrolledDropdown>
+                                        <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
+                                        <R.DropdownMenu>
+                                            <R.DropdownItem
+                                                onClick={() => setSpeed('0')}
+                                                active={!settings.speed || settings.speed === '0'}
+                                            >
+                                                Full
+                                            </R.DropdownItem>
+                                            <R.DropdownItem
+                                                onClick={() => setSpeed('1')}
+                                                active={settings.speed === '1'}
+                                            >
+                                                1x
+                                            </R.DropdownItem>
+                                            <R.DropdownItem
+                                                onClick={() => setSpeed('10')}
+                                                active={settings.speed === '10'}
+                                            >
+                                                10x
+                                            </R.DropdownItem>
+                                            <R.DropdownItem
+                                                onClick={() => setSpeed('100')}
+                                                active={settings.speed === '100'}
+                                            >
+                                                100x
+                                            </R.DropdownItem>
+                                            <R.DropdownItem
+                                                onClick={() => setSpeed('1000')}
+                                                active={settings.speed === '1000'}
+                                            >
+                                                1000x
+                                            </R.DropdownItem>
+                                        </R.DropdownMenu>
+                                    </R.UncontrolledDropdown>
+                                ) : (
+                                    <R.UncontrolledDropdown>
+                                        <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
+                                        <R.DropdownMenu>
+                                            <R.DropdownItem
+                                                onClick={() => canvasStart({ clearState: true })}
+                                                disabled={!canvas.serialized || !canEdit}
+                                            >
+                                                Reset &amp; Start
+                                            </R.DropdownItem>
+                                        </R.DropdownMenu>
+                                    </R.UncontrolledDropdown>
+                                )}
+                            </div>
+                            <div>
+                                <R.ButtonGroup className={styles.runTabToggle}>
+                                    <R.Button
+                                        active={editorState.runTab === RunTabs.realtime}
+                                        onClick={() => setRunTab(RunTabs.realtime)}
+                                        disabled={!canEdit}
+                                    >
+                                        Realtime
+                                    </R.Button>
+                                    <R.Button
+                                        active={editorState.runTab !== RunTabs.realtime}
+                                        onClick={() => setRunTab(RunTabs.historical)}
+                                        disabled={!canEdit}
+                                    >
+                                        Historical
+                                    </R.Button>
+                                </R.ButtonGroup>
+                                {editorState.runTab !== RunTabs.realtime ? (
+                                    <div className={styles.runTabInputs}>
+                                        <TextInput
+                                            placeholder="From"
+                                            onChange={this.getOnChangeHistorical('beginDate')}
+                                            value={settings.beginDate}
+                                            disabled={!canEdit}
+                                            required
                                         />
-                                    </g>
-                                </g>
-                            </svg>
-                        </R.Button>
+                                        <TextInput
+                                            placeholder="To"
+                                            onChange={this.getOnChangeHistorical('endDate')}
+                                            value={settings.endDate}
+                                            disabled={!canEdit}
+                                            required
+                                        />
+                                    </div>
+                                ) : (
+                                    <div className={styles.saveStateToggleSection}>
+                                        {/* eslint-disable react/no-unknown-property */}
+                                        <R.Label
+                                            for="saveStateToggle"
+                                            className={styles.saveStateToggleLabel}
+                                        >
+                                            Save state
+                                        </R.Label>
+                                        {/* eslint-enable react/no-unknown-property */}
+                                        <Toggle
+                                            id="saveStateToggle"
+                                            className={styles.saveStateToggle}
+                                            value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
+                                            onChange={(value) => setSaveState(value)}
+                                            disabled={!canEdit}
+                                        />
+                                    </div>
+                                )}
+                            </div>
+                            <div>
+                                <R.Button
+                                    className={cx(styles.ShareButton, styles.Hollow)}
+                                    onClick={() => shareDialog.open()}
+                                >
+                                    <SvgIcon name="share" className={styles.icon} />
+                                </R.Button>
+                            </div>
+                        </React.Fragment>
                     )}
                 </ModalContainer>
                 <ShareDialog canvas={canvas} />

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -2,6 +2,8 @@
 import React from 'react'
 import * as R from 'reactstrap'
 import cx from 'classnames'
+import ReactTooltip from 'react-tooltip'
+
 import Meatball from '$shared/components/Meatball'
 import Toggle from '$shared/components/Toggle'
 import withErrorBoundary from '$shared/utils/withErrorBoundary'
@@ -135,6 +137,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         className={styles.ToolbarButton}
                                         onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
                                         disabled={!canEdit}
+                                        data-tip="Add module"
                                     >
                                         <SvgIcon name="plus" className={styles.icon} />
                                     </R.Button>
@@ -317,12 +320,14 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 <div className={styles.ModalButtons}>
                                     <R.Button
                                         className={styles.ToolbarButton}
+                                        data-tip="Keyboarding<br>shortcuts"
                                     >
                                         <SvgIcon name="keyboard" className={styles.icon} />
                                     </R.Button>
                                     <R.Button
                                         className={cx(styles.ToolbarButton, styles.ShareButton)}
                                         onClick={() => shareDialog.open()}
+                                        data-tip="Share"
                                     >
                                         <SvgIcon name="share" className={styles.icon} />
                                     </R.Button>
@@ -331,6 +336,14 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                         </React.Fragment>
                     )}
                 </ModalContainer>
+                <ReactTooltip
+                    effect="solid"
+                    className={styles.tooltip}
+                    offset={{
+                        top: -6,
+                    }}
+                    html
+                />
                 <ShareDialog canvas={canvas} />
             </div>
         )

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -94,51 +94,55 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                 <ModalContainer modalId="ShareDialog">
                     {({ api: shareDialog }) => (
                         <React.Fragment>
-                            <div className={styles.CanvasNameContainer}>
-                                <StatusIcon status={isRunning && StatusIcon.OK} className={styles.status} />
-                                <RenameInput
-                                    inputClassName={styles.canvasName}
-                                    title={canvas.name}
-                                    value={canvas.name}
-                                    onChange={renameCanvas}
-                                    innerRef={this.onRenameRef}
-                                    disabled={!canEdit}
-                                    required
-                                />
-                                <DropdownActions
-                                    title={<Meatball alt="Select" />}
-                                    noCaret
-                                    className={styles.DropdownMenu}
-                                >
-                                    <DropdownActions.Item onClick={newCanvas}>New Canvas</DropdownActions.Item>
-                                    <DropdownActions.Item onClick={() => shareDialog.open()}>Share</DropdownActions.Item>
-                                    <DropdownActions.Item onClick={this.onRename} disabled={!canEdit}>Rename</DropdownActions.Item>
-                                    <DropdownActions.Item onClick={() => duplicateCanvas()}>Duplicate</DropdownActions.Item>
-                                    <DropdownActions.Item onClick={() => deleteCanvas()} disabled={!canEdit}>Delete</DropdownActions.Item>
-                                </DropdownActions>
+                            <div className={styles.ToolbarLeft}>
+                                <div className={styles.CanvasNameContainer}>
+                                    <StatusIcon status={isRunning && StatusIcon.OK} className={styles.status} />
+                                    <RenameInput
+                                        inputClassName={styles.canvasName}
+                                        title={canvas.name}
+                                        value={canvas.name}
+                                        onChange={renameCanvas}
+                                        innerRef={this.onRenameRef}
+                                        disabled={!canEdit}
+                                        required
+                                    />
+                                    <DropdownActions
+                                        title={<Meatball alt="Select" />}
+                                        noCaret
+                                        className={styles.DropdownMenu}
+                                    >
+                                        <DropdownActions.Item onClick={newCanvas}>New Canvas</DropdownActions.Item>
+                                        <DropdownActions.Item onClick={() => shareDialog.open()}>Share</DropdownActions.Item>
+                                        <DropdownActions.Item onClick={this.onRename} disabled={!canEdit}>Rename</DropdownActions.Item>
+                                        <DropdownActions.Item onClick={() => duplicateCanvas()}>Duplicate</DropdownActions.Item>
+                                        <DropdownActions.Item onClick={() => deleteCanvas()} disabled={!canEdit}>Delete</DropdownActions.Item>
+                                    </DropdownActions>
+                                </div>
                             </div>
-                            <div style={{ position: 'relative' }}>
-                                <R.Button
-                                    className={cx(styles.ToolbarButton, styles.OpenCanvasButton)}
-                                    onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}
-                                >
-                                    Open
-                                </R.Button>
-                                <CanvasSearch
-                                    isOpen={canvasSearchIsOpen}
-                                    open={this.canvasSearchOpen}
-                                />
-                                <R.Button
-                                    className={styles.ToolbarButton}
-                                    onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
-                                    disabled={!canEdit}
-                                >
-                                    <SvgIcon name="plus" className={styles.icon} />
-                                </R.Button>
+                            <div className={styles.ToolbarLeft}>
+                                <div style={{ position: 'relative' }}>
+                                    <R.Button
+                                        className={cx(styles.ToolbarButton, styles.OpenCanvasButton)}
+                                        onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}
+                                    >
+                                        Open
+                                    </R.Button>
+                                    <CanvasSearch
+                                        isOpen={canvasSearchIsOpen}
+                                        open={this.canvasSearchOpen}
+                                    />
+                                    <R.Button
+                                        className={styles.ToolbarButton}
+                                        onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
+                                        disabled={!canEdit}
+                                    >
+                                        <SvgIcon name="plus" className={styles.icon} />
+                                    </R.Button>
+                                </div>
                             </div>
                             <div>
                                 <R.ButtonGroup
-                                    className={cx(styles.RunButton, {
+                                    className={cx(styles.RunButtonGroup, {
                                         [styles.RunButtonStopped]: !isRunning,
                                         [styles.RunButtonRunning]: !!isRunning,
                                     })}
@@ -146,6 +150,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     <R.Button
                                         disabled={isWaiting}
                                         onClick={() => (isRunning ? canvasStop() : canvasStart())}
+                                        className={styles.RunButton}
                                     >
                                         {isRunning ? 'Stop' : 'Run'}
                                     </R.Button>
@@ -199,7 +204,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                     <SvgIcon name="caretDown" />
                                                 )}
                                             </R.DropdownToggle>
-                                            <R.DropdownMenu>
+                                            <R.DropdownMenu className={styles.RunButtonMenu} right>
                                                 <R.DropdownItem
                                                     onClick={() => canvasStart({ clearState: true })}
                                                     disabled={!canvas.serialized || !canEdit}
@@ -211,67 +216,76 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     )}
                                 </R.ButtonGroup>
                             </div>
-                            <div>
-                                <R.ButtonGroup className={styles.runTabToggle}>
+                            <div className={styles.ToolbarRight}>
+                                <div className={styles.StateSelectorContainer}>
+                                    <div className={styles.StateSelector}>
+                                        <R.ButtonGroup className={styles.runTabToggle}>
+                                            <R.Button
+                                                active={editorState.runTab === RunTabs.realtime}
+                                                onClick={() => setRunTab(RunTabs.realtime)}
+                                                disabled={!canEdit}
+                                            >
+                                                Realtime
+                                            </R.Button>
+                                            <R.Button
+                                                active={editorState.runTab !== RunTabs.realtime}
+                                                onClick={() => setRunTab(RunTabs.historical)}
+                                                disabled={!canEdit}
+                                            >
+                                                Historical
+                                            </R.Button>
+                                        </R.ButtonGroup>
+                                        {editorState.runTab !== RunTabs.realtime ? (
+                                            <div className={styles.runTabInputs}>
+                                                <TextInput
+                                                    placeholder="From"
+                                                    onChange={this.getOnChangeHistorical('beginDate')}
+                                                    value={settings.beginDate}
+                                                    disabled={!canEdit}
+                                                    required
+                                                />
+                                                <TextInput
+                                                    placeholder="To"
+                                                    onChange={this.getOnChangeHistorical('endDate')}
+                                                    value={settings.endDate}
+                                                    disabled={!canEdit}
+                                                    required
+                                                />
+                                            </div>
+                                        ) : (
+                                            <div className={styles.saveStateToggleSection}>
+                                                {/* eslint-disable react/no-unknown-property */}
+                                                <R.Label
+                                                    for="saveStateToggle"
+                                                    className={styles.saveStateToggleLabel}
+                                                >
+                                                    Save state
+                                                </R.Label>
+                                                {/* eslint-enable react/no-unknown-property */}
+                                                <Toggle
+                                                    id="saveStateToggle"
+                                                    className={styles.saveStateToggle}
+                                                    value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
+                                                    onChange={(value) => setSaveState(value)}
+                                                    disabled={!canEdit}
+                                                />
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                                <div>
                                     <R.Button
-                                        active={editorState.runTab === RunTabs.realtime}
-                                        onClick={() => setRunTab(RunTabs.realtime)}
-                                        disabled={!canEdit}
+                                        className={styles.ToolbarButton}
                                     >
-                                        Realtime
+                                        <SvgIcon name="keyboard" className={styles.icon} />
                                     </R.Button>
                                     <R.Button
-                                        active={editorState.runTab !== RunTabs.realtime}
-                                        onClick={() => setRunTab(RunTabs.historical)}
-                                        disabled={!canEdit}
+                                        className={cx(styles.ToolbarButton, styles.ShareButton)}
+                                        onClick={() => shareDialog.open()}
                                     >
-                                        Historical
+                                        <SvgIcon name="share" className={styles.icon} />
                                     </R.Button>
-                                </R.ButtonGroup>
-                                {editorState.runTab !== RunTabs.realtime ? (
-                                    <div className={styles.runTabInputs}>
-                                        <TextInput
-                                            placeholder="From"
-                                            onChange={this.getOnChangeHistorical('beginDate')}
-                                            value={settings.beginDate}
-                                            disabled={!canEdit}
-                                            required
-                                        />
-                                        <TextInput
-                                            placeholder="To"
-                                            onChange={this.getOnChangeHistorical('endDate')}
-                                            value={settings.endDate}
-                                            disabled={!canEdit}
-                                            required
-                                        />
-                                    </div>
-                                ) : (
-                                    <div className={styles.saveStateToggleSection}>
-                                        {/* eslint-disable react/no-unknown-property */}
-                                        <R.Label
-                                            for="saveStateToggle"
-                                            className={styles.saveStateToggleLabel}
-                                        >
-                                            Save state
-                                        </R.Label>
-                                        {/* eslint-enable react/no-unknown-property */}
-                                        <Toggle
-                                            id="saveStateToggle"
-                                            className={styles.saveStateToggle}
-                                            value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
-                                            onChange={(value) => setSaveState(value)}
-                                            disabled={!canEdit}
-                                        />
-                                    </div>
-                                )}
-                            </div>
-                            <div>
-                                <R.Button
-                                    className={cx(styles.ShareButton, styles.Hollow)}
-                                    onClick={() => shareDialog.open()}
-                                >
-                                    <SvgIcon name="share" className={styles.icon} />
-                                </R.Button>
+                                </div>
                             </div>
                         </React.Fragment>
                     )}

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -10,9 +10,10 @@ import { ModalContainer } from '$editor/shared/components/Modal'
 import SvgIcon from '$shared/components/SvgIcon'
 import StatusIcon from '$shared/components/StatusIcon'
 import DropdownActions from '$shared/components/DropdownActions'
-import { RunTabs, RunStates } from '../state'
-
+import WithCalendar from '$shared/components/WithCalendar'
+import dateFormatter from '$utils/dateFormatter'
 import RenameInput from '$editor/shared/components/RenameInput'
+import { RunTabs, RunStates } from '../state'
 
 import ShareDialog from './ShareDialog'
 import CanvasSearch from './CanvasSearch'
@@ -253,26 +254,44 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         </div>
                                         {editorState.runTab !== RunTabs.realtime ? (
                                             <div className={styles.runTabToggle}>
-                                                <button
-                                                    type="button"
-                                                    disabled={!canEdit}
-                                                    className={cx(styles.realTimeButton, {
-                                                        [styles.StateSelectorActive]: !!settings.beginDate,
-                                                    })}
+                                                <WithCalendar
+                                                    date={!!settings.beginDate && new Date(settings.beginDate)}
+                                                    wrapperClassname={styles.CalendarWrapper}
+                                                    onChange={this.getOnChangeHistorical('beginDate')}
                                                 >
-                                                    {!settings.beginDate && ('From')}
-                                                    {!!settings.beginDate && settings.beginDate}
-                                                </button>
-                                                <button
-                                                    type="button"
-                                                    disabled={!canEdit}
-                                                    className={cx(styles.historicalButton, {
-                                                        [styles.StateSelectorActive]: !!settings.endDate,
-                                                    })}
+                                                    {({ toggleCalendar }) => (
+                                                        <button
+                                                            type="button"
+                                                            disabled={!canEdit}
+                                                            onClick={toggleCalendar}
+                                                            className={cx(styles.realTimeButton, {
+                                                                [styles.StateSelectorActive]: !!settings.beginDate,
+                                                            })}
+                                                        >
+                                                            {!settings.beginDate && ('From')}
+                                                            {!!settings.beginDate && dateFormatter('DD/MM/YYYY')(settings.beginDate)}
+                                                        </button>
+                                                    )}
+                                                </WithCalendar>
+                                                <WithCalendar
+                                                    date={!!settings.endDate && new Date(settings.endDate)}
+                                                    wrapperClassname={styles.CalendarWrapper}
+                                                    onChange={this.getOnChangeHistorical('endDate')}
                                                 >
-                                                    {!settings.beginDate && ('To')}
-                                                    {!!settings.beginDate && settings.endDate}
-                                                </button>
+                                                    {({ toggleCalendar }) => (
+                                                        <button
+                                                            type="button"
+                                                            disabled={!canEdit}
+                                                            onClick={toggleCalendar}
+                                                            className={cx(styles.realTimeButton, {
+                                                                [styles.StateSelectorActive]: !!settings.endDate,
+                                                            })}
+                                                        >
+                                                            {!settings.endDate && ('To')}
+                                                            {!!settings.endDate && dateFormatter('DD/MM/YYYY')(settings.endDate)}
+                                                        </button>
+                                                    )}
+                                                </WithCalendar>
                                             </div>
                                         ) : (
                                             <div className={styles.saveStateToggleSection}>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -320,7 +320,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 <div className={styles.ModalButtons}>
                                     <R.Button
                                         className={styles.ToolbarButton}
-                                        data-tip="Keyboarding<br>shortcuts"
+                                        data-tip="Keyboard<br>shortcuts"
                                     >
                                         <SvgIcon name="keyboard" className={styles.icon} />
                                     </R.Button>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -110,14 +110,18 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 </DropdownActions>
                             </div>
                             <div>
-                                <R.ButtonGroup className={styles.OpenCanvasButton}>
-                                    <R.Button onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}>Open</R.Button>
-                                    <CanvasSearch
-                                        isOpen={this.state.canvasSearchIsOpen}
-                                        open={this.canvasSearchOpen}
-                                    />
-                                </R.ButtonGroup>
                                 <R.Button
+                                    className={cx(styles.ToolbarButton, styles.OpenCanvasButton)}
+                                    onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}
+                                >
+                                    Open
+                                </R.Button>
+                                <CanvasSearch
+                                    isOpen={this.state.canvasSearchIsOpen}
+                                    open={this.canvasSearchOpen}
+                                />
+                                <R.Button
+                                    className={styles.ToolbarButton}
                                     onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
                                     disabled={!canEdit}
                                 >
@@ -125,62 +129,72 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 </R.Button>
                             </div>
                             <div>
-                                <R.Button
-                                    color="success"
-                                    disabled={isWaiting}
-                                    onClick={() => (isRunning ? canvasStop() : canvasStart())}
-                                >
-                                    {isRunning ? 'Stop' : 'Start'}
-                                </R.Button>
-                                {editorState.runTab !== RunTabs.realtime ? (
-                                    <R.UncontrolledDropdown>
-                                        <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
+                                <R.ButtonGroup className={styles.RunButton}>
+                                    <R.Button
+                                        disabled={isWaiting}
+                                        onClick={() => (isRunning ? canvasStop() : canvasStart())}
+                                    >
+                                        {isRunning ? 'Stop' : 'Run'}
+                                    </R.Button>
+                                    <R.ButtonDropdown isOpen={false} toggle={() => {}}>
+                                        <R.DropdownToggle className={styles.RunDropdownButton}>
+                                            <SvgIcon name="caretDown" />
+                                        </R.DropdownToggle>
                                         <R.DropdownMenu>
-                                            <R.DropdownItem
-                                                onClick={() => setSpeed('0')}
-                                                active={!settings.speed || settings.speed === '0'}
-                                            >
-                                                Full
-                                            </R.DropdownItem>
-                                            <R.DropdownItem
-                                                onClick={() => setSpeed('1')}
-                                                active={settings.speed === '1'}
-                                            >
-                                                1x
-                                            </R.DropdownItem>
-                                            <R.DropdownItem
-                                                onClick={() => setSpeed('10')}
-                                                active={settings.speed === '10'}
-                                            >
-                                                10x
-                                            </R.DropdownItem>
-                                            <R.DropdownItem
-                                                onClick={() => setSpeed('100')}
-                                                active={settings.speed === '100'}
-                                            >
-                                                100x
-                                            </R.DropdownItem>
-                                            <R.DropdownItem
-                                                onClick={() => setSpeed('1000')}
-                                                active={settings.speed === '1000'}
-                                            >
-                                                1000x
-                                            </R.DropdownItem>
+                                            <R.DropdownItem>Dropdown Link</R.DropdownItem>
+                                            <R.DropdownItem>Dropdown Link</R.DropdownItem>
                                         </R.DropdownMenu>
-                                    </R.UncontrolledDropdown>
-                                ) : (
-                                    <R.UncontrolledDropdown>
-                                        <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
-                                        <R.DropdownMenu>
-                                            <R.DropdownItem
-                                                onClick={() => canvasStart({ clearState: true })}
-                                                disabled={!canvas.serialized || !canEdit}
-                                            >
-                                                Reset &amp; Start
-                                            </R.DropdownItem>
-                                        </R.DropdownMenu>
-                                    </R.UncontrolledDropdown>
-                                )}
+                                    </R.ButtonDropdown>
+                                    {editorState.runTab !== RunTabs.realtime ? (
+                                        <R.UncontrolledDropdown>
+                                            <R.DropdownToggle caret className={styles.RunButton} disabled={!canEdit} />
+                                            <R.DropdownMenu>
+                                                <R.DropdownItem
+                                                    onClick={() => setSpeed('0')}
+                                                    active={!settings.speed || settings.speed === '0'}
+                                                >
+                                                    Full
+                                                </R.DropdownItem>
+                                                <R.DropdownItem
+                                                    onClick={() => setSpeed('1')}
+                                                    active={settings.speed === '1'}
+                                                >
+                                                    1x
+                                                </R.DropdownItem>
+                                                <R.DropdownItem
+                                                    onClick={() => setSpeed('10')}
+                                                    active={settings.speed === '10'}
+                                                >
+                                                    10x
+                                                </R.DropdownItem>
+                                                <R.DropdownItem
+                                                    onClick={() => setSpeed('100')}
+                                                    active={settings.speed === '100'}
+                                                >
+                                                    100x
+                                                </R.DropdownItem>
+                                                <R.DropdownItem
+                                                    onClick={() => setSpeed('1000')}
+                                                    active={settings.speed === '1000'}
+                                                >
+                                                    1000x
+                                                </R.DropdownItem>
+                                            </R.DropdownMenu>
+                                        </R.UncontrolledDropdown>
+                                    ) : (
+                                        <R.UncontrolledDropdown>
+                                            <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
+                                            <R.DropdownMenu>
+                                                <R.DropdownItem
+                                                    onClick={() => canvasStart({ clearState: true })}
+                                                    disabled={!canvas.serialized || !canEdit}
+                                                >
+                                                    Reset &amp; Start
+                                                </R.DropdownItem>
+                                            </R.DropdownMenu>
+                                        </R.UncontrolledDropdown>
+                                    )}
+                                </R.ButtonGroup>
                             </div>
                             <div>
                                 <R.ButtonGroup className={styles.runTabToggle}>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import * as R from 'reactstrap'
 import cx from 'classnames'
-import ReactTooltip from 'react-tooltip'
 
 import Meatball from '$shared/components/Meatball'
 import Toggle from '$shared/components/Toggle'
@@ -12,6 +11,7 @@ import { ModalContainer } from '$editor/shared/components/Modal'
 import SvgIcon from '$shared/components/SvgIcon'
 import StatusIcon from '$shared/components/StatusIcon'
 import DropdownActions from '$shared/components/DropdownActions'
+import Tooltip from '$shared/components/Tooltip'
 import WithCalendar from '$shared/components/WithCalendar'
 import dateFormatter from '$utils/dateFormatter'
 import RenameInput from '$editor/shared/components/RenameInput'
@@ -133,14 +133,15 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         isOpen={canvasSearchIsOpen}
                                         open={this.canvasSearchOpen}
                                     />
-                                    <R.Button
-                                        className={styles.ToolbarButton}
-                                        onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
-                                        disabled={!canEdit}
-                                        data-tip="Add module"
-                                    >
-                                        <SvgIcon name="plus" className={styles.icon} />
-                                    </R.Button>
+                                    <Tooltip value="Add module">
+                                        <R.Button
+                                            className={styles.ToolbarButton}
+                                            onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
+                                            disabled={!canEdit}
+                                        >
+                                            <SvgIcon name="plus" className={styles.icon} />
+                                        </R.Button>
+                                    </Tooltip>
                                 </div>
                             </div>
                             <div>
@@ -318,32 +319,26 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     </div>
                                 </div>
                                 <div className={styles.ModalButtons}>
-                                    <R.Button
-                                        className={styles.ToolbarButton}
-                                        data-tip="Keyboard<br>shortcuts"
-                                    >
-                                        <SvgIcon name="keyboard" className={styles.icon} />
-                                    </R.Button>
-                                    <R.Button
-                                        className={cx(styles.ToolbarButton, styles.ShareButton)}
-                                        onClick={() => shareDialog.open()}
-                                        data-tip="Share"
-                                    >
-                                        <SvgIcon name="share" className={styles.icon} />
-                                    </R.Button>
+                                    <Tooltip value={<React.Fragment>Keyboard<br />shortcuts</React.Fragment>}>
+                                        <R.Button
+                                            className={styles.ToolbarButton}
+                                        >
+                                            <SvgIcon name="keyboard" className={styles.icon} />
+                                        </R.Button>
+                                    </Tooltip>
+                                    <Tooltip value="Share">
+                                        <R.Button
+                                            className={cx(styles.ToolbarButton, styles.ShareButton)}
+                                            onClick={() => shareDialog.open()}
+                                        >
+                                            <SvgIcon name="share" className={styles.icon} />
+                                        </R.Button>
+                                    </Tooltip>
                                 </div>
                             </div>
                         </React.Fragment>
                     )}
                 </ModalContainer>
-                <ReactTooltip
-                    effect="solid"
-                    className={styles.tooltip}
-                    offset={{
-                        top: -6,
-                    }}
-                    html
-                />
                 <ShareDialog canvas={canvas} />
             </div>
         )

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -23,6 +23,7 @@ import styles from './Toolbar.pcss'
 export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends React.PureComponent {
     state = {
         canvasSearchIsOpen: false,
+        runButtonDropdownOpen: false,
     }
 
     onRenameRef = (el) => {
@@ -59,6 +60,12 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
         window.removeEventListener('keydown', this.onKeyDown)
     }
 
+    onToggleRunButtonMenu = () => {
+        this.setState(({ runButtonDropdownOpen }) => ({
+            runButtonDropdownOpen: !runButtonDropdownOpen,
+        }))
+    }
+
     render() {
         const {
             canvas,
@@ -77,6 +84,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
 
         if (!canvas) { return null }
 
+        const { runButtonDropdownOpen, canvasSearchIsOpen } = this.state
         const isRunning = canvas.state === RunStates.Running
         const canEdit = !isWaiting && !isRunning
         const { settings = {} } = canvas
@@ -109,7 +117,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     <DropdownActions.Item onClick={() => deleteCanvas()} disabled={!canEdit}>Delete</DropdownActions.Item>
                                 </DropdownActions>
                             </div>
-                            <div>
+                            <div style={{ position: 'relative' }}>
                                 <R.Button
                                     className={cx(styles.ToolbarButton, styles.OpenCanvasButton)}
                                     onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}
@@ -117,7 +125,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     Open
                                 </R.Button>
                                 <CanvasSearch
-                                    isOpen={this.state.canvasSearchIsOpen}
+                                    isOpen={canvasSearchIsOpen}
                                     open={this.canvasSearchOpen}
                                 />
                                 <R.Button
@@ -129,22 +137,18 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 </R.Button>
                             </div>
                             <div>
-                                <R.ButtonGroup className={styles.RunButton}>
+                                <R.ButtonGroup
+                                    className={cx(styles.RunButton, {
+                                        [styles.RunButtonStopped]: !isRunning,
+                                        [styles.RunButtonRunning]: !!isRunning,
+                                    })}
+                                >
                                     <R.Button
                                         disabled={isWaiting}
                                         onClick={() => (isRunning ? canvasStop() : canvasStart())}
                                     >
                                         {isRunning ? 'Stop' : 'Run'}
                                     </R.Button>
-                                    <R.ButtonDropdown isOpen={false} toggle={() => {}}>
-                                        <R.DropdownToggle className={styles.RunDropdownButton}>
-                                            <SvgIcon name="caretDown" />
-                                        </R.DropdownToggle>
-                                        <R.DropdownMenu>
-                                            <R.DropdownItem>Dropdown Link</R.DropdownItem>
-                                            <R.DropdownItem>Dropdown Link</R.DropdownItem>
-                                        </R.DropdownMenu>
-                                    </R.ButtonDropdown>
                                     {editorState.runTab !== RunTabs.realtime ? (
                                         <R.UncontrolledDropdown>
                                             <R.DropdownToggle caret className={styles.RunButton} disabled={!canEdit} />
@@ -182,8 +186,19 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                             </R.DropdownMenu>
                                         </R.UncontrolledDropdown>
                                     ) : (
-                                        <R.UncontrolledDropdown>
-                                            <R.DropdownToggle caret className={styles.Hollow} disabled={!canEdit} />
+                                        <R.ButtonDropdown
+                                            isOpen={runButtonDropdownOpen}
+                                            toggle={this.onToggleRunButtonMenu}
+                                            className={styles.RunDropdownButton}
+                                        >
+                                            <R.DropdownToggle disabled={!canEdit} caret>
+                                                {!runButtonDropdownOpen && (
+                                                    <SvgIcon name="caretUp" />
+                                                )}
+                                                {runButtonDropdownOpen && (
+                                                    <SvgIcon name="caretDown" />
+                                                )}
+                                            </R.DropdownToggle>
                                             <R.DropdownMenu>
                                                 <R.DropdownItem
                                                     onClick={() => canvasStart({ clearState: true })}
@@ -192,7 +207,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                     Reset &amp; Start
                                                 </R.DropdownItem>
                                             </R.DropdownMenu>
-                                        </R.UncontrolledDropdown>
+                                        </R.ButtonDropdown>
                                     )}
                                 </R.ButtonGroup>
                             </div>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -13,7 +13,6 @@ import DropdownActions from '$shared/components/DropdownActions'
 import { RunTabs, RunStates } from '../state'
 
 import RenameInput from '$editor/shared/components/RenameInput'
-import TextInput from '$editor/shared/components/TextInput'
 
 import ShareDialog from './ShareDialog'
 import CanvasSearch from './CanvasSearch'
@@ -155,9 +154,20 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         {isRunning ? 'Stop' : 'Run'}
                                     </R.Button>
                                     {editorState.runTab !== RunTabs.realtime ? (
-                                        <R.UncontrolledDropdown>
-                                            <R.DropdownToggle caret className={styles.RunButton} disabled={!canEdit} />
-                                            <R.DropdownMenu>
+                                        <R.ButtonDropdown
+                                            isOpen={runButtonDropdownOpen}
+                                            toggle={this.onToggleRunButtonMenu}
+                                            className={styles.RunDropdownButton}
+                                        >
+                                            <R.DropdownToggle disabled={!canEdit} caret>
+                                                {!runButtonDropdownOpen && (
+                                                    <SvgIcon name="caretUp" />
+                                                )}
+                                                {runButtonDropdownOpen && (
+                                                    <SvgIcon name="caretDown" />
+                                                )}
+                                            </R.DropdownToggle>
+                                            <R.DropdownMenu className={styles.RunButtonMenu} right>
                                                 <R.DropdownItem
                                                     onClick={() => setSpeed('0')}
                                                     active={!settings.speed || settings.speed === '0'}
@@ -189,7 +199,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                     1000x
                                                 </R.DropdownItem>
                                             </R.DropdownMenu>
-                                        </R.UncontrolledDropdown>
+                                        </R.ButtonDropdown>
                                     ) : (
                                         <R.ButtonDropdown
                                             isOpen={runButtonDropdownOpen}
@@ -219,38 +229,50 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                             <div className={styles.ToolbarRight}>
                                 <div className={styles.StateSelectorContainer}>
                                     <div className={styles.StateSelector}>
-                                        <R.ButtonGroup className={styles.runTabToggle}>
-                                            <R.Button
-                                                active={editorState.runTab === RunTabs.realtime}
+                                        <div className={styles.runTabToggle}>
+                                            <button
+                                                type="button"
                                                 onClick={() => setRunTab(RunTabs.realtime)}
                                                 disabled={!canEdit}
+                                                className={cx(styles.realTimeButton, {
+                                                    [styles.StateSelectorActive]: editorState.runTab === RunTabs.realtime,
+                                                })}
                                             >
                                                 Realtime
-                                            </R.Button>
-                                            <R.Button
-                                                active={editorState.runTab !== RunTabs.realtime}
+                                            </button>
+                                            <button
+                                                type="button"
                                                 onClick={() => setRunTab(RunTabs.historical)}
                                                 disabled={!canEdit}
+                                                className={cx(styles.historicalButton, {
+                                                    [styles.StateSelectorActive]: editorState.runTab !== RunTabs.realtime,
+                                                })}
                                             >
                                                 Historical
-                                            </R.Button>
-                                        </R.ButtonGroup>
+                                            </button>
+                                        </div>
                                         {editorState.runTab !== RunTabs.realtime ? (
-                                            <div className={styles.runTabInputs}>
-                                                <TextInput
-                                                    placeholder="From"
-                                                    onChange={this.getOnChangeHistorical('beginDate')}
-                                                    value={settings.beginDate}
+                                            <div className={styles.runTabToggle}>
+                                                <button
+                                                    type="button"
                                                     disabled={!canEdit}
-                                                    required
-                                                />
-                                                <TextInput
-                                                    placeholder="To"
-                                                    onChange={this.getOnChangeHistorical('endDate')}
-                                                    value={settings.endDate}
+                                                    className={cx(styles.realTimeButton, {
+                                                        [styles.StateSelectorActive]: !!settings.beginDate,
+                                                    })}
+                                                >
+                                                    {!settings.beginDate && ('From')}
+                                                    {!!settings.beginDate && settings.beginDate}
+                                                </button>
+                                                <button
+                                                    type="button"
                                                     disabled={!canEdit}
-                                                    required
-                                                />
+                                                    className={cx(styles.historicalButton, {
+                                                        [styles.StateSelectorActive]: !!settings.endDate,
+                                                    })}
+                                                >
+                                                    {!settings.beginDate && ('To')}
+                                                    {!!settings.beginDate && settings.endDate}
+                                                </button>
                                             </div>
                                         ) : (
                                             <div className={styles.saveStateToggleSection}>
@@ -273,7 +295,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         )}
                                     </div>
                                 </div>
-                                <div>
+                                <div className={styles.ModalButtons}>
                                     <R.Button
                                         className={styles.ToolbarButton}
                                     >

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -13,6 +13,24 @@
   align-items: center;
 }
 
+.ToolbarLeft {
+  flex: 1;
+}
+
+.ToolbarRight {
+  flex: 2;
+}
+
+.StateSelectorContainer {
+  flex: 1;
+  display: flex;
+  justify-content: space-around;
+}
+
+.StateSelector {
+  display: flex;
+}
+
 .ToolbarButton {
   &:global(.btn) {
     /* Reset button styles for toolbar */
@@ -62,7 +80,21 @@
 }
 
 .CanvasNameContainer {
-  min-width: max-content; /* prevent canvas name being squashed out */
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.RunButtonMenu {
+  font-size: 12px;
+  padding: 0;
+  min-width: 189px !important;
+
+  & :global(.dropdown-item) {
+    font-weight: 500;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+  }
 }
 
 .RunDropdownButton {
@@ -85,7 +117,7 @@
   }
 }
 
-.RunButton :global(.btn) {
+.RunButtonGroup :global(.btn) {
   border: none;
   box-shadow: transparent;
   font-family: inherit;
@@ -139,6 +171,14 @@
 .RunButtonRunning :global(.btn-secondary):global(.dropdown-toggle):active {
   outline: none !important;
   box-shadow: none !important;
+}
+
+.RunButton {
+  min-width: 150px;
+}
+
+.CanvasToolbar .runTabToggle {
+  margin-right: 16px;
 }
 
 .CanvasToolbar .runTabToggle,

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -13,38 +13,40 @@
   align-items: center;
 }
 
-.CanvasToolbar :global .btn {
-  /* Reset button styles for toolbar */
-  font-size: inherit;
-  color: inherit;
-  border: none;
-  background: transparent;
-  box-shadow: transparent;
-  font-family: inherit;
-  text-transform: initial;
-  padding: 12px;
-}
+.ToolbarButton {
+  &:global(.btn) {
+    /* Reset button styles for toolbar */
+    font-size: inherit;
+    color: inherit;
+    border: none;
+    background: transparent;
+    box-shadow: transparent;
+    font-family: inherit;
+    text-transform: initial;
+    padding: 12px;
+  }
 
-.CanvasToolbar :global .btn:focus,
-.CanvasToolbar :global .btn:hover {
-  font-size: inherit;
-  color: inherit !important;
-  border: none;
-  box-shadow: transparent;
-  font-family: inherit;
-  text-transform: initial;
-  background: #EFEFEF !important;
-  outline: none;
-  border-radius: 4px;
-}
+  &:global(.btn):focus,
+  &:global(.btn):hover {
+    font-size: inherit;
+    color: inherit !important;
+    border: none;
+    box-shadow: transparent;
+    font-family: inherit;
+    text-transform: initial;
+    background: #EFEFEF !important;
+    outline: none;
+    border-radius: 4px;
+  }
 
-.CanvasToolbar :global .btn:active {
-  font-size: inherit;
-  border: none;
-  box-shadow: transparent;
-  font-family: inherit;
-  text-transform: initial;
-  color: #323232 !important;
+  &:global(.btn):active {
+    font-size: inherit;
+    border: none;
+    box-shadow: transparent;
+    font-family: inherit;
+    text-transform: initial;
+    color: #323232 !important;
+  }
 }
 
 .OpenCanvasButton {
@@ -61,6 +63,43 @@
 
 .CanvasNameContainer {
   min-width: max-content; /* prevent canvas name being squashed out */
+}
+
+.RunDropdownButton {
+  padding-left: 10px;
+  padding-right: 10px;
+
+  svg {
+    width: 10px;
+    height: 10px;
+  }
+}
+
+.RunButton {
+  & :global(.btn) {
+    border: none;
+    box-shadow: transparent;
+    font-family: inherit;
+    background: #2AC437 !important;
+    color: #FFFFFF !important;
+    font-size: 14px !important;
+    font-weight: 500;
+    text-align: center;
+    letter-spacing: 2px;
+    text-transform: uppercase !important;
+    line-height: 18px;
+    border-radius: 4px;
+  }
+
+  & :global(.btn):focus,
+  & :global(.btn):hover {
+    background: #2BB337 !important;
+    color: #FFFFFF !important;
+  }
+
+  & :global(.btn-group):not(:first-child) {
+    margin-left: 1px;
+  }
 }
 
 .CanvasToolbar .runTabToggle,

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -180,6 +180,8 @@
 .CanvasToolbar .runTabToggle {
   margin: 0 8px;
   white-space: nowrap;
+  position: relative;
+  display: flex;
 }
 
 .realTimeButton,
@@ -279,4 +281,10 @@
 
 .ModalButtons {
   white-space: nowrap;
+}
+
+.CalendarWrapper {
+  bottom: 50px;
+  left: 50%;
+  transform: translate(-50%, 0);
 }

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -4,7 +4,7 @@
   justify-content: space-between;
   background: #F5F5F5;
   color: #A3A3A3;
-  padding: 20px 60px;
+  padding: 20px 30px;
   font-size: 12px;
 }
 
@@ -14,13 +14,6 @@
 }
 
 .CanvasToolbar :global .btn {
-  border-radius: 4px;
-}
-
-.CanvasToolbar :global .btn,
-.CanvasToolbar :global .btn:active,
-.CanvasToolbar :global .btn:focus,
-.CanvasToolbar :global .btn:hover {
   /* Reset button styles for toolbar */
   font-size: inherit;
   color: inherit;
@@ -29,11 +22,41 @@
   box-shadow: transparent;
   font-family: inherit;
   text-transform: initial;
+  padding: 12px;
+}
+
+.CanvasToolbar :global .btn:focus,
+.CanvasToolbar :global .btn:hover {
+  font-size: inherit;
+  color: inherit !important;
+  border: none;
+  box-shadow: transparent;
+  font-family: inherit;
+  text-transform: initial;
+  background: #EFEFEF !important;
+  outline: none;
+  border-radius: 4px;
+}
+
+.CanvasToolbar :global .btn:active {
+  font-size: inherit;
+  border: none;
+  box-shadow: transparent;
+  font-family: inherit;
+  text-transform: initial;
+  color: #323232 !important;
+}
+
+.OpenCanvasButton {
+  margin-right: 8px;
 }
 
 .ShareButton {
-  font-size: 2em;
   padding: 0;
+}
+
+.DropdownMenu {
+  margin-left: 8px;
 }
 
 .CanvasNameContainer {
@@ -72,4 +95,23 @@
 
 .CanvasToolbar .saveStateToggleSection label {
   margin-bottom: 0;
+}
+
+.CanvasToolbar .status {
+  width: 8px;
+  height: 8px;
+  margin-right: 8px;
+}
+
+.CanvasToolbar .canvasName {
+  max-width: 200px;
+  color: #525252;
+  font-weight: 500;
+  letter-spacing: 0;
+  padding: 0;
+}
+
+.CanvasToolbar .icon {
+  width: 14px;
+  height: 14px;
 }

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -73,6 +73,7 @@
 
 .ShareButton {
   padding: 0;
+  margin-left: 8px;
 }
 
 .DropdownMenu {

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -303,3 +303,19 @@
   left: 50%;
   transform: translate(-50%, 0);
 }
+
+.tooltip {
+  padding: 6px 8px;
+  background-color: #323232 !important;
+  border-radius: 2px;
+  color: #EFEFEF !important;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 12px;
+  letter-spacing: 0;
+  line-height: 14px;
+  text-align: center;
+
+  &::after {
+    content: none;
+  }
+}

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -178,14 +178,65 @@
 }
 
 .CanvasToolbar .runTabToggle {
-  margin-right: 16px;
+  margin: 0 8px;
+  white-space: nowrap;
 }
 
-.CanvasToolbar .runTabToggle,
-.CanvasToolbar .saveStateToggleSection,
-.CanvasToolbar .runTabInputs input {
+.realTimeButton,
+.historicalButton {
+  background: #FFFFFF;
+  outline: none;
+  border-radius: 4px;
+  border: none;
+  color: #A3A3A3;
+  font-size: 12px;
+  font-weight: 500;
+  height: 40px;
+  letter-spacing: 0;
+  line-height: 40px;
+  text-align: center;
+  padding: 0 16px;
+  cursor: pointer;
+}
+
+.realTimeButton {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.historicalButton {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: 1px;
+}
+
+.StateSelectorActive {
+  color: #323232;
+}
+
+.realTimeButton:hover,
+.realTimeButton:active,
+.realTimeButton:focus,
+.historicalButton:hover,
+.historicalButton:active,
+.historicalButton:focus {
+  outline: none;
+}
+
+.runTabInputs {
+  display: flex;
+}
+
+.CanvasToolbar .saveStateToggleSection {
   background: #FFFFFF;
   border-radius: 4px;
+  margin: 0 8px;
+  white-space: nowrap;
+  color: #CDCDCD;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
 }
 
 .CanvasToolbar .saveStateToggleSection .saveStateToggleLabel {
@@ -195,14 +246,6 @@
   text-align: left;
   letter-spacing: 0;
   line-height: 40px;
-}
-
-.CanvasToolbar .saveStateToggleSection {
-  color: #CDCDCD;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 16px;
 }
 
 .CanvasToolbar .saveStateToggle {
@@ -232,4 +275,8 @@
 .CanvasToolbar .icon {
   width: 14px;
   height: 14px;
+}
+
+.ModalButtons {
+  white-space: nowrap;
 }

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -66,40 +66,79 @@
 }
 
 .RunDropdownButton {
-  padding-left: 10px;
-  padding-right: 10px;
+  margin-left: 1px !important;
 
-  svg {
-    width: 10px;
-    height: 10px;
+  & :global(.dropdown-toggle) {
+    padding-left: 14px;
+    padding-right: 14px;
+    outline: none;
+    box-shadow: transparent;
+
+    svg {
+      width: 10px;
+      height: 10px;
+    }
+
+    &::after {
+      content: none;
+    }
   }
 }
 
-.RunButton {
-  & :global(.btn) {
-    border: none;
-    box-shadow: transparent;
-    font-family: inherit;
-    background: #2AC437 !important;
-    color: #FFFFFF !important;
-    font-size: 14px !important;
-    font-weight: 500;
-    text-align: center;
-    letter-spacing: 2px;
-    text-transform: uppercase !important;
-    line-height: 18px;
-    border-radius: 4px;
-  }
+.RunButton :global(.btn) {
+  border: none;
+  box-shadow: transparent;
+  font-family: inherit;
+  color: #FFFFFF !important;
+  font-size: 14px !important;
+  font-weight: 500;
+  text-align: center;
+  letter-spacing: 2px;
+  text-transform: uppercase !important;
+  line-height: 18px;
+  border-radius: 4px;
+}
 
-  & :global(.btn):focus,
-  & :global(.btn):hover {
-    background: #2BB337 !important;
-    color: #FFFFFF !important;
-  }
+.RunButtonRunning :global(.btn) {
+  background: #FF5C00 !important;
+  color: #FFFFFF !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
 
-  & :global(.btn-group):not(:first-child) {
-    margin-left: 1px;
-  }
+.RunButtonStopped :global(.btn) {
+  background: #2AC437 !important;
+  color: #FFFFFF !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.RunButtonRunning :global(.btn):focus,
+.RunButtonRunning :global(.btn):hover,
+.RunButtonRunning :global(.btn):active {
+  background: #E75300 !important;
+  color: #FFFFFF !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.RunButtonStopped :global(.btn):hover,
+.RunButtonStopped :global(.btn):active,
+.RunButtonStopped :global(.btn):focus {
+  background: #2BB337 !important;
+  color: #FFFFFF !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.RunButtonRunning :global(.btn-secondary):focus,
+.RunButtonRunning :global(.btn-secondary):hover,
+.RunButtonRunning :global(.btn-secondary):active,
+.RunButtonRunning :global(.btn-secondary):global(.dropdown-toggle):focus,
+.RunButtonRunning :global(.btn-secondary):global(.dropdown-toggle):hover,
+.RunButtonRunning :global(.btn-secondary):global(.dropdown-toggle):active {
+  outline: none !important;
+  box-shadow: none !important;
 }
 
 .CanvasToolbar .runTabToggle,

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -303,19 +303,3 @@
   left: 50%;
   transform: translate(-50%, 0);
 }
-
-.tooltip {
-  padding: 6px 8px;
-  background-color: #323232 !important;
-  border-radius: 2px;
-  color: #EFEFEF !important;
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-size: 12px;
-  letter-spacing: 0;
-  line-height: 14px;
-  text-align: center;
-
-  &::after {
-    content: none;
-  }
-}

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -85,18 +85,6 @@
   justify-content: space-between;
 }
 
-.RunButtonMenu {
-  font-size: 12px;
-  padding: 0;
-  min-width: 189px !important;
-
-  & :global(.dropdown-item) {
-    font-weight: 500;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-  }
-}
-
 .RunDropdownButton {
   margin-left: 1px !important;
 
@@ -143,6 +131,32 @@
   color: #FFFFFF !important;
   outline: none !important;
   box-shadow: none !important;
+}
+
+.RunButtonMenu {
+  font-size: 12px;
+  padding: 0;
+  min-width: 189px !important;
+
+  & :global(.dropdown-item) {
+    font-weight: 500;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: #525252;
+  }
+
+  & :global(.dropdown-item):focus,
+  & :global(.dropdown-item):hover {
+    outline: none;
+    background-color: #F8F9FA;
+  }
+
+  & :global(.dropdown-item):active,
+  & :global(.dropdown-item):global(.active) {
+    background: url('../../../shared/assets/images/tick.svg') no-repeat 8px 50%;
+    outline: none;
+    background-color: transparent;
+  }
 }
 
 .RunButtonRunning :global(.btn):focus,

--- a/app/src/editor/shared/components/RenameInput.pcss
+++ b/app/src/editor/shared/components/RenameInput.pcss
@@ -3,7 +3,7 @@
   color: inherit;
   border: none;
   background: none;
-  min-width: available; /* prevent name being squashed out */
+  min-width: fill-available; /* prevent name being squashed out */
   padding-top: 0;
   padding-bottom: 0;
   border-radius: 2px;

--- a/app/src/editor/shared/components/RenameInput.pcss
+++ b/app/src/editor/shared/components/RenameInput.pcss
@@ -3,12 +3,15 @@
   color: inherit;
   border: none;
   background: none;
-  min-width: max-content; /* prevent name being squashed out */
+  min-width: available; /* prevent name being squashed out */
   padding-top: 0;
   padding-bottom: 0;
   border-radius: 2px;
   margin-top: -0.5em;
   margin-bottom: -0.5em;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .RenameInput:disabled {

--- a/app/src/shared/assets/images/tick.svg
+++ b/app/src/shared/assets/images/tick.svg
@@ -1,15 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="10px" height="8px" viewBox="0 0 10 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
-    <title>Rectangle 3 Copy</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Editor-UI" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-        <g id="Empty-State-Historical-Speed" transform="translate(-671.000000, -904.000000)" stroke="#323232" stroke-width="1.5">
-            <g id="Historical-speed-control" transform="translate(664.000000, 760.000000)">
-                <g id="Icons-/-Tick-/-Gray-1" transform="translate(8.000000, 143.000000)">
-                    <polyline id="Rectangle-3-Copy" transform="translate(3.975698, 3.975698) scale(-1, 1) rotate(-225.000000) translate(-3.975698, -3.975698) " points="2.35321181 0.109161088 5.59818497 -0.024301611 5.59818497 7.97569839"></polyline>
-                </g>
-            </g>
-        </g>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="8">
+  <path fill="none" fill-rule="evenodd" stroke="#323232" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M1.1 4.56l2.2 2.39 5.66-5.66"/>
 </svg>

--- a/app/src/shared/assets/images/tick.svg
+++ b/app/src/shared/assets/images/tick.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="10px" height="8px" viewBox="0 0 10 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+    <title>Rectangle 3 Copy</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Editor-UI" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Empty-State-Historical-Speed" transform="translate(-671.000000, -904.000000)" stroke="#323232" stroke-width="1.5">
+            <g id="Historical-speed-control" transform="translate(664.000000, 760.000000)">
+                <g id="Icons-/-Tick-/-Gray-1" transform="translate(8.000000, 143.000000)">
+                    <polyline id="Rectangle-3-Copy" transform="translate(3.975698, 3.975698) scale(-1, 1) rotate(-225.000000) translate(-3.975698, -3.975698) " points="2.35321181 0.109161088 5.59818497 -0.024301611 5.59818497 7.97569839"></polyline>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/src/shared/components/Calendar/calendar.pcss
+++ b/app/src/shared/components/Calendar/calendar.pcss
@@ -17,6 +17,8 @@
   }
 
   button {
+    background: inherit;
+
     &:--enter {
       outline: none;
     }

--- a/app/src/shared/components/StatusIcon/index.jsx
+++ b/app/src/shared/components/StatusIcon/index.jsx
@@ -6,16 +6,17 @@ import cx from 'classnames'
 import styles from './statusIcon.pcss'
 
 type Props = {
-    status?: 'ok' | 'error',
+    status?: 'ok' | 'error' | 'inactive',
     className?: string,
 }
 
 export default class StatusIcon extends React.Component<Props> {
     static ERROR = 'error'
     static OK = 'ok'
+    static INACTIVE = 'inactive'
 
     static defaultProps = {
-        status: StatusIcon.OK,
+        status: StatusIcon.INACTIVE,
     }
 
     render() {
@@ -26,6 +27,7 @@ export default class StatusIcon extends React.Component<Props> {
                 className={cx(className, styles.status, {
                     [styles.ok]: status === StatusIcon.OK,
                     [styles.error]: status === StatusIcon.ERROR,
+                    [styles.inactive]: status === StatusIcon.INACTIVE,
                 })}
             />
         )

--- a/app/src/shared/components/StatusIcon/statusIcon.pcss
+++ b/app/src/shared/components/StatusIcon/statusIcon.pcss
@@ -4,6 +4,7 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
+  background: #CDCDCD;
 }
 
 .ok {
@@ -12,4 +13,8 @@
 
 .error {
   background: #FF0F2D;
+}
+
+.inactive {
+  background: #CDCDCD;
 }

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -199,6 +199,22 @@ const sources = {
     arrowhead: (
         <MapIcons.ArrowHeadIcon />
     ),
+    keyboard: (
+        <svg viewBox="0 0 24 14" xmlns="http://www.w3.org/2000/svg">
+            <g
+                transform="translate(0 1)"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                fill="none"
+                fillRule="evenodd"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            >
+                <rect x=".75" y=".25" width="22.5" height="12" rx="3" />
+                <path d="M6.75 3.25h1.5M15.75 3.25h1.5M11.25 3.25h1.5M4.5 6.25H6M9 6.25h1.5M13.5 6.25H15M18 6.25h1.5M6.75 9.25h10.5" />
+            </g>
+        </svg>
+    ),
     share: (
         <svg viewBox="0 0 19 22" xmlns="http://www.w3.org/2000/svg">
             <g stroke="currentColor" strokeWidth="1.5" fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round">

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -27,12 +27,12 @@ const sources = {
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 6">
             <path
                 d="M1 5.245L5.245 1l4.243 4.243"
+                stroke="currentColor"
                 strokeWidth="1.5"
                 fill="none"
                 fillRule="evenodd"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className={styles.default}
             />
         </svg>
     ),
@@ -40,12 +40,12 @@ const sources = {
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 6">
             <path
                 d="M9.488 1.243L5.243 5.488 1 1.245"
+                stroke="currentColor"
                 strokeWidth="1.5"
                 fill="none"
                 fillRule="evenodd"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className={styles.default}
             />
         </svg>
     ),

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -199,6 +199,14 @@ const sources = {
     arrowhead: (
         <MapIcons.ArrowHeadIcon />
     ),
+    share: (
+        <svg viewBox="0 0 19 22" xmlns="http://www.w3.org/2000/svg">
+            <g stroke="currentColor" strokeWidth="1.5" fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M17.788 5.375h-7.013c-1.408 0-2.55 1.12-2.55 2.5V11" />
+                <path d="M13.963 9.125l3.825-3.75-3.825-3.75M15.238 12.875v6.25c0 .69-.571 1.25-1.275 1.25H2.488c-.705 0-1.276-.56-1.276-1.25v-10c0-.69.571-1.25 1.276-1.25H4.4" />
+            </g>
+        </svg>
+    ),
 }
 
 type Props = {

--- a/app/src/shared/components/Tooltip/index.jsx
+++ b/app/src/shared/components/Tooltip/index.jsx
@@ -1,0 +1,62 @@
+// @flow
+
+import React, { type Node } from 'react'
+import { Tooltip as RsTooltip } from 'reactstrap'
+
+import styles from './tooltip.pcss'
+
+type Props = {
+    value: Node,
+    children?: Node,
+}
+type State = {
+    id: number,
+    open: boolean,
+}
+
+let counter = 0
+
+class Tooltip extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props)
+        counter += 1
+
+        this.state = {
+            open: false,
+            id: counter + 1,
+        }
+    }
+
+    toggle = () => {
+        this.setState(({ open }) => ({
+            open: !open,
+        }))
+    }
+
+    render() {
+        const { open, id } = this.state
+        const { value, children, ...otherProps } = this.props
+        return (
+            <div id={`tooltip-${id}`} className={styles.tooltipContainer}>
+                {children}
+                <RsTooltip
+                    innerClassName={styles.tooltip}
+                    hideArrow
+                    placement="top"
+                    delay={{
+                        show: 300,
+                        hide: 250,
+                    }}
+                    {...otherProps}
+                    isOpen={open}
+                    target={`tooltip-${id}`}
+                    toggle={this.toggle}
+                >
+                    {value}
+                </RsTooltip>
+            </div>
+        )
+    }
+}
+
+export default Tooltip

--- a/app/src/shared/components/Tooltip/tooltip.pcss
+++ b/app/src/shared/components/Tooltip/tooltip.pcss
@@ -1,0 +1,15 @@
+.tooltipContainer {
+  display: inline-block;
+}
+
+.tooltip {
+  padding: 6px 8px;
+  background-color: #323232 !important;
+  border-radius: 2px;
+  color: #EFEFEF !important;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 12px;
+  letter-spacing: 0;
+  line-height: 14px;
+  text-align: center;
+}

--- a/app/src/shared/components/WithCalendar/index.jsx
+++ b/app/src/shared/components/WithCalendar/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react'
+import cx from 'classnames'
 
 import Calendar from '$shared/components/Calendar'
 import styles from './withCalendar.pcss'
@@ -10,6 +11,7 @@ export type WithCalendarProps = {
     closeOnSelect?: boolean,
     disabled?: boolean,
     openOnFocus?: boolean,
+    wrapperClassname?: string,
 }
 
 type Props = WithCalendarProps & {
@@ -106,6 +108,7 @@ class WithCalendar extends React.Component<Props, State> {
             closeOnSelect,
             disabled,
             onChange,
+            wrapperClassname,
             ...props
         } = this.props
         const { date } = this.state
@@ -123,13 +126,13 @@ class WithCalendar extends React.Component<Props, State> {
 
     render() {
         const { date, open } = this.state
-        const { disabled } = this.props
+        const { disabled, wrapperClassname } = this.props
 
         return (
             <div ref={this.rootRef}>
                 {this.children()}
                 {!disabled && open && (
-                    <div className={styles.wrapper}>
+                    <div className={cx(styles.wrapper, wrapperClassname)}>
                         <Calendar
                             value={date}
                             onChange={this.setDate}

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -39,6 +39,7 @@ import ErrorDialog from '$mp/components/Modal/ErrorDialog'
 import Notifications from '$shared/components/Notifications'
 import Notification from '$shared/utils/Notification'
 import CodeSnippet from '$shared/components/CodeSnippet'
+import Tooltip from '$shared/components/Tooltip'
 
 import sharedStyles from './shared.pcss'
 
@@ -634,4 +635,11 @@ streamr.subscribe({
     console.log(message)
 }`}
         </CodeSnippet>
+    ))
+
+story('Tooltip')
+    .addWithJSX('basic', () => (
+        <Tooltip value="This is a tooltip">
+            Hover to show tooltip
+        </Tooltip>
     ))


### PR DESCRIPTION
Adds toolbar styling. Not 100% according to design but pretty close 😛 Had some trouble overriding `reactstrap` styles, might have been better just to use normal buttons but the button groups we already there...

Normal state:
<img width="1680" alt="Screen Shot 2019-03-17 at 16 10 05" src="https://user-images.githubusercontent.com/1064982/54492463-9d89e180-48cf-11e9-9c7b-f24d66a0de74.png">

Canvas actions:
<img width="359" alt="Screen Shot 2019-03-17 at 16 10 12" src="https://user-images.githubusercontent.com/1064982/54492467-a4185900-48cf-11e9-9462-b2bd2b51de41.png">
<img width="503" alt="Screen Shot 2019-03-17 at 16 10 22" src="https://user-images.githubusercontent.com/1064982/54492474-ada1c100-48cf-11e9-9500-21880e22d467.png">

Run/stop button:
<img width="278" alt="Screen Shot 2019-03-17 at 16 10 33" src="https://user-images.githubusercontent.com/1064982/54492476-b4c8cf00-48cf-11e9-9b0a-2c0834fa786d.png">
<img width="235" alt="Screen Shot 2019-03-17 at 16 10 40" src="https://user-images.githubusercontent.com/1064982/54492485-bc887380-48cf-11e9-825e-19468459ccdb.png">
<img width="974" alt="Screen Shot 2019-03-17 at 16 11 10" src="https://user-images.githubusercontent.com/1064982/54492507-daee6f00-48cf-11e9-8465-09c82c745c24.png">

Realtime/historical:
<img width="358" alt="Screen Shot 2019-03-17 at 16 10 44" src="https://user-images.githubusercontent.com/1064982/54492494-c4481800-48cf-11e9-86a2-62701747b65a.png">
<img width="422" alt="Screen Shot 2019-03-17 at 16 10 50" src="https://user-images.githubusercontent.com/1064982/54492502-cf02ad00-48cf-11e9-8866-76b4669edd82.png">
<img width="485" alt="Screen Shot 2019-03-17 at 16 10 53" src="https://user-images.githubusercontent.com/1064982/54492504-d5912480-48cf-11e9-9e33-dc3c6795a79b.png">



