### PR TITLE
[PLATFORM-650] Search Priority

### DIFF
--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -268,15 +268,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
             }
         })
 
-        return modules.sort(this.compareModules)
-    }
-
-    // Used for sorting module list. Sorts first by path and then by name.
-    compareModules = (a: any, b: any) => {
-        if (a.path === b.path) {
-            return a.name.localeCompare(b.name)
-        }
-        return a.path ? a.path.localeCompare(b.path) : 0
+        return modules
     }
 
     getPositionForClickInsert = () => {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -1000,6 +1000,11 @@ export function moduleSearch(moduleCategories, search) {
         return target.split(/\s+/).join(' ') === terms.join(' ')
     })
 
+    const startsWith = moduleIndex.filter((m) => {
+        const target = m.name.toLowerCase()
+        return target.split(/\s+/).join(' ').startsWith(terms.join(' '))
+    })
+
     const nameMatches = moduleIndex.filter((m) => {
         const target = m.name.toLowerCase()
         return terms.every((searchTerm) => (
@@ -1014,5 +1019,5 @@ export function moduleSearch(moduleCategories, search) {
         ))
     })
 
-    return uniqBy([...exactMatches, ...nameMatches, ...pathMatches], 'id')
+    return uniqBy([...exactMatches, ...startsWith, ...nameMatches, ...pathMatches], 'id')
 }

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -984,7 +984,15 @@ export function moduleCategoriesIndex(modules = [], path = [], index = []) {
             moduleCategoriesIndex(m.children, path.concat(m.data), index)
         }
     })
-    return index
+    return index.sort(compareModules)
+}
+
+// sorts module index. Sorts first by path and then by name.
+function compareModules(a, b) {
+    if (a.path === b.path) {
+        return a.name.localeCompare(b.name)
+    }
+    return a.path ? a.path.localeCompare(b.path) : 0
 }
 
 const getModuleCategoriesIndex = memoize(moduleCategoriesIndex)

--- a/app/src/editor/canvas/tests/search.test.js
+++ b/app/src/editor/canvas/tests/search.test.js
@@ -1,0 +1,73 @@
+import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
+
+import * as State from '../state'
+import * as Services from '../services'
+
+describe('Canvas Module', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setupAuthorizationHeader()
+    }, 60000)
+
+    afterAll(async () => {
+        await Services.deleteAllCanvases()
+        await teardown()
+    })
+
+    let categories
+    let fullList
+
+    beforeAll(async () => {
+        categories = await Services.getModuleCategories()
+        fullList = State.moduleCategoriesIndex(categories)
+    })
+
+    test('empty search returns full list', () => {
+        expect(State.moduleSearch(categories, '')).toEqual(fullList)
+        expect(State.moduleSearch(categories, ' ')).toEqual(fullList)
+        expect(State.moduleSearch(categories, '  ')).toEqual(fullList)
+    })
+
+    test('exact match displays first', () => {
+        fullList.forEach(({ id, name }) => {
+            const [firstResult] = State.moduleSearch(categories, name) || []
+            expect(firstResult).toBeTruthy()
+            expect(firstResult.id).toBe(id)
+        })
+    })
+
+    test('names matches sort before path matches', () => {
+        const search = 'Boolean'
+        const results = State.moduleSearch(categories, search)
+        const nameMatchesSearch = (name) => name.toLowerCase().includes(search.toLowerCase())
+        // find first result that doesn't match on name
+        const firstPathMatchIndex = results.findIndex(({ name }) => !nameMatchesSearch(name))
+        // ensure we have at least some path-matching results
+        expect(firstPathMatchIndex).toBeGreaterThan(0)
+        expect(firstPathMatchIndex).toBeLessThan(results.length - 1)
+        // every item that match
+        results.forEach(({ name }, index) => {
+            if (nameMatchesSearch(name)) {
+                expect(index).toBeLessThan(firstPathMatchIndex)
+            }
+        })
+    })
+
+    test('names starting with search term match before names not starting with search term', () => {
+        const search = 'Map'
+        const results = State.moduleSearch(categories, search)
+        const nameMatchesSearch = (name) => name.toLowerCase().startsWith(search.toLowerCase())
+        // find first result that doesn't start with search
+        const firstNotStartingWithSearchIndex = results.findIndex(({ name }) => !nameMatchesSearch(name))
+        // ensure we have at least some results that don't start with search
+        expect(firstNotStartingWithSearchIndex).toBeGreaterThan(0)
+        expect(firstNotStartingWithSearchIndex).toBeLessThan(results.length - 1)
+        // every item that match
+        results.forEach(({ name }, index) => {
+            if (nameMatchesSearch(name)) {
+                expect(index).toBeLessThan(firstNotStartingWithSearchIndex)
+            }
+        })
+    })
+})


### PR DESCRIPTION
Modules starting with a search term now sort before other modules, but after exact matches.

See ticket for detail: https://streamr.atlassian.net/browse/PLATFORM-650

We should migrate to some sort of more sophisticated search scoring algorithm at some point. I played around with https://fusejs.io/ for this PR, but I couldn't seem to get it to guarantee exact matches would sort before matches that start with a term e.g. searching for "Count" would sort "Count By Key" before "Count". Gave up and implemented a naive solution and here we are.