### PR TITLE
[PLATFORM-518] Implement consistent tile & list styles across Core app

### DIFF
--- a/app/src/marketplace/components/ProductTile/productTile.pcss
+++ b/app/src/marketplace/components/ProductTile/productTile.pcss
@@ -121,8 +121,6 @@
 .publishStatus {
   display: inline;
   font-weight: var(--light);
-  padding: 2px 4px;
-  color: var(--white);
-  background-color: var(--purple2);
-  border-radius: 2px;
+  color: var(--greenGoLive);
+  background-color: transparent;
 }

--- a/app/src/shared/assets/stylesheets/variables.css
+++ b/app/src/shared/assets/stylesheets/variables.css
@@ -21,6 +21,7 @@
   --blueDark7: #1D004E;
   --blueDark8: #010002;
   --blueDark9: #09006D;
+  --greenGoLive: #2AC437;
   --greyLight: #ADADAD;
   --greyLight2: #CECECE;
   --greyLight3: #F8F8F8;

--- a/app/src/shared/components/Tile/tile.pcss
+++ b/app/src/shared/components/Tile/tile.pcss
@@ -53,20 +53,16 @@
 .status {
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 12px;
-  color: #FF5C00;
+  color: #323232;
   letter-spacing: 0;
   line-height: 20px;
 }
 
 .tag {
-  display: inline-block;
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 12px;
   text-transform: capitalize;
-  color: #FFFFFF;
-  background-color: #ADADAD;
-  border-radius: 2px;
-  padding: 0 4px;
+  color: #A3A3A3;
   letter-spacing: 0;
   line-height: 20px;
 }

--- a/app/src/userpages/components/CanvasPage/List/canvasList.pcss
+++ b/app/src/userpages/components/CanvasPage/List/canvasList.pcss
@@ -1,0 +1,7 @@
+.running {
+  color: var(--greenGoLive);
+}
+
+.stopped {
+  color: #323232;
+}

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -9,6 +9,7 @@ import { push } from 'react-router-redux'
 import copy from 'copy-to-clipboard'
 import { Translate, I18n } from 'react-redux-i18n'
 import { Helmet } from 'react-helmet'
+import moment from 'moment'
 
 import type { Filter, SortOption } from '$userpages/flowtype/common-types'
 import type { Canvas, CanvasId } from '$userpages/flowtype/canvas-types'
@@ -33,6 +34,8 @@ import { selectFetchingPermissions, selectCanvasPermissions } from '$userpages/m
 import type { Permission, ResourceId } from '$userpages/flowtype/permission-types'
 import type { User } from '$shared/flowtype/user-types'
 import { selectUserData } from '$shared/modules/user/selectors'
+
+import styles from './canvasList.pcss'
 
 export type StateProps = {
     user: ?User,
@@ -202,6 +205,8 @@ class CanvasList extends Component<Props, State> {
         }
     }
 
+    generateTimeAgoDescription = (canvasUpdatedDate: Date) => moment(canvasUpdatedDate).fromNow()
+
     render() {
         const { canvases, filter, fetching } = this.props
         const { shareDialogCanvas } = this.state
@@ -270,8 +275,15 @@ class CanvasList extends Component<Props, State> {
                                     }}
                                 >
                                     <Tile.Title>{canvas.name}</Tile.Title>
-                                    <Tile.Description>{new Date(canvas.updated).toLocaleString()}</Tile.Description>
-                                    <Tile.Status>{capital(canvas.state)}</Tile.Status>
+                                    <Tile.Description>
+                                        {canvas.updated === canvas.created ? 'Created ' : 'Updated '}
+                                        {this.generateTimeAgoDescription(new Date(canvas.updated))}
+                                    </Tile.Description>
+                                    <Tile.Status
+                                        className={canvas.state === 'RUNNING' ? styles.running : styles.stopped}
+                                    >
+                                        {capital(canvas.state)}
+                                    </Tile.Status>
                                 </Tile>
                             </Col>
                         ))}

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom'
 import { push } from 'react-router-redux'
 import copy from 'copy-to-clipboard'
 import Helmet from 'react-helmet'
+import moment from 'moment'
 
 import Layout from '../Layout'
 import links from '../../../links'
@@ -132,6 +133,8 @@ class ProductsPage extends Component<Props> {
         )
     }
 
+    generateTimeAgoDescription = (productUpdatedDate: Date) => moment(productUpdatedDate).fromNow()
+
     render() {
         const { products, filter, fetching } = this.props
 
@@ -187,8 +190,12 @@ class ProductsPage extends Component<Props> {
                                     dropdownActions={this.getActions(product)}
                                 >
                                     <Tile.Title>{product.name}</Tile.Title>
+                                    <Tile.Tag >
+                                        {product.updated === product.created ? 'Created ' : 'Updated '}
+                                        {product.updated && this.generateTimeAgoDescription(new Date(product.updated))}
+                                    </Tile.Tag>
                                     <Tile.Tag
-                                        className={product.state === productStates.DEPLOYED ? styles.purple : styles.gray}
+                                        className={product.state === productStates.DEPLOYED ? styles.green : styles.grey}
                                     >
                                         {
                                             product.state === productStates.DEPLOYED ?

--- a/app/src/userpages/components/ProductsPage/products.pcss
+++ b/app/src/userpages/components/ProductsPage/products.pcss
@@ -1,7 +1,9 @@
-.purple {
-  background-color: #6240AF;
+.green {
+  color: var(--greenGoLive);
+  background-color: transparent;
 }
 
-.gray {
-  background-color: #ADADAD;
+.grey {
+  color: var(--greyDark);
+  background-color: transparent;
 }

--- a/app/src/userpages/components/PurchasesPage/purchases.pcss
+++ b/app/src/userpages/components/PurchasesPage/purchases.pcss
@@ -18,13 +18,13 @@
 .status {
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 12px;
-  color: #FF5C00;
+  color: #323232;
   letter-spacing: 0;
   line-height: 20px;
 }
 
 .active {
-  color: #FF5C00;
+  color: var(--greenGoLive);
 }
 
 .expired {


### PR DESCRIPTION
Implementing this:
https://app.goabstract.com/projects/667a5970-5f1f-11e9-bf62-2556403415af/branches/e81395ea-cee8-4dc8-95f8-badab055aa60/commits/995b11e9015108f9e9b274b70cbdb10a880c030f/files/632368C4-4D71-4548-97F3-468F89D29073/layers/46BFE6D0-4488-4263-8DD8-85DBA3F614DF?mode=design

***From Jira***
One problem is that current designs for Core > Products uses a badge to show drafts & published products, and this design prevented us showing a friendly "Updated" or "Created" date, making it hard for users to know which drafts or products they had created. Proposed update also unifies display with other tiles (eg canvases) where green is active, current, while grey is used for non-active items.

So changes are: remove badges, add Created / Updated friendly date, show Drafts in #323232 and Published in #2AC437

Also related: we should update Core > Purchases to also show its "Active" labels in #2AC437 (green)
*  for Canvases, Running should be  #2AC437 and stopped grey #323232

This image below shows consistent states across all the Core app tiles. Note that the Dashboard states cannot be implemented until we get some changes in the back end, which will not happen until post launch of the Core app.