### PR TITLE
Prevent react-helmet from clobbering header content (fixes favicon).

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -7,34 +7,34 @@
 <head>
     <title><%= title %></title>
 
-    <link href="https://www.streamr.com/assets/Favicons/favicon-16x16.png" rel="icon" size="16" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/favicon-32x32.png" rel="icon" size="32" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/favicon-96x96.png" rel="icon" size="96" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-57x57.png" rel="apple-touch-icon" size="57" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-60x60.png" rel="apple-touch-icon" size="60" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-72x72.png" rel="apple-touch-icon" size="72" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-76x76.png" rel="apple-touch-icon" size="76" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-114x114.png" rel="apple-touch-icon" size="114" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-120x120.png" rel="apple-touch-icon" size="120" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-144x144.png" rel="apple-touch-icon" size="144" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-152x152.png" rel="apple-touch-icon" size="152" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/apple-icon-180x180.png" rel="apple-touch-icon" size="180" data-react-helmet="true" type="image/png">
-    <link href="https://www.streamr.com/assets/Favicons/android-icon-192x192.png" rel="icon" size="192" data-react-helmet="true" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/favicon-16x16.png" rel="icon" size="16" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/favicon-32x32.png" rel="icon" size="32" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/favicon-96x96.png" rel="icon" size="96" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-57x57.png" rel="apple-touch-icon" size="57" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-60x60.png" rel="apple-touch-icon" size="60" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-72x72.png" rel="apple-touch-icon" size="72" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-76x76.png" rel="apple-touch-icon" size="76" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-114x114.png" rel="apple-touch-icon" size="114" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-120x120.png" rel="apple-touch-icon" size="120" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-144x144.png" rel="apple-touch-icon" size="144" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-152x152.png" rel="apple-touch-icon" size="152" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/apple-icon-180x180.png" rel="apple-touch-icon" size="180" type="image/png">
+    <link href="https://www.streamr.com/assets/Favicons/android-icon-192x192.png" rel="icon" size="192" type="image/png">
 
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1" data-react-helmet="true">
-    <meta name="description" content="<%= description %>" data-react-helmet="true">
-    <meta property="og:title" content="<%= title %>" data-react-helmet="true">
-    <meta property="og:description" content="<%= description %>" data-react-helmet="true">
-    <meta property="og:image" content="https://www.streamr.com/assets/HeroImages/Streamr-Social_Large.jpg" data-react-helmet="true">
-    <meta name="twitter:card" content="summary_large_image" data-react-helmet="true">
-    <meta name="twitter:title" content="<%= title %>" data-react-helmet="true">
-    <meta name="twitter:description" content="<%= description %>" data-react-helmet="true">
-    <meta name="twitter:image" content="https://www.streamr.com/assets/HeroImages/Streamr-Social_Large.jpg" data-react-helmet="true">
-    <meta name="msapplication-TileColor" content="#ffffff" data-react-helmet="true">
-    <meta name="msapplication-TileImage" content="https://www.streamr.com/assets/Favicons/ms-icon-144x144.png" data-react-helmet="true">
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js" data-react-helmet="true"></script>
-    <style data-react-helmet="true">@-ms-viewport { width: device-width; }</style>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="<%= description %>">
+    <meta property="og:title" content="<%= title %>">
+    <meta property="og:description" content="<%= description %>">
+    <meta property="og:image" content="https://www.streamr.com/assets/HeroImages/Streamr-Social_Large.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="<%= title %>">
+    <meta name="twitter:description" content="<%= description %>">
+    <meta name="twitter:image" content="https://www.streamr.com/assets/HeroImages/Streamr-Social_Large.jpg">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="https://www.streamr.com/assets/Favicons/ms-icon-144x144.png">
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+    <style>@-ms-viewport { width: device-width; }</style>
 
     <%/*
         Global site tag (gtag.js) - Google Analytics


### PR DESCRIPTION
You may have noticed the favicon goes missing after the page loads. This seems to fix that. A bunch of other tags in the header were being (unintentionally?) removed as well. It's possible there are unintended side effects of now *not* removing these header items.

#### Before

![image](https://user-images.githubusercontent.com/43438/56352465-e223d800-6201-11e9-9c09-9b266515c2e4.png)

#### After

![image](https://user-images.githubusercontent.com/43438/56352469-e4863200-6201-11e9-8c43-63c206186f60.png)
