### PR TITLE
[PLATFORM-630] Forward `search` in auth redirections

### DIFF
--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -5,6 +5,7 @@ import '$shared/assets/stylesheets'
 import React from 'react'
 import { Route as RouterRoute, Switch, Redirect, type Location } from 'react-router-dom'
 import { ConnectedRouter } from 'react-router-redux'
+import qs from 'query-string'
 
 // Marketplace
 import ProductPage from '$mp/containers/ProductPage'
@@ -92,7 +93,9 @@ const Route = withErrorBoundary(ErrorPageView)(RouterRoute)
 
 const { marketplace, userpages, docs, editor } = links
 
-const forwardTo = (routeFn: Function) => ({ match: { params } }: Location) => <Redirect to={routeFn(params)} />
+const forwardTo = (routeFn: Function) => ({ location: { search } }: Location) => (
+    <Redirect to={routeFn(qs.parse(search))} />
+)
 
 const AuthenticationRouter = () => ([
     <Route exact path={routes.login()} component={LoginPage} key="LoginPage" />,

--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -105,9 +105,9 @@ const AuthenticationRouter = () => ([
     <Route path={routes.resetPassword()} component={ResetPasswordPage} key="ResetPasswordPage" />,
     <Route exact path={routes.register()} component={RegisterPage} key="RegisterPage" />,
     <Redirect from="/login/auth" to={routes.login()} key="LoginRedirect" />,
-    <Redirect from="/register/forgotPassword" to={routes.forgotPassword()} key="ForgotPasswordRedirect" />,
     <Route exact path="/register/register" key="RegisterRedirect" render={forwardTo(routes.register)} />,
     <Route exact path="/register/resetPassword" key="ResetPasswordRedirect" render={forwardTo(routes.resetPassword)} />,
+    <Redirect from="/register/forgotPassword" to={routes.forgotPassword()} key="ForgotPasswordRedirect" />,
 ])
 
 const MarketplaceRouter = () => ([

--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -3,7 +3,7 @@
 import '$shared/assets/stylesheets'
 
 import React from 'react'
-import { Route as RouterRoute, Switch, Redirect } from 'react-router-dom'
+import { Route as RouterRoute, Switch, Redirect, type Location } from 'react-router-dom'
 import { ConnectedRouter } from 'react-router-redux'
 
 // Marketplace
@@ -92,6 +92,8 @@ const Route = withErrorBoundary(ErrorPageView)(RouterRoute)
 
 const { marketplace, userpages, docs, editor } = links
 
+const forwardTo = (routeFn: Function) => ({ match: { params } }: Location) => <Redirect to={routeFn(params)} />
+
 const AuthenticationRouter = () => ([
     <Route exact path={routes.login()} component={LoginPage} key="LoginPage" />,
     <Route exact path={routes.logout()} component={LogoutPage} key="LogoutPage" />,
@@ -100,9 +102,9 @@ const AuthenticationRouter = () => ([
     <Route path={routes.resetPassword()} component={ResetPasswordPage} key="ResetPasswordPage" />,
     <Route exact path={routes.register()} component={RegisterPage} key="RegisterPage" />,
     <Redirect from="/login/auth" to={routes.login()} key="LoginRedirect" />,
-    <Redirect from="/register/register" to={routes.register()} key="RegisterRedirect" />,
-    <Redirect from="/register/resetPassword" to={routes.resetPassword()} key="ResetPasswordRedirect" />,
     <Redirect from="/register/forgotPassword" to={routes.forgotPassword()} key="ForgotPasswordRedirect" />,
+    <Route exact path="/register/register" key="RegisterRedirect" render={forwardTo(routes.register)} />,
+    <Route exact path="/register/resetPassword" key="ResetPasswordRedirect" render={forwardTo(routes.resetPassword)} />,
 ])
 
 const MarketplaceRouter = () => ([


### PR DESCRIPTION
These are the only routes that need it, as well as location's `search` is the only thing needing forwarding. `react-router` doesn't do it OOTB.