### PR TITLE
Throttle subscription message handlers appropriately.

### DIFF
--- a/app/src/editor/shared/components/modules/Button.jsx
+++ b/app/src/editor/shared/components/modules/Button.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import cx from 'classnames'
+import throttle from 'lodash/throttle'
 
 import ModuleSubscription from '../ModuleSubscription'
 
@@ -29,9 +30,9 @@ export default class ButtonModule extends React.Component {
         })
     }
 
-    onMessage = ({ buttonName }) => {
+    onMessage = throttle(({ buttonName }) => {
         this.setName(buttonName)
-    }
+    }, 250)
 
     onClick = async () => {
         this.subscription.current.send({

--- a/app/src/editor/shared/components/modules/Canvas.jsx
+++ b/app/src/editor/shared/components/modules/Canvas.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import cx from 'classnames'
 import { Link } from 'react-router-dom'
 
-import ModuleSubscription from '../ModuleSubscription'
 import links from '../../../../links'
 
 import ButtonStyles from '$shared/components/Button/button.pcss'
@@ -12,16 +11,12 @@ const getCanvasPort = ({ params }) => params.find(({ name }) => name === 'canvas
 
 export default class CanvasModule extends React.Component {
     render() {
-        const { module } = this.props
-        const currentCanvasPort = getCanvasPort(this.props.module)
+        const { module, className } = this.props
+        const currentCanvasPort = getCanvasPort(module)
 
         return (
-            <div className={cx(this.props.className, styles.Button)}>
-                <ModuleSubscription
-                    {...this.props}
-                    module={module}
-                />
-                {currentCanvasPort && currentCanvasPort.value && (
+            <div className={cx(className, styles.Button)}>
+                {currentCanvasPort && currentCanvasPort.value != null && (
                     <Link
                         className={styles.button}
                         to={`${links.editor.canvasEditor}/${currentCanvasPort.value}`}

--- a/app/src/editor/shared/components/modules/ExportCSV.jsx
+++ b/app/src/editor/shared/components/modules/ExportCSV.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import cx from 'classnames'
+import throttle from 'lodash/throttle'
 
 import routes from '$routes'
 import ModuleSubscription from '../ModuleSubscription'
@@ -35,7 +36,7 @@ export default class ExportCSVModule extends React.Component<Props, State> {
         link: undefined,
     }
 
-    onMessage = (msg: CsvMessage) => {
+    onMessage = throttle((msg: CsvMessage) => {
         if (msg && msg.type === 'csvUpdate') {
             this.setState({
                 rows: msg.rows,
@@ -43,7 +44,7 @@ export default class ExportCSVModule extends React.Component<Props, State> {
                 link: msg.file,
             })
         }
-    }
+    }, 250)
 
     render() {
         const { rows, size, link } = this.state

--- a/app/src/editor/shared/components/modules/Label.jsx
+++ b/app/src/editor/shared/components/modules/Label.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import cx from 'classnames'
+import throttle from 'lodash/throttle'
 
 import ModuleSubscription from '../ModuleSubscription'
 import styles from './Label.pcss'
@@ -9,11 +10,11 @@ export default class CommentModule extends React.Component {
         value: '',
     }
 
-    onMessage = ({ value }) => {
+    onMessage = throttle(({ value }) => {
         this.setState({
             value,
         })
-    }
+    }, 250)
 
     render() {
         let { module } = this.props

--- a/app/src/editor/shared/components/modules/Scheduler.jsx
+++ b/app/src/editor/shared/components/modules/Scheduler.jsx
@@ -2,7 +2,6 @@ import React, { Fragment } from 'react'
 import uuid from 'uuid'
 import { arrayMove } from 'react-sortable-hoc'
 
-import ModuleSubscription from '../ModuleSubscription'
 import SortableList from '$shared/components/SortableList'
 import { withHover } from '$shared/components/WithHover'
 import SvgIcon from '$shared/components/SvgIcon'
@@ -601,8 +600,6 @@ const changeRule = (rules, id, properties) => rules.map((r) => {
 })
 
 export default class SchedulerModule extends React.Component {
-    subscription = React.createRef()
-
     state = {
         defaultValue: undefined,
         rules: undefined,
@@ -672,16 +669,11 @@ export default class SchedulerModule extends React.Component {
     }
 
     render() {
-        const { module, isActive } = this.props
+        const { isActive } = this.props
         const { rules, defaultValue } = this.state
 
         return (
             <div className={styles.schedulerContainer}>
-                <ModuleSubscription
-                    {...this.props}
-                    ref={this.subscription}
-                    module={module}
-                />
                 <SortableList
                     distance={1} /* This will allow clicks to pass through */
                     onSortEnd={this.onSortEnd}

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import cx from 'classnames'
+import throttle from 'lodash/throttle'
 
 import Toggle from '$shared/components/Toggle'
 import ModuleSubscription from '../ModuleSubscription'
@@ -20,11 +21,11 @@ export default class SwitcherModule extends React.Component {
         return value
     }
 
-    onMessage = ({ switcherValue: value }) => {
+    onMessage = throttle(({ switcherValue: value }) => {
         this.setState({
             value,
         })
-    }
+    }, 250)
 
     onChange = async (value) => {
         if (this.props.isActive) {

--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import uuid from 'uuid'
 import cx from 'classnames'
+import throttle from 'lodash/throttle'
 
 import ModuleSubscription from '../ModuleSubscription'
 
@@ -99,6 +100,8 @@ export default class TableModule extends React.Component {
         ...(this.props.module.tableConfig || {}),
     }
 
+    pendingState = this.state
+
     componentWillUnmount() {
         this.unmounted = true
     }
@@ -118,13 +121,31 @@ export default class TableModule extends React.Component {
             type: 'initRequest',
         })
         if (this.unmounted) { return }
-        this.setState(initRequest)
+        this.setPendingState(initRequest)
+    }
+
+    setPendingState = (s) => {
+        if (typeof s === 'function') {
+            s = s(this.pendingState)
+        }
+        if (s === null || s === this.pendingState) {
+            return
+        }
+        this.pendingState = {
+            ...this.pendingState,
+            ...s,
+        }
+        this.queueFlushPending()
     }
 
     onMessage = (d) => {
         const { options = {} } = this.props.module
-        this.setState(parseMessage(d, options))
+        this.setPendingState(parseMessage(d, options))
     }
+
+    queueFlushPending = throttle(() => {
+        this.setState(this.pendingState)
+    }, 250)
 
     render() {
         const { className, module } = this.props

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import cx from 'classnames'
+import throttle from 'lodash/throttle'
 
 import ModuleSubscription from '../ModuleSubscription'
 
@@ -25,11 +26,11 @@ export default class TextFieldModule extends React.Component {
         }
     }
 
-    onMessage = ({ textFieldValue: value }) => {
+    onMessage = throttle(({ textFieldValue: value }) => {
         this.setState({
             value,
         })
-    }
+    }, 250)
 
     onClick = async () => {
         this.subscription.current.send({


### PR DESCRIPTION
Currently a historical canvas run with a 1second clock -> table will totally freeze the current browser tab, due to too many queued renders inside the table component.

This PR throttles existing component subscription message handlers, batching updates where appropriate (e.g. table).

To test: connect a clock to a table, run in historical mode. It should display some values then revert back to old canvas (this reverting behaviour is a known, unrelated issue). Previously, the entire tab would lock up.