### PR TITLE
[PLATFORM-245] Heatmap module

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14830,10 +14830,67 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
       "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
+    "lodash._arraymap": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY="
+    },
+    "lodash._basecallback": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+      "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+      "requires": {
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
+      }
+    },
+    "lodash._baseeach": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
+      "requires": {
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._baseget": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/lodash._baseget/-/lodash._baseget-3.7.2.tgz",
+      "integrity": "sha1-G2rh1frPPCVTI1ChPBGXy4u2dPQ="
+    },
+    "lodash._baseisequal": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+      "requires": {
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash._topath": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/lodash._topath/-/lodash._topath-3.8.1.tgz",
+      "integrity": "sha1-PsXiYGAU9MuX91X+aRTt2L/ADqw=",
+      "requires": {
+        "lodash.isarray": "^3.0.0"
+      }
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -14860,15 +14917,35 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
     },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isempty": {
       "version": "4.4.0",
@@ -14885,6 +14962,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
       "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
     },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
     "lodash.isobject": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
@@ -14894,6 +14976,31 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+    },
+    "lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -14910,10 +15017,53 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
     },
+    "lodash.min": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.min/-/lodash.min-4.0.1.tgz",
+      "integrity": "sha1-SsG5qLr4ttKKaQ1xZRJRDPwUcIw="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.pairs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+      "requires": {
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash.pluck": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.pluck/-/lodash.pluck-3.1.2.tgz",
+      "integrity": "sha1-s0fwN0wBafDusE1nLYnOyGMsIjE=",
+      "requires": {
+        "lodash._baseget": "^3.0.0",
+        "lodash._topath": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.map": "^3.0.0"
+      },
+      "dependencies": {
+        "lodash.map": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-3.1.4.tgz",
+          "integrity": "sha1-tIOs0beGxce0ksSV97UmYim8AMI=",
+          "requires": {
+            "lodash._arraymap": "^3.0.0",
+            "lodash._basecallback": "^3.0.0",
+            "lodash._baseeach": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        }
+      }
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
     },
     "lodash.some": {
       "version": "4.6.0",
@@ -20585,6 +20735,22 @@
         }
       }
     },
+    "react-leaflet-heatmap-layer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-heatmap-layer/-/react-leaflet-heatmap-layer-2.0.0.tgz",
+      "integrity": "sha512-mgzXLPASseUtHpzK9P34cOiJeC3C/rL1/3Pcmc67HFEhutCr7EumUtlbBaPToEdlRjrTqIo4N6ANdLm9keVnYQ==",
+      "requires": {
+        "lodash.filter": "^4.3.0",
+        "lodash.foreach": "^4.2.0",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.map": "^4.3.0",
+        "lodash.max": "^4.0.0",
+        "lodash.min": "^4.0.0",
+        "lodash.pluck": "^3.1.2",
+        "lodash.reduce": "^4.3.0",
+        "simpleheat": "^0.4.0"
+      }
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -22899,6 +23065,11 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
+    },
+    "simpleheat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/simpleheat/-/simpleheat-0.4.0.tgz",
+      "integrity": "sha1-4t6NRUj88aaWC2Nr+pOdBbzUmns="
     },
     "sinon": {
       "version": "6.3.5",

--- a/app/package.json
+++ b/app/package.json
@@ -179,6 +179,7 @@
     "react-helmet": "^5.2.0",
     "react-image": "^1.4.0",
     "react-leaflet": "^2.2.0",
+    "react-leaflet-heatmap-layer": "^2.0.0",
     "react-loading-skeleton": "^0.5.0",
     "react-modal2": "^5.0.0",
     "react-notification-system": "^0.2.17",

--- a/app/src/editor/shared/components/ModuleUI.jsx
+++ b/app/src/editor/shared/components/ModuleUI.jsx
@@ -13,6 +13,7 @@ import LabelModule from './modules/Label'
 import CanvasModule from './modules/Canvas'
 import StreamrSwitcher from './modules/Switcher'
 import MapModule from './modules/Map'
+import HeatmapModule from './modules/Heatmap'
 import ModuleLoader from './ModuleLoader'
 import ExportCSVModule from './modules/ExportCSV'
 import SchedulerModule from './modules/Scheduler'
@@ -29,6 +30,7 @@ const Modules = {
     SchedulerModule,
     MapModule,
     ImageMapModule: MapModule,
+    HeatmapModule,
     CustomModule,
 }
 

--- a/app/src/editor/shared/components/modules/Heatmap.jsx
+++ b/app/src/editor/shared/components/modules/Heatmap.jsx
@@ -1,0 +1,169 @@
+// @flow
+
+import React from 'react'
+import cx from 'classnames'
+import throttle from 'lodash/throttle'
+
+import Map from '../Map/Map'
+import ModuleSubscription from '../ModuleSubscription'
+
+import styles from './Map.pcss'
+
+const UPDATE_INTERVAL_MS = 100
+
+type Props = {
+    className: string,
+    module: Object,
+}
+
+type HeatmapMarker = {
+    lat: number,
+    long: number,
+    value: number,
+    ttl: number,
+}
+
+type State = {
+    markers: Array<HeatmapMarker>,
+    lastUpdate: number,
+}
+
+type HeatmapMessage = {
+    t: string, // type
+    g: number, // longitude
+    l: number, // latitude
+    v: number, // value
+}
+
+type Message = HeatmapMessage
+
+export default class HeatmapModule extends React.Component<Props, State> {
+    state = {
+        markers: [],
+        lastUpdate: 0,
+    }
+
+    updateInterval: IntervalID
+    queuedMarkers: Array<HeatmapMarker> = []
+    unmounted = false
+
+    componentDidMount() {
+        this.updateInterval = setInterval(this.updateMarkers, UPDATE_INTERVAL_MS)
+    }
+
+    componentWillUnmount() {
+        this.unmounted = true
+        clearInterval(this.updateInterval)
+    }
+
+    onMessage = (msg: Message) => {
+        if (msg.t === 'p') {
+            const marker = this.getMarkerFromMessage(msg)
+            this.queuedMarkers.push(marker)
+            this.flushMarkerData()
+        } else {
+            console.error('Unknown message type on HeatmapModule:', msg)
+        }
+    }
+
+    getMarkerFromMessage = (msg: HeatmapMessage): HeatmapMarker => (
+        {
+            lat: msg.l,
+            long: msg.g,
+            value: msg.v,
+            ttl: this.getModuleOption('lifeTime', 7000),
+        }
+    )
+
+    getModuleOption = (key: string, defaultValue: any) => {
+        const obj = this.props.module.options[key]
+        return this.getValueOrDefault(obj, defaultValue)
+    }
+
+    getModuleParam = (key: string, defaultValue: any) => {
+        const matchingParams = this.props.module.params
+            .filter((p) => p.name === key)
+
+        if (matchingParams.length > 0) {
+            return this.getValueOrDefault(matchingParams[0], defaultValue)
+        }
+        return defaultValue
+    }
+
+    getValueOrDefault = (obj: { type: string, value: any }, defaultValue: any) => {
+        const { type, value } = obj || {}
+        if ((type === 'int' || type === 'double') && value != null) {
+            return value
+        } else if (!value) {
+            return defaultValue
+        }
+        return value
+    }
+
+    flushMarkerData = throttle(() => {
+        if (this.unmounted) {
+            return
+        }
+
+        const { queuedMarkers } = this
+        this.queuedMarkers = []
+
+        this.setState(({ markers }) => ({
+            markers: markers.concat(queuedMarkers),
+        }))
+    }, UPDATE_INTERVAL_MS)
+
+    updateMarkers = () => {
+        const { markers, lastUpdate } = this.state
+        const now = Date.now()
+        const timeDiff = now - lastUpdate
+
+        markers.forEach((marker) => {
+            marker.ttl -= timeDiff
+        })
+
+        this.setState(({ markers }) => ({
+            lastUpdate: now,
+            markers: markers.filter((m) => m.ttl > 0), // remove expired
+        }))
+    }
+
+    render() {
+        const { className } = this.props
+        const { markers } = this.state
+
+        const heatmapProps = {
+            isHeatmap: true,
+            fadeInTime: this.getModuleOption('fadeInTime', 500),
+            fadeOutTime: this.getModuleOption('fadeOutTime', 500),
+            lifeTime: this.getModuleOption('lifeTime', 7000),
+            min: this.getModuleOption('min', 0),
+            max: this.getModuleOption('max', 20),
+            maxOpacity: this.getModuleOption('maxOpacity', 0.8),
+            radius: this.getModuleOption('radius', 30),
+            scaleRadius: this.getModuleOption('scaleRadius', false),
+            useLocalExtrema: this.getModuleOption('useLocalExtrema', false),
+        }
+
+        return (
+            <div className={cx(className)}>
+                <ModuleSubscription
+                    {...this.props}
+                    onMessage={this.onMessage}
+                />
+                <Map
+                    {...this.props.module.options}
+                    className={styles.map}
+                    centerLat={this.getModuleOption('centerLat', 60.18)}
+                    centerLong={this.getModuleOption('centerLng', 24.92)}
+                    minZoom={this.getModuleOption('minZoom', 2)}
+                    maxZoom={this.getModuleOption('maxZoom', 18)}
+                    zoom={this.getModuleOption('zoom', 12)}
+                    markers={markers}
+                    skin={this.getModuleOption('skin', 'default')}
+                    {...heatmapProps}
+                />
+            </div>
+        )
+    }
+}

--- a/app/src/editor/shared/components/modules/Map.jsx
+++ b/app/src/editor/shared/components/modules/Map.jsx
@@ -41,6 +41,9 @@ type Message = {
     pointList?: Array<string>,
 }
 
+/*
+    MapModule handles following modules: Map, ImageMap
+*/
 export default class MapModule extends React.Component<Props, State> {
     state = {
         markers: {},
@@ -130,7 +133,10 @@ export default class MapModule extends React.Component<Props, State> {
             }
 
             // If tracing is enabled, update last positions
-            if (this.props.module.options.drawTrace.value && msg.tracePointId) {
+            if (this.props.module.options.drawTrace &&
+                this.props.module.options.drawTrace.value &&
+                msg.tracePointId
+            ) {
                 this.addTracePoint(marker.id, marker.lat, marker.long, msg.tracePointId)
                 marker.previousPositions = this.positionHistory[marker.id]
             }
@@ -261,6 +267,7 @@ export default class MapModule extends React.Component<Props, State> {
                     minZoom={this.getModuleOption('minZoom', 2)}
                     maxZoom={this.getModuleOption('maxZoom', 18)}
                     zoom={this.getModuleOption('zoom', 12)}
+                    /* For Map */
                     traceColor={this.getModuleParam('traceColor', '#FFFFFF')}
                     traceWidth={this.getModuleOption('traceWidth', 2)}
                     markerIcon={markerIcon}
@@ -268,6 +275,7 @@ export default class MapModule extends React.Component<Props, State> {
                     markerColor={this.getModuleOption('markerColor', '#FFFFFF')}
                     directionalMarkers={directionalMarkers}
                     skin={this.getModuleOption('skin', 'default')}
+                    /* For ImageMap */
                     isImageMap={imageMap}
                     imageBounds={imageBounds}
                     imageUrl={this.getModuleOption('customImageUrl', null)}


### PR DESCRIPTION
Added Heatmap module with help of `react-leaflet-heatmap-layer`. The new heatmap library does not have the same parameters as the component in the old editor had, so most of the module parameters actually do nothing.

The heatmap that gets drawn looks a bit different with this version and the old editor. Could not spot where the difference comes from but might be related to the parameters or the fade-in/out algorithm. IMO the new heatmap looks a lot better :)

Also this version does not implement fade-in/out. I have created https://streamr.atlassian.net/browse/PLATFORM-513 so that we can implement it later if actually needed.