### PR TITLE
[PLATFORM-557] Ensure generated module hash is within valid range for server.

### DIFF
--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -522,7 +522,8 @@ export function removeModule(canvas, moduleHash) {
     }
 }
 
-let ID = 0
+// Hash is stored as a Java Integer.
+const HASH_RANGE = ((2 ** 31) - 1) + (2 ** 31)
 
 function getHash(canvas, iterations = 0) {
     if (iterations >= 100) {
@@ -530,14 +531,7 @@ function getHash(canvas, iterations = 0) {
         throw new Error(`could not find unique hash after ${iterations} attempts`)
     }
 
-    ID += 1
-    const hash = Number((
-        String(Date.now() + ID)
-            .slice(-10) // 32 bits
-            .split('')
-            .reverse() // in order (for debugging)
-            .join('')
-    ))
+    const hash = Math.floor((Math.random() * HASH_RANGE) - (HASH_RANGE / 2))
 
     if (canvas.modules.find((m) => m.hash === hash)) {
         // double-check doesn't exist


### PR DESCRIPTION
The client-generated module hash was larger than the valid Java `Integer` range supported by `hash` on the server, so the `hash` that comes back from the server was different than the `hash` that the client sent, which causes the subscriptions to disconnect and reconnect due to the container thinking the original module (+ subscription) had been removed and a new module added.

To test: 

1. Create a new Canvas
2. Create a test stream + add a numeric "message" field (or whatever)
3. Grab your API key and created stream id.
4. Publish a message to the stream using cli-tools:

```
npm install -g @streamr/cli-tools
echo -n '{"message": 1}' | publish-to-stream-dev $STREAM_ID $API_KEY
```

Message should appear.
Previously the message would be lost.