### PR TITLE
Fix draggability for dashboard modules.

### DIFF
--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -124,13 +124,13 @@ class CanvasModule extends React.PureComponent {
                 {...props}
             >
                 <ModuleHeader
-                    className={styles.header}
+                    className={cx(styles.header, ModuleStyles.dragHandle)}
                     editable={!isRunning}
                     label={module.displayName || module.name}
                     onLabelChange={this.onChangeModuleName}
                 >
                     <HamburgerButton
-                        className={ModuleHeader.styles.dragCancel}
+                        className={ModuleStyles.dragCancel}
                         onClick={this.onTriggerOptions}
                         onFocus={this.onHamburgerButtonFocus}
                     />

--- a/app/src/editor/canvas/components/ModuleDragger.jsx
+++ b/app/src/editor/canvas/components/ModuleDragger.jsx
@@ -2,12 +2,10 @@ import React from 'react'
 
 import { updateModulePosition } from '../state'
 import { Draggable } from './DragDropContext'
-import ModuleHeader from '$editor/shared/components/ModuleHeader'
+import ModuleStyles from '$editor/shared/components/Module.pcss'
 import styles from './Module.pcss'
 
 export default class ModuleDragger extends React.Component {
-    static dragHandle = 'moduleDragHandle'
-
     onDropModule = (event, data) => {
         if (this.context.isCancelled) { return }
         if (data.diff.x === 0 && data.diff.y === 0) {
@@ -45,8 +43,8 @@ export default class ModuleDragger extends React.Component {
         return (
             <Draggable
                 defaultClassNameDragging={styles.isDragging}
-                cancel={`.${ModuleHeader.styles.dragCancel}`}
-                handle={`.${ModuleHeader.styles.dragHandle}`}
+                cancel={`.${ModuleStyles.dragCancel}`}
+                handle={`.${ModuleStyles.dragHandle}`}
                 bounds={this.bounds}
                 defaultPosition={defaultPosition}
                 onStop={this.onDropModule}

--- a/app/src/editor/dashboard/components/Dashboard.jsx
+++ b/app/src/editor/dashboard/components/Dashboard.jsx
@@ -102,7 +102,7 @@ class DashboardItem extends React.Component {
                 data-itemid={item.id}
             >
                 <ModuleHeader
-                    className={styles.header}
+                    className={cx(styles.header, ModuleStyles.dragHandle)}
                     editable={!disabled}
                     label={item.title}
                     limitWidth

--- a/app/src/editor/shared/components/ModuleHeader/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/index.jsx
@@ -27,7 +27,7 @@ const ModuleHeader = ({
 
     return (
         <div
-            className={cx(styles.root, styles.dragHandle, className)}
+            className={cx(styles.root, className)}
             {...props}
         >
             {/* TODO: Replace the following line with the actual toggle. This here is just a placeholder. */}

--- a/app/src/editor/shared/components/ModuleHeader/moduleHeader.pcss
+++ b/app/src/editor/shared/components/ModuleHeader/moduleHeader.pcss
@@ -24,11 +24,6 @@
   width: 24px;
 }
 
-.dragHandle,
-.dragCancel {
-  /* Class names for react-draggable. */
-}
-
 .limitedWidth {
   max-width: calc(100% - 24px);
 }


### PR DESCRIPTION
Modules currently can't be dragged to reposition them on the dashboard. This fixes that by reading dragHandle consistently from the shared module styles. 

Logged by @mattatgit in https://streamr.atlassian.net/browse/PLATFORM-519