### PR TITLE
[PLATFORM-499] Human-friendly login failure messages

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -23603,9 +23603,9 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "streamr-client": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-2.0.0-beta.5.tgz",
-      "integrity": "sha512-m9MwSHqNigg5hCuc9ag+Hgr8cyEAYk8eJJtk/froCcJSKjbSzFTSL7U6DpsfDgFTMHa04+DGSbJXCkDHelCnXQ==",
+      "version": "2.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-2.0.0-beta.7.tgz",
+      "integrity": "sha512-USuvJ2fOlsABmLSYm/FOQjZdFIu1foyUdm9hpUebY2VEoJjJMlbACPNKd6peCB7fHIPR9yOI1hv1Tp9Da+aygA==",
       "requires": {
         "debug": "^3.1.0",
         "ethers": "^4.0.27",
@@ -23665,9 +23665,9 @@
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
         },
         "node-fetch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
         },
         "qs": {
           "version": "6.7.0",

--- a/app/package.json
+++ b/app/package.json
@@ -215,7 +215,7 @@
     "storybook-addon-jsx": "^5.4.0",
     "storybook-chromatic": "^1.2.0",
     "storybook-react-router": "^1.0.1",
-    "streamr-client": "^2.0.0-beta.5",
+    "streamr-client": "^2.0.0-beta.7",
     "stringify-object": "^3.2.2",
     "style-loader": "^0.21.0",
     "stylelint": "^9.2.1",

--- a/app/src/auth/utils/getSessionToken.js
+++ b/app/src/auth/utils/getSessionToken.js
@@ -2,9 +2,22 @@
 
 import StreamrClient from 'streamr-client'
 
-export default async (auth: Object): Promise<?string> => (
-    new StreamrClient({
-        restUrl: process.env.STREAMR_API_URL,
-        auth,
-    }).session.getSessionToken()
-)
+const parseError = async (error) => {
+    try {
+        return new Error(JSON.parse(error.body).message)
+    } catch (e) {
+        // Noop. Will rethrow.
+    }
+    return error
+}
+
+export default async (auth: Object): Promise<?string> => {
+    try {
+        return await new StreamrClient({
+            restUrl: process.env.STREAMR_API_URL,
+            auth,
+        }).session.getSessionToken()
+    } catch (e) {
+        throw await parseError(e)
+    }
+}

--- a/app/src/auth/utils/getSessionToken.js
+++ b/app/src/auth/utils/getSessionToken.js
@@ -2,13 +2,16 @@
 
 import StreamrClient from 'streamr-client'
 
-const parseError = async (error) => {
-    try {
-        return new Error(JSON.parse(error.body).message)
-    } catch (e) {
-        // Noop. Will rethrow.
-    }
-    return error
+const parseError = ({ body }) => {
+    const message = ((defaultMessage) => {
+        try {
+            return JSON.parse(body).message || defaultMessage
+        } catch (e) {
+            return defaultMessage
+        }
+    })('Something went wrong.')
+
+    return new Error(message)
 }
 
 export default async (auth: Object): Promise<?string> => {
@@ -18,6 +21,6 @@ export default async (auth: Object): Promise<?string> => {
             auth,
         }).session.getSessionToken()
     } catch (e) {
-        throw await parseError(e)
+        throw parseError(e)
     }
 }


### PR DESCRIPTION
`StreamrClient` does not give us response bodies, statuses, etc. on failure. We need them so we're waiting for streamr-dev/streamr-client-javascript/pull/60. This here is just a preparation.

- [x] Update `streamr-client` after the fix is live.