### PR TITLE
Restart data-api a second time if not up after first restart. Limit service check retries. 

### DIFF
--- a/app/travis_scripts/build-docker-env.sh
+++ b/app/travis_scripts/build-docker-env.sh
@@ -30,7 +30,7 @@ fi
 streamr-docker-dev/streamr-docker-dev/bin.sh restart data-api # let's restart it for good measure (?!)
 
 # wait briefly for data-api to come up. it probably needs restarting again.
-waitFor 15 3s scheckHTTP "data-api" 401 http://localhost:8890/
+waitFor 15 3s checkHTTP "data-api" 401 http://localhost:8890/
 
 # try restarting data-api again if still not up
 if [ $? -eq 1 ] ; then

--- a/app/travis_scripts/build-docker-env.sh
+++ b/app/travis_scripts/build-docker-env.sh
@@ -27,14 +27,14 @@ if [ $? -eq 1 ] ; then
     exit 1;
 fi
 
-streamr-docker-dev restart data-api # let's restart it for good measure (?!)
+streamr-docker-dev/streamr-docker-dev/bin.sh restart data-api # let's restart it for good measure (?!)
 
 # wait briefly for data-api to come up. it probably needs restarting again.
 waitFor 15 3s scheckHTTP "data-api" 401 http://localhost:8890/
 
 # try restarting data-api again if still not up
 if [ $? -eq 1 ] ; then
-    streamr-docker-dev restart data-api
+    streamr-docker-dev/streamr-docker-dev/bin.sh restart data-api
     # try waiting again
     waitFor $RETRIES $RETRY_DELAY checkHTTP "data-api" 404 http://localhost:8890/
     # exit if data-api ever came up (ffs)

--- a/app/travis_scripts/build-docker-env.sh
+++ b/app/travis_scripts/build-docker-env.sh
@@ -4,6 +4,8 @@
 ## Pulls down streamr-docker-dev and starts an engine-and-editor instance + associated services ##
 ##
 
+source "${BASH_SOURCE%/*}/utils.sh"
+
 cd $TRAVIS_BUILD_DIR
 sudo /etc/init.d/mysql stop
 sudo sysctl fs.inotify.max_user_watches=524288; sudo sysctl -p
@@ -12,11 +14,32 @@ sudo ifconfig docker0 10.200.10.1/24
 git clone https://github.com/streamr-dev/streamr-docker-dev.git
 # start everything except eth watcher
 streamr-docker-dev/streamr-docker-dev/bin.sh start 5
-# wait for e&e to be up
-while true; do http_code=$(curl -s -o /dev/null -I -w "%{http_code}" http://localhost:8081/streamr-core/login/auth); if [ $http_code = 200 ]; then echo "EE up and running"; break; else echo "EE not receiving connections"; sleep 5s; fi; done
-# data-api sometimes fails to boot properly (??!) if services start in wrong order
-streamr-docker-dev/streamr-docker-dev/bin.sh restart data-api # let's restart it for good measure (?!)
-# wait for data-api to be up
-while true; do http_code=$(curl -s -o /dev/null -I -w "%{http_code}" http://localhost:8890/); if [ $http_code = 404 ]; then echo "Data-api up and running"; break; else echo "Data API not receiving connections"; sleep 5s; fi; done
-# add a few more waits
-sleep 10
+
+RETRIES=30;
+RETRY_DELAY=5s;
+
+# wait for E&E to come up
+waitFor $RETRIES $RETRY_DELAY checkHTTP "engine-and-editor" 200 http://localhost:8081/streamr-core/login/auth
+
+# exit if E&E never comes up
+if [ $? -eq 1 ] ; then
+    echo "engine-and-editor never up";
+    exit 1;
+fi
+
+streamr-docker-dev restart data-api # let's restart it for good measure (?!)
+
+# wait briefly for data-api to come up. it probably needs restarting again.
+waitFor 15 3s scheckHTTP "data-api" 401 http://localhost:8890/
+
+# try restarting data-api again if still not up
+if [ $? -eq 1 ] ; then
+    streamr-docker-dev restart data-api
+    # try waiting again
+    waitFor $RETRIES $RETRY_DELAY checkHTTP "data-api" 404 http://localhost:8890/
+    # exit if data-api ever came up (ffs)
+    if [ $? -eq 1 ] ; then
+        echo "data-api never up.";
+        exit 1;
+    fi
+fi

--- a/app/travis_scripts/build-docker-env.sh
+++ b/app/travis_scripts/build-docker-env.sh
@@ -20,29 +20,27 @@ RETRIES=30;
 RETRY_DELAY=5s;
 
 # wait for E&E to come up
-waitFor $RETRIES $RETRY_DELAY checkHTTP "engine-and-editor" 200 http://localhost:8081/streamr-core/login/auth
+waitFor $RETRIES $RETRY_DELAY checkHTTP "engine-and-editor" 200 http://localhost:8081/streamr-core/login/auth;
+$streamr_docker_dev log -f &;
 
 # exit if E&E never comes up
 if [ $? -eq 1 ] ; then
     echo "engine-and-editor never up";
     $streamr_docker_dev ps;
-    $streamr_docker_dev log engine-and-editor | tail -n200;
     exit 1;
 fi
 
-streamr-docker-dev/streamr-docker-dev/bin.sh restart data-api # let's restart it for good measure (?!)
+streamr-docker-dev/streamr-docker-dev/bin.sh restart data-api; # let's restart it for good measure (?!)
 
 # wait briefly for data-api to come up. it probably needs restarting again.
-waitFor 15 3s checkHTTP "data-api" 401 http://localhost:8890/
+waitFor 15 3s checkHTTP "data-api" 401 http://localhost:8890/;
 
 # try restarting data-api again if still not up
 if [ $? -eq 1 ] ; then
     echo "data-api still not up"
     $streamr_docker_dev ps;
-    $streamr_docker_dev log data-api | tail -n200;
-    $streamr_docker_dev restart data-api
     # try waiting again
-    waitFor $RETRIES $RETRY_DELAY checkHTTP "data-api" 404 http://localhost:8890/
+    waitFor $RETRIES $RETRY_DELAY checkHTTP "data-api" 404 http://localhost:8890/;
     # exit if data-api ever came up (ffs)
     if [ $? -eq 1 ] ; then
         echo "data-api never up.";

--- a/app/travis_scripts/utils.sh
+++ b/app/travis_scripts/utils.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Check url responds with expected http response code
+# arguments: name expected_status url
+# e.g. checkHTTP 'data-api' 404 http://localhost:8890/
+checkHTTP() {
+    name=$1;
+    expected_status=$2;
+    url=$3;
+    http_code=$(curl -s -o /dev/null -I -w "%{http_code}" $url);
+    if [ $http_code = $expected_status ]; then
+        echo "$name up";
+        return 0;
+    else
+        echo "$name not up";
+        return 1;
+    fi;
+}
+
+# retry a command after a delay maxtries times
+# arguments: maxtries delay (in seconds)
+# e.g. waitFor 10 3 checkHTTP 'data-api' 404 http://localhost:8890/
+waitFor() {
+    maxtries=$1;
+    delay=$2;
+    shift;
+    shift;
+    exit_code=1
+    for n in $(seq $maxtries); do
+        if $@ ; then
+            exit_code=0
+            break;
+        else
+            echo "retry $n of $maxtries after $delay."
+            sleep $delay;
+        fi
+    done
+    return $exit_code;
+}

--- a/app/travis_scripts/utils.sh
+++ b/app/travis_scripts/utils.sh
@@ -8,7 +8,7 @@ checkHTTP() {
     expected_status=$2;
     url=$3;
     http_code=$(curl -s -o /dev/null -I -w "%{http_code}" $url);
-    if [ $http_code = $expected_status ]; then
+    if [ $http_code -eq $expected_status ]; then
         echo "$name up";
         return 0;
     else


### PR DESCRIPTION
CI builds are frequently getting stuck waiting for either data-api or e&e (less common) to come up and end up waiting a full hour before travis kills the script and reports failure. Restarting a stuck build often makes it magically work. This is very annoying to say the least. Despite data-api being restarted after e&e is up, it still frequently doesn't start properly 😡. It probably got restarted too soon? Who knows.

**This PR changes the build script to not wait forever, instead performs a number of retries before deciding it's not going to happen.**

 **This PR also adjusts the logic to try connect to data-api for a short while, if it doesn't come up it will try restarting it again.** 

This doesn't really fix whatever the underlying problem is with reliably starting `data-api` but this PR *should* work around the issue for now.

The PR sets the retries to 30 with a 5s delay. This should be more than enough. Currently, it retries after 5s and e&e comes up after ~7 retries, data-api usually comes up even quicker.

```
r_dev_engine-and-editor
EE not receiving connections
EE not receiving connections
EE not receiving connections
EE not receiving connections
EE not receiving connections
EE not receiving connections
EE up and running
```