### PR TITLE
Add travis_retry to CI test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - STREAMR_API_URL=http://localhost:8081/streamr-core/api/v1
     - STREAMR_WS_URL=ws://localhost:8890/api/v1/ws
     - STREAMR_URL=http://localhost:8081/streamr-core
-    script: "$TRAVIS_BUILD_DIR/app/travis_scripts/unit-tests.sh"
+    script: "travis_retry $TRAVIS_BUILD_DIR/app/travis_scripts/unit-tests.sh"
   - stage: Platform tests
     if: type IN (pull_request)
     env:

--- a/app/travis_scripts/build-docker-env.sh
+++ b/app/travis_scripts/build-docker-env.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap "killall background" EXIT # clean up background jobs
+
 ##
 ## Pulls down streamr-docker-dev and starts an engine-and-editor instance + associated services ##
 ##

--- a/app/travis_scripts/build-docker-env.sh
+++ b/app/travis_scripts/build-docker-env.sh
@@ -21,7 +21,8 @@ RETRY_DELAY=5s;
 
 # wait for E&E to come up
 waitFor $RETRIES $RETRY_DELAY checkHTTP "engine-and-editor" 200 http://localhost:8081/streamr-core/login/auth;
-$streamr_docker_dev log -f &;
+
+$streamr_docker_dev log -f &
 
 # exit if E&E never comes up
 if [ $? -eq 1 ] ; then


### PR DESCRIPTION
* Enables retrying CI test runs.
* Also fixes logging step (syntax works in zsh but not bash) and cleans up.