### PR TITLE
Add warning/deprecation tracing to test runs.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --hot",
     "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack",
-    "test": "jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/* ./src/editor/canvas/tests/*",
+    "test": "NODE_OPTIONS='--trace-warnings --trace-deprecation' jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/* ./src/editor/canvas/tests/*",
     "flow": "flow",
     "flow-stop": "flow stop",
     "eslint": "eslint .",

--- a/app/travis_scripts/unit-tests.sh
+++ b/app/travis_scripts/unit-tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 $(dirname $0)/build-docker-env.sh
-npm test
+NODE_OPTIONS='--trace-warnings --trace-deprecation' npm test

--- a/app/travis_scripts/unit-tests.sh
+++ b/app/travis_scripts/unit-tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 $(dirname $0)/build-docker-env.sh
-NODE_OPTIONS='--trace-warnings --trace-deprecation' npm test
+npm test


### PR DESCRIPTION
Prints stack traces instead of just the error message. 
Should help to track down unhandled rejections, event emitter max listeners exceeded etc issues.