### PR TITLE
"Fix" webpack out of memory issues

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -240,6 +240,13 @@ module.exports = {
         port: process.env.PORT || 3333,
         publicPath,
     },
+    // automatically creates a vendor chunk & also
+    // seems to prevent out of memory errors during dev ??
+    optimization: {
+        splitChunks: {
+            chunks: 'all',
+        },
+    },
     resolve: {
         extensions: ['.js', '.jsx', '.json'],
         symlinks: false,


### PR DESCRIPTION
I'm not sure if anyone else has been having this same problem but for me webpack seems to be running out of memory with increasing frequency. This is annoying.

Some quick googling turned up this: https://github.com/webpack/webpack/issues/6929#issuecomment-447118252

```js
// file: webpack.config.js
optimization: {
  splitChunks: {
    chunks: 'all',
  },
},
```

This seems to work? I've been running builds with this setting on for the last two days and I haven't seen an out of memory error since. 🤷‍♀

Other consequence of this change is that we're now serving the app in (at least) two bundles, one vendor bundle containing everything in `node_modules`, and another bundle containing everything else. Have seen no problems as a result of this, everything appears to just work. These bundles are loaded in parallel so in theory it should actually improve load times.

This uses the default `splitChunks` settings. Read more about what it does here: https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks