### PR TITLE
[PLATFORM-524] Update deduping naming scheme

### DIFF
--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -61,8 +61,6 @@ async function getCanvasNames() {
 async function createCanvas(canvas) {
     return api().post(canvasesUrl, {
         ...canvas,
-        // adhoc canvases should use parent name
-        name: canvas.adhoc ? canvas.name : await getUniqueCanvasName(canvas.name),
         state: RunStates.Stopped, // always create stopped canvases
     }).then(getData)
 }
@@ -72,7 +70,7 @@ export async function create(config) {
     return createCanvas({
         ...canvas,
         // adhoc canvases should use parent name
-       name: canvas.adhoc ? canvas.name : nextUniqueName(canvas.name, await getCanvasNames()),
+        name: canvas.adhoc ? canvas.name : nextUniqueName(canvas.name, await getCanvasNames()),
     })
 }
 
@@ -80,6 +78,7 @@ export async function duplicateCanvas(canvas) {
     if (!isRunning(canvas) && !canvas.adhoc) {
         canvas = await saveNow(canvas) // ensure canvas saved before duplicating
     }
+
     return createCanvas({
         ...canvas,
         adhoc: false, // duplicate canvases are never adhoc

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -4,6 +4,7 @@
 
 import api from '$editor/shared/utils/api'
 import Autosave from '$editor/shared/utils/autosave'
+import { nextUniqueName, nextUniqueCopyName } from '$editor/shared/utils/uniqueName'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
 import { emptyCanvas, isRunning, RunStates, RunTabs } from './state'
@@ -52,37 +53,9 @@ export async function loadCanvases() {
     return api().get(canvasesUrl).then(getData)
 }
 
-function getUniqueName(originalName = '', existingNames = []) {
-    let name = originalName
-    const nameSplit = /(.*) \((\d+)\)$/g.exec(name)
-    let highestCounter = 1
-    let nameCounter = 0
-    if (nameSplit) {
-        name = nameSplit[1] // eslint-disable-line prefer-destructuring
-        nameCounter = parseInt(nameSplit[2], 10) // eslint-disable-line prefer-destructuring
-    }
-
-    name = name.trim()
-    const matchingNames = existingNames.filter((currentName) => {
-        if (currentName === name) { return true }
-        const matches = /(.*) \((\d+)\)$/g.exec(currentName)
-        if (!matches) { return false }
-        const [, innerName, counter] = matches
-        if (innerName !== name) { return false }
-        highestCounter = Math.max(highestCounter, parseInt(counter, 10))
-        return true
-    })
-    if (!matchingNames.length) { return originalName }
-    return `${name} (${Math.max(highestCounter + 1, nameCounter)})`
-}
-
-async function getUniqueCanvasName(canvasName) {
-    if (!canvasName) {
-        canvasName = emptyCanvas().name // eslint-disable-line prefer-destructuring
-    }
+async function getCanvasNames() {
     const canvases = await loadCanvases()
-    const names = canvases.map(({ name }) => name)
-    return getUniqueName(canvasName, names)
+    return canvases.map(({ name }) => name)
 }
 
 async function createCanvas(canvas) {
@@ -95,11 +68,12 @@ async function createCanvas(canvas) {
 }
 
 export async function create(config) {
-    return createCanvas(emptyCanvas(config)) // create new empty
-}
-
-export async function moduleHelp({ id }) {
-    return api().get(`${process.env.STREAMR_API_URL}/modules/${id}/help`).then(getData)
+    const canvas = emptyCanvas(config)
+    return createCanvas({
+        ...canvas,
+        // adhoc canvases should use parent name
+       name: canvas.adhoc ? canvas.name : nextUniqueName(canvas.name, await getCanvasNames()),
+    })
 }
 
 export async function duplicateCanvas(canvas) {
@@ -109,12 +83,17 @@ export async function duplicateCanvas(canvas) {
     return createCanvas({
         ...canvas,
         adhoc: false, // duplicate canvases are never adhoc
+        name: nextUniqueCopyName(canvas.name, await getCanvasNames()),
     })
 }
 
 export async function deleteCanvas({ id } = {}) {
     await autosave.cancel()
     return api().delete(`${canvasesUrl}/${id}`).then(getData)
+}
+
+export async function moduleHelp({ id }) {
+    return api().get(`${process.env.STREAMR_API_URL}/modules/${id}/help`).then(getData)
 }
 
 export async function getModuleCategories() {

--- a/app/src/editor/canvas/tests/services.test.js
+++ b/app/src/editor/canvas/tests/services.test.js
@@ -43,6 +43,11 @@ describe('Canvas Services', () => {
                 updated: canvasMatcher.updated,
             })
         })
+        it('deduplicates canvas name', async () => {
+            const canvas = await Services.create()
+            const canvas2 = await Services.create()
+            expect(canvas.name).not.toEqual(canvas2.name)
+        })
     })
 
     describe('loadCanvas', () => {
@@ -107,29 +112,29 @@ describe('Canvas Services', () => {
             expect(duplicateCanvas).toMatchObject({
                 ...canvas,
                 ...canvasMatcher,
-                name: `${name} (2)`,
+                name: `${name} Copy`,
             })
             const duplicateCanvas2 = await Services.duplicateCanvas(duplicateCanvas)
             expect(duplicateCanvas2).toMatchObject({
                 ...canvas,
                 ...canvasMatcher,
-                name: `${name} (3)`,
+                name: `${name} Copy 02`,
             })
             // test works with double-digit numbers
             const duplicateCanvas3 = await Services.create({
                 ...canvas,
-                name: `${name} (10)`,
+                name: `${name} Copy 10`,
             })
             expect(duplicateCanvas3).toMatchObject({
                 ...canvas,
                 ...canvasMatcher,
-                name: `${name} (10)`, // should not change
+                name: `${name} Copy 10`, // should not change from what was passed in
             })
             const duplicateCanvas4 = await Services.duplicateCanvas(duplicateCanvas3)
             expect(duplicateCanvas4).toMatchObject({
                 ...canvas,
                 ...canvasMatcher,
-                name: `${name} (11)`,
+                name: `${name} Copy 11`,
             })
         })
 

--- a/app/src/editor/shared/tests/uniqueName.test.js
+++ b/app/src/editor/shared/tests/uniqueName.test.js
@@ -1,9 +1,9 @@
 import { nextUniqueName, nextUniqueCopyName } from '../utils/uniqueName'
 
-const simpleName = 'existingname'
+const name = 'existingname'
 const nameWithSpaces = 'existing name'
 
-describe('nextUniqueName generator', () => {
+describe('nextUniqueName', () => {
     it('errors if not passed string name', () => {
         expect(() => nextUniqueName(undefined, [])).toThrow()
         expect(() => nextUniqueName(null, [])).toThrow()
@@ -24,9 +24,9 @@ describe('nextUniqueName generator', () => {
 
     describe('returns passed in name if no duplicates', () => {
         it('works with simple name', () => {
-            expect(nextUniqueName(simpleName, [])).toBe(simpleName)
-            expect(nextUniqueName(simpleName, [])).toBe(simpleName)
-            expect(nextUniqueName(simpleName, ['othername'])).toBe(simpleName)
+            expect(nextUniqueName(name, [])).toBe(name)
+            expect(nextUniqueName(name, [])).toBe(name)
+            expect(nextUniqueName(name, ['othername'])).toBe(name)
         })
 
         it('works with names with spaces', () => {
@@ -36,99 +36,105 @@ describe('nextUniqueName generator', () => {
         })
 
         it('trims whitespace', () => {
-            expect(nextUniqueName(` ${simpleName} `, [])).toBe(simpleName)
+            expect(nextUniqueName(` ${name} `, [])).toBe(name)
             expect(nextUniqueName(` ${nameWithSpaces} `, [])).toBe(nameWithSpaces)
         })
 
         it('is not case sensitive', () => {
-            const capitalizedName = simpleName.toUpperCase()
-            expect(nextUniqueName(capitalizedName, [simpleName])).toBe(capitalizedName)
-            expect(nextUniqueName(simpleName, [capitalizedName])).toBe(simpleName)
+            const capitalizedName = name.toUpperCase()
+            expect(nextUniqueName(capitalizedName, [name])).toBe(capitalizedName)
+            expect(nextUniqueName(name, [capitalizedName])).toBe(name)
         })
     })
 
     describe('appends " 02" on first duplicate', () => {
         it('works for simple cases', () => {
-            expect(nextUniqueName(simpleName, [simpleName])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(name, [name])).toBe(`${name} 02`)
             expect(nextUniqueName(nameWithSpaces, [nameWithSpaces])).toBe(`${nameWithSpaces} 02`)
         })
 
         it('ignores trimmable whitespace', () => {
-            expect(nextUniqueName(` ${simpleName} `, [` ${simpleName} `])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(` ${name} `, [` ${name} `])).toBe(`${name} 02`)
             expect(nextUniqueName(` ${nameWithSpaces} `, [` ${nameWithSpaces} `])).toBe(`${nameWithSpaces} 02`)
         })
     })
 
     describe('appends " 0n" on subsequent duplicate', () => {
         it('works for 02', () => {
-            expect(nextUniqueName(simpleName, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
+            expect(nextUniqueName(name, [`${name} 02`])).toBe(`${name} 03`)
             expect(nextUniqueName(nameWithSpaces, [`${nameWithSpaces} 02 `])).toBe(`${nameWithSpaces} 03`)
         })
 
         it('works for 02-09', () => {
-            expect(nextUniqueName(simpleName, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
-            expect(nextUniqueName(simpleName, [`${simpleName} 03`])).toBe(`${simpleName} 04`)
+            expect(nextUniqueName(name, [`${name} 02`])).toBe(`${name} 03`)
+            expect(nextUniqueName(name, [`${name} 03`])).toBe(`${name} 04`)
         })
 
         it('works for 09-n', () => {
-            expect(nextUniqueName(simpleName, [`${simpleName} 09`])).toBe(`${simpleName} 10`)
-            expect(nextUniqueName(simpleName, [`${simpleName} 10`])).toBe(`${simpleName} 11`)
-            expect(nextUniqueName(simpleName, [`${simpleName} 99`])).toBe(`${simpleName} 100`)
+            expect(nextUniqueName(name, [`${name} 09`])).toBe(`${name} 10`)
+            expect(nextUniqueName(name, [`${name} 10`])).toBe(`${name} 11`)
+            expect(nextUniqueName(name, [`${name} 99`])).toBe(`${name} 100`)
         })
 
         it('picks largest index found of passed in name and existing names', async () => {
-            expect(nextUniqueName(simpleName, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
-            expect(nextUniqueName(`${simpleName} 02`, [simpleName])).toBe(`${simpleName} 02`)
-            expect(nextUniqueName(`${simpleName} 02`, [`${simpleName} 03`])).toBe(`${simpleName} 04`)
-            expect(nextUniqueName(`${simpleName} 03`, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
+            expect(nextUniqueName(name, [`${name} 02`])).toBe(`${name} 03`)
+            expect(nextUniqueName(`${name} 02`, [name])).toBe(`${name} 02`)
+            expect(nextUniqueName(`${name} 02`, [`${name} 03`])).toBe(`${name} 04`)
+            expect(nextUniqueName(`${name} 03`, [`${name} 02`])).toBe(`${name} 03`)
         })
 
         it('ignores leading 0', () => {
-            expect(nextUniqueName(`${simpleName} 02`, [`${simpleName} 2`])).toBe(`${simpleName} 03`)
-            expect(nextUniqueName(`${simpleName} 2`, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
-            expect(nextUniqueName(`${simpleName} 2`, [`${simpleName} 2`])).toBe(`${simpleName} 03`)
-            expect(nextUniqueName(`${simpleName} 1`, [`${simpleName} 01`])).toBe(`${simpleName} 02`)
-            expect(nextUniqueName(simpleName, [`${simpleName} 010`])).toBe(`${simpleName} 11`)
+            expect(nextUniqueName(`${name} 02`, [`${name} 2`])).toBe(`${name} 03`)
+            expect(nextUniqueName(`${name} 2`, [`${name} 02`])).toBe(`${name} 03`)
+            expect(nextUniqueName(`${name} 2`, [`${name} 2`])).toBe(`${name} 03`)
+            expect(nextUniqueName(`${name} 1`, [`${name} 01`])).toBe(`${name} 02`)
+            expect(nextUniqueName(name, [`${name} 010`])).toBe(`${name} 11`)
         })
 
         it('works with bad names', () => {
-            expect(nextUniqueName(`${simpleName} 0`, [simpleName])).toBe(`${simpleName} 02`)
-            expect(nextUniqueName(`${simpleName} 01`, [simpleName])).toBe(`${simpleName} 02`)
-            expect(nextUniqueName(simpleName, [`${simpleName} 0`])).toBe(`${simpleName} 02`)
-            expect(nextUniqueName(simpleName, [`${simpleName} 01`])).toBe(`${simpleName} 02`)
-            expect(nextUniqueName(simpleName, [`${simpleName} 0`, `${simpleName} 01`])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(`${name} 0`, [name])).toBe(`${name} 02`)
+            expect(nextUniqueName(`${name} 01`, [name])).toBe(`${name} 02`)
+            expect(nextUniqueName(name, [`${name} 0`])).toBe(`${name} 02`)
+            expect(nextUniqueName(name, [`${name} 01`])).toBe(`${name} 02`)
+            expect(nextUniqueName(name, [`${name} 0`, `${name} 01`])).toBe(`${name} 02`)
         })
 
         it('ignores trimmable whitespace', () => {
-            expect(nextUniqueName(` ${simpleName} `, [` ${simpleName} `])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(` ${name} `, [` ${name} `])).toBe(`${name} 02`)
             expect(nextUniqueName(` ${nameWithSpaces} `, [` ${nameWithSpaces} `])).toBe(`${nameWithSpaces} 02`)
         })
 
         it('works with names that already contain digits', async () => {
-            expect(nextUniqueName(`${simpleName} 1 Copy`, [`${simpleName} 1 Copy`])).toBe(`${simpleName} 1 Copy 02`)
-            expect(nextUniqueName(`${simpleName} Copy`, [`${simpleName} Copy`])).toBe(`${simpleName} Copy 02`)
-            expect(nextUniqueName(`${simpleName} Copy 02`, [`${simpleName} Copy`])).toBe(`${simpleName} Copy 02`)
-            expect(nextUniqueName(`${simpleName} Copy`, [`${simpleName} Copy 02`])).toBe(`${simpleName} Copy 03`)
-            expect(nextUniqueName(`${simpleName} 1 Copy 02`, [`${simpleName} 1 Copy 02`])).toBe(`${simpleName} 1 Copy 03`)
-            expect(nextUniqueName(`${simpleName}1`, [`${simpleName}1`])).toBe(`${simpleName}1 02`)
+            expect(nextUniqueName(`${name} 1 Copy`, [`${name} 1 Copy`])).toBe(`${name} 1 Copy 02`)
+            expect(nextUniqueName(`${name} Copy`, [`${name} Copy`])).toBe(`${name} Copy 02`)
+            expect(nextUniqueName(`${name} Copy 02`, [`${name} Copy`])).toBe(`${name} Copy 02`)
+            expect(nextUniqueName(`${name} Copy`, [`${name} Copy 02`])).toBe(`${name} Copy 03`)
+            expect(nextUniqueName(`${name} 1 Copy 02`, [`${name} 1 Copy 02`])).toBe(`${name} 1 Copy 03`)
+            expect(nextUniqueName(`${name}1`, [`${name}1`])).toBe(`${name}1 02`)
         })
     })
 })
 
-describe('copyName', () => {
+describe('nextUniqueCopyName', () => {
     it('appends copy if necessary', () => {
-        expect(nextUniqueCopyName(simpleName, [])).toBe(`${simpleName} Copy`)
-        expect(nextUniqueCopyName(`${simpleName} Copy`, [])).toBe(`${simpleName} Copy`)
+        expect(nextUniqueCopyName(name, [])).toBe(`${name} Copy`)
+        expect(nextUniqueCopyName(`${name} Copy`, [])).toBe(`${name} Copy`)
+    })
+
+    it('works with names with digits', () => {
+        expect(nextUniqueCopyName(`${name} 02`, [])).toBe(`${name} 02 Copy`)
+        expect(nextUniqueCopyName(`${name} 02`, [`${name} 02 Copy`])).toBe(`${name} 02 Copy 02`)
+        expect(nextUniqueCopyName(`${name} 02 Copy 02`, [`${name} 02 Copy`])).toBe(`${name} 02 Copy 02`)
     })
 
     it('returns original name if already copy & no dupes', () => {
-        expect(nextUniqueCopyName(`${simpleName} Copy 02`, [])).toBe(`${simpleName} Copy 02`)
-        expect(nextUniqueCopyName(`${simpleName} Copy 2`, [])).toBe(`${simpleName} Copy 2`)
+        expect(nextUniqueCopyName(`${name} Copy 02`, [])).toBe(`${name} Copy 02`)
+        expect(nextUniqueCopyName(`${name} Copy 2`, [])).toBe(`${name} Copy 2`)
     })
 
     it('applies appropriate counter', () => {
-        expect(nextUniqueCopyName(simpleName, [`${simpleName} Copy`])).toBe(`${simpleName} Copy 02`)
-        expect(nextUniqueCopyName(simpleName, [`${simpleName} Copy`])).toBe(`${simpleName} Copy 02`)
-        expect(nextUniqueCopyName(simpleName, [`${simpleName} Copy 2`])).toBe(`${simpleName} Copy 03`)
+        expect(nextUniqueCopyName(name, [`${name} Copy`])).toBe(`${name} Copy 02`)
+        expect(nextUniqueCopyName(name, [`${name} Copy`])).toBe(`${name} Copy 02`)
+        expect(nextUniqueCopyName(name, [`${name} Copy 2`])).toBe(`${name} Copy 03`)
     })
 })

--- a/app/src/editor/shared/tests/uniqueName.test.js
+++ b/app/src/editor/shared/tests/uniqueName.test.js
@@ -1,0 +1,134 @@
+import { nextUniqueName, nextUniqueCopyName } from '../utils/uniqueName'
+
+const simpleName = 'existingname'
+const nameWithSpaces = 'existing name'
+
+describe('nextUniqueName generator', () => {
+    it('errors if not passed string name', () => {
+        expect(() => nextUniqueName(undefined, [])).toThrow()
+        expect(() => nextUniqueName(null, [])).toThrow()
+        expect(() => nextUniqueName({}, [])).toThrow()
+        expect(() => nextUniqueName([], [])).toThrow()
+        expect(() => nextUniqueName(3, [])).toThrow()
+    })
+
+    it('errors if not passed array of existing names', () => {
+        expect(() => nextUniqueName('name')).toThrow()
+        expect(() => nextUniqueName('name', null)).toThrow()
+        expect(() => nextUniqueName('name', {})).toThrow()
+        expect(() => nextUniqueName('name', [1])).toThrow()
+        expect(() => nextUniqueName('name', [null])).toThrow()
+        expect(() => nextUniqueName('name', [[]])).toThrow()
+        expect(() => nextUniqueName()).toThrow()
+    })
+
+    describe('returns passed in name if no duplicates', () => {
+        it('works with simple name', () => {
+            expect(nextUniqueName(simpleName, [])).toBe(simpleName)
+            expect(nextUniqueName(simpleName, [])).toBe(simpleName)
+            expect(nextUniqueName(simpleName, ['othername'])).toBe(simpleName)
+        })
+
+        it('works with names with spaces', () => {
+            expect(nextUniqueName(nameWithSpaces, [])).toBe(nameWithSpaces)
+            expect(nextUniqueName(nameWithSpaces, [])).toBe(nameWithSpaces)
+            expect(nextUniqueName(nameWithSpaces, ['other name'])).toBe(nameWithSpaces)
+        })
+
+        it('trims whitespace', () => {
+            expect(nextUniqueName(` ${simpleName} `, [])).toBe(simpleName)
+            expect(nextUniqueName(` ${nameWithSpaces} `, [])).toBe(nameWithSpaces)
+        })
+
+        it('is not case sensitive', () => {
+            const capitalizedName = simpleName.toUpperCase()
+            expect(nextUniqueName(capitalizedName, [simpleName])).toBe(capitalizedName)
+            expect(nextUniqueName(simpleName, [capitalizedName])).toBe(simpleName)
+        })
+    })
+
+    describe('appends " 02" on first duplicate', () => {
+        it('works for simple cases', () => {
+            expect(nextUniqueName(simpleName, [simpleName])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(nameWithSpaces, [nameWithSpaces])).toBe(`${nameWithSpaces} 02`)
+        })
+
+        it('ignores trimmable whitespace', () => {
+            expect(nextUniqueName(` ${simpleName} `, [` ${simpleName} `])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(` ${nameWithSpaces} `, [` ${nameWithSpaces} `])).toBe(`${nameWithSpaces} 02`)
+        })
+    })
+
+    describe('appends " 0n" on subsequent duplicate', () => {
+        it('works for 02', () => {
+            expect(nextUniqueName(simpleName, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
+            expect(nextUniqueName(nameWithSpaces, [`${nameWithSpaces} 02 `])).toBe(`${nameWithSpaces} 03`)
+        })
+
+        it('works for 02-09', () => {
+            expect(nextUniqueName(simpleName, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
+            expect(nextUniqueName(simpleName, [`${simpleName} 03`])).toBe(`${simpleName} 04`)
+        })
+
+        it('works for 09-n', () => {
+            expect(nextUniqueName(simpleName, [`${simpleName} 09`])).toBe(`${simpleName} 10`)
+            expect(nextUniqueName(simpleName, [`${simpleName} 10`])).toBe(`${simpleName} 11`)
+            expect(nextUniqueName(simpleName, [`${simpleName} 99`])).toBe(`${simpleName} 100`)
+        })
+
+        it('picks largest index found of passed in name and existing names', async () => {
+            expect(nextUniqueName(simpleName, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
+            expect(nextUniqueName(`${simpleName} 02`, [simpleName])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(`${simpleName} 02`, [`${simpleName} 03`])).toBe(`${simpleName} 04`)
+            expect(nextUniqueName(`${simpleName} 03`, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
+        })
+
+        it('ignores leading 0', () => {
+            expect(nextUniqueName(`${simpleName} 02`, [`${simpleName} 2`])).toBe(`${simpleName} 03`)
+            expect(nextUniqueName(`${simpleName} 2`, [`${simpleName} 02`])).toBe(`${simpleName} 03`)
+            expect(nextUniqueName(`${simpleName} 2`, [`${simpleName} 2`])).toBe(`${simpleName} 03`)
+            expect(nextUniqueName(`${simpleName} 1`, [`${simpleName} 01`])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(simpleName, [`${simpleName} 010`])).toBe(`${simpleName} 11`)
+        })
+
+        it('works with bad names', () => {
+            expect(nextUniqueName(`${simpleName} 0`, [simpleName])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(`${simpleName} 01`, [simpleName])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(simpleName, [`${simpleName} 0`])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(simpleName, [`${simpleName} 01`])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(simpleName, [`${simpleName} 0`, `${simpleName} 01`])).toBe(`${simpleName} 02`)
+        })
+
+        it('ignores trimmable whitespace', () => {
+            expect(nextUniqueName(` ${simpleName} `, [` ${simpleName} `])).toBe(`${simpleName} 02`)
+            expect(nextUniqueName(` ${nameWithSpaces} `, [` ${nameWithSpaces} `])).toBe(`${nameWithSpaces} 02`)
+        })
+
+        it('works with names that already contain digits', async () => {
+            expect(nextUniqueName(`${simpleName} 1 Copy`, [`${simpleName} 1 Copy`])).toBe(`${simpleName} 1 Copy 02`)
+            expect(nextUniqueName(`${simpleName} Copy`, [`${simpleName} Copy`])).toBe(`${simpleName} Copy 02`)
+            expect(nextUniqueName(`${simpleName} Copy 02`, [`${simpleName} Copy`])).toBe(`${simpleName} Copy 02`)
+            expect(nextUniqueName(`${simpleName} Copy`, [`${simpleName} Copy 02`])).toBe(`${simpleName} Copy 03`)
+            expect(nextUniqueName(`${simpleName} 1 Copy 02`, [`${simpleName} 1 Copy 02`])).toBe(`${simpleName} 1 Copy 03`)
+            expect(nextUniqueName(`${simpleName}1`, [`${simpleName}1`])).toBe(`${simpleName}1 02`)
+        })
+    })
+})
+
+describe('copyName', () => {
+    it('appends copy if necessary', () => {
+        expect(nextUniqueCopyName(simpleName, [])).toBe(`${simpleName} Copy`)
+        expect(nextUniqueCopyName(`${simpleName} Copy`, [])).toBe(`${simpleName} Copy`)
+    })
+
+    it('returns original name if already copy & no dupes', () => {
+        expect(nextUniqueCopyName(`${simpleName} Copy 02`, [])).toBe(`${simpleName} Copy 02`)
+        expect(nextUniqueCopyName(`${simpleName} Copy 2`, [])).toBe(`${simpleName} Copy 2`)
+    })
+
+    it('applies appropriate counter', () => {
+        expect(nextUniqueCopyName(simpleName, [`${simpleName} Copy`])).toBe(`${simpleName} Copy 02`)
+        expect(nextUniqueCopyName(simpleName, [`${simpleName} Copy`])).toBe(`${simpleName} Copy 02`)
+        expect(nextUniqueCopyName(simpleName, [`${simpleName} Copy 2`])).toBe(`${simpleName} Copy 03`)
+    })
+})

--- a/app/src/editor/shared/utils/uniqueName.js
+++ b/app/src/editor/shared/utils/uniqueName.js
@@ -19,6 +19,16 @@ function validate(originalName, existingNames) {
     if (!Array.isArray(existingNames)) {
         throw new TypeError(`existingNames must be array of non-empty strings, got: ${existingNames} (${typeof existingNames})`)
     }
+
+    existingNames.forEach((existingOriginalName, index) => {
+        if (typeof existingOriginalName !== 'string') {
+            const v = existingOriginalName
+            throw new TypeError(`existingNames must be array of non-empty strings, got: ${v} (${typeof v}) at index ${index}`)
+        }
+        if (existingOriginalName === '') {
+            throw new TypeError(`existingNames must be array of non-empty strings. Empty string found at index ${index}`)
+        }
+    })
 }
 
 export function nextUniqueName(originalName, existingNames) {
@@ -29,14 +39,7 @@ export function nextUniqueName(originalName, existingNames) {
     const [name, currentCounter] = getNameAndCounter(originalName)
 
     let highestCounter = 1
-    const matchingNames = existingNames.filter((existingOriginalName, index) => {
-        if (typeof existingOriginalName !== 'string') {
-            const v = existingOriginalName
-            throw new TypeError(`existingNames must be array of non-empty strings, got: ${v} (${typeof v}) at index ${index}`)
-        }
-        if (existingOriginalName === '') {
-            throw new TypeError(`existingNames must be array of non-empty strings. Empty string found at index ${index}`)
-        }
+    const matchingNames = existingNames.filter((existingOriginalName) => {
         if (existingOriginalName.trim() === name) { return true }
         const [existingName, existingCounter] = getNameAndCounter(existingOriginalName)
         if (existingName !== name) { return false }
@@ -57,7 +60,7 @@ export function nextUniqueCopyName(originalName, existingNames) {
     let [name] = getNameAndCounter(originalName)
     const alreadyCopy = name.endsWith(' Copy')
     if (!alreadyCopy) {
-        name = `${name} Copy`
+        name = `${originalName.trim()} Copy`
     }
     const created = nextUniqueName(name, existingNames)
     if (created === name) {

--- a/app/src/editor/shared/utils/uniqueName.js
+++ b/app/src/editor/shared/utils/uniqueName.js
@@ -1,0 +1,67 @@
+function getNameAndCounter(originalName) {
+    originalName = originalName.trim()
+    const matches = /(.+?)((\s(\d+))?)?$/g.exec(originalName)
+    if (!matches) { return [originalName, 0] }
+
+    const name = matches[1].trim()
+    const counter = Math.max(parseInt(matches[4], 10) || 0, 1)
+    return [name, counter]
+}
+
+function zeroFirst(number) {
+    return number < 10 ? `0${number}` : `${number}`
+}
+
+function validate(originalName, existingNames) {
+    if (typeof originalName !== 'string' || originalName === '') {
+        throw new TypeError(`Name must be non-empty string, got: ${originalName} (${typeof originalName})`)
+    }
+    if (!Array.isArray(existingNames)) {
+        throw new TypeError(`existingNames must be array of non-empty strings, got: ${existingNames} (${typeof existingNames})`)
+    }
+}
+
+export function nextUniqueName(originalName, existingNames) {
+    validate(originalName, existingNames)
+
+    originalName = originalName.trim()
+
+    const [name, currentCounter] = getNameAndCounter(originalName)
+
+    let highestCounter = 1
+    const matchingNames = existingNames.filter((existingOriginalName, index) => {
+        if (typeof existingOriginalName !== 'string') {
+            const v = existingOriginalName
+            throw new TypeError(`existingNames must be array of non-empty strings, got: ${v} (${typeof v}) at index ${index}`)
+        }
+        if (existingOriginalName === '') {
+            throw new TypeError(`existingNames must be array of non-empty strings. Empty string found at index ${index}`)
+        }
+        if (existingOriginalName.trim() === name) { return true }
+        const [existingName, existingCounter] = getNameAndCounter(existingOriginalName)
+        if (existingName !== name) { return false }
+        highestCounter = Math.max(highestCounter, existingCounter)
+        return true
+    })
+    if (!matchingNames.length) { return originalName }
+
+    const index = Math.max(highestCounter + 1, currentCounter)
+
+    return `${name} ${zeroFirst(index)}`
+}
+
+export function nextUniqueCopyName(originalName, existingNames) {
+    if (typeof originalName !== 'string' || originalName === '') {
+        throw new TypeError(`Name must be non-empty string, got: ${originalName} (${typeof originalName})`)
+    }
+    let [name] = getNameAndCounter(originalName)
+    const alreadyCopy = name.endsWith(' Copy')
+    if (!alreadyCopy) {
+        name = `${name} Copy`
+    }
+    const created = nextUniqueName(name, existingNames)
+    if (created === name) {
+        return alreadyCopy ? originalName : name
+    }
+    return created
+}


### PR DESCRIPTION
See tests for usage.

1. No more parens around index.
2. "Duplicate" now adds "Copy" to file name.
3. Creating new increases index.
4. Factored into reusable utility
5. Added deduping to dashboard name.

Doesn't dedupe when user creates custom name. Deferring for now: https://streamr.atlassian.net/browse/PLATFORM-549 

