### PR TITLE
[PLATFORM-483] Insert modules with drag and drop

### DIFF
--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -65,9 +65,25 @@ export class ModuleMenuCategory extends React.PureComponent<MenuCategoryProps, M
     }
 }
 
+const onDragStart = (e: any) => {
+    e.stopPropagation()
+    console.log(e)
+    console.log(e.target)
+    const dragImage = document.querySelector('#dragImage')
+    if (dragImage) {
+        const textElement = dragImage.querySelector('.dragModuleName')
+        if (textElement) {
+            textElement.textContent = e.target.textContent
+        }
+        e.dataTransfer.setDragImage(dragImage, 0, 0)
+    }
+
+    e.dataTransfer.setData('text/plain', 'some_dummy_data')
+}
+
 const ModuleMenuItem = ({ module, onSelect }) => (
     /* eslint-disable-next-line */
-    <div className={styles.ModuleItem} role="option" onClick={() => onSelect(module.id)}>
+    <div draggable onDragStart={onDragStart} className={styles.ModuleItem} role="option" onClick={() => onSelect(module.id)}>
         {startCase(module.name)}
     </div>
 )
@@ -384,6 +400,13 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                         </ResizableBox>
                     </div>
                 </Draggable>
+                <div className={styles.dragElement} id="dragImage">
+                    <SvgIcon className={styles.dragImage} name="crossHeavy" />
+                    <div>
+                        <span>Drop to create</span>
+                        <span className="dragModuleName" />
+                    </div>
+                </div>
             </React.Fragment>
         )
     }

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -144,7 +144,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         matchingModules: [],
         matchingStreams: [],
         isExpanded: true,
-        width: 250,
+        width: MIN_WIDTH,
         height: MAX_HEIGHT,
         /* eslint-disable-next-line react/no-unused-state */
         heightBeforeMinimize: 0,

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -3,9 +3,6 @@
   left: 32px;
   top: 10%;
   background: white;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto auto 1fr;
   z-index: 12;
   border: 1px solid #EFEFEF;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
@@ -96,7 +93,6 @@
   letter-spacing: 2px;
   line-height: 32px;
   overflow: auto;
-  height: 100%;
 }
 
 .ModuleSearch .Content > * {

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -142,6 +142,11 @@
   text-transform: none;
   letter-spacing: 0;
   line-height: 40px;
+  cursor: grab;
+}
+
+.ModuleSearch .Content .ModuleItem:focus {
+  outline: none;
 }
 
 .ModuleSearch .Content .ModuleItem.WithCategory {
@@ -178,6 +183,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  cursor: grab;
+}
+
+.ModuleSearch .Content .StreamItem:focus {
+  outline: none;
 }
 
 .ModuleSearch .Content .StreamItem .Description {
@@ -215,10 +225,38 @@
   background-color: #FFFFFF;
   color: #323232;
   border-radius: 4px;
+  max-width: 200px;
+  height: 60px;
+}
+
+.dropText {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 1px;
+  text-align: center;
+  text-transform: uppercase;
+  padding: 0 16px;
+  margin-top: -16px;
+}
+
+.dragModuleName {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin-top: -12px;
 }
 
 .dragImage {
   color: red;
   width: 24px;
   height: 24px;
+  position: relative;
+  top: -12px;
+  left: -12px;
 }

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -206,3 +206,19 @@
 
 .dragHandle {
 }
+
+.dragElement {
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: -1;
+  background-color: #FFFFFF;
+  color: #323232;
+  border-radius: 4px;
+}
+
+.dragImage {
+  color: red;
+  width: 24px;
+  height: 24px;
+}

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -3,8 +3,6 @@
   left: 32px;
   top: 10%;
   background: white;
-  min-width: 248px;
-  max-width: 248px;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto auto 1fr;
@@ -98,6 +96,7 @@
   letter-spacing: 2px;
   line-height: 32px;
   overflow: auto;
+  height: 100%;
 }
 
 .ModuleSearch .Content > * {

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -3,6 +3,11 @@
   left: 32px;
   top: 10%;
   background: white;
+  min-width: 248px;
+  max-width: 248px;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto 1fr;
   z-index: 12;
   border: 1px solid #EFEFEF;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -86,11 +86,11 @@
 .ModuleSearch .Content {
   color: #525252;
   font-size: 12px;
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-weight: var(--medium);
   text-align: left;
   text-transform: uppercase;
-  letter-spacing: 2px;
+  letter-spacing: 1px;
   line-height: 32px;
   overflow: auto;
 }
@@ -106,10 +106,10 @@
 
 .ModuleSearch .Content .Category {
   color: #323232;
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-size: 12px;
   font-weight: var(--medium);
-  letter-spacing: 2px;
+  letter-spacing: 1px;
   line-height: 40px;
   text-transform: uppercase;
 }
@@ -121,7 +121,7 @@
 
 .ModuleSearch .Content .SearchCategory {
   font-size: 10px;
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-weight: 600;
   color: #323232;
   text-transform: uppercase;
@@ -132,7 +132,7 @@
 
 .ModuleSearch .Content .ModuleItem {
   font-size: 12px;
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-weight: 400;
   color: #323232;
   text-transform: none;
@@ -159,7 +159,7 @@
 
 .ModuleSearch .Content .ModuleItem .ModuleCategory {
   font-size: 12px;
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-weight: 400;
   text-transform: uppercase;
   color: #ADADAD;
@@ -170,7 +170,7 @@
 
 .ModuleSearch .Content .StreamItem {
   font-size: 12px;
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-weight: 400;
   color: #323232;
   text-transform: none;
@@ -188,7 +188,7 @@
 
 .ModuleSearch .Content .StreamItem .Description {
   font-size: 10px;
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-weight: 400;
   color: #ADADAD;
   line-height: 12px;
@@ -241,6 +241,7 @@
   font-size: 12px;
   font-weight: var(--medium);
   letter-spacing: 0;
+  padding: 0 16px;
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -6,7 +6,7 @@
   z-index: 12;
   border: 1px solid #EFEFEF;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
-  border-radius: 4px;
+  border-radius: calc(0.25 * var(--um));
   overflow: hidden;
   cursor: pointer;
   user-select: none;
@@ -86,8 +86,8 @@
 .ModuleSearch .Content {
   color: #525252;
   font-size: 12px;
-  font-family: 'IBM Plex Mono', monospace;
-  font-weight: 500;
+  font-family: var(--mono);
+  font-weight: var(--medium);
   text-align: left;
   text-transform: uppercase;
   letter-spacing: 2px;
@@ -106,9 +106,9 @@
 
 .ModuleSearch .Content .Category {
   color: #323232;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: var(--medium);
   letter-spacing: 2px;
   line-height: 40px;
   text-transform: uppercase;
@@ -121,7 +121,7 @@
 
 .ModuleSearch .Content .SearchCategory {
   font-size: 10px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-weight: 600;
   color: #323232;
   text-transform: uppercase;
@@ -132,7 +132,7 @@
 
 .ModuleSearch .Content .ModuleItem {
   font-size: 12px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-weight: 400;
   color: #323232;
   text-transform: none;
@@ -159,7 +159,7 @@
 
 .ModuleSearch .Content .ModuleItem .ModuleCategory {
   font-size: 12px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-weight: 400;
   text-transform: uppercase;
   color: #ADADAD;
@@ -170,7 +170,7 @@
 
 .ModuleSearch .Content .StreamItem {
   font-size: 12px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-weight: 400;
   color: #323232;
   text-transform: none;
@@ -188,7 +188,7 @@
 
 .ModuleSearch .Content .StreamItem .Description {
   font-size: 10px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-weight: 400;
   color: #ADADAD;
   line-height: 12px;
@@ -220,15 +220,15 @@
   z-index: -1;
   background-color: #FFFFFF;
   color: #323232;
-  border-radius: 4px;
-  max-width: 200px;
-  height: 60px;
+  border-radius: calc(0.25 * var(--um));
+  max-width: calc(12.5 * var(--um));
+  height: calc(3.75 * var(--um));
 }
 
 .dropText {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: var(--medium);
   letter-spacing: 1px;
   text-align: center;
   text-transform: uppercase;
@@ -237,9 +237,9 @@
 }
 
 .dragModuleName {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: var(--medium);
   letter-spacing: 0;
   text-align: center;
   text-overflow: ellipsis;

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -160,26 +160,13 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         ))
     }
 
-    addModule = async ({ id, configuration, position }) => {
+    addModule = async ({ id, configuration }) => {
         const action = { type: 'Add Module' }
         const moduleData = await sharedServices.getModule({
             id,
             configuration,
         })
         if (this.unmounted) { return }
-
-        // Overwrite layout position if it was provided
-        if (position) {
-            const newPosition = {
-                left: `${position.x}px`,
-                top: `${position.y}px`,
-            }
-
-            moduleData.layout = {
-                ...moduleData.layout,
-                position: newPosition,
-            }
-        }
 
         this.setCanvas(action, (canvas) => (
             CanvasState.addModule(canvas, moduleData)

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -160,13 +160,27 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         ))
     }
 
-    addModule = async ({ id, configuration }) => {
+    addModule = async ({ id, configuration, position }) => {
         const action = { type: 'Add Module' }
         const moduleData = await sharedServices.getModule({
             id,
             configuration,
         })
         if (this.unmounted) { return }
+
+        // Overwrite layout position if it was provided
+        if (position) {
+            const newPosition = {
+                left: `${position.x}px`,
+                top: `${position.y}px`,
+            }
+
+            moduleData.layout = {
+                ...moduleData.layout,
+                position: newPosition,
+            }
+        }
+
         this.setCanvas(action, (canvas) => (
             CanvasState.addModule(canvas, moduleData)
         ))

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -557,6 +557,7 @@ export function addModule(canvas, moduleData) {
         hash: getHash(canvas), // TODO: better IDs
         layout: {
             ...defaultModuleLayout, // TODO: read position from mouse
+            ...moduleData.layout,
         },
     }
 

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -278,6 +278,14 @@ const sources = {
             />
         </svg>
     ),
+    dropPlus: (
+        <svg viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
+            <g transform="translate(1 1)" fill="none" fillRule="evenodd">
+                <circle fill="#FCFBF9" cx="11.5" cy="11.5" r="11.5" />
+                <path d="M11.5 23C17.851 23 23 17.851 23 11.5S17.851 0 11.5 0 0 5.149 0 11.5C.007 17.848 5.152 22.993 11.5 23zm-6-12.5h4.75a.25.25 0 0 0 .25-.25V5.5a1 1 0 0 1 2 0v4.75c0 .138.112.25.25.25h4.75a1 1 0 0 1 0 2h-4.75a.25.25 0 0 0-.25.25v4.75a1 1 0 0 1-2 0v-4.75a.25.25 0 0 0-.25-.25H5.5a1 1 0 0 1 0-2z" fill="#FF5C00" fillRule="nonzero" />
+            </g>
+        </svg>
+    ),
 }
 
 type Props = {


### PR DESCRIPTION
Modules can be now dragged and dropped from module search into the canvas. Or actually that is the only way to add modules now. Also the search window now stays open until you close it so you can easily build the canvas.

Position of the module is calculated from the drop position.