### PR TITLE
Update indicators for exported ports

### DIFF
--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -141,6 +141,7 @@ class PortIcon extends React.PureComponent {
         const from = this.context.data || {}
         const fromId = from.sourceId || from.portId
         const canDrop = dragPortInProgress && canConnectPorts(this.props.canvas, fromId, this.props.port.id)
+        const isExported = !!port.export
 
         return (
             <div
@@ -149,6 +150,7 @@ class PortIcon extends React.PureComponent {
                 title={port.id}
                 className={cx(styles.PortIcon, {
                     [styles.isInput]: isInput,
+                    [styles.isExported]: isExported,
                     [styles.isOutput]: !isInput,
                     [styles.connected]: port.connected,
                     [styles.requiresConnection]: port.requiresConnection,
@@ -286,16 +288,6 @@ class PortOptions extends React.PureComponent {
                         NR
                     </button>
                 )}
-                <button
-                    type="button"
-                    title={`Export: ${port.export ? 'On' : 'Off'}`}
-                    value={!!port.export}
-                    className={styles.export}
-                    onClick={this.getToggleOption('export')}
-                    disabled={!!isRunning}
-                >
-                    EX
-                </button>
             </div>
         )
     }

--- a/app/src/editor/canvas/components/Ports.jsx
+++ b/app/src/editor/canvas/components/Ports.jsx
@@ -175,7 +175,7 @@ class PortIcon extends React.PureComponent {
                     isOpen={this.state.isMenuOpen}
                 >
                     <ContextMenu.Item text="Disconnect all" onClick={() => this.disconnectAll(port)} />
-                    <ContextMenu.Item text="Toggle export" onClick={() => this.toggleExport(port)} />
+                    <ContextMenu.Item text={isExported ? 'Disable export' : 'Enable export'} onClick={() => this.toggleExport(port)} />
                 </ContextMenu>
             </div>
         )

--- a/app/src/editor/canvas/components/Ports.pcss
+++ b/app/src/editor/canvas/components/Ports.pcss
@@ -1,10 +1,10 @@
 @import '../../shared/components/variables.pcss';
 
 :root {
-  --driving-input-color: #FF5C00;
+  --driving-input-color: #0324FF;
   --no-repeat-color: #0324FF;
   --connected-color: #2AC437;
-  --export-color: #6240AF; /* invented in lieu of design */
+  --exported-color: #FFB600; /* invented in lieu of design */
   --port-size: 8px;
 }
 
@@ -108,6 +108,14 @@
 
 .ports .PortIcon.noRepeat .portIconGraphic {
   border-color: var(--no-repeat-color);
+}
+
+/* isExported colour should override drivingInput, noRepeat */
+.ports .PortIcon.isExported .portIconGraphic,
+.ports .PortIcon.isExported.drivingInput .portIconGraphic,
+.ports .PortIcon.isExported.noRepeat .portIconGraphic,
+.ports .PortIcon.connected.isExported .portIconGraphic {
+  border-color: var(--exported-color);
 }
 
 .ports .PortIcon:not(.isDragging):not(.draggingFromSameModule).dragPortInProgress .portIconGraphic {
@@ -244,10 +252,6 @@
   letter-spacing: 0;
   line-height: 10px;
   transition: background 0.25s;
-}
-
-.ports .PortIcon .portOptions > .export[value='true'] {
-  background-color: var(--export-color);
 }
 
 .ports .PortIcon .portOptions > .drivingInputOption[value='true'] {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43438/54897003-a860f980-4f01-11e9-8013-cc1de437296f.png)

* Removes the temporary "EX" option from the hover menu.
* Add orange "exported" port colour (from https://share.goabstract.com/e7a8ad3f-bdbe-4431-acab-44ecd585c227).
* Updated DI/NR colours (both are blue now according to abstract).
* Switches 'toggle export' text between 'enable export' & 'disable export' based on port export state. (as discussed https://share.goabstract.com/dc943ddb-bd93-4260-abf9-c77df13c2acf)