### PR TITLE
[PLATFORM-608] Remove letterspacing from username / email

### DIFF
--- a/app/src/userpages/components/Avatar/NameAndEmail/nameAndEmail.pcss
+++ b/app/src/userpages/components/Avatar/NameAndEmail/nameAndEmail.pcss
@@ -15,7 +15,7 @@
   color: #525252;
   font-size: 12px;
   font-family: 'IBM Plex Sans', sans-serif;
-  letter-spacing: 0.75px;
+  letter-spacing: 0;
   background: #EFEFEF;
   border-radius: 2px;
   padding: 6px;


### PR DESCRIPTION
Letter spacing set to 0.

<img width="722" alt="Screen Shot 2019-05-09 at 11 56 45" src="https://user-images.githubusercontent.com/1064982/57441048-cedcb900-7251-11e9-963b-186df520f957.png">
