### PR TITLE
[PLATFORM-648] Larger Map modules

### DIFF
--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -94,7 +94,7 @@ export default class Map extends React.Component<Props> {
             .values(markers)
 
         return (
-            <UiSizeConstraint minWidth={200} minHeight={200}>
+            <UiSizeConstraint minWidth={368} minHeight={224}>
                 <div className={cx(className)}>
                     <LeafletMap
                         center={mapCenter}

--- a/app/src/editor/shared/components/Map/Map.pcss
+++ b/app/src/editor/shared/components/Map/Map.pcss
@@ -2,3 +2,21 @@
   height: 100%;
   width: 100%;
 }
+
+/* Custom zoom in/out controls. `:global` is never pretty. */
+
+:global(.leaflet-control-zoom) {
+  border: 0 !important;
+  box-shadow: 0 0 calc(0.3125 * var(--um)) rgba(0, 0, 0, 0.15) !important;
+}
+
+:global(.leaflet-control-zoom-in) {
+  border-bottom-color: #DCDCDC !important;
+}
+
+:global(.leaflet-control-zoom > a) {
+  font-size: var(--um) !important;
+  height: 1.5em !important;
+  line-height: 1.25em !important;
+  width: 1.5em !important;
+}


### PR DESCRIPTION
This small update sets min/default sizes for all Map module types to match the design. This includes:
- Map Geo
- Map Image
- Heatmap

And anything else that uses `Map` component. Preview:

![x](https://user-images.githubusercontent.com/320066/57675470-69f2db80-7622-11e9-8d69-733844369f62.png)

cc @mattatgit @hpihkala 

_(Thank gods I built the resize constraint mechanism this way, yay!)_ 💃 