### PR TITLE
Wait up to a minute to connect to services in test.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --hot",
     "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack",
-    "test": "jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/*",
+    "test": "jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/* ./src/editor/canvas/tests/*",
     "flow": "flow",
     "flow-stop": "flow stop",
     "eslint": "eslint .",

--- a/app/src/editor/canvas/tests/services.test.js
+++ b/app/src/editor/canvas/tests/services.test.js
@@ -17,7 +17,7 @@ describe('Canvas Services', () => {
 
     beforeAll(async () => {
         teardown = await setup(Services.API)
-    })
+    }, 60000) // service can take some time to respond initially
 
     afterAll(async () => {
         await teardown()


### PR DESCRIPTION
Possible that the CI flakiness is caused by not waiting long enough for the services to respond.

The `getSessionToken` call in particular seems to take some time when the docker environment has just booted. This PR raises the initial connection wait time from 5 seconds to a minute.