### PR TITLE
[PLATFORM-572] Create new dashboard editor is not opening

### DIFF
--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -177,7 +177,15 @@ const DashboardLoader = withRouter(withErrorBoundary(ErrorComponentView)(class D
         this.unmounted = true
     }
 
-    init() {
+    async init() {
+        if (!this.props.match.params.id) {
+            // if no id, create new
+            const newDashboard = await services.create()
+            if (this.unmounted) { return }
+            this.props.history.replace(`${links.editor.dashboardEditor}/${newDashboard.id}`)
+            return
+        }
+
         const dashboard = this.context.state
         const currentId = dashboard && dashboard.id
         const dashboardId = currentId || this.props.match.params.id


### PR DESCRIPTION
Quick fix since this a blocker. Should be refactored to use similar loading as canvas.