### PR TITLE
[PLATFORM-450] Linked Variadic Ports

### DIFF
--- a/app/src/editor/canvas/components/PortDragger.jsx
+++ b/app/src/editor/canvas/components/PortDragger.jsx
@@ -44,8 +44,9 @@ class DraggablePort extends React.Component {
             let nextCanvas = canvas
             if (sourceId) {
                 // if dragging from an already connected input, treat as if dragging output
-                nextCanvas = CanvasState.disconnectPorts(nextCanvas, sourceId, portId)
-                nextCanvas = CanvasState.connectPorts(nextCanvas, sourceId, overId)
+                nextCanvas = CanvasState.movePortConnection(nextCanvas, sourceId, overId, {
+                    currentInputId: portId,
+                })
             } else {
                 nextCanvas = CanvasState.connectPorts(nextCanvas, portId, overId)
             }

--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -6,7 +6,15 @@ import startCase from 'lodash/startCase'
 import RenameInput from '$editor/shared/components/RenameInput'
 import ContextMenu from '$shared/components/ContextMenu'
 
-import { RunStates, canConnectPorts, arePortsOfSameModule, hasPort, disconnectAllFromPort } from '../state'
+import {
+    RunStates,
+    canConnectPorts,
+    arePortsOfSameModule,
+    hasPort,
+    disconnectAllFromPort,
+    findLinkedVariadicPort,
+    isPortConnected,
+} from '../state'
 import { DropTarget, DragSource } from './PortDragger'
 import { DragDropContext } from './DragDropContext'
 import styles from './Ports.pcss'
@@ -194,6 +202,17 @@ class Port extends React.PureComponent {
         const isParam = 'defaultValue' in port
         const hasInputField = isParam || port.canHaveInitialValue
         const isRunning = canvas.state === 'RUNNING'
+
+        let isHidden = false
+        if (!isInput) {
+            const linkedInput = findLinkedVariadicPort(canvas, port.id)
+            if (linkedInput) {
+                // hide output if linked input is not connected
+                isHidden = !isPortConnected(canvas, linkedInput.id)
+            }
+        }
+
+        if (isHidden) { return [<div />, <div />, <div />] }
 
         const portContent = [
             <RenameInput

--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -212,7 +212,10 @@ class Port extends React.PureComponent {
             }
         }
 
-        if (isHidden) { return [<div />, <div />, <div />] }
+        if (isHidden) {
+            // layout placeholder
+            return <React.Fragment><div /><div /><div /></React.Fragment>
+        }
 
         const portContent = [
             <RenameInput

--- a/app/src/editor/canvas/components/Ports.pcss
+++ b/app/src/editor/canvas/components/Ports.pcss
@@ -48,6 +48,7 @@
   font-weight: 500;
   white-space: nowrap;
   width: auto;
+  text-align: inherit;
 }
 
 .ports .portNameContainer.isOutput {

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -19,7 +19,7 @@ export const API = axios.create({
 const getData = ({ data }) => data
 
 const canvasesUrl = `${process.env.STREAMR_API_URL}/canvases`
-const getModuleURL = `${process.env.STREAMR_API_URL}/modules`
+const getModulesURL = `${process.env.STREAMR_API_URL}/modules`
 const getModuleTreeURL = `${process.env.STREAMR_URL}/module/jsonGetModuleTree`
 const streamsUrl = `${process.env.STREAMR_API_URL}/streams`
 
@@ -78,8 +78,12 @@ export async function getModuleTree() {
     return API.get(getModuleTreeURL).then(getData)
 }
 
+export async function getModules() {
+    return API.get(getModulesURL).then(getData)
+}
+
 export async function addModule({ id, configuration } = {}) {
-    return API.post(`${getModuleURL}/${id}`, configuration).then(getData)
+    return API.post(`${getModulesURL}/${id}`, configuration).then(getData)
 }
 
 export async function loadCanvas({ id } = {}) {

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -19,7 +19,7 @@ export const API = axios.create({
 const getData = ({ data }) => data
 
 const canvasesUrl = `${process.env.STREAMR_API_URL}/canvases`
-const getModuleURL = `${process.env.STREAMR_URL}/module/jsonGetModule`
+const getModuleURL = `${process.env.STREAMR_API_URL}/modules`
 const getModuleTreeURL = `${process.env.STREAMR_URL}/module/jsonGetModuleTree`
 const streamsUrl = `${process.env.STREAMR_API_URL}/streams`
 
@@ -79,12 +79,7 @@ export async function getModuleTree() {
 }
 
 export async function addModule({ id, configuration } = {}) {
-    const form = new FormData()
-    form.append('id', id)
-    if (configuration) {
-        form.append('configuration', JSON.stringify(configuration))
-    }
-    return API.post(getModuleURL, form).then(getData)
+    return API.post(`${getModuleURL}/${id}`, configuration).then(getData)
 }
 
 export async function loadCanvas({ id } = {}) {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -665,6 +665,12 @@ function getHash(canvas, iterations = 0) {
  */
 
 export function addModule(canvas, moduleData) {
+    if (!moduleData || !moduleData.id) {
+        throw createError(`trying to add bad module: ${moduleData}`, {
+            canvas,
+            moduleData,
+        })
+    }
     const canvasModule = {
         ...moduleData,
         hash: getHash(canvas), // TODO: better IDs

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -745,7 +745,7 @@ function addVariadic(canvas, moduleHash, type, config = {}) {
     return updateVariadics(newCanvas, moduleHash, type)
 }
 
-function findLinkedVariadicPort(canvas, portId) {
+export function findLinkedVariadicPort(canvas, portId) {
     const port = getPort(canvas, portId)
     if (!port.variadic) { return }
     if (getIsOutput(canvas, portId)) {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -741,7 +741,7 @@ function updateVariadics(canvas, moduleHash, type) {
 
     variadics.forEach(({ id }, index) => {
         nextCanvas = updatePort(nextCanvas, id, (port) => {
-            const portIndex = index + 1 // variadic indexes start at 1
+            const portIndex = variadics[0].variadic.index + index // variadic indexes start at 1
             return {
                 ...port,
                 displayName: getVariadicDisplayName(canvas, port.id, portIndex),

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -1,5 +1,7 @@
 import * as State from '../state'
+import * as Services from '../services'
 import * as Mocks from './mocks'
+import { setup, loadModuleDefinition } from './utils'
 
 const portMatcher = {
     id: expect.any(String),
@@ -9,6 +11,23 @@ const portMatcher = {
 }
 
 describe('Canvas State', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setup(Services.API)
+    }, 60000)
+
+    afterAll(async () => {
+        await teardown()
+    })
+
+    let Clock
+
+    beforeAll(async () => {
+        Clock = await loadModuleDefinition('Clock')
+        expect(Clock).toHaveProperty('id')
+    })
+
     describe('emptyCanvas', () => {
         it('creates an empty canvas', () => {
             expect(State.emptyCanvas()).toMatchSnapshot({
@@ -18,7 +37,11 @@ describe('Canvas State', () => {
     })
 
     describe('getModule/findModule', () => {
-        const canvas = State.addModule(State.emptyCanvas(), Mocks.Clock())
+        let canvas
+
+        beforeAll(() => {
+            canvas = State.addModule(State.emptyCanvas(), Clock)
+        })
 
         test('findModule should find modules by matcher', () => {
             const clock = State.findModule(canvas, ({ name }) => name === 'Clock')
@@ -40,8 +63,13 @@ describe('Canvas State', () => {
     })
 
     describe('module port access', () => {
-        const canvas = State.addModule(State.emptyCanvas(), Mocks.Clock())
-        const clock = State.findModule(canvas, ({ name }) => name === 'Clock')
+        let canvas
+        let clock
+
+        beforeAll(() => {
+            canvas = State.addModule(State.emptyCanvas(), Clock)
+            clock = State.findModule(canvas, ({ name }) => name === 'Clock')
+        })
 
         describe('getModulePorts', () => {
             it('should get all module ports', () => {
@@ -58,8 +86,8 @@ describe('Canvas State', () => {
         })
 
         describe('getPort', () => {
-            const modulePorts = State.getModulePorts(canvas, clock.hash)
             it('should get port', () => {
+                const modulePorts = State.getModulePorts(canvas, clock.hash)
                 Object.values(modulePorts).forEach((port) => {
                     expect(State.getPort(canvas, port.id)).toBe(port)
                 })
@@ -71,8 +99,13 @@ describe('Canvas State', () => {
         })
 
         describe('getAllPorts', () => {
-            const canvasWithTwoModules = State.addModule(canvas, Mocks.Clock())
-            const clocks = State.findModules(canvasWithTwoModules, ({ name }) => name === 'Clock')
+            let canvasWithTwoModules
+            let clocks
+
+            beforeAll(async () => {
+                canvasWithTwoModules = State.addModule(canvas, await loadModuleDefinition('Clock'))
+                clocks = State.findModules(canvasWithTwoModules, ({ name }) => name === 'Clock')
+            })
 
             it('should get all ports', () => {
                 // get all expected ports via getModulePorts
@@ -84,74 +117,82 @@ describe('Canvas State', () => {
             })
         })
 
-        describe('hasPort', () => {
-            const modulePorts = State.getModulePorts(canvas, clock.hash)
-            it('should be true if has port', () => {
-                Object.values(modulePorts).forEach((port) => {
-                    expect(State.hasPort(canvas, port.id)).toBe(true)
+        describe('ports', () => {
+            let modulePorts
+
+            beforeAll(() => {
+                modulePorts = State.getModulePorts(canvas, clock.hash)
+            })
+
+            describe('hasPort', () => {
+                it('should be true if has port', () => {
+                    Object.values(modulePorts).forEach((port) => {
+                        expect(State.hasPort(canvas, port.id)).toBe(true)
+                    })
+                })
+
+                it('should be false on missing port', () => {
+                    expect(State.hasPort(canvas, 'missing')).toBe(false)
                 })
             })
 
-            it('should be false on missing port', () => {
-                expect(State.hasPort(canvas, 'missing')).toBe(false)
-            })
-        })
+            describe('findModulePort', () => {
+                it('should find ports by matcher', () => {
+                    Object.values(modulePorts).forEach((port) => {
+                        expect(State.findModulePort(canvas, clock.hash, ({ id }) => id === port.id)).toBe(port)
+                    })
+                })
 
-        describe('findModulePort', () => {
-            const modulePorts = State.getModulePorts(canvas, clock.hash)
+                it('should error on missing module', () => {
+                    expect(() => State.findModulePort(canvas, 'missing', () => true)).toThrowError(State.MissingEntityError)
+                })
 
-            it('should find ports by matcher', () => {
-                Object.values(modulePorts).forEach((port) => {
-                    expect(State.findModulePort(canvas, clock.hash, ({ id }) => id === port.id)).toBe(port)
+                it('should not error on missing port', () => {
+                    expect(State.findModulePort(canvas, clock.hash, () => false)).toBeUndefined()
                 })
             })
 
-            it('should error on missing module', () => {
-                expect(() => State.findModulePort(canvas, 'missing', () => true)).toThrowError(State.MissingEntityError)
-            })
+            describe('getModuleForPort', () => {
+                it('should get module for port', () => {
+                    Object.values(modulePorts).forEach((port) => {
+                        expect(State.getModuleForPort(canvas, port.id)).toBe(clock)
+                    })
+                })
 
-            it('should not error on missing port', () => {
-                expect(State.findModulePort(canvas, clock.hash, () => false)).toBeUndefined()
-            })
-        })
-
-        describe('getModuleForPort', () => {
-            const modulePorts = State.getModulePorts(canvas, clock.hash)
-
-            it('should get module for port', () => {
-                Object.values(modulePorts).forEach((port) => {
-                    expect(State.getModuleForPort(canvas, port.id)).toBe(clock)
+                it('should error on missing port', () => {
+                    expect(() => State.getModuleForPort(canvas, 'missing')).toThrowError(State.MissingEntityError)
                 })
             })
 
-            it('should error on missing port', () => {
-                expect(() => State.getModuleForPort(canvas, 'missing')).toThrowError(State.MissingEntityError)
-            })
-        })
+            describe('arePortsOfSameModule', () => {
+                let canvasWithTwoModules
+                let clocks
 
-        describe('arePortsOfSameModule', () => {
-            const canvasWithTwoModules = State.addModule(canvas, Mocks.Clock())
-            const clocks = State.findModules(canvasWithTwoModules, ({ name }) => name === 'Clock')
+                beforeAll(async () => {
+                    canvasWithTwoModules = State.addModule(canvas, await loadModuleDefinition('Clock'))
+                    clocks = State.findModules(canvasWithTwoModules, ({ name }) => name === 'Clock')
+                })
 
-            it('should be true for same module', () => {
-                const modulePorts = State.getModulePorts(canvasWithTwoModules, clocks[0].hash)
-                const [port1, port2] = Object.values(modulePorts)
-                expect(State.arePortsOfSameModule(canvasWithTwoModules, port1.id, port2.id)).toBe(true)
-            })
+                it('should be true for same module', () => {
+                    const modulePorts = State.getModulePorts(canvasWithTwoModules, clocks[0].hash)
+                    const [port1, port2] = Object.values(modulePorts)
+                    expect(State.arePortsOfSameModule(canvasWithTwoModules, port1.id, port2.id)).toBe(true)
+                })
 
-            it('should be false if not of same module', () => {
-                const modulePorts1 = State.getModulePorts(canvasWithTwoModules, clocks[0].hash)
-                const modulePorts2 = State.getModulePorts(canvasWithTwoModules, clocks[1].hash)
-                const [port1] = Object.values(modulePorts1)
-                const [port2] = Object.values(modulePorts2)
-                expect(State.arePortsOfSameModule(canvasWithTwoModules, port1.id, port2.id)).toBe(false)
-            })
+                it('should be false if not of same module', () => {
+                    const modulePorts1 = State.getModulePorts(canvasWithTwoModules, clocks[0].hash)
+                    const modulePorts2 = State.getModulePorts(canvasWithTwoModules, clocks[1].hash)
+                    const [port1] = Object.values(modulePorts1)
+                    const [port2] = Object.values(modulePorts2)
+                    expect(State.arePortsOfSameModule(canvasWithTwoModules, port1.id, port2.id)).toBe(false)
+                })
 
-            it('should error on missing port', () => {
-                const modulePorts = State.getModulePorts(canvasWithTwoModules, clocks[0].hash)
-                const port = Object.values(modulePorts)[0]
-                expect(() => State.arePortsOfSameModule(canvasWithTwoModules, port.id, 'missing')).toThrowError(State.MissingEntityError)
-                expect(() => State.arePortsOfSameModule(canvasWithTwoModules, 'missing', port.id)).toThrowError(State.MissingEntityError)
+                it('should error on missing port', () => {
+                    const modulePorts = State.getModulePorts(canvasWithTwoModules, clocks[0].hash)
+                    const port = Object.values(modulePorts)[0]
+                    expect(() => State.arePortsOfSameModule(canvasWithTwoModules, port.id, 'missing')).toThrowError(State.MissingEntityError)
+                    expect(() => State.arePortsOfSameModule(canvasWithTwoModules, 'missing', port.id)).toThrowError(State.MissingEntityError)
+                })
             })
         })
     })

--- a/app/src/editor/canvas/tests/utils.js
+++ b/app/src/editor/canvas/tests/utils.js
@@ -51,3 +51,15 @@ export async function setup(API) {
         }
     }
 }
+
+const MODULE_IDS = {
+    Clock: 209,
+    Canvas: 81,
+    Table: 527,
+}
+
+export async function loadModuleDefinition(name) {
+    return Services.addModule({
+        id: MODULE_IDS[name],
+    })
+}

--- a/app/src/editor/canvas/tests/utils.js
+++ b/app/src/editor/canvas/tests/utils.js
@@ -52,14 +52,24 @@ export async function setup(API) {
     }
 }
 
-const MODULE_IDS = {
-    Clock: 209,
-    Canvas: 81,
-    Table: 527,
+let modulesCache
+
+async function getModules() {
+    if (modulesCache) { return modulesCache }
+    modulesCache = new Map()
+    const modules = await Services.getModules()
+    modules.forEach((m) => {
+        if (modulesCache.has(m.name)) {
+            throw new Error(`Duplicate module name: ${m.name}`)
+        }
+        modulesCache.set(m.name, m.id)
+    })
+    return modulesCache
 }
 
 export async function loadModuleDefinition(name) {
+    const modules = await getModules()
     return Services.addModule({
-        id: MODULE_IDS[name],
+        id: modules.get(name),
     })
 }

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -145,4 +145,47 @@ describe('Variadic Port Handling', () => {
             expect(firstVariadicPort.variadic.isLast).toBeTruthy()
         })
     })
+
+    describe('Variadic Input/Output Pairs', () => {
+        let PassThrough
+
+        beforeAll(async () => {
+            PassThrough = await loadModuleDefinition('PassThrough')
+            expect(PassThrough).toHaveProperty('id')
+        })
+
+        it('can add/remove variadic inputs as connections added/removed', async () => {
+            // connect clock to a table (table has variadic inputs)
+            let canvas = State.emptyCanvas()
+            canvas = State.addModule(canvas, PassThrough)
+            canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+
+            const passThrough = canvas.modules.find((m) => m.name === 'PassThrough')
+            const constant = canvas.modules.find((m) => m.name === 'Constant')
+            expect(passThrough).toBeTruthy()
+            expect(constant).toBeTruthy()
+
+            const fromPort = State.findModulePort(canvas, constant.hash, (p) => p.name === 'out')
+            const toPort = State.findModulePort(canvas, passThrough.hash, (p) => p.displayName === 'in1')
+            expect(fromPort).toBeTruthy()
+            expect(toPort).toBeTruthy()
+
+            canvas = State.updateCanvas(State.connectPorts(canvas, fromPort.id, toPort.id))
+            expect(State.isPortConnected(canvas, fromPort.id)).toBeTruthy()
+            expect(State.isPortConnected(canvas, toPort.id)).toBeTruthy()
+
+            // check a new output is created
+            const newVariadicOutput = State.findModulePort(canvas, passThrough.hash, (p) => p.displayName === 'out2')
+            expect(newVariadicOutput).toBeTruthy()
+            // new output is last
+            expect(newVariadicOutput.variadic.isLast).toBeTruthy()
+            // new output is not connected
+            expect(State.isPortConnected(canvas, newVariadicOutput.id)).not.toBeTruthy()
+            // disconnecting should remove new output
+            canvas = State.updateCanvas(State.disconnectPorts(canvas, fromPort.id, toPort.id))
+
+            // check new ouput is gone
+            expect(State.findModulePort(canvas, passThrough.hash, (p) => p.displayName === 'out')).toBeUndefined()
+        })
+    })
 })

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -1,11 +1,32 @@
 import * as State from '../state'
-import * as Mocks from './mocks'
+import * as Services from '../services'
+import { loadModuleDefinition, setup } from './utils'
 
 describe('Variadic Port Handling', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setup(Services.API)
+    }, 60000)
+
+    afterAll(async () => {
+        await teardown()
+    })
+
+    let Clock
+    let Table
+
+    beforeAll(async () => {
+        Clock = await loadModuleDefinition('Clock')
+        Table = await loadModuleDefinition('Table')
+        expect(Clock).toHaveProperty('id')
+        expect(Table).toHaveProperty('id')
+    })
+
     it('can add/connect modules', () => {
         let canvas = State.emptyCanvas()
-        canvas = State.addModule(canvas, Mocks.Clock())
-        canvas = State.addModule(canvas, Mocks.Table())
+        canvas = State.addModule(canvas, Clock)
+        canvas = State.addModule(canvas, Table)
         const clock = canvas.modules.find((m) => m.name === 'Clock')
         const table = canvas.modules.find((m) => m.name === 'Table')
         expect(clock).toBeTruthy()

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -13,36 +13,58 @@ describe('Variadic Port Handling', () => {
         await teardown()
     })
 
-    let Clock
-    let Table
+    describe('Variadic Inputs', () => {
+        let Clock
+        let Table
 
-    beforeAll(async () => {
-        Clock = await loadModuleDefinition('Clock')
-        Table = await loadModuleDefinition('Table')
-        expect(Clock).toHaveProperty('id')
-        expect(Table).toHaveProperty('id')
-    })
+        beforeAll(async () => {
+            Clock = await loadModuleDefinition('Clock')
+            Table = await loadModuleDefinition('Table')
+            expect(Clock).toHaveProperty('id')
+            expect(Table).toHaveProperty('id')
+        })
 
-    it('can add/connect modules', () => {
-        let canvas = State.emptyCanvas()
-        canvas = State.addModule(canvas, Clock)
-        canvas = State.addModule(canvas, Table)
-        const clock = canvas.modules.find((m) => m.name === 'Clock')
-        const table = canvas.modules.find((m) => m.name === 'Table')
-        expect(clock).toBeTruthy()
-        expect(table).toBeTruthy()
-        expect(clock.hash).not.toEqual(table.hash)
-        const fromPort = State.findModulePort(canvas, clock.hash, (p) => p.name === 'timestamp')
-        const toPort = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 1)
-        expect(fromPort).toBeTruthy()
-        expect(toPort).toBeTruthy()
+        it('can add/remove variadic inputs as connections added/removed', () => {
+            // connect clock to a table (table has variadic inputs)
+            let canvas = State.emptyCanvas()
+            canvas = State.addModule(canvas, Clock)
+            canvas = State.addModule(canvas, Table)
+            const clock = canvas.modules.find((m) => m.name === 'Clock')
+            const table = canvas.modules.find((m) => m.name === 'Table')
+            expect(clock).toBeTruthy()
+            expect(table).toBeTruthy()
+            expect(clock.hash).not.toEqual(table.hash)
+            const fromPort = State.findModulePort(canvas, clock.hash, (p) => p.name === 'timestamp')
+            const toPort = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 1)
+            expect(fromPort).toBeTruthy()
+            expect(toPort).toBeTruthy()
 
-        canvas = State.updateCanvas(State.connectPorts(canvas, fromPort.id, toPort.id))
-        expect(State.isPortConnected(canvas, fromPort.id)).toBeTruthy()
-        expect(State.isPortConnected(canvas, toPort.id)).toBeTruthy()
+            canvas = State.updateCanvas(State.connectPorts(canvas, fromPort.id, toPort.id))
+            expect(State.isPortConnected(canvas, fromPort.id)).toBeTruthy()
+            expect(State.isPortConnected(canvas, toPort.id)).toBeTruthy()
 
-        const newVariadicInput = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 2)
-        expect(newVariadicInput).toBeTruthy()
-        expect(newVariadicInput.variadic.isLast).toBeTruthy()
+            // check a new input is created
+            const newVariadicInput = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 2)
+            expect(newVariadicInput).toBeTruthy()
+            // new input is last
+            expect(newVariadicInput.variadic.isLast).toBeTruthy()
+            // new input is not connected
+            expect(State.isPortConnected(canvas, newVariadicInput.id)).not.toBeTruthy()
+            let firstVariadicPort = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 1)
+            // first is not last
+            expect(firstVariadicPort.variadic.isLast).not.toBeTruthy()
+
+            // disconnecting should remove new input
+            canvas = State.updateCanvas(State.disconnectPorts(canvas, fromPort.id, toPort.id))
+
+            // check new input is gone
+            expect(State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 2)).toBeUndefined()
+
+            firstVariadicPort = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 1)
+            expect(firstVariadicPort).toBeTruthy()
+
+            // first is now last
+            expect(firstVariadicPort.variadic.isLast).toBeTruthy()
+        })
     })
 })

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -67,4 +67,59 @@ describe('Variadic Port Handling', () => {
             expect(firstVariadicPort.variadic.isLast).toBeTruthy()
         })
     })
+
+    describe('Variadic Outputs', () => {
+        let GetMultiFromMap
+        let Table
+
+        beforeAll(async () => {
+            GetMultiFromMap = await loadModuleDefinition('GetMultiFromMap')
+            Table = await loadModuleDefinition('Table')
+            expect(GetMultiFromMap).toHaveProperty('id')
+            expect(Table).toHaveProperty('id')
+        })
+
+        it('can add/remove variadic inputs as connections added/removed', () => {
+            // connect clock to a table (table has variadic inputs)
+            let canvas = State.emptyCanvas()
+            canvas = State.addModule(canvas, GetMultiFromMap)
+            canvas = State.addModule(canvas, Table)
+            const multi = canvas.modules.find((m) => m.name === 'GetMultiFromMap')
+            const table = canvas.modules.find((m) => m.name === 'Table')
+            expect(multi).toBeTruthy()
+            expect(table).toBeTruthy()
+            const fromPort = State.findModulePort(canvas, multi.hash, (p) => p.displayName === 'out1')
+            // table input happens to be variadic but not related to this test
+            const toPort = State.findModulePort(canvas, table.hash, (p) => p.variadic.index === 1)
+            expect(fromPort).toBeTruthy()
+            expect(toPort).toBeTruthy()
+
+            canvas = State.updateCanvas(State.connectPorts(canvas, fromPort.id, toPort.id))
+            expect(State.isPortConnected(canvas, fromPort.id)).toBeTruthy()
+            expect(State.isPortConnected(canvas, toPort.id)).toBeTruthy()
+
+            // check a new output is created
+            const newVariadicOutput = State.findModulePort(canvas, multi.hash, (p) => p.variadic && p.variadic.index === 2)
+            expect(newVariadicOutput).toBeTruthy()
+            // new output is last
+            expect(newVariadicOutput.variadic.isLast).toBeTruthy()
+            // new output is not connected
+            expect(State.isPortConnected(canvas, newVariadicOutput.id)).not.toBeTruthy()
+            let firstVariadicPort = State.findModulePort(canvas, multi.hash, (p) => p.variadic && p.variadic.index === 1)
+            // first is not last
+            expect(firstVariadicPort.variadic.isLast).not.toBeTruthy()
+
+            // disconnecting should remove new output
+            canvas = State.updateCanvas(State.disconnectPorts(canvas, fromPort.id, toPort.id))
+
+            // check new input is gone
+            expect(State.findModulePort(canvas, multi.hash, (p) => p.variadic && p.variadic.index === 2)).toBeUndefined()
+
+            firstVariadicPort = State.findModulePort(canvas, multi.hash, (p) => p.variadic && p.variadic.index === 1)
+            expect(firstVariadicPort).toBeTruthy()
+
+            // first is now last
+            expect(firstVariadicPort.variadic.isLast).toBeTruthy()
+        })
+    })
 })

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -253,7 +253,7 @@ describe('Variadic Port Handling', () => {
             // connect passThrough.out1 to tableIn1.in1
             canvas = State.updateCanvas(State.connectPorts(canvas, passThroughOut1.id, tableIn1.id))
             const tableIn2 = State.findModulePort(canvas, table.hash, (p) => p.displayName === 'in2')
-            const passThroughOut2 = State.findModulePort(canvas, passThrough.hash, (p) => p.displayName === 'out2')
+            const passThroughOut2 = State.findModulePort(canvas, passThrough.hash, (p) => p.longName === 'PassThrough.out2')
             // connect passThrough.out2 to tableIn1.in2
             canvas = State.updateCanvas(State.connectPorts(canvas, passThroughOut2.id, tableIn2.id))
             // disconnect passthrough.in1
@@ -287,7 +287,7 @@ describe('Variadic Port Handling', () => {
             // connect passThrough.out1 to tableIn1.in1
             canvas = State.updateCanvas(State.connectPorts(canvas, passThroughOut1.id, tableIn1.id))
             const tableIn2 = State.findModulePort(canvas, table.hash, (p) => p.displayName === 'in2')
-            const passThroughOut2 = State.findModulePort(canvas, passThrough.hash, (p) => p.displayName === 'out2')
+            const passThroughOut2 = State.findModulePort(canvas, passThrough.hash, (p) => p.longName === 'PassThrough.out2')
             // connect passThrough.out2 to tableIn1.in2
             canvas = State.updateCanvas(State.connectPorts(canvas, passThroughOut2.id, tableIn2.id))
             const tableIn3 = State.findModulePort(canvas, table.hash, (p) => p.displayName === 'in3')


### PR DESCRIPTION
* Reworked the canvas editor tests to use live module definitions.
* Added tests for variadic outputs
* Creates new input/output pairs when something is connected to input of previous pair.
* When linked input is disconnected, linked output is also disconnected.
* Removes spurious pairs from end of ports list, like normal variadics but makes sure to remove both input and output.
* `displayName` of incoming connection's output port is adopted when connecting to a variadic input.
* if variadic input has a `linkedOutput`, same `displayName` is copied to output.
* On disconnection, `displayName`s are reset to use index e.g. `in1`, `out2`, etc.
* Linked variadic outputs are hidden until linked input is connected.
* Appropriate port `longName` is maintained based on port index e.g. `Table.in1`.
* Port index is no longer forever increasing, but does take into account initial index as an offset e.g. `Add` module starts at index 3 because it already has non-variadic `in1` and `in2` ports.
* Value type of the value entering the connected input is used as value when determining whether ports can be connected. e.g. can't normally connect ConstantText to Add because ConstantText output type is incompatible with Add input type, but you can connect it if you first pass the text via a PassThrough module, whose input/output types are both `Object` (i.e. `any`). This change follows the connection chain back to the original `ConstantText` module's output type and forbids the connection.

To test, try connecting/disconnecting things to inputs/outputs of the `PassThrough` module. try connecting in different orders, note when input disconnected, output is disconnected. Note variadic inputs like that of Table are cleaned up appropriately, no dangling ports or invalid connection statuses. Try connecting ports in different orders and crossing wires, or chaining variadic modules together.