### PR TITLE
Avoid creating undo entry for drag drop events with no movement.

### DIFF
--- a/app/src/editor/canvas/components/DragDropContext.jsx
+++ b/app/src/editor/canvas/components/DragDropContext.jsx
@@ -161,7 +161,10 @@ class EditorDraggable extends React.PureComponent {
         }
 
         if (this.props.onStop) {
-            this.props.onStop(event, data, this.reset)
+            this.props.onStop(event, {
+                diff: this.getDiff(data),
+                ...data,
+            }, this.reset)
         }
 
         this.setState({

--- a/app/src/editor/canvas/components/ModuleDragger.jsx
+++ b/app/src/editor/canvas/components/ModuleDragger.jsx
@@ -9,16 +9,19 @@ export default class ModuleDragger extends React.Component {
     static dragHandle = 'moduleDragHandle'
 
     onDropModule = (event, data) => {
-        this.init = undefined
-
         if (this.context.isCancelled) { return }
+        if (data.diff.x === 0 && data.diff.y === 0) {
+            return // do nothing if not moved
+        }
+
         const moduleHash = this.props.module.hash
-        const offset = {
+        const newPosition = {
             top: data.y,
             left: data.x,
         }
+
         this.props.api.setCanvas({ type: 'Move Module' }, (canvas) => (
-            updateModulePosition(canvas, moduleHash, offset)
+            updateModulePosition(canvas, moduleHash, newPosition)
         ))
     }
 

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -301,13 +301,13 @@ export function updateModule(canvas, moduleHash, fn) {
     return update(modules[moduleHash], fn, canvas)
 }
 
-export function updateModulePosition(canvas, moduleHash, offset) {
+export function updateModulePosition(canvas, moduleHash, newPosition) {
     const { modules } = getIndex(canvas)
     const modulePath = modules[moduleHash]
     return update(modulePath.concat('layout', 'position'), (position) => ({
         ...position,
-        top: `${Number.parseInt(offset.top, 10)}px`,
-        left: `${Number.parseInt(offset.left, 10)}px`,
+        top: `${Number.parseInt(newPosition.top, 10)}px`,
+        left: `${Number.parseInt(newPosition.left, 10)}px`,
     }), canvas)
 }
 


### PR DESCRIPTION
Currently clicking on a module can trigger the start of the module drag-drop process, which is fine except for the fact that even if you don't actually move the module (i.e. just clicked on it), it registers a "move module" event in the undo history. This leads to undo/redo sometimes seemingly requiring multiple attempt to get it activate. Undo/redo is actually working but it's just undoing/redoing pointless "move module exactly where it was already" actions.

This PR bails out of creating the undo entry if there was no movement in the drag/drop.