### PR TITLE
[PLATFORM-174] Soft-deduplicate canvas names on canvas creation.

### DIFF
--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -6,7 +6,7 @@ import api from '$editor/shared/utils/api'
 import Autosave from '$editor/shared/utils/autosave'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
-import { emptyCanvas } from './state'
+import { emptyCanvas, isRunning, RunStates } from './state'
 
 const getData = ({ data }) => data
 
@@ -88,6 +88,7 @@ async function createCanvas(canvas) {
     return api().post(canvasesUrl, {
         ...canvas,
         name: await getUniqueCanvasName(canvas.name),
+        state: RunStates.Stopped, // always create stopped canvases
     }).then(getData)
 }
 
@@ -100,8 +101,10 @@ export async function moduleHelp({ id }) {
 }
 
 export async function duplicateCanvas(canvas) {
-    const savedCanvas = await saveNow(canvas) // ensure canvas saved before duplicating
-    return createCanvas(savedCanvas)
+    if (!isRunning(canvas)) {
+        canvas = await saveNow(canvas) // ensure canvas saved before duplicating
+    }
+    return createCanvas(canvas)
 }
 
 export async function deleteCanvas({ id } = {}) {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -75,6 +75,7 @@ export function emptyCanvas(config = {}) {
         name: 'Untitled Canvas',
         settings: {},
         modules: [],
+        state: RunStates.Stopped,
         ...config,
     }
 }
@@ -901,6 +902,10 @@ export function updateVariadic(canvas) {
     return canvas.modules.reduce((nextCanvas, { hash }) => (
         updateVariadicModule(nextCanvas, hash)
     ), canvas)
+}
+
+export function isRunning(canvas) {
+    return canvas.state === RunStates.Running
 }
 
 /**

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -70,11 +70,12 @@ export const PortTypes = {
     param: 'param',
 }
 
-export function emptyCanvas() {
+export function emptyCanvas(config = {}) {
     return {
         name: 'Untitled Canvas',
         settings: {},
         modules: [],
+        ...config,
     }
 }
 

--- a/app/src/editor/canvas/tests/__snapshots__/services.test.js.snap
+++ b/app/src/editor/canvas/tests/__snapshots__/services.test.js.snap
@@ -7,7 +7,7 @@ Object {
   "hasExports": false,
   "id": Any<String>,
   "modules": Array [],
-  "name": "Untitled Canvas",
+  "name": Any<String>,
   "serialized": false,
   "settings": Object {},
   "startedById": null,

--- a/app/src/editor/canvas/tests/__snapshots__/state.test.js.snap
+++ b/app/src/editor/canvas/tests/__snapshots__/state.test.js.snap
@@ -5,5 +5,6 @@ Object {
   "modules": Array [],
   "name": "Untitled Canvas",
   "settings": Object {},
+  "state": "STOPPED",
 }
 `;

--- a/app/src/editor/canvas/tests/services.test.js
+++ b/app/src/editor/canvas/tests/services.test.js
@@ -132,6 +132,19 @@ describe('Canvas Services', () => {
                 name: `${name} (11)`,
             })
         })
+
+        it('can duplicate a running canvas', async () => {
+            const canvas = await Services.create()
+            const startedCanvas = await Services.start(canvas)
+
+            const duplicateCanvas = await Services.duplicateCanvas(startedCanvas)
+            expect(duplicateCanvas).toMatchObject({
+                ...canvas,
+                ...canvasMatcher,
+                state: State.RunStates.Stopped,
+            })
+            await Services.stop(startedCanvas)
+        })
     })
 
     describe('start/stop canvas', () => {
@@ -146,7 +159,10 @@ describe('Canvas Services', () => {
 
         it('can start & stop a canvas', async () => {
             const canvas = await Services.create()
+            expect(State.isRunning(canvas)).toBeFalsy()
+
             const startedCanvas = await Services.start(canvas)
+            expect(State.isRunning(startedCanvas)).toBeTruthy()
             expect(startedCanvas).toMatchObject({
                 ...canvas,
                 ...canvasMatcher,
@@ -159,6 +175,7 @@ describe('Canvas Services', () => {
             await expect(Services.start(canvas)).rejects.toThrow()
 
             const stoppedCanvas = await Services.stop(canvas)
+            expect(State.isRunning(stoppedCanvas)).toBeFalsy()
             expect(stoppedCanvas).toMatchObject({
                 ...startedCanvas,
                 ...canvasMatcher,

--- a/app/src/editor/canvas/tests/services.test.js
+++ b/app/src/editor/canvas/tests/services.test.js
@@ -1,3 +1,4 @@
+import uniqueId from 'lodash/uniqueId'
 import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
 
 import * as Services from '../services'
@@ -5,6 +6,7 @@ import * as State from '../state'
 
 const canvasMatcher = {
     id: expect.any(String),
+    name: expect.any(String),
     created: expect.any(String),
     updated: expect.any(String),
     uiChannel: expect.objectContaining({
@@ -92,6 +94,42 @@ describe('Canvas Services', () => {
             expect(duplicateCanvas).toMatchObject({
                 ...canvas,
                 ...canvasMatcher,
+            })
+            expect(duplicateCanvas.name.startsWith(canvas.name))
+        })
+
+        it('deduplicates canvas name', async () => {
+            const name = `test${uniqueId()}`
+            const canvas = await Services.create({
+                name,
+            })
+            const duplicateCanvas = await Services.duplicateCanvas(canvas)
+            expect(duplicateCanvas).toMatchObject({
+                ...canvas,
+                ...canvasMatcher,
+                name: `${name} (2)`,
+            })
+            const duplicateCanvas2 = await Services.duplicateCanvas(duplicateCanvas)
+            expect(duplicateCanvas2).toMatchObject({
+                ...canvas,
+                ...canvasMatcher,
+                name: `${name} (3)`,
+            })
+            // test works with double-digit numbers
+            const duplicateCanvas3 = await Services.create({
+                ...canvas,
+                name: `${name} (10)`,
+            })
+            expect(duplicateCanvas3).toMatchObject({
+                ...canvas,
+                ...canvasMatcher,
+                name: `${name} (10)`, // should not change
+            })
+            const duplicateCanvas4 = await Services.duplicateCanvas(duplicateCanvas3)
+            expect(duplicateCanvas4).toMatchObject({
+                ...canvas,
+                ...canvasMatcher,
+                name: `${name} (11)`,
             })
         })
     })


### PR DESCRIPTION
e.g. `Untitled Canvas` becomes `Untitled Canvas (2)` if you already have an `Untitled Canvas`

To test, try duplicate an existing canvas.