### PR TITLE
[PLATFORM-610] Dialog wait state spinner size

### DIFF
--- a/app/src/shared/components/Spinner/spinner.pcss
+++ b/app/src/shared/components/Spinner/spinner.pcss
@@ -19,6 +19,12 @@
 
 .large {
   font-size: 4px;
+
+  &,
+  &::after {
+    width: 40px;
+    height: 40px;
+  }
 }
 
 .white {


### PR DESCRIPTION
Fixes spinner size in dialogs.

<img width="545" alt="Screen Shot 2019-05-08 at 13 40 30" src="https://user-images.githubusercontent.com/1064982/57370888-ece6e280-7199-11e9-8604-07e154366a5f.png">
