### PR TITLE
Force NODE_ENV=test for npm test.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --hot",
     "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack",
-    "test": "jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/* ./src/editor/canvas/tests/*",
+    "test": "NODE_ENV=test jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/* ./src/editor/canvas/tests/*",
     "flow": "flow",
     "flow-stop": "flow stop",
     "eslint": "eslint .",


### PR DESCRIPTION
In case you have your `NODE_ENV` set to something e.g. `development` by default.