### PR TITLE
[PLATFORM-585][PLATFORM-538] Fix select's (port value) placeholder

### DIFF
--- a/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
@@ -25,7 +25,7 @@ const Select = ({
     const optionMap = useMemo(() => (
         options.reduce((memo, { name, value }) => ({
             ...memo,
-            [value]: name,
+            [value || '']: name,
         }), {})
     ), [options])
 


### PR DESCRIPTION
~I've used solution suggested by @juhah here!~ It fixes preselecting the valueless option that acts as a placeholder.