### PR TITLE
[PLATFORM-516] Permanently delete item modal improvements

### DIFF
--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -76,7 +76,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                 color: 'danger',
             },
             centerButtons: true,
-            dontShowAgain: true,
+            dontShowAgain: false,
         })
 
         if (confirmed) {

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import * as R from 'reactstrap'
 import cx from 'classnames'
+import { I18n } from 'react-redux-i18n'
 
 import Meatball from '$shared/components/Meatball'
 import Toggle from '$shared/components/Toggle'
@@ -18,6 +19,7 @@ import EditableText from '$shared/components/EditableText'
 import UseState from '$shared/components/UseState'
 import { RunTabs } from '../state'
 import Toolbar from '$editor/shared/components/Toolbar'
+import confirmDialog from '$shared/utils/confirm'
 
 import ShareDialog from './ShareDialog'
 import CanvasSearch from './CanvasSearch'
@@ -65,12 +67,28 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
         }))
     }
 
+    onDeleteCanvas = async () => {
+        const confirmed = await confirmDialog('canvas', {
+            title: I18n.t('userpages.canvases.delete.confirmTitle'),
+            message: I18n.t('userpages.canvases.delete.confirmMessage'),
+            acceptButton: {
+                title: I18n.t('userpages.canvases.delete.confirmButton'),
+                color: 'danger',
+            },
+            centerButtons: true,
+            dontShowAgain: true,
+        })
+
+        if (confirmed) {
+            this.props.deleteCanvas()
+        }
+    }
+
     render() {
         const {
             canvas,
             className,
             duplicateCanvas,
-            deleteCanvas,
             setSaveState,
             setRunTab,
             renameCanvas,
@@ -135,7 +153,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                                     Rename
                                                 </DropdownActions.Item>
                                                 <DropdownActions.Item onClick={() => duplicateCanvas()}>Duplicate</DropdownActions.Item>
-                                                <DropdownActions.Item onClick={() => deleteCanvas()} disabled={!canEdit}>Delete</DropdownActions.Item>
+                                                <DropdownActions.Item onClick={this.onDeleteCanvas} disabled={!canEdit}>Delete</DropdownActions.Item>
                                             </DropdownActions>
                                         </div>
                                     )}

--- a/app/src/shared/components/ConfirmDialog/confirmDialog.pcss
+++ b/app/src/shared/components/ConfirmDialog/confirmDialog.pcss
@@ -1,3 +1,26 @@
 .centerButtons {
   justify-content: center;
 }
+
+.footer {
+  padding: 0 37px;
+  display: flex;
+  align-items: center;
+}
+
+.downShowAgain {
+  flex: 1;
+  text-align: left;
+}
+
+.formGroup {
+  padding: 0;
+}
+
+.label {
+  font-size: 0.9em;
+
+  & > input {
+    top: 3px;
+  }
+}

--- a/app/src/shared/components/ConfirmDialog/index.jsx
+++ b/app/src/shared/components/ConfirmDialog/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { type Node, useState } from 'react'
-import { I18n } from 'react-redux-i18n'
+import { I18n, Translate } from 'react-redux-i18n'
 import cx from 'classnames'
 import { Label, FormGroup } from 'reactstrap'
 
@@ -104,7 +104,7 @@ const ConfirmDialog = (props: Props) => {
                                                 setChecked(e.target.checked)
                                             }}
                                         />
-                                        Dont show this again
+                                        <Translate value="modal.confirm.dontShowAgain" />
                                     </Label>
                                 </FormGroup>
                             </div>

--- a/app/src/shared/components/ConfirmDialog/index.jsx
+++ b/app/src/shared/components/ConfirmDialog/index.jsx
@@ -87,9 +87,15 @@ const ConfirmDialog = (props: Props) => {
                 onClose={actions.cancel.onClick}
                 actions={actions}
                 renderActions={() => (
-                    <div className={styles.footer}>
+                    <div className={cx({
+                        [styles.footer]: !!dontShowAgain,
+                    })}
+                    >
                         {!!dontShowAgain && (
-                            <div className={styles.downShowAgain}>
+                            <div className={cx({
+                                [styles.downShowAgain]: !!dontShowAgain,
+                            })}
+                            >
                                 <FormGroup check className={styles.formGroup}>
                                     <Label check className={styles.label}>
                                         <Checkbox

--- a/app/src/shared/components/ConfirmDialog/index.jsx
+++ b/app/src/shared/components/ConfirmDialog/index.jsx
@@ -1,11 +1,14 @@
 // @flow
 
-import React, { type Node } from 'react'
+import React, { type Node, useState } from 'react'
 import { I18n } from 'react-redux-i18n'
 import cx from 'classnames'
+import { Label, FormGroup } from 'reactstrap'
 
 import Dialog from '$shared/components/Dialog'
 import Modal from '$shared/components/Modal'
+import Buttons from '$shared/components/Buttons'
+import Checkbox from '$shared/components/Checkbox'
 
 import styles from './confirmDialog.pcss'
 
@@ -22,6 +25,7 @@ export type Properties = {
     acceptButton?: Button,
     cancelButton?: Button,
     centerButtons?: boolean,
+    dontShowAgain?: boolean,
 }
 
 type Actions = {
@@ -32,12 +36,14 @@ type Actions = {
 type Props = Properties & Actions
 
 const ConfirmDialog = (props: Props) => {
+    const [checked, setChecked] = useState(false)
     const {
         title,
         message,
         acceptButton,
         cancelButton,
         centerButtons,
+        dontShowAgain,
         onReject,
         onAccept,
     } = props
@@ -77,12 +83,34 @@ const ConfirmDialog = (props: Props) => {
     return (
         <Modal>
             <Dialog
-                actionsClassName={cx({
-                    [styles.centerButtons]: !!centerButtons,
-                })}
                 title={title}
                 onClose={actions.cancel.onClick}
                 actions={actions}
+                renderActions={() => (
+                    <div className={styles.footer}>
+                        {!!dontShowAgain && (
+                            <div className={styles.downShowAgain}>
+                                <FormGroup check className={styles.formGroup}>
+                                    <Label check className={styles.label}>
+                                        <Checkbox
+                                            checked={checked}
+                                            onChange={(e) => {
+                                                setChecked(e.target.checked)
+                                            }}
+                                        />
+                                        Dont show this again
+                                    </Label>
+                                </FormGroup>
+                            </div>
+                        )}
+                        <Buttons
+                            className={cx({
+                                [styles.centerButtons]: !!centerButtons,
+                            })}
+                            actions={actions}
+                        />
+                    </div>
+                )}
             >
                 {message}
             </Dialog>

--- a/app/src/shared/components/ConfirmDialog/index.jsx
+++ b/app/src/shared/components/ConfirmDialog/index.jsx
@@ -74,7 +74,7 @@ const ConfirmDialog = (props: Props) => {
         },
         save: {
             title: I18n.t('modal.common.ok'),
-            onClick: onAccept,
+            onClick: (event) => onAccept(event, checked),
             color: 'primary',
             ...acceptButtonProps,
         },

--- a/app/src/shared/components/Dialog/index.jsx
+++ b/app/src/shared/components/Dialog/index.jsx
@@ -3,7 +3,7 @@
 import React, { Component, type Node } from 'react'
 import classNames from 'classnames'
 
-import Buttons, { type Props as ButtonsProps } from '$shared/components/Buttons'
+import Buttons, { type Props as ButtonsProps, type ButtonActions } from '$shared/components/Buttons'
 import ModalDialog, { type Props as ModalDialogProps } from '$shared/components/ModalDialog'
 import { dialogAutoCloseTimeout } from '$shared/utils/constants'
 import Spinner from '$shared/components/Spinner'
@@ -28,6 +28,7 @@ export type Props = {
     showCloseIcon?: boolean,
     autoCloseAfter?: number, // in milliseconds, use this to close the dialog after a custom timeout
     autoClose?: boolean, // use this to close the dialog after default timeout
+    renderActions?: (ButtonActions) => Node,
 } & ButtonsProps & ModalDialogProps
 
 type State = {
@@ -88,6 +89,7 @@ class Dialog extends Component<Props, State> {
             actionsClassName,
             onClose,
             showCloseIcon,
+            renderActions,
             ...otherProps
         } = this.props
         const { isHelpOpen } = this.state
@@ -110,9 +112,10 @@ class Dialog extends Component<Props, State> {
                         ))}
                         {(!!helpText && isHelpOpen) && helpText}
                     </ContentArea>
-                    {!waiting && (!helpText || !this.state.isHelpOpen) && (
+                    {!waiting && (!helpText || !this.state.isHelpOpen) && !renderActions && (
                         <Buttons className={classNames(styles.buttons, actionsClassName)} actions={actions} />
                     )}
+                    {!waiting && (!helpText || !this.state.isHelpOpen) && renderActions && renderActions(actions || {})}
                 </Container>
             </ModalDialog>
         )

--- a/app/src/shared/i18n/en.po
+++ b/app/src/shared/i18n/en.po
@@ -179,6 +179,9 @@ msgstr "Access your wallet"
 msgid "modal##unlockWallet##waiting"
 msgstr "Connecting..."
 
+msgid "modal##confirm##dontShowAgain"
+msgstr "Don't show this again"
+
 msgid "shared##errors##unlockWallet"
 msgstr "Please unlock your wallet"
 

--- a/app/src/shared/utils/confirm.jsx
+++ b/app/src/shared/utils/confirm.jsx
@@ -4,13 +4,35 @@ import React from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
 
 import ConfirmDialog, { type Properties } from '$shared/components/ConfirmDialog'
+import { isLocalStorageAvailable } from '$shared/utils/storage'
 
-const confirmDialog = (props: Properties): Promise<boolean> => new Promise((resolve: Function) => {
+const CONFIRM_DIALOG_KEY = 'confirm.dialog'
+
+const storage = isLocalStorageAvailable() ? localStorage : null
+
+const confirmDialog = (name: string, props: Properties): Promise<boolean> => new Promise((resolve: Function) => {
+    const { dontShowAgain, ...rest } = props
+
+    if (!!dontShowAgain && storage) {
+        const dialogPrefs = JSON.parse(storage.getItem(CONFIRM_DIALOG_KEY) || '{}')
+        if (dialogPrefs[name]) {
+            resolve(true)
+            return
+        }
+    }
+
     // Modal component takes care of mounting the dialog, just render dummy component
     const divTarget = document.createElement('div')
 
     render(<ConfirmDialog
-        onAccept={() => {
+        onAccept={(dontShow) => {
+            // Store "Don't show again selection"
+            if (dontShowAgain && storage && dontShow) {
+                const dialogPrefs = JSON.parse(storage.getItem(CONFIRM_DIALOG_KEY) || '{}')
+                dialogPrefs[name] = true
+                storage.setItem(CONFIRM_DIALOG_KEY, JSON.stringify(dialogPrefs))
+            }
+
             unmountComponentAtNode(divTarget)
             resolve(true)
         }}
@@ -18,7 +40,8 @@ const confirmDialog = (props: Properties): Promise<boolean> => new Promise((reso
             unmountComponentAtNode(divTarget)
             resolve(false)
         }}
-        {...props}
+        dontShowAgain={!!storage && !!dontShowAgain}
+        {...rest}
     />, divTarget)
 })
 

--- a/app/src/shared/utils/confirm.jsx
+++ b/app/src/shared/utils/confirm.jsx
@@ -14,7 +14,7 @@ const confirmDialog = (name: string, props: Properties): Promise<boolean> => new
     const { dontShowAgain, ...rest } = props
 
     if (!!dontShowAgain && storage) {
-        const dialogPrefs = JSON.parse(storage.getItem(CONFIRM_DIALOG_KEY) || '{}')
+        const dialogPrefs = JSON.parse(storage.getItem(CONFIRM_DIALOG_KEY) || '{}') || {}
         if (dialogPrefs[name]) {
             resolve(true)
             return
@@ -28,7 +28,7 @@ const confirmDialog = (name: string, props: Properties): Promise<boolean> => new
         onAccept={(dontShow) => {
             // Store "Don't show again selection"
             if (dontShowAgain && storage && dontShow) {
-                const dialogPrefs = JSON.parse(storage.getItem(CONFIRM_DIALOG_KEY) || '{}')
+                const dialogPrefs = JSON.parse(storage.getItem(CONFIRM_DIALOG_KEY) || '{}') || {}
                 dialogPrefs[name] = true
                 storage.setItem(CONFIRM_DIALOG_KEY, JSON.stringify(dialogPrefs))
             }

--- a/app/src/shared/utils/confirm.jsx
+++ b/app/src/shared/utils/confirm.jsx
@@ -25,7 +25,7 @@ const confirmDialog = (name: string, props: Properties): Promise<boolean> => new
     const divTarget = document.createElement('div')
 
     render(<ConfirmDialog
-        onAccept={(dontShow) => {
+        onAccept={(event, dontShow) => {
             // Store "Don't show again selection"
             if (dontShowAgain && storage && dontShow) {
                 const dialogPrefs = JSON.parse(storage.getItem(CONFIRM_DIALOG_KEY) || '{}') || {}

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -110,9 +110,7 @@ class CanvasList extends Component<Props, State> {
 
     confirmDeleteCanvas = async (canvas: Canvas) => {
         const confirmed = await confirmDialog('canvas', {
-            title: I18n.t('userpages.canvases.delete.confirmTitle', {
-                canvas: canvas.name,
-            }),
+            title: I18n.t('userpages.canvases.delete.confirmTitle'),
             message: I18n.t('userpages.canvases.delete.confirmMessage'),
             acceptButton: {
                 title: I18n.t('userpages.canvases.delete.confirmButton'),

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -117,7 +117,7 @@ class CanvasList extends Component<Props, State> {
                 color: 'danger',
             },
             centerButtons: true,
-            dontShowAgain: true,
+            dontShowAgain: false,
         })
 
         if (confirmed) {

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -109,7 +109,7 @@ class CanvasList extends Component<Props, State> {
     }
 
     confirmDeleteCanvas = async (canvas: Canvas) => {
-        const confirmed = await confirmDialog({
+        const confirmed = await confirmDialog('canvas', {
             title: I18n.t('userpages.canvases.delete.confirmTitle', {
                 canvas: canvas.name,
             }),
@@ -119,6 +119,7 @@ class CanvasList extends Component<Props, State> {
                 color: 'danger',
             },
             centerButtons: true,
+            dontShowAgain: true,
         })
 
         if (confirmed) {

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -184,14 +184,13 @@ class StreamList extends Component<Props, State> {
 
     confirmDeleteStream = async (stream: Stream) => {
         const confirmed = await confirmDialog('stream', {
-            title: I18n.t('userpages.streams.delete.confirmTitle', {
-                stream: stream.name,
-            }),
+            title: I18n.t('userpages.streams.delete.confirmTitle'),
             message: I18n.t('userpages.streams.delete.confirmMessage'),
             acceptButton: {
                 title: I18n.t('userpages.streams.delete.confirmButton'),
                 color: 'danger',
             },
+            centerButtons: true,
             dontShowAgain: true,
         })
 

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -183,7 +183,7 @@ class StreamList extends Component<Props, State> {
     }
 
     confirmDeleteStream = async (stream: Stream) => {
-        const confirmed = await confirmDialog({
+        const confirmed = await confirmDialog('stream', {
             title: I18n.t('userpages.streams.delete.confirmTitle', {
                 stream: stream.name,
             }),
@@ -192,7 +192,7 @@ class StreamList extends Component<Props, State> {
                 title: I18n.t('userpages.streams.delete.confirmButton'),
                 color: 'danger',
             },
-            centerButtons: true,
+            dontShowAgain: true,
         })
 
         if (confirmed) {

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -191,7 +191,7 @@ class StreamList extends Component<Props, State> {
                 color: 'danger',
             },
             centerButtons: true,
-            dontShowAgain: true,
+            dontShowAgain: false,
         })
 
         if (confirmed) {

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -54,7 +54,7 @@ msgid "userpages##canvases##delete##confirmTitle"
 msgstr "Delete this canvas?"
 
 msgid "userpages##canvases##delete##confirmMessage"
-msgstr "This is an unrecoverable action. Please make sure this is what you want before you proceed."
+msgstr "This is an unrecoverable action. Please confirm this is what you want before you proceed."
 
 msgid "userpages##canvases##delete##confirmButton"
 msgstr "Yes, delete"
@@ -327,7 +327,7 @@ msgid "userpages##streams##delete##confirmTitle"
 msgstr "Delete this stream?"
 
 msgid "userpages##streams##delete##confirmMessage"
-msgstr "This is an unrecoverable action. Please make sure this is what you want before you proceed."
+msgstr "This is an unrecoverable action. Please confirm this is what you want before you proceed."
 
 msgid "userpages##streams##delete##confirmButton"
 msgstr "Yes, delete"

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -51,7 +51,7 @@ msgid "userpages##canvases##menu##share"
 msgstr "Share"
 
 msgid "userpages##canvases##delete##confirmTitle"
-msgstr "Delete %{canvas}?"
+msgstr "Delete this canvas?"
 
 msgid "userpages##canvases##delete##confirmMessage"
 msgstr "This is an unrecoverable action. Please make sure this is what you want before you proceed."
@@ -324,7 +324,7 @@ msgid "userpages##streams##edit##preview##inspect"
 msgstr "Inspect"
 
 msgid "userpages##streams##delete##confirmTitle"
-msgstr "Delete %{stream}?"
+msgstr "Delete this stream?"
 
 msgid "userpages##streams##delete##confirmMessage"
 msgstr "This is an unrecoverable action. Please make sure this is what you want before you proceed."


### PR DESCRIPTION
Adds an option confirm dialog to never show it again which is stored in local storage. There's no way to reset it again except by removing the local storage value.

- Uses shared `Checkbox` component which is not styled as in the mock
- Added confirm modal also to canvas delete
- Removed stream/canvas name from modal title

<img width="542" alt="Screen Shot 2019-05-10 at 10 35 35" src="https://user-images.githubusercontent.com/1064982/57510400-6227f400-730f-11e9-9da9-0821b6c958ba.png">
<img width="556" alt="Screen Shot 2019-05-10 at 10 35 32" src="https://user-images.githubusercontent.com/1064982/57510401-62c08a80-730f-11e9-9315-6d05871e329e.png">

