### PR TITLE
Load module data from new api/v1 modules routes.

### DIFF
--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -5,8 +5,8 @@ import startCase from 'lodash/startCase'
 
 import type { Stream } from '$shared/flowtype/stream-types'
 
-import { getModuleTree, getStreams } from '../services'
-import { moduleTreeSearch } from '../state'
+import { getModuleCategories, getStreams } from '../services'
+import { moduleSearch } from '../state'
 
 import styles from './ModuleSearch.pcss'
 
@@ -45,12 +45,12 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
     }
 
     async load() {
-        const modules = await getModuleTree()
+        const modules = await getModuleCategories()
         if (this.unmounted) { return }
         this.setState({
             allModules: modules,
             // Default to showing all modules
-            matchingModules: moduleTreeSearch(modules, ''),
+            matchingModules: moduleSearch(modules, ''),
         })
     }
 
@@ -58,7 +58,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         const { value } = event.currentTarget
 
         // Search modules
-        const matchingModules = moduleTreeSearch(this.state.allModules, value)
+        const matchingModules = moduleSearch(this.state.allModules, value)
 
         // Search streams
         const params = {

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -20,7 +20,7 @@ const getData = ({ data }) => data
 
 const canvasesUrl = `${process.env.STREAMR_API_URL}/canvases`
 const getModulesURL = `${process.env.STREAMR_API_URL}/modules`
-const getModuleTreeURL = `${process.env.STREAMR_URL}/module/jsonGetModuleTree`
+const getModuleCategoriesURL = `${process.env.STREAMR_API_URL}/module_categories`
 const streamsUrl = `${process.env.STREAMR_API_URL}/streams`
 
 const AUTOSAVE_DELAY = 3000
@@ -74,8 +74,8 @@ export async function deleteCanvas({ id } = {}) {
     return API.delete(`${canvasesUrl}/${id}`).then(getData)
 }
 
-export async function getModuleTree() {
-    return API.get(getModuleTreeURL).then(getData)
+export async function getModuleCategories() {
+    return API.get(getModuleCategoriesURL).then(getData)
 }
 
 export async function getModules() {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -910,7 +910,7 @@ export function updateCanvas(canvas, path, fn) {
     return limitLayout(updateVariadic(updatePortConnections(update(path, fn, canvas))))
 }
 
-export function moduleTreeIndex(modules = [], path = [], index = []) {
+export function moduleCategoriesIndex(modules = [], path = [], index = []) {
     modules.forEach((m) => {
         if (m.metadata.canAdd) {
             index.push({
@@ -920,16 +920,16 @@ export function moduleTreeIndex(modules = [], path = [], index = []) {
             })
         }
         if (m.children && m.children.length) {
-            moduleTreeIndex(m.children, path.concat(m.data), index)
+            moduleCategoriesIndex(m.children, path.concat(m.data), index)
         }
     })
     return index
 }
 
-const getModuleTreeIndex = memoize(moduleTreeIndex)
+const getModuleCategoriesIndex = memoize(moduleCategoriesIndex)
 
-export function moduleTreeSearch(moduleTree, search) {
-    const moduleIndex = getModuleTreeIndex(moduleTree)
+export function moduleSearch(moduleCategories, search) {
+    const moduleIndex = getModuleCategoriesIndex(moduleCategories)
     search = search.trim().toLowerCase()
     if (!search) { return moduleIndex }
     const nameMatches = moduleIndex.filter((m) => (

--- a/app/src/editor/dashboard/services.js
+++ b/app/src/editor/dashboard/services.js
@@ -17,8 +17,7 @@ const API = axios.create({
 const getData = ({ data }) => data
 
 const dashboardsURL = `${process.env.STREAMR_API_URL}/dashboards`
-const getModuleURL = `${process.env.STREAMR_URL}/module/jsonGetModule`
-const getModuleTreeURL = `${process.env.STREAMR_URL}/module/jsonGetModuleTree`
+const getModulesURL = `${process.env.STREAMR_API_URL}/modules`
 const canvasesURL = `${process.env.STREAMR_API_URL}/canvases?adhoc=false&sort=dateCreated&order=desc`
 
 const AUTOSAVE_DELAY = 3000
@@ -70,14 +69,10 @@ export async function deleteDashboard({ id }) {
     return API.delete(`${dashboardsURL}/${id}`).then(getData)
 }
 
-export async function getModuleTree() {
-    return API.get(getModuleTreeURL).then(getData)
-}
-
 export async function addModule({ id }) {
     const form = new FormData()
     form.append('id', id)
-    return API.post(getModuleURL, form).then(getData)
+    return API.post(getModulesURL, form).then(getData)
 }
 
 export async function loadDashboard({ id }) {


### PR DESCRIPTION
This allows tests to fetch module categories data, and should fix the CORS issue preventing loading of module categories on staging i.e.
```
Access to XMLHttpRequest at 'https://ee-staging.streamr.com/module/jsonGetModuleTree' from origin 'https://marketplace-staging.streamr.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

This is preventing @mattatgit from properly testing.