### PR TITLE
Toolbar start/run button text

### DIFF
--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -165,7 +165,8 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         onClick={() => (isRunning ? canvasStop() : canvasStart())}
                                         className={styles.RunButton}
                                     >
-                                        {isRunning ? 'Stop' : 'Run'}
+                                        {!!isRunning && 'Stop'}
+                                        {!isRunning && (editorState.runTab === RunTabs.realtime ? 'Start' : 'Run')}
                                     </R.Button>
                                     {editorState.runTab !== RunTabs.realtime ? (
                                         <R.ButtonDropdown

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -243,12 +243,16 @@
   margin: 0 16px;
   white-space: nowrap;
   position: relative;
-  display: flex;
+}
+
+.CanvasToolbar .runTabToggle,
+.CanvasToolbar .runTabValueToggle {
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-column-gap: 1px;
 }
 
 .CanvasToolbar .runTabValueToggle {
-  display: flex;
-  justify-content: flex-start;
   position: relative;
 }
 
@@ -277,7 +281,6 @@
 .ToolbarSolidButton.lastButton {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  margin-left: 1px;
 }
 
 .ToolbarSolidButton:hover,


### PR DESCRIPTION
The start/run button text should switch between "RUN" & "START" based on whether user has chosen realtime or historical mode.

See mocks:
* https://share.goabstract.com/2830d496-15f1-4fce-8ffe-8bd7b1afafa8
* https://share.goabstract.com/c1cf1d18-3fcf-4c8a-85a9-73acfcb355b4

Also prevents toolbar items from shifting 1px when toggling between realtime & historical modes on a slightly width-constrained screen.