### PR TITLE
Fix console warning when focusing EditableText

### DIFF
--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -92,7 +92,7 @@ const EditableText = ({
                     <Fragment>
                         <TextControl
                             {...props}
-                            autocomplete="off"
+                            autoComplete="off"
                             autoFocus
                             flushHistoryOnBlur
                             onBlur={onBlur}
@@ -102,7 +102,7 @@ const EditableText = ({
                             placeholder={placeholder}
                             revertOnEsc
                             selectAllOnFocus
-                            spellcheck="false"
+                            spellCheck="false"
                             value={children}
                         />
                         <span className={styles.spaceholder}>


### PR DESCRIPTION
Fixes console log warnings when focusing module input value or canvas name.

<img width="509" alt="Screen Shot 2019-05-03 at 12 08 27" src="https://user-images.githubusercontent.com/1064982/57128649-c7726700-6d9c-11e9-8fa6-5336a5654e2d.png">
<img width="536" alt="Screen Shot 2019-05-03 at 12 08 20" src="https://user-images.githubusercontent.com/1064982/57128650-c7726700-6d9c-11e9-94dc-7d8a21f54a6d.png">
