### PR TITLE
[PLATFORM-488] Prevent scrollbars around the canvas box

### DIFF
--- a/app/src/editor/canvas/components/Canvas.pcss
+++ b/app/src/editor/canvas/components/Canvas.pcss
@@ -19,8 +19,6 @@
   left: 0;
   bottom: 0;
   right: 0;
-  margin-bottom: 20px;
-  margin-right: 20px;
 }
 
 .Modules {


### PR DESCRIPTION
100% width and 100% height + bottom and right margins make the box exceed the available space and cause scrollbars.

@timoxley, let me know if there's anything I missed or should know about those margins I've thrown away. We may want to address it differently.