### PR TITLE
Chart & Table init requests

### DIFF
--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -171,9 +171,7 @@ export default class ChartModule extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.isActive) {
-            this.load()
-        }
+        this.initIfActive(this.props.isActive)
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -225,7 +223,13 @@ export default class ChartModule extends React.Component {
         }
     }, 10)
 
-    load = async () => {
+    initIfActive = (isActive) => {
+        if (isActive) {
+            this.init()
+        }
+    }
+
+    init = async () => {
         const { initRequest } = await this.subscription.current.send({
             type: 'initRequest',
         })
@@ -274,6 +278,7 @@ export default class ChartModule extends React.Component {
                     {...this.props}
                     ref={this.subscription}
                     onMessage={this.onMessage}
+                    onActiveChange={this.initIfActive}
                 />
                 {!!(options.displayTitle && options.displayTitle.value && title) && (
                     <h4>{title}</h4>

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -230,7 +230,7 @@ export default class ChartModule extends React.Component {
     }, 10)
 
     initIfActive = (isActive) => {
-        if (isActive) {
+        if (isActive && !this.props.canvas.adhoc) {
             this.init()
         }
     }

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -138,6 +138,7 @@ export default class ChartModule extends React.Component {
     }
 
     flushDataPoints = throttle(() => {
+        if (this.unmounted) { return }
         const { queuedDatapoints } = this
         this.queuedDatapoints = []
         this.setState(({ datapoints }) => ({
@@ -172,6 +173,10 @@ export default class ChartModule extends React.Component {
 
     componentDidMount() {
         this.initIfActive(this.props.isActive)
+    }
+
+    componentWillUnmount() {
+        this.unmounted = true
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -218,6 +223,7 @@ export default class ChartModule extends React.Component {
     }
 
     resize = debounce(() => {
+        if (this.unmounted) { return }
         if (this.chart) {
             this.chart.reflow()
         }
@@ -233,6 +239,7 @@ export default class ChartModule extends React.Component {
         const { initRequest } = await this.subscription.current.send({
             type: 'initRequest',
         })
+        if (this.unmounted) { return }
         this.setState(initRequest)
     }
 
@@ -259,6 +266,7 @@ export default class ChartModule extends React.Component {
     }
 
     setExtremes = (e) => {
+        if (this.unmounted) { return }
         if (e.trigger === 'navigator' || e.trigger === 'zoom') {
             this.rangeMin = e.min
             this.rangeMax = e.max

--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -98,7 +98,7 @@ export default class TableModule extends React.Component {
     }
 
     initIfActive = (isActive) => {
-        if (isActive) {
+        if (isActive && !this.props.canvas.adhoc) {
             this.init()
         }
     }

--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -107,6 +107,7 @@ export default class TableModule extends React.Component {
         const { initRequest } = await this.subscription.current.send({
             type: 'initRequest',
         })
+        if (this.unmounted) { return }
         this.setState(initRequest)
     }
 

--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -79,6 +79,8 @@ const parseMessage = (d, options) => (state) => {
 }
 
 export default class TableModule extends React.Component {
+    subscription = React.createRef()
+
     state = {
         rows: [],
         headers: [],
@@ -89,6 +91,23 @@ export default class TableModule extends React.Component {
 
     componentWillUnmount() {
         this.unmounted = true
+    }
+
+    componentDidMount() {
+        this.initIfActive(this.props.isActive)
+    }
+
+    initIfActive = (isActive) => {
+        if (isActive) {
+            this.init()
+        }
+    }
+
+    init = async () => {
+        const { initRequest } = await this.subscription.current.send({
+            type: 'initRequest',
+        })
+        this.setState(initRequest)
     }
 
     onMessage = (d) => {
@@ -105,7 +124,9 @@ export default class TableModule extends React.Component {
             <div className={cx(styles.tableModule, className)}>
                 <ModuleSubscription
                     {...this.props}
+                    ref={this.subscription}
                     onMessage={this.onMessage}
+                    onActiveChange={this.initIfActive}
                 />
                 {!!(options.displayTitle && options.displayTitle.value && title) && (
                     <h4>{title}</h4>


### PR DESCRIPTION
Fixes `initRequest` calls to be consistent for table & chart modules.

I don't see much behavioural difference with this change but it matches the old UI behaviour.