### PR TITLE
Editor Toolbar design feedback

### DIFF
--- a/app/src/editor/canvas/components/CanvasSearch.pcss
+++ b/app/src/editor/canvas/components/CanvasSearch.pcss
@@ -1,10 +1,9 @@
 .CanvasSearch {
-  top: 0;
+  top: -12px;
   left: 0;
   bottom: initial;
   transform: translateY(-100%);
   grid-template-rows: auto 1fr;
-  margin-bottom: 1em;
 }
 
 .canvasState {

--- a/app/src/editor/canvas/components/CanvasSearch.pcss
+++ b/app/src/editor/canvas/components/CanvasSearch.pcss
@@ -1,5 +1,5 @@
 .CanvasSearch {
-  top: -12px;
+  top: -8px;
   left: 0;
   bottom: initial;
   transform: translateY(-100%);

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -11,6 +11,7 @@
   grid-template-rows: auto auto 1fr;
   z-index: 12;
   border: 1px solid #EFEFEF;
+  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
   border-radius: 4px;
   overflow: hidden;
   cursor: pointer;

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -309,7 +309,10 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                     {/* eslint-disable react/no-unknown-property */}
                                                     <R.Label
                                                         for="saveStateToggle"
-                                                        className={styles.saveStateToggleLabel}
+                                                        className={cx(styles.saveStateToggleLabel, {
+                                                            [styles.StateSelectorActive]: settings.serializationEnabled === 'true',
+                                                        })}
+
                                                     >
                                                         Save state
                                                     </R.Label>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -106,9 +106,16 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                 {canvas.name}
                                             </EditableText>
                                             <DropdownActions
-                                                title={<Meatball alt="Select" />}
+                                                title={
+                                                    <R.Button className={cx(styles.MeatballContainer, styles.ToolbarButton)}>
+                                                        <Meatball alt="Select" />
+                                                    </R.Button>
+                                                }
                                                 noCaret
                                                 className={styles.DropdownMenu}
+                                                menuProps={{
+                                                    className: styles.DropdownMenuMenu,
+                                                }}
                                             >
                                                 <DropdownActions.Item onClick={newCanvas}>New Canvas</DropdownActions.Item>
                                                 <DropdownActions.Item onClick={() => shareDialog.open()}>Share</DropdownActions.Item>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -223,7 +223,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                     <SvgIcon name="caretDown" />
                                                 )}
                                             </R.DropdownToggle>
-                                            <R.DropdownMenu className={styles.RunButtonMenu} right>
+                                            <R.DropdownMenu className={cx(styles.RunButtonMenu, styles.RealtimeRunButtonMenu)} right>
                                                 <R.DropdownItem
                                                     onClick={() => canvasStart({ clearState: true })}
                                                     disabled={!canvas.serialized || !canEdit}
@@ -261,9 +261,10 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                             </button>
                                         </div>
                                         {editorState.runTab !== RunTabs.realtime ? (
-                                            <div className={styles.runTabToggle}>
+                                            <div className={styles.runTabValueToggle}>
                                                 <WithCalendar
                                                     date={!!settings.beginDate && new Date(settings.beginDate)}
+                                                    className={styles.CalendarRoot}
                                                     wrapperClassname={styles.CalendarWrapper}
                                                     onChange={this.getOnChangeHistorical('beginDate')}
                                                 >
@@ -283,6 +284,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                 </WithCalendar>
                                                 <WithCalendar
                                                     date={!!settings.endDate && new Date(settings.endDate)}
+                                                    className={styles.CalendarRoot}
                                                     wrapperClassname={styles.CalendarWrapper}
                                                     onChange={this.getOnChangeHistorical('endDate')}
                                                 >
@@ -302,22 +304,26 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                 </WithCalendar>
                                             </div>
                                         ) : (
-                                            <div className={styles.saveStateToggleSection}>
-                                                {/* eslint-disable react/no-unknown-property */}
-                                                <R.Label
-                                                    for="saveStateToggle"
-                                                    className={styles.saveStateToggleLabel}
-                                                >
-                                                    Save state
-                                                </R.Label>
-                                                {/* eslint-enable react/no-unknown-property */}
-                                                <Toggle
-                                                    id="saveStateToggle"
-                                                    className={styles.saveStateToggle}
-                                                    value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
-                                                    onChange={(value) => setSaveState(value)}
-                                                    disabled={!canEdit}
-                                                />
+                                            <div className={styles.runTabValueToggle}>
+                                                <div className={styles.saveStateToggleSection}>
+                                                    {/* eslint-disable react/no-unknown-property */}
+                                                    <R.Label
+                                                        for="saveStateToggle"
+                                                        className={styles.saveStateToggleLabel}
+                                                    >
+                                                        Save state
+                                                    </R.Label>
+                                                    {/* eslint-enable react/no-unknown-property */}
+                                                    {/* eslint-disable max-len */}
+                                                    <Toggle
+                                                        id="saveStateToggle"
+                                                        className={styles.saveStateToggle}
+                                                        value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
+                                                        onChange={(value) => setSaveState(value)}
+                                                        disabled={!canEdit}
+                                                    />
+                                                    {/* eslint-enable max-len */}
+                                                </div>
                                             </div>
                                         )}
                                     </div>
@@ -325,9 +331,9 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 <div className={styles.ModalButtons}>
                                     <Tooltip value={<React.Fragment>Keyboard<br />shortcuts</React.Fragment>}>
                                         <R.Button
-                                            className={styles.ToolbarButton}
+                                            className={cx(styles.ToolbarButton, styles.KeyboardButton)}
                                         >
-                                            <SvgIcon name="keyboard" className={styles.icon} />
+                                            <SvgIcon name="keyboard" />
                                         </R.Button>
                                     </Tooltip>
                                     <Tooltip value="Share">
@@ -335,7 +341,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                             className={cx(styles.ToolbarButton, styles.ShareButton)}
                                             onClick={() => shareDialog.open()}
                                         >
-                                            <SvgIcon name="share" className={styles.icon} />
+                                            <SvgIcon name="share" />
                                         </R.Button>
                                     </Tooltip>
                                 </div>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -125,28 +125,26 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     )}
                                 </UseState>
                             </div>
-                            <div className={styles.ToolbarLeft}>
-                                <div style={{ position: 'relative' }}>
+                            <div className={cx(styles.ToolbarLeft, styles.OpenAddButtons)}>
+                                <R.Button
+                                    className={cx(styles.ToolbarButton, styles.OpenCanvasButton)}
+                                    onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}
+                                >
+                                    Open
+                                </R.Button>
+                                <CanvasSearch
+                                    isOpen={canvasSearchIsOpen}
+                                    open={this.canvasSearchOpen}
+                                />
+                                <Tooltip value="Add module">
                                     <R.Button
-                                        className={cx(styles.ToolbarButton, styles.OpenCanvasButton)}
-                                        onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}
+                                        className={styles.ToolbarButton}
+                                        onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
+                                        disabled={!canEdit}
                                     >
-                                        Open
+                                        <SvgIcon name="plus" className={styles.icon} />
                                     </R.Button>
-                                    <CanvasSearch
-                                        isOpen={canvasSearchIsOpen}
-                                        open={this.canvasSearchOpen}
-                                    />
-                                    <Tooltip value="Add module">
-                                        <R.Button
-                                            className={styles.ToolbarButton}
-                                            onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
-                                            disabled={!canEdit}
-                                        >
-                                            <SvgIcon name="plus" className={styles.icon} />
-                                        </R.Button>
-                                    </Tooltip>
-                                </div>
+                                </Tooltip>
                             </div>
                             <div>
                                 <R.ButtonGroup

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -329,19 +329,19 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     </div>
                                 </div>
                                 <div className={styles.ModalButtons}>
-                                    <Tooltip value={<React.Fragment>Keyboard<br />shortcuts</React.Fragment>}>
-                                        <R.Button
-                                            className={cx(styles.ToolbarButton, styles.KeyboardButton)}
-                                        >
-                                            <SvgIcon name="keyboard" />
-                                        </R.Button>
-                                    </Tooltip>
                                     <Tooltip value="Share">
                                         <R.Button
                                             className={cx(styles.ToolbarButton, styles.ShareButton)}
                                             onClick={() => shareDialog.open()}
                                         >
                                             <SvgIcon name="share" />
+                                        </R.Button>
+                                    </Tooltip>
+                                    <Tooltip value={<React.Fragment>Keyboard<br />shortcuts</React.Fragment>}>
+                                        <R.Button
+                                            className={cx(styles.ToolbarButton, styles.KeyboardButton)}
+                                        >
+                                            <SvgIcon name="keyboard" />
                                         </R.Button>
                                     </Tooltip>
                                 </div>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -243,7 +243,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                 type="button"
                                                 onClick={() => setRunTab(RunTabs.realtime)}
                                                 disabled={!canEdit}
-                                                className={cx(styles.realTimeButton, {
+                                                className={cx(styles.ToolbarSolidButton, styles.firstButton, {
                                                     [styles.StateSelectorActive]: editorState.runTab === RunTabs.realtime,
                                                 })}
                                             >
@@ -253,7 +253,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                 type="button"
                                                 onClick={() => setRunTab(RunTabs.historical)}
                                                 disabled={!canEdit}
-                                                className={cx(styles.historicalButton, {
+                                                className={cx(styles.ToolbarSolidButton, styles.lastButton, {
                                                     [styles.StateSelectorActive]: editorState.runTab !== RunTabs.realtime,
                                                 })}
                                             >
@@ -273,7 +273,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                             type="button"
                                                             disabled={!canEdit}
                                                             onClick={toggleCalendar}
-                                                            className={cx(styles.realTimeButton, {
+                                                            className={cx(styles.ToolbarSolidButton, styles.firstButton, {
                                                                 [styles.StateSelectorActive]: !!settings.beginDate,
                                                             })}
                                                         >
@@ -293,7 +293,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                             type="button"
                                                             disabled={!canEdit}
                                                             onClick={toggleCalendar}
-                                                            className={cx(styles.realTimeButton, {
+                                                            className={cx(styles.ToolbarSolidButton, styles.lastButton, {
                                                                 [styles.StateSelectorActive]: !!settings.endDate,
                                                             })}
                                                         >

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -11,6 +11,7 @@
 .CanvasToolbar > * {
   display: flex;
   align-items: center;
+  flex-wrap: nowrap;
 }
 
 .ToolbarLeft {
@@ -24,12 +25,19 @@
 .StateSelectorContainer {
   flex: 1;
   display: flex;
-  justify-content: space-around;
 }
 
 .StateSelector {
   display: flex;
   flex: 1;
+  justify-content: center;
+}
+
+.OpenAddButtons {
+  position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  margin: 0 16px;
 }
 
 .ToolbarButton {
@@ -214,17 +222,14 @@
 }
 
 .CanvasToolbar .runTabToggle {
-  margin: 0 8px;
+  margin: 0 16px;
   white-space: nowrap;
   position: relative;
   display: flex;
-  flex: 1;
-  justify-content: flex-end;
 }
 
 .CanvasToolbar .runTabValueToggle {
   display: flex;
-  flex: 1;
   justify-content: flex-start;
   position: relative;
 }
@@ -270,18 +275,17 @@
 .CanvasToolbar .saveStateToggleSection {
   background: #FFFFFF;
   border-radius: 4px;
-  margin: 0 8px;
   white-space: nowrap;
-  color: #CDCDCD;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   padding: 0 16px;
+  min-width: 176px;
+  color: #CDCDCD;
 }
 
 .CanvasToolbar .saveStateToggleSection .saveStateToggleLabel {
-  margin-right: 20px;
-  color: #CDCDCD;
+  margin-right: 16px;
   font-weight: 500;
   text-align: left;
   letter-spacing: 0;
@@ -319,6 +323,10 @@
 
 .CalendarRoot {
   position: relative;
+}
+
+.CalendarRoot .StateSelectorActive {
+  padding: 0 8px; /* half padding once calendar item set */
 }
 
 .CalendarWrapper {

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -101,6 +101,10 @@
   margin-left: 8px;
 }
 
+.CanvasNameContainer .DropdownMenu svg {
+  margin-bottom: -3px; /* counter default margin of meatball */
+}
+
 .CanvasNameContainer {
   display: flex;
   align-items: center;

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -97,18 +97,28 @@
   }
 }
 
-.DropdownMenu {
+.CanvasNameContainer .DropdownMenu {
   margin-left: 8px;
-}
-
-.CanvasNameContainer .DropdownMenu svg {
-  margin-bottom: -3px; /* counter default margin of meatball */
 }
 
 .CanvasNameContainer {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.CanvasNameContainer .DropdownMenu .DropdownMenuMenu {
+  margin-bottom: 10px;
+  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
+}
+
+.CanvasNameContainer .DropdownMenu svg {
+  margin-bottom: -3px; /* counter default margin of meatball */
+}
+
+.CanvasNameContainer .MeatballContainer {
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
 .RunDropdownButton {
@@ -168,7 +178,7 @@
   font-size: 12px;
   padding: 8px;
   min-width: 152px !important;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
   border: none;
 

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -166,13 +166,17 @@
 
 .RunButtonMenu {
   font-size: 12px;
-  padding: 0;
+  padding: 8px;
   min-width: 152px !important;
+  margin-bottom: 12px;
+  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
+  border: none;
 
   & :global(.dropdown-item) {
     font-weight: 500;
     letter-spacing: 2px;
     text-transform: uppercase;
+    line-height: 1.2;
 
     &:not(:disabled) {
       color: #525252;
@@ -182,10 +186,10 @@
   & :global(.dropdown-item):focus,
   & :global(.dropdown-item):hover {
     outline: none;
-    background-color: #F8F9FA;
   }
 
   & :global(.dropdown-item):active,
+  & :global(.dropdown-item):hover,
   & :global(.dropdown-item):global(.active) {
     background: url('../../../shared/assets/images/tick.svg') no-repeat 8px 50%;
     outline: none;

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -29,6 +29,7 @@
 
 .StateSelector {
   display: flex;
+  flex: 1;
 }
 
 .ToolbarButton {
@@ -69,11 +70,23 @@
 
 .OpenCanvasButton {
   margin-right: 8px;
+  letter-spacing: 0;
 }
 
 .ShareButton {
-  padding: 0;
   margin-left: 8px;
+}
+
+.ShareButton,
+.KeyboardButton {
+  padding: 0 !important;
+  width: 40px;
+  height: 40px;
+
+  & > svg {
+    width: 22px;
+    height: 22px;
+  }
 }
 
 .DropdownMenu {
@@ -90,8 +103,8 @@
   margin-left: 1px !important;
 
   & :global(.dropdown-toggle) {
-    padding-left: 14px;
-    padding-right: 14px;
+    padding: 0;
+    width: 40px;
     outline: none;
     box-shadow: transparent;
 
@@ -134,16 +147,24 @@
   box-shadow: none !important;
 }
 
+.RealtimeRunButtonMenu :global(.dropdown-item) {
+  padding: 0.25rem 0.5rem !important;
+  text-align: center;
+}
+
 .RunButtonMenu {
   font-size: 12px;
   padding: 0;
-  min-width: 189px !important;
+  min-width: 152px !important;
 
   & :global(.dropdown-item) {
     font-weight: 500;
     letter-spacing: 2px;
     text-transform: uppercase;
-    color: #525252;
+
+    &:not(:disabled) {
+      color: #525252;
+    }
   }
 
   & :global(.dropdown-item):focus,
@@ -189,7 +210,7 @@
 }
 
 .RunButton {
-  min-width: 150px;
+  min-width: 111px;
 }
 
 .CanvasToolbar .runTabToggle {
@@ -197,6 +218,15 @@
   white-space: nowrap;
   position: relative;
   display: flex;
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.CanvasToolbar .runTabValueToggle {
+  display: flex;
+  flex: 1;
+  justify-content: flex-start;
+  position: relative;
 }
 
 .realTimeButton,
@@ -282,12 +312,16 @@
 }
 
 .CanvasToolbar .icon {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
 }
 
 .ModalButtons {
   white-space: nowrap;
+}
+
+.CalendarRoot {
+  position: relative;
 }
 
 .CalendarWrapper {

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -229,8 +229,7 @@
   position: relative;
 }
 
-.realTimeButton,
-.historicalButton {
+.ToolbarSolidButton {
   background: #FFFFFF;
   outline: none;
   border-radius: 4px;
@@ -244,29 +243,23 @@
   text-align: center;
   padding: 0 16px;
   cursor: pointer;
+  min-width: 88px;
 }
 
-.realTimeButton {
+.ToolbarSolidButton.firstButton {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.historicalButton {
+.ToolbarSolidButton.lastButton {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   margin-left: 1px;
 }
 
-.StateSelectorActive {
-  color: #323232;
-}
-
-.realTimeButton:hover,
-.realTimeButton:active,
-.realTimeButton:focus,
-.historicalButton:hover,
-.historicalButton:active,
-.historicalButton:focus {
+.ToolbarSolidButton:hover,
+.ToolbarSolidButton:active,
+.ToolbarSolidButton:focus {
   outline: none;
 }
 
@@ -303,6 +296,10 @@
 
 .CanvasToolbar .saveStateToggleSection label {
   margin-bottom: 0;
+}
+
+.CanvasToolbar .StateSelectorActive {
+  color: #323232;
 }
 
 .CanvasToolbar .status {

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -202,7 +202,6 @@ const sources = {
     keyboard: (
         <svg viewBox="0 0 24 14" xmlns="http://www.w3.org/2000/svg">
             <g
-                transform="translate(0 1)"
                 stroke="currentColor"
                 strokeWidth="1.5"
                 fill="none"
@@ -216,8 +215,8 @@ const sources = {
         </svg>
     ),
     share: (
-        <svg viewBox="0 0 19 22" xmlns="http://www.w3.org/2000/svg">
-            <g stroke="currentColor" strokeWidth="1.5" fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round">
+        <svg viewBox="0 0 19 24" xmlns="http://www.w3.org/2000/svg">
+            <g transform="translate(0 -2)" stroke="currentColor" strokeWidth="1.5" fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M17.788 5.375h-7.013c-1.408 0-2.55 1.12-2.55 2.5V11" />
                 <path d="M13.963 9.125l3.825-3.75-3.825-3.75M15.238 12.875v6.25c0 .69-.571 1.25-1.275 1.25H2.488c-.705 0-1.276-.56-1.276-1.25v-10c0-.69.571-1.25 1.276-1.25H4.4" />
             </g>

--- a/app/src/shared/components/WithCalendar/index.jsx
+++ b/app/src/shared/components/WithCalendar/index.jsx
@@ -12,6 +12,7 @@ export type WithCalendarProps = {
     closeOnSelect?: boolean,
     disabled?: boolean,
     openOnFocus?: boolean,
+    className?: string,
     wrapperClassname?: string,
 }
 
@@ -127,10 +128,10 @@ class WithCalendar extends React.Component<Props, State> {
 
     render() {
         const { date, open } = this.state
-        const { disabled, wrapperClassname } = this.props
+        const { disabled, className, wrapperClassname } = this.props
 
         return (
-            <div ref={this.rootRef}>
+            <div ref={this.rootRef} className={cx(styles.root, className)}>
                 {this.children()}
                 {!disabled && open && (
                     <div className={cx(styles.wrapper, wrapperClassname)}>

--- a/app/src/shared/components/WithCalendar/withCalendar.pcss
+++ b/app/src/shared/components/WithCalendar/withCalendar.pcss
@@ -1,3 +1,5 @@
+.root {}
+
 .wrapper {
   position: absolute;
   z-index: 2;


### PR DESCRIPTION
Address design feedback for Editor toolbar, fixes:

- [ ] PLATFORM-455 "Open” type should have 0 letterspacing applied
- [ ] PLATFORM-456 Share/Keyboard Toolbar Icon Sizes Too Small 
- [ ] PLATFORM-457 Canvas Name Weight Too Heavy
- [ ] PLATFORM-458 Prevent Historical/Realtime buttons from moving when switching
- [ ] Run / stop button is incorrect size (should be 152px)