### PR TITLE
[PLATFORM-636] ToC hightlighting doesn't follow scroll properly

### DIFF
--- a/app/src/shared/components/ConfigureAnchorOffset/index.jsx
+++ b/app/src/shared/components/ConfigureAnchorOffset/index.jsx
@@ -1,0 +1,27 @@
+// @flow
+
+import { memo, useEffect } from 'react'
+import { configureAnchors } from 'react-scrollable-anchor'
+
+type Props = {
+    value: number,
+}
+
+const ConfigureAnchorOffset = ({ value: offset }: Props) => {
+    useEffect(() => {
+        configureAnchors({
+            offset,
+        })
+    }, [offset])
+
+    useEffect(() => () => {
+        configureAnchors({
+            offset: 0,
+        })
+    }, [])
+
+    return null
+}
+
+// $FlowFixMe
+export default memo(ConfigureAnchorOffset)

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -6,10 +6,13 @@ import { I18n } from 'react-redux-i18n'
 import { push } from 'react-router-redux'
 import cx from 'classnames'
 import Helmet from 'react-helmet'
+import MediaQuery from 'react-responsive'
 
 import { saveCurrentUser } from '$shared/modules/user/actions'
 import Toolbar from '$shared/components/Toolbar'
 import TOCPage from '$userpages/components/TOCPage'
+import ConfigureAnchorOffset from '$shared/components/ConfigureAnchorOffset'
+import { lg } from '$app/scripts/breakpoints'
 
 import Layout from '../Layout'
 import ProfileSettings from './ProfileSettings'
@@ -77,6 +80,9 @@ export class ProfilePage extends Component<Props, State> {
                     <title>{I18n.t('userpages.title.profile')}</title>
                 </Helmet>
                 <div className={styles.profilePage}>
+                    <MediaQuery minWidth={lg.min}>
+                        <ConfigureAnchorOffset value={-80} />
+                    </MediaQuery>
                     <Toolbar
                         altMobileLayout
                         actions={{

--- a/app/src/userpages/components/StreamPage/Show/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/index.jsx
@@ -8,6 +8,7 @@ import cx from 'classnames'
 import { withRouter } from 'react-router-dom'
 import MediaQuery from 'react-responsive'
 
+import ConfigureAnchorOffset from '$shared/components/ConfigureAnchorOffset'
 import type { Stream, StreamId } from '$shared/flowtype/stream-types'
 import type { StoreState } from '$shared/flowtype/store-state'
 import type { User } from '$shared/flowtype/user-types'
@@ -170,6 +171,7 @@ export class StreamShowView extends Component<Props, State> {
             <Layout noHeader noFooter>
                 <div className={styles.streamShowView}>
                     <MediaQuery minWidth={lg.min}>
+                        <ConfigureAnchorOffset value={-80} />
                         <Toolbar
                             altMobileLayout
                             actions={{

--- a/app/src/userpages/components/TOCPage/index.jsx
+++ b/app/src/userpages/components/TOCPage/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component, type Node } from 'react'
+import React, { type Node } from 'react'
 import { Col, Row } from 'reactstrap'
 import { withRouter } from 'react-router-dom'
 import cx from 'classnames'
@@ -16,46 +16,40 @@ type Props = {
     },
 }
 
-class TOCPage extends Component<Props> {
-    static Section = TOCSection
+const TOCPage = withRouter(({ children, location: { hash }, title }: Props) => (
+    <Row>
+        <Col xs={12} sm={12} md={3}>
+            <ul className={styles.tocList}>
+                {React.Children.map(children, (child) => {
+                    if (child.type === TOCSection) {
+                        return (
+                            <li
+                                key={child.props.id}
+                                className={cx(styles.tocListItem, {
+                                    [styles.hideTablet]: child.props.customStyled,
+                                })}
+                            >
+                                <a
+                                    href={`#${child.props.id}`}
+                                    className={cx({
+                                        [styles.active]: hash.substr(1) === child.props.id,
+                                    })}
+                                >
+                                    {child.props.linkTitle || child.props.title}
+                                </a>
+                            </li>
+                        )
+                    }
+                })}
+            </ul>
+        </Col>
+        <Col xs={12} sm={12} md={9} >
+            {!!title && (<h1 className={styles.pageTitle}>{title}</h1>)}
+            {children}
+        </Col>
+    </Row>
+))
 
-    parseMenu = () => React.Children.map(this.props.children, (child) => {
-        if (child.type === TOCSection) {
-            return (
-                <li
-                    key={child.props.id}
-                    className={cx(styles.tocListItem, {
-                        [styles.hideTablet]: child.props.customStyled,
-                    })}
-                >
-                    <a
-                        href={`#${child.props.id}`}
-                        className={this.props.location.hash.substr(1) === child.props.id ? styles.active : ''}
-                    >
-                        {child.props.linkTitle || child.props.title}
-                    </a>
-                </li>
-            )
-        }
-    })
+TOCPage.Section = TOCSection
 
-    render() {
-        const { title, children } = this.props
-
-        return (
-            <Row>
-                <Col xs={12} sm={12} md={3} >
-                    <ul className={styles.tocList}>
-                        {this.parseMenu()}
-                    </ul>
-                </Col>
-                <Col xs={12} sm={12} md={9} >
-                    {!!title && (<h1 className={styles.pageTitle}>{title}</h1>)}
-                    {children}
-                </Col>
-            </Row>
-        )
-    }
-}
-
-export default withRouter(TOCPage)
+export default TOCPage


### PR DESCRIPTION
There were 2 bugs. This PR solves one of them.

1. `react-scrollable-anchor` removes the hash using `history.replaceState`. It doesn't trigger location change via `react-router`. It also doesn't trigger `hashchanged` event which means when you scroll to the top of the page (which removes the hash) `TOCPage` highlights an item with the last known id.
2. Because of the floating `Save & exit` toolbar the offsets were calculated incorrectly for our case.

I fixed "2". Still looking into "1".