### PR TITLE
[PLATFORM-533] Module header cursors

### DIFF
--- a/app/src/shared/components/EditableText/editableText.pcss
+++ b/app/src/shared/components/EditableText/editableText.pcss
@@ -31,7 +31,7 @@
 }
 
 .idle {
-  cursor: text;
+  cursor: default;
 }
 
 .idle .inner {

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -92,6 +92,7 @@ const EditableText = ({
                     <Fragment>
                         <TextControl
                             {...props}
+                            autocomplete="off"
                             autoFocus
                             flushHistoryOnBlur
                             onBlur={onBlur}
@@ -101,6 +102,7 @@ const EditableText = ({
                             placeholder={placeholder}
                             revertOnEsc
                             selectAllOnFocus
+                            spellcheck="false"
                             value={children}
                         />
                         <span className={styles.spaceholder}>


### PR DESCRIPTION
Very quick fix for the cursor situation. `EditableText` in idle state comes with the default one. I also disabled spell checking and autocomplete in that component.