### PR TITLE
[PLATFORM-502] Module search visibility

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/useCanvasLoadCallback.js
+++ b/app/src/editor/canvas/components/CanvasController/useCanvasLoadCallback.js
@@ -13,6 +13,9 @@ export default function useCanvasLoadCallback() {
     return useCallback(async (canvasId) => (
         wrap(async () => {
             const canvas = await services.loadRelevantCanvas({ id: canvasId })
+            // Get permissions and save them temporarily to canvas
+            const permissions = await services.getCanvasPermissions({ id: canvasId })
+            canvas.permissions = permissions.data
             if (!isMountedRef.current) { return }
             canvasUpdater.replaceCanvas(() => canvas)
         })

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -451,7 +451,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
             <React.Fragment>
                 <Draggable
                     handle={`.${styles.dragHandle}`}
-                    bounds="parent"
+                    bounds={`.${CanvasStyles.Modules}`}
                 >
                     <div
                         className={styles.ModuleSearch}

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -1,7 +1,7 @@
 .ModuleSearch {
   position: absolute;
   left: 32px;
-  top: 10%;
+  top: calc(50% - 352px + 64px + 80px); /* center - my height + top header + bottom header */
   background: white;
   z-index: 12;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -47,9 +47,19 @@ function setUpdated(canvas) {
     return updated
 }
 
+function isEditable(canvas, runController) {
+    const { isActive } = runController
+    const canEdit = !isActive && !canvas.adhoc
+    return canEdit
+}
+
+function isOwn(canvas) {
+    return canvas.permissions && canvas.permissions.some((p) => p.operation === 'share')
+}
+
 const CanvasEditComponent = class CanvasEdit extends Component {
     state = {
-        moduleSearchIsOpen: false,
+        moduleSearchIsOpen: isOwn(this.props.canvas) && isEditable(this.props.canvas, this.props.runController),
         moduleSidebarIsOpen: false,
         keyboardShortcutIsOpen: false,
     }

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -84,6 +84,10 @@ export async function getModuleCategories() {
     return api().get(getModuleCategoriesURL).then(getData)
 }
 
+export async function getCanvasPermissions({ id }) {
+    return api().get(`${process.env.STREAMR_API_URL}/canvases/${id}/permissions/me`)
+}
+
 async function startCanvas(canvas, { clearState }) {
     const savedCanvas = await saveNow(canvas)
     return api().post(`${canvasesUrl}/${savedCanvas.id}/start`, {


### PR DESCRIPTION
Implemented these changes requested by @mattatgit:

-  if the canvas belongs to the user, is editable, always show the module panel
- if the canvas does not belong to the user, is not editable, do not show the module panel. In this case we should also make the + icon disabled (ie 50% opacity)
- for all new canvases created by the user, always show the module panel

Also module search is now vertically centered when initially shown.