### PR TITLE
Fix load definition to always pass existing module config.

### DIFF
--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -187,33 +187,10 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     loadNewDefinition = async (hash) => {
         const module = CanvasState.getModule(this.props.canvas, hash)
 
-        // Stream module needs configuration for the getModule call
-        let configuration = null
-        if (module.id === 147) {
-            const streamPort = CanvasState.findModulePort(this.props.canvas, hash, (port) => port.type === 'Stream')
-            if (streamPort) {
-                configuration = {
-                    params: [
-                        {
-                            name: 'stream',
-                            value: streamPort.value,
-                        },
-                    ],
-                }
-            }
-        }
-
         const newModule = await sharedServices.getModule({
             id: module.id,
-            configuration,
+            configuration: module,
         })
-
-        // If we load new definition for the Stream module
-        // we still need to preserve current module layout etc.
-        if (module.id === 147) {
-            newModule.layout = module.layout
-            newModule.hash = hash
-        }
 
         if (this.unmounted) { return }
         this.replaceCanvas((canvas) => (


### PR DESCRIPTION
Currently this doesn't work for http module's VERB select. The module that comes back doesn't have layout information, etc.

@juhah maybe you can recall better than I but I don't think the Stream module needs to be special-cased, nor does it need to be conservative about what it sends as the config in `getModule`. Maybe you can break it?