### PR TITLE
[PLATFORM-459] Historical Runs

### DIFF
--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -26,7 +26,7 @@ import * as CanvasState from './state'
 
 import styles from './index.pcss'
 
-const { RunTabs, RunStates } = CanvasState
+const { RunStates } = CanvasState
 
 const UpdatedTime = new Map()
 
@@ -102,6 +102,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     componentDidMount() {
         window.addEventListener('keydown', this.onKeyDown)
         this.autosave()
+        this.autostart()
     }
 
     componentWillUnmount() {
@@ -113,6 +114,14 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     componentDidUpdate(prevProps) {
         if (this.props.canvas !== prevProps.canvas) {
             this.autosave()
+        }
+    }
+
+    async autostart() {
+        const { canvas } = this.props
+        if (canvas.adhoc && canvas.state !== RunStates.Running) {
+            // do not autostart running/non-adhoc canvases
+            return this.canvasStart()
         }
     }
 
@@ -292,15 +301,8 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     canvasStart = async (options = {}) => {
         const { canvas } = this.props
-        const { settings = {} } = canvas
-        const { editorState = {} } = settings
-        const isHistorical = editorState.runTab === RunTabs.historical
-        if (this.unmounted) { return }
         return this.getNewCanvas(() => (
-            services.start(canvas, {
-                clearState: !!options.clearState || isHistorical,
-                adhoc: isHistorical,
-            })
+            services.startOrCreateAdhocCanvas(canvas, options)
         ))
     }
 
@@ -308,6 +310,13 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         const { canvas } = this.props
         return this.getNewCanvas(() => (
             services.stop(canvas)
+        ))
+    }
+
+    canvasExit = async () => {
+        const { canvas } = this.props
+        return this.getNewCanvas(() => (
+            services.exitAdhocCanvas(canvas)
         ))
     }
 
@@ -332,7 +341,9 @@ const CanvasEditComponent = class CanvasEdit extends Component {
             }
         }
         if (this.unmounted) { return }
-        if (!newCanvas) { return this.loadParent() }
+        if (!newCanvas) {
+            return this.loadSelf()
+        }
         this.replaceCanvas(() => newCanvas)
     }
 
@@ -342,6 +353,13 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         const newCanvas = await services.loadCanvas({ id: nextId })
         if (this.unmounted) { return }
         this.replaceCanvas(() => newCanvas)
+    }
+
+    loadSelf = async () => {
+        const { canvas } = this.props
+        return this.getNewCanvas(() => (
+            services.loadCanvas(canvas)
+        ))
     }
 
     render() {
@@ -359,7 +377,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     resendFrom={canvas.adhoc ? resendFrom : undefined}
                     resendTo={canvas.adhoc ? resendTo : undefined}
                     isActive={canvas.state === RunStates.Running}
-                    onUnsubscribed={this.loadParent}
+                    onUnsubscribed={this.loadSelf}
                 />
                 <Canvas
                     className={styles.Canvas}
@@ -394,6 +412,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                         setSaveState={this.setSaveState}
                         canvasStart={this.canvasStart}
                         canvasStop={this.canvasStop}
+                        canvasExit={this.canvasExit}
                     />
                 </ModalProvider>
                 <ModuleSidebar
@@ -442,9 +461,9 @@ const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class Canv
         }
 
         const canvas = this.context.state
-        const currentId = canvas && canvas.id
-        const canvasId = currentId || this.props.match.params.id
-        if (canvasId && currentId !== canvasId && this.state.isLoading !== canvasId) {
+        const rootId = canvas && CanvasState.getRootCanvasId(canvas)
+        const canvasId = rootId || this.props.match.params.id
+        if (canvasId && rootId !== canvasId && this.state.isLoading !== canvasId) {
             // load canvas if needed and not already loading
             this.load(canvasId)
         }
@@ -452,12 +471,12 @@ const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class Canv
 
     load = async (canvasId) => {
         this.setState({ isLoading: canvasId })
-        let newCanvas = await services.loadCanvas({ id: canvasId })
+        let canvas = await services.loadRelevantCanvas({ id: canvasId })
         // ignore result if unmounted or canvas changed
         if (this.unmounted || this.state.isLoading !== canvasId) { return }
-        newCanvas = CanvasState.updateCanvas(newCanvas)
+        canvas = CanvasState.updateCanvas(canvas)
         // replace/init top of undo stack with loaded canvas
-        this.context.replace(() => newCanvas)
+        this.context.replace(() => canvas)
         this.setState({ isLoading: false })
     }
 

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, useContext } from 'react'
 import { withRouter } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
 
@@ -471,18 +471,17 @@ function isDisabled({ state: canvas }) {
     return !canvas || (canvas.state === RunStates.Running || canvas.adhoc)
 }
 
-const CanvasEditWrap = () => (
-    <UndoContainer.Consumer>
-        {({ state: canvas, push, replace }) => (
-            <CanvasEdit
-                key={canvas && canvas.id}
-                push={push}
-                replace={replace}
-                canvas={canvas}
-            />
-        )}
-    </UndoContainer.Consumer>
-)
+const CanvasEditWrap = () => {
+    const { state: canvas, push, replace } = useContext(UndoContainer.Context)
+    return (
+        <CanvasEdit
+            key={canvas && canvas.id}
+            push={push}
+            replace={replace}
+            canvas={canvas}
+        />
+    )
+}
 
 export default withRouter((props) => (
     <Layout className={styles.layout} footer={false}>

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -908,6 +908,30 @@ export function isRunning(canvas) {
     return canvas.state === RunStates.Running
 }
 
+export function getChildCanvasId(canvas) {
+    return canvas.settings.childCanvasId
+}
+
+export function getParentCanvasId(canvas) {
+    return canvas.settings.parentCanvasId
+}
+
+/**
+ * Gets parent id, or own if no parent
+ */
+
+export function getRootCanvasId(canvas) {
+    return getParentCanvasId(canvas) || canvas.id
+}
+
+/**
+ * Gets child id, or own if no child
+ */
+
+export function getRelevantCanvasId(canvas) {
+    return getChildCanvasId(canvas) || canvas.id
+}
+
 /**
  * Cleanup
  */

--- a/app/src/editor/canvas/tests/adhoc.test.js
+++ b/app/src/editor/canvas/tests/adhoc.test.js
@@ -1,0 +1,86 @@
+import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
+
+import * as Services from '../services'
+
+const canvasMatcher = {
+    id: expect.any(String),
+    name: expect.any(String),
+    created: expect.any(String),
+    updated: expect.any(String),
+    uiChannel: expect.objectContaining({
+        id: expect.any(String),
+    }),
+}
+
+describe('Adhoc Canvases', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setupAuthorizationHeader()
+    }, 60000) // service can take some time to respond initially
+
+    afterAll(async () => {
+        await Services.deleteAllCanvases()
+        await teardown()
+    })
+
+    describe('create adhoc canvas', () => {
+        it('creates a new canvas', async () => {
+            const parentCanvas = await Services.create()
+            const adhocCanvas = await Services.createAdhocCanvas(parentCanvas)
+            expect(adhocCanvas.id).not.toEqual(parentCanvas.id)
+            expect(adhocCanvas).toMatchObject({
+                ...parentCanvas,
+                ...canvasMatcher,
+                name: parentCanvas.name, // name identical (no deduping)
+                adhoc: true, // created canvas is adhoc
+                settings: expect.objectContaining({
+                    parentCanvasId: parentCanvas.id, // captures parent canvas id
+                }),
+            })
+
+            // check parent canvas updated
+            const updatedParentCanvas = await Services.loadCanvas(parentCanvas)
+            expect(updatedParentCanvas).toMatchObject({
+                ...parentCanvas,
+                ...canvasMatcher,
+                settings: expect.objectContaining({
+                    childCanvasId: adhocCanvas.id, // captures child canvas id
+                }),
+            })
+        })
+
+        it('can "exit" adhoc canvas', async () => {
+            const parentCanvas = await Services.create()
+            const adhocCanvas = await Services.createAdhocCanvas(parentCanvas)
+            const updatedParentCanvas = await Services.exitAdhocCanvas(adhocCanvas)
+            expect(updatedParentCanvas).toMatchObject({
+                ...parentCanvas,
+                ...canvasMatcher,
+                id: parentCanvas.id, // should have loaded parent canvas
+                settings: expect.not.objectContaining({
+                    childCanvasId: expect.anything(), // child canvas id unset
+                }),
+            })
+        })
+
+        it('will load adhoc canvas as the "relevant" canvas', async () => {
+            const parentCanvas = await Services.create()
+            const adhocCanvas = await Services.createAdhocCanvas(parentCanvas)
+            const loadedCanvas = await Services.loadRelevantCanvas(parentCanvas)
+            expect(loadedCanvas).toMatchObject({
+                ...adhocCanvas,
+                ...canvasMatcher,
+                id: adhocCanvas.id, // should have loaded adhoc canvas
+            })
+            await Services.exitAdhocCanvas(adhocCanvas)
+            const nextLoadedCanvas = await Services.loadRelevantCanvas(parentCanvas)
+            expect(nextLoadedCanvas).toMatchObject({
+                ...parentCanvas,
+                ...canvasMatcher,
+                id: parentCanvas.id, // should have loaded adhoc canvas
+            })
+        })
+    })
+})
+

--- a/app/src/editor/canvas/tests/services.test.js
+++ b/app/src/editor/canvas/tests/services.test.js
@@ -187,24 +187,5 @@ describe('Canvas Services', () => {
             // can't stop a stopped canvas
             await expect(Services.stop(canvas)).rejects.toThrow()
         })
-
-        it('can start adhoc canvases', async () => {
-            const canvas = await Services.create()
-            const startedAdhocCanvas = await Services.start(canvas, { adhoc: true })
-            expect(startedAdhocCanvas.id).not.toEqual(canvas.id)
-            expect(startedAdhocCanvas).toMatchObject({
-                ...canvas,
-                ...canvasMatcher,
-                adhoc: true,
-                state: State.RunStates.Running,
-                startedById: expect.any(Number),
-                settings: expect.objectContaining({
-                    parentCanvasId: canvas.id, // captures parent canvas id
-                }),
-            })
-
-            // adhoc canvas will immediately stop, so this should throw
-            await expect(Services.stop(startedAdhocCanvas)).rejects.toThrow()
-        })
     })
 })


### PR DESCRIPTION
This "fixes" some difficult issues with historical runs.

1. Refreshing the page while viewing a historical run will return to that historical run.
2. Historical runs now need to be "exited" after they stop.
3. "Exiting" will clear the UI data and switch user back to editing the original canvas. 

* Redirecting to the historical canvas prevents historical runs from being "lost", and also prevents background canvas edits.
* Exit state means historical visualisation data will not disappear until user commands it so.
* The exit state exists so we don't have to do any trickery to "pretend" the adhoc historical canvas is actually the original canvas. i.e. once user hits exit, there's a clean break between the two canvases.
* This also reinforces the concept of realtime/historical runs being exclusive "modes" of a canvas.

One downside is that **this prevents running historical canvases in parallel** without duplicating the canvas first, but I think if we want to support parallel historical runs (either with one realtime or multiple historical runs) then **the design should cater for this usecase explicitly**, rather than it being implicitly possible though a quirk of the implementation and in conflict with the "mode" messaging in the UI.

To test:

1. Create canvas with clock -> table.
2. Set clock to emit event once every 10s.
3. Change to historical mode.
4. Change canvas speed via Run menu to 10x
5. Start historical canvas.
6. You should see 1 event every second.
7. Refresh the page.
8. Should still be on historical canvas and it should be running.
9. Stop the canvas. Data should stop flowing but remain visible. Stop button becomes exit. All but a few controls in toolbar are disabled.
10. Press Exit.
11. Visualisation & module positions are reset, toolbar enabled again.

Possible this flow needs to be refined or adjusted, but this at least makes the behaviour more closely aligned with the UI's treatment of realtime/historical as "modes" of a single canvas.

This PR also paves a sensible way forward for the "subscribe before start" task.

----

### The Problem

In the old editor, historical runs pretend to be a different "mode" of the same canvas, but in reality they're implemented by creating an entirely new canvas and starting that. In the old editor if you refresh the page, the historical canvas is effectively lost as there is no link between the original and the created canvas.

Once the historical run ends, subsequent edits should apply to canvas which started it. Currently the new editor achieves this by swapping the canvas with the original. One issue with this approach is that it currently detects this as a "new canvas", which wipes all the visualisation data. This means that historical runs will start, some data will appears then once it ends the data automatically disappears. This makes it impossible to analyse a historical run after the run is complete. One solution to this could be to "pretend" the two canvases are the same canvas, however there are some difficulties deciding what should happen when a historical run ends. Historical runs can be set into slowed playback modes (e.g. realtime) where the canvas can continue to exist and run for an extended period. It's currently possible to run historical canvas(es) in the background, while continuing to edit the original canvas. What to do when the historical canvas ends and the underlying canvas changed?

* If we reload the underlying canvas data, then the historical canvas’ visualisations will (potentially) disappear.
* If we keep the stopped historical canvas data around as the "new" version of the original canvas, the  historical canvas data will clobber any changes on the original canvas. This is how it works in the old editor but the issue is somewhat mitigated due to no autosave.

The solution proposed here is: prevent edits while running historical canvases & draw hard line between the historical and original canvas.

### Implementation

1. When running a canvas in historical mode, create a duplicate the current canvas (the “parent”) as a new canvas with `adhoc: true` (the “child”). Note to not deduplicate canvas name. New canvas is not started yet.
2. Take the created child canvases’ id and set it as the `childCanvasId` on the parent canvas. Save parent canvas.
3. Replace current canvas with the created child canvas.

Then:
3. When loading a canvas, if we see a `childCanvasId`, load that child canvas instead. (i.e. refreshing page will take us back to historical canvas until exited)
4. Whenever canvas is updated, if it’s an adhoc canvas that is not (yet) running, automatically start the canvas.
6. When a canvas sees the “done” event, reload the current canvas. The reloaded canvas should now no longer be running (works in either realtime/historical context).
7. If the canvas Toolbar sees a non-running adhoc canvas, show “Exit” instead of start/run/stop.
8. If user presses Exit button, load the `parentCanvasId` canvas, unset it's `childCanvasId` (stops the redirection), resave then use the saved result as new current canvas.

In summary:
• Adhoc canvases are not started immediately, they’re created & loaded like a normal canvas first.
* Creating an adhoc canvas links the original "parent" to the adhoc "child" (and vice versa)
• Adhoc canvases will be automatically started if not currently running.
• Once the adhoc canvas is done, the Exit button will show.
• Clicking the exit button removes the link to the adhoc child on the parent, then reloads the parent.
• Reloading the canvas while the parent has a link to the child will always show the child.