### PR TITLE
[PLATFORM-522] Module search scalability

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -188,6 +188,7 @@
     "react-player": "^1.9.3",
     "react-redux": "^5.0.6",
     "react-redux-i18n": "^1.9.3",
+    "react-resizable": "^1.7.5",
     "react-responsive": "^4.1.0",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -254,14 +254,14 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                     /* TODO: follow the disabled jsx-a11y recommendations below to add keyboard support */
                     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events */
                     <div
-                        className={styles.ModuleItem}
+                        className={cx(styles.ModuleItem, styles.WithCategory)}
                         role="option"
                         aria-selected="false"
                         key={m.id}
                         onClick={() => this.onSelect(m.id)}
                         tabIndex="0"
                     >
-                        {startCase(m.name)}
+                        <span className={styles.ModuleName}>{startCase(m.name)}</span>
                         <span className={styles.ModuleCategory}>{m.path}</span>
                     </div>
                 ))}

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import startCase from 'lodash/startCase'
 import cx from 'classnames'
 import Draggable from 'react-draggable'
+import { ResizableBox } from 'react-resizable'
 
 import type { Stream } from '$shared/flowtype/stream-types'
 import SvgIcon from '$shared/components/SvgIcon'
@@ -295,27 +296,43 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                 <div className={styles.Overlay} onClick={() => open(false)} hidden={!isOpen} />
                 <Draggable
                     handle={`.${styles.dragHandle}`}
+                    bounds="parent"
                 >
-                    <div className={styles.ModuleSearch} hidden={!isOpen}>
-                        <div className={cx(styles.Header, styles.dragHandle)}>
-                            <button className={styles.minimize} onClick={() => this.toggleMinimize()}>
-                                {isExpanded ?
-                                    <SvgIcon name="caretUp" /> :
-                                    <SvgIcon name="caretDown" />
-                                }
-                            </button>
-                            <button className={styles.close} onClick={() => open(false)}>
-                                <SvgIcon name="crossHeavy" />
-                            </button>
-                        </div>
-                        <div className={styles.Input}>
-                            <input ref={this.onInputRef} placeholder="Search for modules and streams" value={search} onChange={this.onChange} />
-                        </div>
-                        <div role="listbox" className={styles.Content}>
-                            {(search && search.length > 0) ?
-                                this.renderSearchResults() :
-                                this.renderMenu()}
-                        </div>
+                    <div
+                        className={styles.ModuleSearch}
+                        hidden={!isOpen}
+                    >
+                        <ResizableBox
+                            width={250}
+                            height={450}
+                            minConstraints={[250, 450]}
+                            maxConstraints={[450, 700]}
+                        >
+                            <div className={cx(styles.Header, styles.dragHandle)}>
+                                <button className={styles.minimize} onClick={() => this.toggleMinimize()}>
+                                    {isExpanded ?
+                                        <SvgIcon name="caretUp" /> :
+                                        <SvgIcon name="caretDown" />
+                                    }
+                                </button>
+                                <button className={styles.close} onClick={() => open(false)}>
+                                    <SvgIcon name="crossHeavy" />
+                                </button>
+                            </div>
+                            <div className={styles.Input}>
+                                <input
+                                    ref={this.onInputRef}
+                                    placeholder="Search for modules and streams"
+                                    value={search}
+                                    onChange={this.onChange}
+                                />
+                            </div>
+                            <div role="listbox" className={styles.Content}>
+                                {(search && search.length > 0) ?
+                                    this.renderSearchResults() :
+                                    this.renderMenu()}
+                            </div>
+                        </ResizableBox>
                     </div>
                 </Draggable>
             </React.Fragment>

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -84,7 +84,17 @@ type State = {
     matchingModules: Array<Object>,
     matchingStreams: Array<Stream>,
     isExpanded: boolean,
+    height: number,
+    width: number,
+    heightBeforeMinimize: number,
 }
+
+const MIN_WIDTH = 250
+const MAX_WIDTH = 450
+const MIN_HEIGHT = 450
+const MAX_HEIGHT = 700
+const MIN_HEIGHT_MINIMIZED = 90
+const MODULE_ITEM_HEIGHT = 52
 
 export class ModuleSearch extends React.PureComponent<Props, State> {
     state = {
@@ -93,6 +103,10 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         matchingModules: [],
         matchingStreams: [],
         isExpanded: true,
+        width: 250,
+        height: MIN_HEIGHT,
+        /* eslint-disable-next-line react/no-unused-state */
+        heightBeforeMinimize: 0,
     }
 
     unmounted = false
@@ -137,16 +151,42 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         const streams = await getStreams(params)
 
         if (this.unmounted) { return }
+
         this.setState({
             matchingModules,
             matchingStreams: streams,
+        }, () => this.recalculateHeight())
+    }
+
+    recalculateHeight = () => {
+        const { isExpanded, matchingModules, matchingStreams, search } = this.state
+
+        if (isExpanded) {
+            this.setState(({ heightBeforeMinimize, height }) => ({
+                height: heightBeforeMinimize > 0 ? heightBeforeMinimize : height,
+            }))
+            return
+        }
+
+        const searchResultItemCount = matchingModules.length + matchingStreams.length +
+            (matchingModules.length > 0 ? 1 : 0) + // take headers into account
+            (matchingStreams.length > 0 ? 1 : 0)
+        let requiredHeight = MIN_HEIGHT_MINIMIZED + (searchResultItemCount * MODULE_ITEM_HEIGHT)
+
+        if (search === '') {
+            requiredHeight = 0
+        }
+
+        this.setState({
+            height: Math.min(Math.max(requiredHeight, MIN_HEIGHT_MINIMIZED), MAX_HEIGHT),
         })
     }
 
     toggleMinimize = () => {
-        this.setState(({ isExpanded }) => ({
+        this.setState(({ isExpanded, height, heightBeforeMinimize }) => ({
             isExpanded: !isExpanded,
-        }))
+            heightBeforeMinimize: isExpanded ? height : heightBeforeMinimize,
+        }), () => this.recalculateHeight())
     }
 
     onSelect = (id: string) => {
@@ -289,7 +329,8 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
 
     render() {
         const { open, isOpen } = this.props
-        const { search, isExpanded } = this.state
+        const { search, isExpanded, width, height } = this.state
+        const minHeight = isExpanded ? MIN_HEIGHT : MIN_HEIGHT_MINIMIZED
         return (
             <React.Fragment>
                 {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
@@ -303,34 +344,42 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                         hidden={!isOpen}
                     >
                         <ResizableBox
-                            width={250}
-                            height={450}
-                            minConstraints={[250, 450]}
-                            maxConstraints={[450, 700]}
+                            width={width}
+                            height={height}
+                            minConstraints={[MIN_WIDTH, minHeight]}
+                            maxConstraints={[MAX_WIDTH, MAX_HEIGHT]}
+                            onResize={(e, data) => {
+                                this.setState({
+                                    height: data.size.height,
+                                    width: data.size.width,
+                                })
+                            }}
                         >
-                            <div className={cx(styles.Header, styles.dragHandle)}>
-                                <button className={styles.minimize} onClick={() => this.toggleMinimize()}>
-                                    {isExpanded ?
-                                        <SvgIcon name="caretUp" /> :
-                                        <SvgIcon name="caretDown" />
-                                    }
-                                </button>
-                                <button className={styles.close} onClick={() => open(false)}>
-                                    <SvgIcon name="crossHeavy" />
-                                </button>
-                            </div>
-                            <div className={styles.Input}>
-                                <input
-                                    ref={this.onInputRef}
-                                    placeholder="Search for modules and streams"
-                                    value={search}
-                                    onChange={this.onChange}
-                                />
-                            </div>
-                            <div role="listbox" className={styles.Content}>
-                                {(search && search.length > 0) ?
-                                    this.renderSearchResults() :
-                                    this.renderMenu()}
+                            <div className={styles.Container}>
+                                <div className={cx(styles.Header, styles.dragHandle)}>
+                                    <button className={styles.minimize} onClick={() => this.toggleMinimize()}>
+                                        {isExpanded ?
+                                            <SvgIcon name="caretUp" /> :
+                                            <SvgIcon name="caretDown" />
+                                        }
+                                    </button>
+                                    <button className={styles.close} onClick={() => open(false)}>
+                                        <SvgIcon name="crossHeavy" />
+                                    </button>
+                                </div>
+                                <div className={styles.Input}>
+                                    <input
+                                        ref={this.onInputRef}
+                                        placeholder="Search for modules and streams"
+                                        value={search}
+                                        onChange={this.onChange}
+                                    />
+                                </div>
+                                <div role="listbox" className={styles.Content}>
+                                    {(search && search.length > 0) ?
+                                        this.renderSearchResults() :
+                                        this.renderMenu()}
+                                </div>
                             </div>
                         </ResizableBox>
                     </div>

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -6,8 +6,8 @@
   margin-left: auto;
   margin-right: auto;
   background: white;
-  min-width: 30vw;
-  max-width: 30vw;
+  min-width: 248px;
+  max-width: 248px;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto auto 1fr;
@@ -131,9 +131,18 @@
   text-transform: none;
   letter-spacing: 0;
   line-height: 40px;
+}
+
+.ModuleSearch .Content .ModuleItem.WithCategory {
   display: grid;
   grid-template-columns: 50% 50%;
   grid-gap: 12px;
+}
+
+.ModuleSearch .Content .ModuleItem .ModuleName {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .ModuleSearch .Content .ModuleItem .ModuleCategory {
@@ -142,6 +151,9 @@
   font-weight: 400;
   text-transform: uppercase;
   color: #ADADAD;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .ModuleSearch .Content .StreamItem {
@@ -152,6 +164,9 @@
   text-transform: none;
   letter-spacing: 0;
   line-height: 28px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .ModuleSearch .Content .StreamItem .Description {
@@ -160,6 +175,9 @@
   font-weight: 400;
   color: #ADADAD;
   line-height: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .Overlay {

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -3,9 +3,6 @@
   left: 32px;
   top: 10%;
   background: white;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto auto 1fr;
   z-index: 12;
   border: 1px solid #EFEFEF;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
@@ -13,6 +10,22 @@
   overflow: hidden;
   cursor: pointer;
   user-select: none;
+
+  :global(.react-resizable-handle) {
+    width: 24px;
+    height: 24px;
+    right: 0;
+    bottom: 0;
+    position: absolute;
+    cursor: nwse-resize;
+  }
+}
+
+.ModuleSearch .Container {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto 1fr;
 }
 
 .ModuleSearch .Header {
@@ -80,7 +93,6 @@
   letter-spacing: 2px;
   line-height: 32px;
   overflow: auto;
-  height: 100%;
 }
 
 .ModuleSearch .Content > * {
@@ -189,13 +201,4 @@
 }
 
 .dragHandle {
-}
-
-:global(.react-resizable-handle) {
-  width: 24px;
-  height: 24px;
-  right: 0;
-  bottom: 0;
-  position: absolute;
-  cursor: nwse-resize;
 }

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -1,13 +1,8 @@
 .ModuleSearch {
   position: absolute;
-  left: 0;
-  right: 0;
-  top: 10vw;
-  margin-left: auto;
-  margin-right: auto;
+  left: 32px;
+  top: 10%;
   background: white;
-  min-width: 248px;
-  max-width: 248px;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto auto 1fr;
@@ -84,8 +79,8 @@
   text-transform: uppercase;
   letter-spacing: 2px;
   line-height: 32px;
-  max-height: 40vh;
   overflow: auto;
+  height: 100%;
 }
 
 .ModuleSearch .Content > * {
@@ -193,5 +188,14 @@
   opacity: 0;
 }
 
-global(.dragHandle) {
+.dragHandle {
+}
+
+:global(.react-resizable-handle) {
+  width: 24px;
+  height: 24px;
+  right: 0;
+  bottom: 0;
+  position: absolute;
+  cursor: nwse-resize;
 }


### PR DESCRIPTION
Made the search window resizable and made search results names & descriptions truncate instead of wrapping.

I left the module tree unchanged so it will still wrap when module name or category is too long. I thought that it's better this way because when user uses the tree to browse modules, he or she is not knowing exactly what to search so it's good that category and name are shown fully.