### PR TITLE
[PLATFORM-504] Module Search Panel minimising behavior

### DIFF
--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -91,7 +91,6 @@ type State = {
 
 const MIN_WIDTH = 250
 const MAX_WIDTH = 450
-const MIN_HEIGHT = 208
 const MAX_HEIGHT = 352
 const MIN_HEIGHT_MINIMIZED = 90
 const MODULE_ITEM_HEIGHT = 52
@@ -331,7 +330,6 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
     render() {
         const { open, isOpen } = this.props
         const { search, isExpanded, width, height } = this.state
-        const minHeight = isExpanded ? MIN_HEIGHT : MIN_HEIGHT_MINIMIZED
         return (
             <React.Fragment>
                 {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
@@ -347,12 +345,13 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                         <ResizableBox
                             width={width}
                             height={height}
-                            minConstraints={[MIN_WIDTH, minHeight]}
+                            minConstraints={[MIN_WIDTH, MIN_HEIGHT_MINIMIZED]}
                             maxConstraints={[MAX_WIDTH, MAX_HEIGHT]}
                             onResize={(e, data) => {
                                 this.setState({
                                     height: data.size.height,
                                     width: data.size.width,
+                                    isExpanded: data.size.height > MIN_HEIGHT_MINIMIZED,
                                 })
                             }}
                         >

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -91,8 +91,8 @@ type State = {
 
 const MIN_WIDTH = 250
 const MAX_WIDTH = 450
-const MIN_HEIGHT = 450
-const MAX_HEIGHT = 700
+const MIN_HEIGHT = 208
+const MAX_HEIGHT = 352
 const MIN_HEIGHT_MINIMIZED = 90
 const MODULE_ITEM_HEIGHT = 52
 
@@ -104,7 +104,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         matchingStreams: [],
         isExpanded: true,
         width: 250,
-        height: MIN_HEIGHT,
+        height: MAX_HEIGHT,
         /* eslint-disable-next-line react/no-unused-state */
         heightBeforeMinimize: 0,
     }
@@ -134,7 +134,8 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         const { value } = event.currentTarget
         this.setState({
             search: value,
-        })
+            isExpanded: true,
+        }, () => this.recalculateHeight())
 
         // Search modules
         const matchingModules = this.getMappedModuleTree(value)
@@ -161,10 +162,10 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
     recalculateHeight = () => {
         const { isExpanded, matchingModules, matchingStreams, search } = this.state
 
-        if (isExpanded) {
-            this.setState(({ heightBeforeMinimize, height }) => ({
-                height: heightBeforeMinimize > 0 ? heightBeforeMinimize : height,
-            }))
+        if (!isExpanded) {
+            this.setState({
+                height: MIN_HEIGHT_MINIMIZED,
+            })
             return
         }
 
@@ -174,7 +175,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         let requiredHeight = MIN_HEIGHT_MINIMIZED + (searchResultItemCount * MODULE_ITEM_HEIGHT)
 
         if (search === '') {
-            requiredHeight = 0
+            requiredHeight = MAX_HEIGHT
         }
 
         this.setState({


### PR DESCRIPTION
I changed the minimising behaviour so that it expands if minimised and a search text is entered (instead of disabling). I also made the box smaller (max height) by default to what it is in the designs (352px). 

![module-search-minimise](https://user-images.githubusercontent.com/1064982/56894655-3a26ce00-6a8f-11e9-8f89-3562b4dc4e19.gif)
