### PR TITLE
Remove resend_all for subscriptions

### DIFF
--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -310,7 +310,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     resendFrom={canvas.adhoc ? resendFrom : undefined}
                     resendTo={canvas.adhoc ? resendTo : undefined}
                     isActive={canvas.state === RunStates.Running}
-                    onUnsubscribe={this.loadParent}
+                    onUnsubscribed={this.loadParent}
                 />
                 <Canvas
                     className={styles.Canvas}

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -297,6 +297,9 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     render() {
         const { canvas } = this.props
+        const { settings } = canvas
+        const resendFrom = settings.beginDate
+        const resendTo = settings.endDate
         return (
             <div className={styles.CanvasEdit}>
                 <Helmet>
@@ -304,7 +307,8 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                 </Helmet>
                 <Subscription
                     uiChannel={canvas.uiChannel}
-                    resendAll={canvas.adhoc}
+                    resendFrom={canvas.adhoc ? resendFrom : undefined}
+                    resendTo={canvas.adhoc ? resendTo : undefined}
                     isActive={canvas.state === RunStates.Running}
                     onUnsubscribe={this.loadParent}
                 />

--- a/app/src/editor/shared/components/ModuleSubscription.jsx
+++ b/app/src/editor/shared/components/ModuleSubscription.jsx
@@ -84,9 +84,9 @@ export default class ModuleSubscription extends React.PureComponent {
             <Subscription
                 {...this.props}
                 uiChannel={module.uiChannel}
-                resendAll={options.uiResendAll && options.uiResendAll.value}
                 resendLast={options.uiResendLast && options.uiResendLast.value}
                 resendFrom={options.uiResendFrom && options.uiResendFrom.value}
+                resendTo={options.resendTo && options.resendTo.value}
                 resendFromTime={options.uiResendFromTime && options.uiResendFromTime.value}
             />
         )

--- a/app/src/editor/shared/components/Subscription.jsx
+++ b/app/src/editor/shared/components/Subscription.jsx
@@ -63,8 +63,8 @@ class Subscription extends Component {
     subscribe() {
         const {
             uiChannel,
-            resendAll,
             resendFrom,
+            resendTo,
             resendFromTime,
             resendLast,
         } = this.props
@@ -77,10 +77,10 @@ class Subscription extends Component {
         const { id } = uiChannel
         this.subscription = this.client.subscribe({
             stream: id,
-            resend_all: resendAll != null ? !!resendAll : undefined,
-            resend_last: (!resendAll && resendLast != null) ? resendLast : undefined,
-            resend_from: (!resendAll && resendFrom != null) ? resendFrom : undefined,
-            resend_from_time: (!resendAll && resendFromTime != null) ? resendFromTime : undefined,
+            resend_last: resendLast != null ? resendLast : undefined,
+            resend_from: resendFrom != null ? resendFrom : undefined,
+            resend_to: resendTo != null ? resendTo : undefined,
+            resend_from_time: resendFromTime != null ? resendFromTime : undefined,
         }, this.onMessage)
     }
 


### PR DESCRIPTION
This partially fixes historical runs. Historical runs now correctly start (avoids `resend_all` error) and also correctly disconnecting and restoring original canvas after running.

There seems to be an issue running historical canvases twice, seems to have issues re-subscribing using the same client after disconnecting, not sure if this is related to something in the new UI, something in the JS streamr-client or perhaps some broken behaviour on the backend.