### PR TITLE
[PLATFORM-587] Hide sensitive data from LogRocket

### DIFF
--- a/app/src/analytics.js
+++ b/app/src/analytics.js
@@ -67,11 +67,29 @@ if (process.env.SENTRY_URL) {
     })
 }
 
+// empty the request body for these paths
+const urlBlackList = [
+    '/api/v1/login/password',
+]
+
 if (process.env.LOGROCKET_SLUG) {
     analytics.register({
         id: 'LogRocket',
         init: () => {
-            LogRocket.init(process.env.LOGROCKET_SLUG)
+            LogRocket.init(process.env.LOGROCKET_SLUG, {
+                network: {
+                    requestSanitizer: (request) => {
+                        const requestUrl = request.url.toLowerCase()
+                        // if the url contains one of the blacklisted paths
+                        if (urlBlackList.some((search) => requestUrl.indexOf(search) !== -1)) {
+                            // scrub out the body
+                            request.body = null
+                        }
+
+                        return request
+                    },
+                },
+            })
         },
         reportError: (error: Error, extra: Object = {}) => {
             LogRocket.captureException(error, {


### PR DESCRIPTION
Prevents LogRocket from sending username and password from login request. Can be tested locally by adding the slug to `.env` and checking the result in LogRocket:

`LOGROCKET_SLUG=et0uhu/streamr-frontend-local`

<img width="422" alt="Screen Shot 2019-05-07 at 14 33 17" src="https://user-images.githubusercontent.com/1064982/57296440-b051b300-70d5-11e9-99b9-50c014751fc0.png">
