### PR TITLE
[PLATFORM-472] Subscribe to streams before starting historical canvases

### DIFF
--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -154,7 +154,7 @@ class CanvasModule extends React.PureComponent {
                     moduleHash={module.hash}
                     canvasId={canvas.id}
                     isActive={isRunning}
-                    isSubscriptionActive={this.context.isActive}
+                    isSubscriptionActive={this.context.isStarting || this.context.isActive}
                 />
                 {isResizable && (
                     <Resizer

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -13,12 +13,15 @@ import { RunStates } from '../state'
 
 import Ports from './Ports'
 import ModuleDragger from './ModuleDragger'
+import * as RunController from './RunController'
 
 import ModuleStyles from '$editor/shared/components/Module.pcss'
 import styles from './Module.pcss'
 import { Resizer, isModuleResizable } from './Resizer'
 
 class CanvasModule extends React.PureComponent {
+    static contextType = RunController.Context
+
     state = {}
 
     /**
@@ -151,6 +154,7 @@ class CanvasModule extends React.PureComponent {
                     moduleHash={module.hash}
                     canvasId={canvas.id}
                     isActive={isRunning}
+                    isSubscriptionActive={this.context.isActive}
                 />
                 {isResizable && (
                     <Resizer

--- a/app/src/editor/canvas/components/RunController.jsx
+++ b/app/src/editor/canvas/components/RunController.jsx
@@ -1,0 +1,76 @@
+/**
+ * Provides a shared streamr-client instance.
+ */
+
+/* eslint-disable react/no-unused-state */
+
+import React, { useContext, useState, useCallback, useMemo, useEffect, useRef } from 'react'
+
+export const RunControllerContext = React.createContext()
+
+import * as SubscriptionStatus from '$editor/shared/components/SubscriptionStatus'
+import * as services from '../services'
+import * as CanvasState from '../state'
+
+function useRunMachine(canvas) {
+    const subscriptionStatus = useContext(SubscriptionStatus.Context)
+    const isMountedRef = useRef(true)
+
+    useEffect(() => () => {
+        isMountedRef.current = false
+    }, [])
+
+    const [state, setState] = useState({})
+
+    const start = useCallback(async (canvas, options) => {
+        const isHistorical = CanvasState.isHistoricalModeSelected(canvas)
+        if (isHistorical && !canvas.adhoc) {
+            return services.createAdhocCanvas(canvas)
+        }
+        setState({
+            isStarting: true,
+        })
+        if (isHistorical) {
+            await subscriptionStatus.onAllReady()
+        }
+        if (!isMountedRef.current) { return canvas }
+        return services.start(canvas, {
+            clearState: !!options.clearState || isHistorical,
+        })
+    }, [state, setState, subscriptionStatus, canvas])
+
+    useEffect(() => {
+        if (canvas.state === CanvasState.RunStates.Running) {
+            setState({
+                isStarting: false,
+            })
+        }
+    }, canvas && canvas.state)
+
+    const stop = useCallback((canvas) => (
+        services.stop(canvas)
+    ), [])
+
+    const isActive = !!(canvas && (state.isStarting || canvas.state === CanvasState.RunStates.Running))
+
+    return useMemo(() => ({
+        ...state,
+        canvas: canvas && canvas.id,
+        isActive,
+        start,
+        stop,
+    }), [canvas && canvas.id, isActive, state, start, stop])
+}
+
+export default function RunControllerProvider({ children, canvas }) {
+    return (
+        <RunControllerContext.Provider value={useRunMachine(canvas)}>
+            {children || null}
+        </RunControllerContext.Provider>
+    )
+}
+
+export {
+    RunControllerContext as Context,
+    RunControllerProvider as Provider,
+}

--- a/app/src/editor/canvas/components/RunController.jsx
+++ b/app/src/editor/canvas/components/RunController.jsx
@@ -2,8 +2,9 @@
  * Handles starting & stopping a canvas.
  */
 
-import React, { useContext, useState, useCallback, useMemo, useEffect, useRef } from 'react'
+import React, { useContext, useState, useCallback, useMemo, useEffect } from 'react'
 
+import useIsMountedRef from '$shared/utils/useIsMountedRef'
 import * as SubscriptionStatus from '$editor/shared/components/SubscriptionStatus'
 import * as services from '../services'
 import * as CanvasState from '../state'
@@ -12,11 +13,7 @@ export const RunControllerContext = React.createContext()
 
 function useRunController(canvas) {
     const subscriptionStatus = useContext(SubscriptionStatus.Context)
-    const isMountedRef = useRef(true)
-
-    useEffect(() => () => {
-        isMountedRef.current = false
-    }, [])
+    const isMountedRef = useIsMountedRef()
 
     const [state, setState] = useState({
         isStarting: false, // true immediately before starting a canvas
@@ -74,7 +71,7 @@ function useRunController(canvas) {
                 throw err
             })
             .finally(() => setPending(false))
-    }, [subscriptionStatus, setState, setPending, isHistorical])
+    }, [subscriptionStatus, setState, setPending, isHistorical, isMountedRef])
 
     const stop = useCallback((canvas) => {
         setPending(true)

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -21,10 +21,13 @@ import Toolbar from '$editor/shared/components/Toolbar'
 
 import ShareDialog from './ShareDialog'
 import CanvasSearch from './CanvasSearch'
+import * as RunController from './RunController'
 
 import styles from './Toolbar.pcss'
 
 export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends React.PureComponent {
+    static contextType = RunController.Context
+
     state = {
         canvasSearchIsOpen: false,
         runButtonDropdownOpen: false,
@@ -76,14 +79,13 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
             canvasExit,
             newCanvas,
             setSpeed,
-            isWaiting,
         } = this.props
 
         if (!canvas) { return null }
-
+        const runController = this.context
         const { runButtonDropdownOpen, canvasSearchIsOpen } = this.state
         const isRunning = canvas.state === RunStates.Running
-        const canEdit = !isWaiting && !isRunning && !canvas.adhoc
+        const canEdit = !runController.isActive && !canvas.adhoc
         const { settings = {} } = canvas
         const { editorState = {} } = settings
         return (
@@ -163,7 +165,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     })}
                                 >
                                     <R.Button
-                                        disabled={isWaiting}
+                                        disabled={runController.isPending}
                                         onClick={() => {
                                             if (isRunning) {
                                                 return canvasStop()
@@ -177,7 +179,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     >
                                         {((() => {
                                             if (isRunning) { return 'Stop' }
-                                            if (canvas.adhoc && !isWaiting) { return 'Clear' }
+                                            if (canvas.adhoc && !runController.isActive) { return 'Clear' }
                                             if (editorState.runTab === RunTabs.realtime) { return 'Start' }
                                             return 'Run'
                                         })())}

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -165,7 +165,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     })}
                                 >
                                     <R.Button
-                                        disabled={isPending}
+                                        disabled={!!isPending}
                                         onClick={() => {
                                             if (isRunning) {
                                                 return canvasStop()

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -177,7 +177,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     >
                                         {((() => {
                                             if (isRunning) { return 'Stop' }
-                                            if (canvas.adhoc && !isWaiting) { return 'Exit' }
+                                            if (canvas.adhoc && !isWaiting) { return 'Clear' }
                                             if (editorState.runTab === RunTabs.realtime) { return 'Start' }
                                             return 'Run'
                                         })())}

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -16,7 +16,7 @@ import WithCalendar from '$shared/components/WithCalendar'
 import dateFormatter from '$utils/dateFormatter'
 import EditableText from '$shared/components/EditableText'
 import UseState from '$shared/components/UseState'
-import { RunTabs, RunStates } from '../state'
+import { RunTabs } from '../state'
 import Toolbar from '$editor/shared/components/Toolbar'
 
 import ShareDialog from './ShareDialog'
@@ -84,8 +84,8 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
         if (!canvas) { return null }
         const runController = this.context
         const { runButtonDropdownOpen, canvasSearchIsOpen } = this.state
-        const isRunning = canvas.state === RunStates.Running
-        const canEdit = !runController.isActive && !canvas.adhoc
+        const { isRunning, isActive, isPending } = runController
+        const canEdit = !isActive && !canvas.adhoc
         const { settings = {} } = canvas
         const { editorState = {} } = settings
         return (
@@ -165,7 +165,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     })}
                                 >
                                     <R.Button
-                                        disabled={runController.isPending}
+                                        disabled={isPending}
                                         onClick={() => {
                                             if (isRunning) {
                                                 return canvasStop()
@@ -178,8 +178,8 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         className={styles.RunButton}
                                     >
                                         {((() => {
-                                            if (isRunning) { return 'Stop' }
-                                            if (canvas.adhoc && !runController.isActive) { return 'Clear' }
+                                            if (isActive) { return 'Stop' }
+                                            if (canvas.adhoc && !isActive) { return 'Clear' }
                                             if (editorState.runTab === RunTabs.realtime) { return 'Start' }
                                             return 'Run'
                                         })())}

--- a/app/src/editor/canvas/hooks/useCanvasNotifications.jsx
+++ b/app/src/editor/canvas/hooks/useCanvasNotifications.jsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useRef, useEffect } from 'react'
+import Notification from '$shared/utils/Notification'
+import { NotificationIcon } from '$shared/utils/constants'
+
+import * as services from '../services'
+
+import useCanvasStateChangeEffect from './useCanvasStateChangeEffect'
+
+const EMPTY = {}
+
+function useAutosaveNotification(autosave, canvas = EMPTY) {
+    const onAutosaveFail = useCallback((error, failedCanvas = {}) => {
+        if (failedCanvas.id !== canvas.id) { return }
+        Notification.push({
+            title: 'Autosave failed.',
+            icon: NotificationIcon.ERROR,
+            error,
+        })
+    }, [canvas])
+
+    const lastCallback = useRef(onAutosaveFail)
+
+    useEffect(() => {
+        autosave.off('fail', lastCallback.current)
+        lastCallback.current = onAutosaveFail
+        autosave.on('fail', onAutosaveFail)
+        return () => {
+            autosave.off('fail', lastCallback.current)
+        }
+    }, [onAutosaveFail, autosave, lastCallback])
+}
+
+function useCanvasRunNotification(canvas = EMPTY) {
+    const onStart = useCallback(() => {
+        Notification.push({
+            title: 'Canvas started.',
+            icon: NotificationIcon.CHECKMARK,
+        })
+    }, [])
+
+    const onStop = useCallback(() => {
+        Notification.push({
+            title: 'Canvas stopped.',
+            icon: NotificationIcon.CHECKMARK,
+        })
+    }, [])
+
+    useCanvasStateChangeEffect(canvas, useCallback((canvasIsRunning) => {
+        if (canvasIsRunning) {
+            onStart()
+        } else {
+            onStop()
+        }
+    }, [onStart, onStop]))
+}
+
+export function pushErrorNotification(error) {
+    console.error(error) // eslint-disable-line no-console
+    // eslint-disable-next-line react/no-danger
+    const title = error.message ? <span dangerouslySetInnerHTML={{ __html: error.message }} /> : 'Error'
+    Notification.push({
+        title,
+        icon: NotificationIcon.ERROR,
+        error,
+    })
+}
+
+export default function useCanvasNotifications(canvas = {}) {
+    useAutosaveNotification(services.autosave, canvas)
+    useCanvasRunNotification(canvas)
+}

--- a/app/src/editor/canvas/hooks/useCanvasStateChangeEffect.js
+++ b/app/src/editor/canvas/hooks/useCanvasStateChangeEffect.js
@@ -1,0 +1,22 @@
+/**
+ * Handles starting & stopping a canvas.
+ */
+
+import React, { useRef, useEffect } from 'react'
+
+import * as CanvasState from '../state'
+
+export const RunControllerContext = React.createContext()
+
+const EMPTY = {}
+
+export default function useCanvasStateChangeEffect(canvas = EMPTY, onChange) {
+    const canvasIsRunning = CanvasState.isRunning(canvas)
+    const prevIsRunning = useRef(canvasIsRunning)
+
+    useEffect(() => {
+        if (canvasIsRunning === prevIsRunning.current) { return }
+        prevIsRunning.current = canvasIsRunning
+        onChange(canvasIsRunning)
+    }, [canvasIsRunning, prevIsRunning, onChange, canvas])
+}

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -10,6 +10,7 @@ import links from '../../links'
 
 import UndoContainer, { UndoControls } from '$editor/shared/components/UndoContainer'
 import Subscription from '$editor/shared/components/Subscription'
+import * as SubscriptionStatus from '$editor/shared/components/SubscriptionStatus'
 import { ClientProvider } from '$editor/shared/components/Client'
 import { ModalProvider } from '$editor/shared/components/Modal'
 import * as sharedServices from '$editor/shared/services'
@@ -18,6 +19,7 @@ import Sidebar from '$editor/shared/components/Sidebar'
 import ModuleSidebar from './components/ModuleSidebar'
 import KeyboardShortcutsSidebar from './components/KeyboardShortcutsSidebar'
 
+import * as RunController from './components/RunController'
 import Canvas from './components/Canvas'
 import CanvasToolbar from './components/Toolbar'
 import CanvasStatus from './components/Status'
@@ -129,16 +131,16 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 
     async autostart() {
-        const { canvas } = this.props
-        if (canvas.adhoc && canvas.state !== RunStates.Running) {
+        const { canvas, runController } = this.props
+        if (canvas.adhoc && !runController.isActive) {
             // do not autostart running/non-adhoc canvases
             return this.canvasStart()
         }
     }
 
     async autosave() {
-        const { canvas } = this.props
-        if (canvas.state === RunStates.Running || canvas.adhoc) {
+        const { canvas, runController } = this.props
+        if (runController.isActive || canvas.adhoc) {
             // do not autosave running/adhoc canvases
             return
         }
@@ -289,15 +291,16 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     canvasStart = async (options = {}) => {
         const { canvas } = this.props
+
         return this.getNewCanvas(() => (
-            services.startOrCreateAdhocCanvas(canvas, options)
+            this.props.runController.start(canvas, options)
         ))
     }
 
     canvasStop = async () => {
         const { canvas } = this.props
         return this.getNewCanvas(() => (
-            services.stop(canvas)
+            this.props.runController.stop(canvas)
         ))
     }
 
@@ -313,6 +316,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
      * Sets appropriate isWaiting state
      * Loads parent canvas on failure/no canvas response
      */
+
     getNewCanvas = async (fn) => {
         this.setState({ isWaiting: true })
         let newCanvas
@@ -350,8 +354,15 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         ))
     }
 
+    onChangeSubscriptionStatus(subscriptionsReady) {
+        this.setState({
+            subscriptionsReady,
+        })
+    }
+
     render() {
-        const { canvas } = this.props
+        const { canvas, runController } = this.props
+        if (!canvas) { return null }
         const { moduleSidebarIsOpen, keyboardShortcutIsOpen } = this.state
         const { settings } = canvas
         const resendFrom = settings.beginDate
@@ -365,8 +376,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     uiChannel={canvas.uiChannel}
                     resendFrom={canvas.adhoc ? resendFrom : undefined}
                     resendTo={canvas.adhoc ? resendTo : undefined}
-                    isActive={canvas.state === RunStates.Running}
-                    onUnsubscribed={this.loadSelf}
+                    isActive={runController.isActive}
                 />
                 <Canvas
                     className={styles.Canvas}
@@ -433,8 +443,6 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 }
 
-const CanvasEdit = withRouter(CanvasEditComponent)
-
 const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class CanvasLoader extends React.PureComponent {
     static contextType = UndoContainer.Context
     state = { isLoading: false }
@@ -486,20 +494,34 @@ const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class Canv
     }
 }))
 
-function isDisabled({ state: canvas }) {
-    return !canvas || (canvas.state === RunStates.Running || canvas.adhoc)
-}
+const CanvasEdit = withRouter((props) => {
+    const runController = useContext(RunController.Context)
+    return (
+        <CanvasEditComponent
+            {...props}
+            runController={runController}
+        />
+    )
+})
 
 const CanvasEditWrap = () => {
     const { state: canvas, push, replace } = useContext(UndoContainer.Context)
+    const key = !!canvas && canvas.id
     return (
-        <CanvasEdit
-            key={canvas && canvas.id}
-            push={push}
-            replace={replace}
-            canvas={canvas}
-        />
+        <SubscriptionStatus.Provider key={key}>
+            <RunController.Provider canvas={canvas}>
+                <CanvasEdit
+                    push={push}
+                    replace={replace}
+                    canvas={canvas}
+                />
+            </RunController.Provider>
+        </SubscriptionStatus.Provider>
     )
+}
+
+function isDisabled({ state: canvas }) {
+    return !canvas || (canvas.state === RunStates.Running || canvas.adhoc)
 }
 
 export default withRouter((props) => (

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -354,10 +354,8 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         ))
     }
 
-    onChangeSubscriptionStatus(subscriptionsReady) {
-        this.setState({
-            subscriptionsReady,
-        })
+    onDoneMessage = () => {
+        this.loadSelf()
     }
 
     render() {
@@ -377,6 +375,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     resendFrom={canvas.adhoc ? resendFrom : undefined}
                     resendTo={canvas.adhoc ? resendTo : undefined}
                     isActive={runController.isActive}
+                    onDoneMessage={this.onDoneMessage}
                 />
                 <Canvas
                     className={styles.Canvas}

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -25,6 +25,8 @@ import CanvasToolbar from './components/Toolbar'
 import CanvasStatus from './components/Status'
 import ModuleSearch from './components/ModuleSearch'
 
+import useCanvasNotifications, { pushErrorNotification } from './hooks/useCanvasNotifications'
+
 import * as services from './services'
 import * as CanvasState from './state'
 
@@ -347,8 +349,16 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         ))
     }
 
-    onDoneMessage = () => {
+    onDoneMessage = () => (
         this.loadSelf()
+    )
+
+    onErrorMessage = (error) => {
+        pushErrorNotification({
+            message: error.error,
+            error,
+        })
+        return this.loadSelf()
     }
 
     render() {
@@ -367,6 +377,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     resendTo={canvas.adhoc ? resendTo : undefined}
                     isActive={runController.isActive}
                     onDoneMessage={this.onDoneMessage}
+                    onErrorMessage={this.onErrorMessage}
                 />
                 <Canvas
                     className={styles.Canvas}
@@ -483,11 +494,14 @@ const CanvasLoader = withRouter(withErrorBoundary(ErrorComponentView)(class Canv
     }
 }))
 
-const CanvasEdit = withRouter((props) => {
+const CanvasEdit = withRouter(({ canvas, ...props }) => {
     const runController = useContext(RunController.Context)
+    useCanvasNotifications(canvas)
+
     return (
         <CanvasEditComponent
             {...props}
+            canvas={canvas}
             runController={runController}
         />
     )

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -306,7 +306,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     canvasExit = async () => {
         const { canvas } = this.props
         return this.getNewCanvas(() => (
-            services.exitAdhocCanvas(canvas)
+            this.props.runController.exit(canvas)
         ))
     }
 

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -51,7 +51,6 @@ function canvasUpdater(fn) {
 
 const CanvasEditComponent = class CanvasEdit extends Component {
     state = {
-        isWaiting: false,
         moduleSearchIsOpen: false,
         moduleSidebarIsOpen: false,
         keyboardShortcutIsOpen: false,
@@ -313,12 +312,10 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     /**
      * Loads new canvas via async fn
-     * Sets appropriate isWaiting state
      * Loads parent canvas on failure/no canvas response
      */
 
     getNewCanvas = async (fn) => {
-        this.setState({ isWaiting: true })
         let newCanvas
         try {
             newCanvas = await fn()
@@ -327,10 +324,6 @@ const CanvasEditComponent = class CanvasEdit extends Component {
             console.error({ error }) // eslint-disable-line no-console
             if (this.unmounted) { return }
             return this.loadParent()
-        } finally {
-            if (!this.unmounted) {
-                this.setState({ isWaiting: false })
-            }
         }
         if (this.unmounted) { return }
         if (!newCanvas) {
@@ -390,11 +383,10 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     loadNewDefinition={this.loadNewDefinition}
                     pushNewDefinition={this.pushNewDefinition}
                 >
-                    <CanvasStatus updated={this.state.updated} isWaiting={this.state.isWaiting} />
+                    <CanvasStatus updated={this.state.updated} />
                 </Canvas>
                 <ModalProvider>
                     <CanvasToolbar
-                        isWaiting={this.state.isWaiting}
                         className={styles.CanvasToolbar}
                         canvas={canvas}
                         setCanvas={this.setCanvas}

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -360,9 +360,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         const resendTo = settings.endDate
         return (
             <div className={styles.CanvasEdit}>
-                <Helmet>
-                    <title>{canvas.name}</title>
-                </Helmet>
+                <Helmet title={canvas.name} />
                 <Subscription
                     uiChannel={canvas.uiChannel}
                     resendFrom={canvas.adhoc ? resendFrom : undefined}

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -5,8 +5,6 @@
 import api from '$editor/shared/utils/api'
 import Autosave from '$editor/shared/utils/autosave'
 import { nextUniqueName, nextUniqueCopyName } from '$editor/shared/utils/uniqueName'
-import Notification from '$shared/utils/Notification'
-import { NotificationIcon } from '$shared/utils/constants'
 import { emptyCanvas, isRunning, RunStates, isHistoricalModeSelected } from './state'
 
 const getData = ({ data }) => data
@@ -21,20 +19,7 @@ async function save(canvas) {
     return api().put(`${canvasesUrl}/${canvas.id}`, canvas).then(getData)
 }
 
-function autoSaveWithNotification() {
-    const autosave = Autosave(save, AUTOSAVE_DELAY)
-
-    autosave.on('fail', () => {
-        Notification.push({
-            title: 'Autosave failed.',
-            icon: NotificationIcon.ERROR,
-        })
-    })
-
-    return autosave
-}
-
-export const autosave = autoSaveWithNotification()
+export const autosave = Autosave(save, AUTOSAVE_DELAY)
 
 export async function saveNow(canvas, ...args) {
     if (autosave.pending) {
@@ -103,13 +88,7 @@ async function startCanvas(canvas, { clearState }) {
     const savedCanvas = await saveNow(canvas)
     return api().post(`${canvasesUrl}/${savedCanvas.id}/start`, {
         clearState: !!clearState,
-    }).then((data) => {
-        Notification.push({
-            title: 'Canvas started.',
-            icon: NotificationIcon.CHECKMARK,
-        })
-        return getData(data)
-    })
+    }).then(getData)
 }
 
 /**
@@ -143,13 +122,7 @@ export async function start(canvas, options = {}) {
 
 export async function stop(canvas) {
     return api().post(`${canvasesUrl}/${canvas.id}/stop`)
-        .then((data) => {
-            Notification.push({
-                title: 'Canvas stopped.',
-                icon: NotificationIcon.CHECKMARK,
-            })
-            return getData(data)
-        })
+        .then(getData)
 }
 
 /**
@@ -168,11 +141,16 @@ export async function startOrCreateAdhocCanvas(canvas, options) {
     })
 }
 
+export async function loadParentCanvas(canvas) {
+    const { settings = {} } = canvas
+    return loadCanvas({ id: settings.parentCanvasId })
+}
+
 /**
  * Unlinks parent from child.
  */
 
-export async function exitAdhocCanvas(canvas) {
+export async function unlinkParentCanvas(canvas) {
     const { settings = {} } = canvas
     const parent = await loadCanvas({ id: settings.parentCanvasId })
     return saveNow({

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -7,7 +7,7 @@ import Autosave from '$editor/shared/utils/autosave'
 import { nextUniqueName, nextUniqueCopyName } from '$editor/shared/utils/uniqueName'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
-import { emptyCanvas, isRunning, RunStates, RunTabs } from './state'
+import { emptyCanvas, isRunning, RunStates, isHistoricalModeSelected } from './state'
 
 const getData = ({ data }) => data
 
@@ -138,8 +138,7 @@ export async function createAdhocCanvas(canvas) {
 }
 
 export async function start(canvas, options = {}) {
-    const savedCanvas = await saveNow(canvas)
-    return startCanvas(savedCanvas, options)
+    return startCanvas(canvas, options)
 }
 
 export async function stop(canvas) {
@@ -159,9 +158,7 @@ export async function stop(canvas) {
  */
 
 export async function startOrCreateAdhocCanvas(canvas, options) {
-    const { settings = {} } = canvas
-    const { editorState = {} } = settings
-    const isHistorical = editorState.runTab === RunTabs.historical
+    const isHistorical = isHistoricalModeSelected(canvas)
     if (isHistorical && !canvas.adhoc) {
         return createAdhocCanvas(canvas)
     }

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -70,6 +70,12 @@ export const PortTypes = {
     param: 'param',
 }
 
+export function isHistoricalModeSelected(canvas) {
+    const { settings = {} } = canvas
+    const { editorState = {} } = settings
+    return editorState.runTab === RunTabs.historical
+}
+
 export function emptyCanvas(config = {}) {
     return {
         name: 'Untitled Canvas',

--- a/app/src/editor/canvas/tests/adhoc.test.js
+++ b/app/src/editor/canvas/tests/adhoc.test.js
@@ -50,10 +50,10 @@ describe('Adhoc Canvases', () => {
             })
         })
 
-        it('can "exit" adhoc canvas', async () => {
+        it('can unlink adhoc canvas', async () => {
             const parentCanvas = await Services.create()
             const adhocCanvas = await Services.createAdhocCanvas(parentCanvas)
-            const updatedParentCanvas = await Services.exitAdhocCanvas(adhocCanvas)
+            const updatedParentCanvas = await Services.unlinkParentCanvas(adhocCanvas)
             expect(updatedParentCanvas).toMatchObject({
                 ...parentCanvas,
                 ...canvasMatcher,
@@ -73,7 +73,7 @@ describe('Adhoc Canvases', () => {
                 ...canvasMatcher,
                 id: adhocCanvas.id, // should have loaded adhoc canvas
             })
-            await Services.exitAdhocCanvas(adhocCanvas)
+            await Services.unlinkParentCanvas(adhocCanvas)
             const nextLoadedCanvas = await Services.loadRelevantCanvas(parentCanvas)
             expect(nextLoadedCanvas).toMatchObject({
                 ...parentCanvas,

--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -133,9 +133,7 @@ const DashboardEdit = withRouter(class DashboardEdit extends Component {
         const { dashboard } = this.props
         return (
             <div className={styles.DashboardEdit}>
-                <Helmet>
-                    <title>{dashboard.name}</title>
-                </Helmet>
+                <Helmet title={dashboard.name} />
                 <ModalProvider>
                     <SelectionProvider>
                         <Dashboard

--- a/app/src/editor/shared/components/Client.jsx
+++ b/app/src/editor/shared/components/Client.jsx
@@ -59,7 +59,6 @@ export class ClientProviderComponent extends Component {
 
         client = createClient(apiKey)
         client.once('disconnecting', this.forceSetup)
-
         this.setState({
             client,
         })

--- a/app/src/editor/shared/components/Client.jsx
+++ b/app/src/editor/shared/components/Client.jsx
@@ -4,12 +4,13 @@
 
 /* eslint-disable react/no-unused-state */
 
-import React, { Component } from 'react'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { connect } from 'react-redux'
 import t from 'prop-types'
 import StreamrClient from 'streamr-client'
 import { selectAuthApiKeyId } from '$shared/modules/resourceKey/selectors'
 import { getMyResourceKeys } from '$shared/modules/resourceKey/actions'
+import useIsMountedRef from '$shared/utils/useIsMountedRef'
 
 import * as services from '../services'
 
@@ -27,73 +28,71 @@ export function createClient(apiKey) {
     })
 }
 
-export class ClientProviderComponent extends Component {
-    static propTypes = {
-        apiKey: t.string,
-    }
+function useClientProvider({ apiKey }) {
+    const [client, setClient] = useState(apiKey ? createClient(apiKey) : undefined)
+    const isMountedRef = useIsMountedRef()
 
-    componentDidMount() {
-        this.setup()
-    }
-
-    componentDidUpdate() {
-        this.setup()
-    }
-
-    componentWillUnmount() {
-        this.teardown()
-    }
-
-    forceSetup = () => this.setup(true)
-
-    setup(forceCreate) {
-        const { apiKey } = this.props
-        let { client } = this.state
-        if (!forceCreate) {
-            if (!apiKey) { return }
-            if (client) {
-                client.ensureConnected()
-                return
-            }
-        }
-
-        client = createClient(apiKey)
-        client.once('disconnecting', this.forceSetup)
-        this.setState({
-            client,
-        })
-    }
-
-    disconnect() {
-        const { client } = this.state
+    const reset = useCallback(() => {
         if (!client) { return }
-        client.off('disconnecting', this.forceSetup)
-        return client.ensureDisconnected()
-    }
+        // clean up listeners
+        client.connection.off('disconnecting', reset)
+        client.connection.off('disconnected', reset)
+        client.off('error', reset)
+        if (!isMountedRef.current) { return }
+        // reset client unless already changed
+        setClient((currentClient) => {
+            if (currentClient !== client) { return currentClient }
+            return undefined
+        })
+    }, [client, setClient, isMountedRef])
 
-    teardown() {
-        this.disconnect()
-    }
+    // listen for state changes which should trigger reset
+    useEffect(() => {
+        if (!client) { return }
+        client.connection.once('disconnecting', reset)
+        client.connection.once('disconnected', reset)
+        client.once('error', reset)
+        return reset
+    }, [reset, client])
+    const hasClient = !!client
 
-    send = async (rest) => (
+    // (re)create client if none
+    useEffect(() => {
+        if (!apiKey || hasClient) { return }
+        setClient(createClient(apiKey))
+    }, [hasClient, setClient, apiKey])
+
+    // disconnect on unmount/client change
+    useEffect(() => {
+        if (!client) { return }
+        return () => {
+            client.ensureDisconnected()
+        }
+    }, [client, setClient])
+
+    const send = useCallback(async (rest) => (
         services.send({
-            apiKey: this.props.apiKey,
+            apiKey,
             ...rest,
         })
+    ), [apiKey])
+
+    return useMemo(() => ({
+        client,
+        send,
+    }), [client, send])
+}
+
+export function ClientProviderComponent({ children, apiKey }) {
+    return (
+        <ClientContext.Provider value={useClientProvider({ apiKey })}>
+            {children || null}
+        </ClientContext.Provider>
     )
+}
 
-    state = {
-        client: undefined,
-        send: this.send,
-    }
-
-    render() {
-        return (
-            <ClientContext.Provider value={this.state}>
-                {this.props.children || null}
-            </ClientContext.Provider>
-        )
-    }
+ClientProviderComponent.propTypes = {
+    apiKey: t.string,
 }
 
 const withAuthApiKey = connect((state) => ({

--- a/app/src/editor/shared/components/ModuleSubscription.jsx
+++ b/app/src/editor/shared/components/ModuleSubscription.jsx
@@ -83,6 +83,7 @@ export default class ModuleSubscription extends React.PureComponent {
         return (
             <Subscription
                 {...this.props}
+                isActive={!!this.props.isSubscriptionActive}
                 uiChannel={module.uiChannel}
                 resendLast={options.uiResendLast && options.uiResendLast.value}
                 resendFrom={options.uiResendFrom && options.uiResendFrom.value}

--- a/app/src/editor/shared/components/Subscription.jsx
+++ b/app/src/editor/shared/components/Subscription.jsx
@@ -11,11 +11,11 @@ import t from 'prop-types'
 import { ClientContext } from './Client'
 import { SubscriptionStatusContext } from './SubscriptionStatus'
 
-const MessageTypes = {
+const Message = {
     Done: 'D',
     Error: 'E',
     Notification: 'N',
-    ModuleWarning: 'MW',
+    Warning: 'MW',
 }
 
 class Subscription extends Component {
@@ -23,21 +23,31 @@ class Subscription extends Component {
 
     static defaultProps = {
         onMessage: Function.prototype,
+        onDoneMessage: Function.prototype,
+        onErrorMessage: Function.prototype,
+        onWarningMessage: Function.prototype,
+        onNotificationMessage: Function.prototype,
         onSubscribed: Function.prototype,
         onUnsubscribed: Function.prototype,
         onResending: Function.prototype,
         onResent: Function.prototype,
         onNoResend: Function.prototype,
+        onError: Function.prototype,
         resendFrom: 0,
     }
 
     static propTypes = {
         onMessage: t.func.isRequired,
+        onDoneMessage: t.func.isRequired,
+        onErrorMessage: t.func.isRequired,
+        onWarningMessage: t.func.isRequired,
+        onNotificationMessage: t.func.isRequired,
         onSubscribed: t.func.isRequired,
         onUnsubscribed: t.func.isRequired,
         onResending: t.func.isRequired,
         onResent: t.func.isRequired,
         onNoResend: t.func.isRequired,
+        onError: t.func.isRequired,
     }
 
     uid = uniqueId('sub')
@@ -137,15 +147,32 @@ class Subscription extends Component {
         client.unsubscribe(subscription)
     }
 
+    handleKnownMessageTypes = (message, ...args) => {
+        switch (message.type) {
+            case Message.Done: {
+                this.props.onDoneMessage(message, ...args)
+                break
+            }
+            case Message.Error: {
+                this.props.onErrorMessage(message, ...args)
+                break
+            }
+            case Message.Warning: {
+                this.props.onWarningMessage(message, ...args)
+                break
+            }
+            case Message.Notification: {
+                this.props.onNotificationMessage(message, ...args)
+                break
+            }
+            default: // continue
+        }
+    }
+
     onMessage = (message, ...args) => {
         if (!this.isSubscribed) { return }
-
+        this.handleKnownMessageTypes(message, ...args)
         this.props.onMessage(message, ...args)
-
-        if (message.type === MessageTypes.Done) {
-            // unsubscribe when done
-            // this.unsubscribe()
-        }
     }
 
     /**

--- a/app/src/editor/shared/components/Subscription.jsx
+++ b/app/src/editor/shared/components/Subscription.jsx
@@ -53,7 +53,9 @@ class Subscription extends Component {
     uid = uniqueId('sub')
 
     componentDidMount() {
-        this.props.subscriptionStatus.register(this.uid)
+        if (this.props.subscriptionStatus) {
+            this.props.subscriptionStatus.register(this.uid)
+        }
         this.autosubscribe()
     }
 
@@ -69,7 +71,9 @@ class Subscription extends Component {
 
     componentWillUnmount() {
         this.unmounted = true
-        this.props.subscriptionStatus.unregister(this.uid)
+        if (this.props.subscriptionStatus) {
+            this.props.subscriptionStatus.unregister(this.uid)
+        }
         this.unsubscribe()
     }
 
@@ -180,12 +184,16 @@ class Subscription extends Component {
      */
 
     onSubscribed = (...args) => {
-        this.props.subscriptionStatus.subscribed(this.uid)
+        if (this.props.subscriptionStatus) {
+            this.props.subscriptionStatus.subscribed(this.uid)
+        }
         this.props.onSubscribed(...args)
     }
 
     onUnsubscribed = (...args) => {
-        this.props.subscriptionStatus.unsubscribed(this.uid)
+        if (this.props.subscriptionStatus) {
+            this.props.subscriptionStatus.unsubscribed(this.uid)
+        }
         this.props.onUnsubscribed(...args)
     }
 

--- a/app/src/editor/shared/components/Subscription.jsx
+++ b/app/src/editor/shared/components/Subscription.jsx
@@ -31,7 +31,6 @@ class Subscription extends Component {
         onResent: Function.prototype,
         onNoResend: Function.prototype,
         onError: Function.prototype,
-        resendFrom: 0,
     }
 
     static propTypes = {

--- a/app/src/editor/shared/components/SubscriptionStatus.jsx
+++ b/app/src/editor/shared/components/SubscriptionStatus.jsx
@@ -105,7 +105,7 @@ export default function SubscriptionStatusProvider({ children }) {
         unregister,
         subscribed,
         unsubscribed,
-    }), [allReady, register, unregister, subscribed, unsubscribed])
+    }), [onAllReady, allReady, register, unregister, subscribed, unsubscribed])
 
     return (
         <SubscriptionStatusContext.Provider value={subscriptionStatus}>

--- a/app/src/editor/shared/components/SubscriptionStatus.jsx
+++ b/app/src/editor/shared/components/SubscriptionStatus.jsx
@@ -5,7 +5,7 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import useIsMountedRef from '$shared/utils/useIsMountedRef'
 
-export const SubscriptionStatusContext = React.createContext({})
+export const SubscriptionStatusContext = React.createContext()
 
 /**
  * Returns a promise + its resolve/reject functions

--- a/app/src/editor/shared/components/SubscriptionStatus.jsx
+++ b/app/src/editor/shared/components/SubscriptionStatus.jsx
@@ -1,0 +1,120 @@
+/**
+ * Provides a shared streamr-client instance.
+ */
+
+/* eslint-disable react/no-unused-state */
+
+import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+
+export const SubscriptionStatusContext = React.createContext({})
+
+function getPromiseResolver() {
+    let resolver
+    let rejector
+    const promise = new Promise((resolve, reject) => {
+        resolver = resolve
+        rejector = reject
+    })
+    return {
+        promise,
+        resolve: resolver,
+        reject: rejector,
+    }
+}
+
+export default function SubscriptionStatusProvider({ children }) {
+    const [subscriptions, setSubscriptions] = useState({})
+
+    const isMountedRef = useRef(true)
+
+    useEffect(() => () => {
+        isMountedRef.current = false
+    }, [])
+
+    const unregister = useCallback((uid) => {
+        if (!isMountedRef.current) { return }
+        if (subscriptions[uid] == null) { return }
+        const nextState = { ...subscriptions }
+        delete nextState[uid]
+        setSubscriptions(nextState)
+    }, [subscriptions, setSubscriptions])
+
+    const register = useCallback((uid) => {
+        if (!isMountedRef.current) { return }
+        // noop if already have subscription
+        if (subscriptions[uid] != null) { return }
+        setSubscriptions({
+            ...subscriptions,
+            [uid]: false,
+        })
+    }, [subscriptions, setSubscriptions])
+
+    const unsubscribed = useCallback((uid) => {
+        if (!isMountedRef.current) { return }
+        // noop if don't have subscription or already unsubscribed
+        if (!subscriptions[uid]) { return }
+        setSubscriptions({
+            ...subscriptions,
+            [uid]: false,
+        })
+    }, [subscriptions, setSubscriptions])
+
+    const subscribed = useCallback((uid) => {
+        if (!isMountedRef.current) { return }
+        // noop if already subscribed
+        if (subscriptions[uid]) { return }
+        setSubscriptions({
+            ...subscriptions,
+            [uid]: true,
+        })
+    }, [subscriptions, setSubscriptions])
+
+    const subscriptionIds = Object.keys(subscriptions)
+    const allReady = !!(subscriptionIds.length && subscriptionIds.every((key) => subscriptions[key]))
+
+    const onAllReadyRef = useRef()
+    useEffect(() => {
+        if (allReady && onAllReadyRef.current) {
+            onAllReadyRef.current.resolved = true
+            onAllReadyRef.current.resolve() // resolve
+            onAllReadyRef.current = undefined
+        }
+        return () => {
+            if (onAllReadyRef.current) {
+                onAllReadyRef.current.resolve()
+                onAllReadyRef.current = undefined
+            }
+        }
+    }, [allReady])
+
+    const onAllReady = useCallback(() => {
+        if (allReady || !isMountedRef.current) {
+            return Promise.resolve()
+        }
+
+        if (!onAllReadyRef.current) {
+            onAllReadyRef.current = getPromiseResolver() // reset
+        }
+        return onAllReadyRef.current.promise
+    }, [allReady])
+
+    const subscriptionStatus = useMemo(() => ({
+        onAllReady,
+        allReady,
+        register,
+        unregister,
+        subscribed,
+        unsubscribed,
+    }), [allReady, register, unregister, subscribed, unsubscribed])
+
+    return (
+        <SubscriptionStatusContext.Provider value={subscriptionStatus}>
+            {children || null}
+        </SubscriptionStatusContext.Provider>
+    )
+}
+
+export {
+    SubscriptionStatusProvider as Provider,
+    SubscriptionStatusContext as Context,
+}

--- a/app/src/editor/shared/components/SubscriptionStatus.jsx
+++ b/app/src/editor/shared/components/SubscriptionStatus.jsx
@@ -1,8 +1,6 @@
 /**
- * Provides a shared streamr-client instance.
+ * Enables waiting for all registered subscriptions to be subscribed.
  */
-
-/* eslint-disable react/no-unused-state */
 
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 

--- a/app/src/editor/shared/tests/Subscription.test.jsx
+++ b/app/src/editor/shared/tests/Subscription.test.jsx
@@ -74,8 +74,6 @@ describe('Subscription', () => {
                         onMessage={(received) => {
                             expect(received).toEqual(msg)
                             result.unmount()
-                        }}
-                        onUnsubscribed={() => {
                             done()
                         }}
                         isActive
@@ -85,9 +83,11 @@ describe('Subscription', () => {
         })
 
         it('unsubscribes on unmount', async (done) => {
+            const sub = React.createRef()
             const result = mount((
                 <ClientProviderComponent apiKey={apiKey}>
                     <Subscription
+                        ref={sub}
                         uiChannel={stream}
                         onResent={() => {
                             // don't unmount on subscribed as this
@@ -95,11 +95,11 @@ describe('Subscription', () => {
                             result.unmount()
                         }}
                         onNoResend={() => {
+                            sub.current.subscription.once('unsubscribed', () => {
+                                done()
+                            })
                             // don't care if resent or not, just unmount
                             result.unmount()
-                        }}
-                        onUnsubscribed={() => {
-                            done()
                         }}
                         isActive
                     />

--- a/app/src/editor/shared/tests/Subscription.test.jsx
+++ b/app/src/editor/shared/tests/Subscription.test.jsx
@@ -89,6 +89,7 @@ describe('Subscription', () => {
                     <Subscription
                         ref={sub}
                         uiChannel={stream}
+                        resendLast={1}
                         onResent={() => {
                             // don't unmount on subscribed as this
                             // breaks the client

--- a/app/src/editor/shared/utils/autosave.js
+++ b/app/src/editor/shared/utils/autosave.js
@@ -76,8 +76,8 @@ export function CancellableDebounce(fn, waitTime) {
         cancel: Function.prototype,
         emitter,
         on: emitter.on.bind(emitter),
-        off: emitter.on.bind(emitter),
-        once: emitter.on.bind(emitter),
+        off: emitter.removeListener.bind(emitter),
+        once: emitter.once.bind(emitter),
     })
 }
 


### PR DESCRIPTION
* Subscriptions register themselves with SubscriptionController.
* RunController keeps track of current pending/starting states and exposes start/stop/exit api.
* On starting a historical canvas, RunController will wait for registered subscriptions before issuing the start command.

To test: start & stop realtime & historical canvases. Data should flow.