### PR TITLE
[PLATFORM-480] Generated Canvas & Dashboard previews

### DIFF
--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -18,6 +18,26 @@ function curvedHorizontal(x1, y1, x2, y2) {
 const LAYER_0 = 0
 const LAYER_1 = 1
 
+export function Cable({ cable }) {
+    if (!cable) { return null }
+    const [from, to] = cable
+    return (
+        <path
+            className={styles.Connection}
+            d={curvedHorizontal(
+                from.left,
+                from.top,
+                to.left,
+                to.top,
+            )}
+        />
+    )
+}
+
+export function getCableKey([from, to] = []) {
+    return `${from && from.id}-${to && to.id}`
+}
+
 class Cables extends React.PureComponent {
     el = React.createRef()
 
@@ -139,24 +159,6 @@ class Cables extends React.PureComponent {
         ]
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    renderPath(cable) {
-        if (!cable) { return null }
-        const [from, to] = cable
-        return (
-            <path
-                key={`${from.id}-${to.id}`}
-                className={styles.Connection}
-                d={curvedHorizontal(
-                    from.left,
-                    from.top,
-                    to.left,
-                    to.top,
-                )}
-            />
-        )
-    }
-
     render() {
         const cables = this.getCables()
         const layer0 = cables.filter(([, , layer]) => !layer)
@@ -169,7 +171,9 @@ class Cables extends React.PureComponent {
                     height="100%"
                     width="100%"
                 >
-                    {layer0.map((cable) => this.renderPath(cable))}
+                    {layer0.filter(Boolean).map((cable) => (
+                        <Cable key={getCableKey(cable)} cable={cable} />
+                    ))}
                 </svg>
                 <svg
                     className={styles.Cables}
@@ -177,7 +181,9 @@ class Cables extends React.PureComponent {
                     height="100%"
                     width="100%"
                 >
-                    {layer1.map((cable) => this.renderPath(cable))}
+                    {layer1.filter(Boolean).map((cable) => (
+                        <Cable key={getCableKey(cable)} cable={cable} />
+                    ))}
                 </svg>
             </React.Fragment>
         )

--- a/app/src/editor/canvas/components/Canvas.pcss
+++ b/app/src/editor/canvas/components/Canvas.pcss
@@ -1,5 +1,5 @@
 .Canvas {
-  background: #EFEFEF;
+  background: #E7E7E7;
   position: relative;
 }
 

--- a/app/src/editor/canvas/components/Preview.jsx
+++ b/app/src/editor/canvas/components/Preview.jsx
@@ -22,6 +22,7 @@ function PreviewCables({ canvas, preview }) {
         const key = getModuleKey(m)
         const p = preview.modules.find((m) => m.key === key)
         return {
+            id: m.id,
             left: p.left + (p.width / 2),
             top: p.top + (p.height / 2),
         }

--- a/app/src/editor/canvas/components/Preview.jsx
+++ b/app/src/editor/canvas/components/Preview.jsx
@@ -51,21 +51,21 @@ function PreviewCables({ canvas, preview }) {
     )
 }
 
-function ModulePreview({
-    x,
-    y,
+export function ModulePreview({
+    x = 0,
+    y = 0,
     height,
     width,
-    titleWidth,
+    um = 16,
+    title = ' ',
 }) {
     x = Math.round(x)
     y = Math.round(y)
     width = Math.round(width)
     height = Math.round(height)
 
-    const um = 16 // pseudo 'grid' unit
     const titleMaxWidth = width - (2 * um)
-    const titleActualWidth = Math.min(titleWidth * um, titleMaxWidth)
+    const titleActualWidth = Math.min(title.length * um, titleMaxWidth)
     return (
         <React.Fragment>
             <g>
@@ -119,7 +119,7 @@ function getPreviewCanvas({ canvas, aspect, screen }) {
         width: Number.parseInt(m.layout.width, 10) || defaultLayout.width,
         isResizable: isModuleResizable(m),
         portRows: getPortRows(m),
-        titleWidth: (m.displayName || m.name).length,
+        title: (m.displayName || m.name),
     }))
         .map((m) => (
             // set sensible min-height on non-resizable modules using number of ports
@@ -203,7 +203,6 @@ export default function Preview({
                 fill="#e7e7e7"
             />
             <svg
-                className={className}
                 preserveAspectRatio="none"
                 viewBox={`0 0 ${preview.width} ${preview.height}`}
             >
@@ -215,7 +214,7 @@ export default function Preview({
                         x={m.left}
                         width={m.width}
                         height={m.height}
-                        titleWidth={m.titleWidth}
+                        title={m.title}
                     />
                 ))}
             </svg>

--- a/app/src/editor/canvas/components/Preview.jsx
+++ b/app/src/editor/canvas/components/Preview.jsx
@@ -125,7 +125,7 @@ function getPreviewCanvas({ canvas, aspect, screen }) {
         .map((m) => (
             // set sensible min-height on non-resizable modules using number of ports
             Object.assign(m, {
-                height: m.isResizable ? m.height : Math.max(m.height, defaultLayout.height + (m.portRows * 30)),
+                height: m.isResizable ? m.height : Math.max(m.height, defaultLayout.height + (m.portRows * 16)),
             })
         ))
 

--- a/app/src/editor/canvas/components/Preview.jsx
+++ b/app/src/editor/canvas/components/Preview.jsx
@@ -1,0 +1,194 @@
+import React, { useMemo } from 'react'
+import { defaultModuleLayout } from '../state'
+import { isModuleResizable } from './Resizer'
+
+function aspectSize({ width, height, minWidth, minHeight }) {
+    const ratio = Math.max(minWidth / width, minHeight / height)
+    return {
+        width: Math.round(width * ratio * 100) / 100,
+        height: Math.round(height * ratio * 100) / 100,
+    }
+}
+
+function ModulePreview({
+    x,
+    y,
+    height,
+    width,
+    titleWidth,
+}) {
+    x = Math.round(x)
+    y = Math.round(y)
+    width = Math.round(width)
+    height = Math.round(height)
+
+    const um = 16 // pseudo 'grid' unit
+    const titleMaxWidth = width - (2 * um)
+    const titleActualWidth = Math.min(titleWidth * um, titleMaxWidth)
+    return (
+        <React.Fragment>
+            <g>
+                <rect
+                    x={x}
+                    y={y}
+                    height={height}
+                    width={width}
+                    fill="#FCFBF9"
+                    rx="0.2%"
+                    stroke="#EFEFEF"
+                    strokeWidth="0.5px"
+                    vectorEffect="non-scaling-stroke"
+                />
+                <rect
+                    x={x + um}
+                    y={y + um}
+                    width={titleActualWidth}
+                    height={um * 1.3}
+                    fill="#D8D8D8"
+                    rx="0.2%"
+                />
+                <path
+                    stroke="#EFEFEF"
+                    strokeLinecap="square"
+                    strokeWidth="0.5px"
+                    vectorEffect="non-scaling-stroke"
+                    d={`M${x},${y + (um * 3.333)} H${x + width}`}
+                />
+            </g>
+        </React.Fragment>
+    )
+}
+
+const defaultLayout = {
+    height: Number.parseInt(defaultModuleLayout.height, 10),
+    width: Number.parseInt(defaultModuleLayout.width, 10),
+}
+
+function getPortRows({ inputs = [], outputs = [], params = [] }) {
+    return Math.max(inputs.length + params.length, outputs.length)
+}
+
+function getPreviewCanvas({ canvas, aspect, screen }) {
+    // grab basic module dimensions
+    const modulePreviews = canvas.modules.map((m) => ({
+        key: `${m.id}-${m.hash}`,
+        top: Number.parseInt(m.layout.position.top, 10) || 0,
+        left: Number.parseInt(m.layout.position.left, 10) || 0,
+        height: Number.parseInt(m.layout.height, 10) || defaultLayout.height,
+        width: Number.parseInt(m.layout.width, 10) || defaultLayout.width,
+        isResizable: isModuleResizable(m),
+        portRows: getPortRows(m),
+        titleWidth: (m.displayName || m.name).length,
+    }))
+        .map((m) => (
+            // set sensible min-height on non-resizable modules using number of ports
+            Object.assign(m, {
+                height: m.isResizable ? m.height : Math.max(m.height, defaultLayout.height + (m.portRows * 30)),
+            })
+        ))
+
+    // find bounds of modules
+    const bounds = modulePreviews.reduce((b, m) => (
+        Object.assign(b, {
+            maxX: Math.max(b.maxX, m.left + m.width),
+            maxY: Math.max(b.maxY, m.top + m.height),
+            minX: Math.min(b.minX, m.left),
+            minY: Math.min(b.minY, m.top),
+        })
+    ), {
+        maxX: -Infinity,
+        maxY: -Infinity,
+        minX: Infinity,
+        minY: Infinity,
+    })
+
+    const ratio = aspect.height / aspect.width
+
+    // set a minimum canvas size so a single module doesn't take up entire preview
+    const minWidth = Math.max(bounds.maxX, screen.width || screen.height * (1 / ratio))
+    const minHeight = Math.max(bounds.maxY, screen.height || screen.width * ratio)
+
+    // force dimensions to fit aspect
+    const canvasSize = aspectSize({
+        height: aspect.height,
+        width: aspect.width,
+        minHeight,
+        minWidth,
+    })
+
+    return {
+        width: canvasSize.width,
+        height: canvasSize.height,
+        modules: modulePreviews,
+        bounds,
+        minWidth,
+        minHeight,
+    }
+}
+
+export default function Preview({
+    className,
+    style,
+    canvas,
+    aspect,
+    screen,
+    ...props
+}) {
+    const preview = useMemo(() => (
+        getPreviewCanvas({
+            canvas,
+            aspect,
+            screen,
+        })
+    ), [canvas, aspect, screen])
+
+    return (
+        <svg
+            className={className}
+            preserveAspectRatio="none"
+            viewBox={`0 0 ${aspect.width} ${aspect.height}`}
+            style={{
+                ...style,
+                background: '#e7e7e7',
+                padding: '8px',
+            }}
+            {...props}
+        >
+            <rect
+                x="0"
+                y="0"
+                height="100%"
+                width="100%"
+                fill="#e7e7e7"
+            />
+            <svg
+                className={className}
+                preserveAspectRatio="none"
+                viewBox={`0 0 ${preview.width} ${preview.height}`}
+            >
+                {preview.modules.map((m) => (
+                    <ModulePreview
+                        key={m.key}
+                        y={m.top}
+                        x={m.left}
+                        width={m.width}
+                        height={m.height}
+                        titleWidth={m.titleWidth}
+                    />
+                ))}
+
+            </svg>
+        </svg>
+    )
+}
+
+Preview.defaultProps = {
+    aspect: {
+        width: 318,
+        height: 200,
+    },
+    screen: {
+        width: 1680,
+        // calculate height based on aspect
+    },
+}

--- a/app/src/editor/canvas/components/Preview.jsx
+++ b/app/src/editor/canvas/components/Preview.jsx
@@ -85,7 +85,6 @@ export function ModulePreview({
     const portsBottomY = headerBottomY + getPortsHeight(um, portRows)
     return (
         <g className={cx(styles.ModulePreview, styles[type])}>
-            <title>{title}</title>
             <rect
                 className={styles.ModulePreviewBackground}
                 x={x}

--- a/app/src/editor/canvas/components/Preview.pcss
+++ b/app/src/editor/canvas/components/Preview.pcss
@@ -1,0 +1,28 @@
+.ModulePreview {
+  width: 100%;
+  height: auto;
+}
+
+.ModulePreviewHeaderText {
+  fill: #D8D8D8;
+  rx: 0.2%;
+}
+
+.ModulePreviewBottomBorder {
+  stroke: #EFEFEF;
+  stroke-linecap: square;
+  stroke-width: 0.5px;
+  vector-effect: non-scaling-stroke;
+}
+
+.ModulePreviewBackground {
+  fill: #FCFBF9;
+  rx: 0.2%;
+  stroke: #EFEFEF;
+  stroke-width: 0.5px;
+  vector-effect: non-scaling-stroke;
+}
+
+.ModulePreview.CommentModule .ModulePreviewBackground {
+  fill: #FAE7DD;
+}

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -89,7 +89,7 @@ export function emptyCanvas(config = {}) {
     }
 }
 
-const DEFAULT_MODULE_LAYOUT = {
+export const defaultModuleLayout = {
     position: {
         top: 0,
         left: 0,
@@ -562,7 +562,7 @@ export function addModule(canvas, moduleData) {
         ...moduleData,
         hash: getHash(canvas), // TODO: better IDs
         layout: {
-            ...DEFAULT_MODULE_LAYOUT, // TODO: read position from mouse
+            ...defaultModuleLayout, // TODO: read position from mouse
         },
     }
 

--- a/app/src/editor/dashboard/components/Dashboard.jsx
+++ b/app/src/editor/dashboard/components/Dashboard.jsx
@@ -47,11 +47,30 @@ const normalizeItemList = (itemList = []) => (
     sortBy(itemList, 'i').map(normalizeLayoutItem)
 )
 
-const normalizeLayout = (targetLayout) => dashboardConfig.layout.sizes.reduce((obj, size) => (
+export const normalizeLayout = (targetLayout) => dashboardConfig.layout.sizes.reduce((obj, size) => (
     Object.assign(obj, {
         [size]: (targetLayout && targetLayout[size]) ? normalizeItemList(targetLayout[size]) : [],
     })
 ), {})
+
+export function generateLayout(dashboard) {
+    return dashboard && zipObject(
+        dashboardConfig.layout.sizes,
+        dashboardConfig.layout.sizes.map((size) => (
+            dashboard.items.map((item) => {
+                if (!item.webcomponent) { return {} }
+                const id = generateItemId(item)
+                const layoutInfo = ((dashboard.layout && dashboard.layout[size]) && dashboard.layout[size].find((l) => l.i === id)) || {}
+                return {
+                    ...dashboardConfig.layout.defaultLayout,
+                    ...dashboardConfig.layout.layoutsBySizeAndModule[size][item.webcomponent],
+                    ...layoutInfo,
+                    i: id,
+                }
+            })
+        )),
+    )
+}
 
 /**
  * Each module on a dashboard is a DashboardItem
@@ -151,27 +170,6 @@ export default WidthProvider(class DashboardEditor extends React.Component {
         }
     }
 
-    generateLayout = () => {
-        const { dashboard } = this.props
-        const layout = dashboard && zipObject(
-            dashboardConfig.layout.sizes,
-            dashboardConfig.layout.sizes.map((size) => (
-                dashboard.items.map((item) => {
-                    if (!item.webcomponent) { return {} }
-                    const id = generateItemId(item)
-                    const layoutInfo = ((dashboard.layout && dashboard.layout[size]) && dashboard.layout[size].find((l) => l.i === id)) || {}
-                    return {
-                        ...dashboardConfig.layout.defaultLayout,
-                        ...dashboardConfig.layout.layoutsBySizeAndModule[size][item.webcomponent],
-                        ...layoutInfo,
-                        i: id,
-                    }
-                })
-            )),
-        )
-        return layout
-    }
-
     onLayoutChange = (layout, allLayouts) => {
         this.updateLayout(layout)
         this.updateDashboardLayout(allLayouts)
@@ -210,7 +208,7 @@ export default WidthProvider(class DashboardEditor extends React.Component {
 
         const select = this.context
 
-        const layout = dashboard && dashboard.items && this.generateLayout()
+        const layout = dashboard && dashboard.items && generateLayout(dashboard)
         const items = dashboard && dashboard.items ? sortBy(dashboard.items, ['canvas', 'module']) : []
         const locked = editorLocked || this.state.isFullscreen
         const { breakpoints } = dashboardConfig.layout

--- a/app/src/editor/dashboard/components/Preview.jsx
+++ b/app/src/editor/dashboard/components/Preview.jsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { ModulePreview } from '$editor/canvas/components/Preview'
+import { normalizeLayout, generateLayout } from './Dashboard'
+
+export default function Preview({
+    className,
+    style,
+    dashboard,
+    aspect,
+    screen,
+    ...props
+}) {
+    const layout = normalizeLayout(generateLayout(dashboard))
+    const itemLayout = layout.lg || layout[Object.keys(layout)[0]] || []
+    const bounds = itemLayout.reduce((b, m) => (
+        Object.assign(b, {
+            maxX: Math.max(b.maxX, m.x + m.w),
+            maxY: Math.max(b.maxY, m.y + m.h),
+            minX: Math.min(b.minX, m.x),
+            minY: Math.min(b.minY, m.y),
+        })
+    ), {
+        maxX: -Infinity,
+        maxY: -Infinity,
+        minX: Infinity,
+        minY: Infinity,
+    })
+
+    // set a minimum canvas size so a single module doesn't take up entire preview
+    const minWidth = Math.max(bounds.maxX, screen.width || 0)
+    const minHeight = Math.max(bounds.maxY, screen.height || 0)
+
+    return (
+        <svg
+            className={className}
+            preserveAspectRatio="none"
+            viewBox={`0 0 ${aspect.width} ${aspect.height}`}
+            style={{
+                ...style,
+                background: '#e7e7e7',
+                padding: '8px',
+            }}
+            {...props}
+        >
+            <rect
+                x="0"
+                y="0"
+                height="100%"
+                width="100%"
+                fill="#e7e7e7"
+            />
+            {!!itemLayout.length && (
+                <svg
+                    preserveAspectRatio="none"
+                    viewBox={`0 0 ${minWidth} ${minHeight}`}
+                >
+                    {itemLayout.map((m, index) => (
+                        <svg
+                            key={m.i}
+                            preserveAspectRatio="none"
+                            viewBox={`0 0 ${m.w} ${m.h}`}
+                            y={m.y}
+                            x={m.x}
+                            width={m.w}
+                            height={m.h}
+                        >
+                            <g transform="scale(0.95)">
+                                <ModulePreview
+                                    um={0.25}
+                                    title={dashboard.items[index].title}
+                                    width={m.w}
+                                    height={m.h}
+                                />
+                            </g>
+                        </svg>
+                    ))}
+                </svg>
+            )}
+        </svg>
+    )
+}
+
+Preview.defaultProps = {
+    aspect: {
+        width: 318,
+        height: 200,
+    },
+    screen: {
+        width: 12,
+        height: 12,
+    },
+}

--- a/app/src/shared/components/Tile/index.jsx
+++ b/app/src/shared/components/Tile/index.jsx
@@ -13,6 +13,7 @@ import styles from './tile.pcss'
 
 type Props = {
     children: Node,
+    image?: ?Node,
     link: string,
     imageUrl?: string,
     isHovered?: boolean,
@@ -23,6 +24,7 @@ type Props = {
 const Tile = ({
     link,
     imageUrl,
+    image,
     children,
     isHovered,
     dropdownActions,
@@ -49,7 +51,9 @@ const Tile = ({
                 {dropdownActions}
             </DropdownActions>
         }
-        <FallbackImage src={imageUrl || ''} alt="Tile" className={styles.image} />
+        {image || (
+            <FallbackImage src={imageUrl || ''} alt="Tile" className={styles.image} />
+        )}
         <div className={styles.content}>
             {children}
         </div>

--- a/app/src/userpages/components/CanvasPage/List/canvasList.pcss
+++ b/app/src/userpages/components/CanvasPage/List/canvasList.pcss
@@ -5,3 +5,8 @@
 .stopped {
   color: #A3A3A3;
 }
+
+.CanvasPreview {
+  width: 100%;
+  height: auto;
+}

--- a/app/src/userpages/components/CanvasPage/List/canvasList.pcss
+++ b/app/src/userpages/components/CanvasPage/List/canvasList.pcss
@@ -6,7 +6,7 @@
   color: #A3A3A3;
 }
 
-.CanvasPreview {
+.PreviewImage {
   width: 100%;
   height: auto;
 }

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -37,6 +37,8 @@ import type { User } from '$shared/flowtype/user-types'
 import { selectUserData } from '$shared/modules/user/selectors'
 import { RunStates } from '$editor/canvas/state'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
+import Onboarding from '$shared/components/Onboarding'
+import CanvasPreview from '$editor/canvas/components/Preview'
 
 import styles from './canvasList.pcss'
 
@@ -269,6 +271,7 @@ class CanvasList extends Component<Props, State> {
                                 <Tile
                                     link={`${links.editor.canvasEditor}/${canvas.id}`}
                                     dropdownActions={this.getActions(canvas)}
+                                    image={<CanvasPreview className={styles.CanvasPreview} canvas={canvas} />}
                                     onMenuToggle={(open) => {
                                         if (open) {
                                             this.loadCanvasPermissions(canvas.id)

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -271,7 +271,7 @@ class CanvasList extends Component<Props, State> {
                                 <Tile
                                     link={`${links.editor.canvasEditor}/${canvas.id}`}
                                     dropdownActions={this.getActions(canvas)}
-                                    image={<CanvasPreview className={styles.CanvasPreview} canvas={canvas} />}
+                                    image={<CanvasPreview className={styles.PreviewImage} canvas={canvas} />}
                                     onMenuToggle={(open) => {
                                         if (open) {
                                             this.loadCanvasPermissions(canvas.id)

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -20,6 +20,7 @@ import Search from '$shared/components/Search'
 import Dropdown from '$shared/components/Dropdown'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import DashboardPreview from '$editor/dashboard/components/Preview'
+import canvasListStyles from '../../CanvasPage/List/canvasList.pcss'
 
 import NoDashboardsView from './NoDashboards'
 
@@ -132,7 +133,7 @@ class DashboardList extends Component<Props> {
                                 <Col {...defaultColumns} key={dashboard.id}>
                                     <Tile
                                         link={`${links.editor.dashboardEditor}/${dashboard.id}`}
-                                        image={<DashboardPreview dashboard={dashboard} />}
+                                        image={<DashboardPreview className={canvasListStyles.PreviewImage} dashboard={dashboard} />}
                                     >
                                         <Tile.Title>{dashboard.name}</Tile.Title>
                                     </Tile>

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -19,6 +19,7 @@ import Tile from '$shared/components/Tile'
 import Search from '$shared/components/Search'
 import Dropdown from '$shared/components/Dropdown'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
+import DashboardPreview from '$editor/dashboard/components/Preview'
 
 import NoDashboardsView from './NoDashboards'
 
@@ -129,7 +130,10 @@ class DashboardList extends Component<Props> {
                         <Row>
                             {dashboards.map((dashboard) => (
                                 <Col {...defaultColumns} key={dashboard.id}>
-                                    <Tile link={`${links.editor.dashboardEditor}/${dashboard.id}`}>
+                                    <Tile
+                                        link={`${links.editor.dashboardEditor}/${dashboard.id}`}
+                                        image={<DashboardPreview dashboard={dashboard} />}
+                                    >
                                         <Tile.Title>{dashboard.name}</Tile.Title>
                                     </Tile>
                                 </Col>


### PR DESCRIPTION
# Canvas Previews

![image](https://user-images.githubusercontent.com/43438/56861113-852ddc00-69d0-11e9-9b37-3d0bfb9d9af2.png)

* Maintains a 318/200 ratio (from mocks).
* Small canvases are drawn at least "1680px" wide, this ensures small canvases don't display as a few gigantic modules.
* Large canvases scale module "details" down as appropriate, maintaining aspect ratio.

# Dashboard Previews

* Roughly "simulates" `react-grid-layout` rendering.

![image](https://user-images.githubusercontent.com/43438/56861110-83641880-69d0-11e9-8ac6-18a6e8c6e57d.png)

----

No custom UI for individual modules, let's do that in another pass, it's made more complicated for dashboards as we don't know the module `id` upfront (i.e. it's type e.g. "Table", etc), we only know its `hash` (the "real" unique id for a module on a canvas).