### PR TITLE
[PLATFORM-582] Canvas Preview Errors

### DIFF
--- a/app/src/editor/canvas/components/Preview.jsx
+++ b/app/src/editor/canvas/components/Preview.jsx
@@ -22,7 +22,13 @@ function getModuleKey(m) {
 function PreviewCables({ canvas, preview }) {
     function getPosition(portId) {
         if (!portId) { return }
-        const m = getModuleForPort(canvas, portId)
+        let m
+        try {
+            m = getModuleForPort(canvas, portId)
+        } catch (error) {
+            // ignore error if problem with canvas/port
+            return
+        }
         const key = getModuleKey(m)
         const p = preview.modules.find((m) => m.key === key)
         return {


### PR DESCRIPTION
Wraps a try/catch around the code which does any canvas "validation". Not totally robust, ideally we could wrap the entire component, but I think there's some issues with that + hooks due to no current equivalent of `componentDidCatch` or `getDerivedStateFromError` but "they will be added soon". This should cover us for now.