### PR TITLE
[PLATFORM-664] Fix code editor state/async issues

### DIFF
--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -10,6 +10,7 @@ import styles from './CodeEditorWindow.pcss'
 
 class CodeEditorWindow extends React.Component {
     state = {
+        editorResetKey: 0,
         code: undefined,
         errors: [],
         sending: false,
@@ -25,10 +26,21 @@ class CodeEditorWindow extends React.Component {
         this.unmounted = true
     }
 
-    onChange = (newValue) => {
+    onChange = (code) => {
         this.setState({
-            code: newValue,
+            code,
         })
+    }
+
+    onBlur = () => {
+        const { code } = this.state
+        if (code != null && code !== this.props.code) {
+            this.props.onChange(code)
+        }
+        this.setState(({ editorResetKey }) => ({
+            code: undefined,
+            editorResetKey: editorResetKey + 1,
+        }))
     }
 
     onApply = () => {
@@ -37,8 +49,9 @@ class CodeEditorWindow extends React.Component {
             sending: true,
         }, async () => {
             if (this.unmounted) { return }
+            const code = this.state.code != null ? this.state.code : this.props.code
             try {
-                await this.props.onApply(this.state.code)
+                await this.props.onApply(code)
 
                 if (this.unmounted) { return }
 
@@ -65,7 +78,7 @@ class CodeEditorWindow extends React.Component {
     }
 
     render() {
-        const { errors, sending } = this.state
+        const { editorResetKey, errors, sending } = this.state
         const {
             onClose,
             onShowDebug,
@@ -89,11 +102,13 @@ class CodeEditorWindow extends React.Component {
                         <div className={styles.editorContainer}>
                             <AceEditor
                                 ref={this.editor}
+                                name={editorResetKey}
                                 value={code}
                                 className={styles.editor}
                                 mode="java"
                                 theme="textmate"
                                 onChange={this.onChange}
+                                onBlur={this.onBlur}
                                 width="100%"
                                 height="100%"
                                 maxLines={20}

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -10,7 +10,7 @@ import styles from './CodeEditorWindow.pcss'
 
 class CodeEditorWindow extends React.Component {
     state = {
-        code: this.props.code,
+        code: undefined,
         errors: [],
         sending: false,
     }
@@ -43,6 +43,7 @@ class CodeEditorWindow extends React.Component {
                 if (this.unmounted) { return }
 
                 this.setState({
+                    code: undefined,
                     sending: false,
                 })
             } catch (e) {
@@ -64,7 +65,7 @@ class CodeEditorWindow extends React.Component {
     }
 
     render() {
-        const { code, errors, sending } = this.state
+        const { errors, sending } = this.state
         const {
             onClose,
             onShowDebug,
@@ -72,6 +73,8 @@ class CodeEditorWindow extends React.Component {
             position,
             onPositionUpdate,
         } = this.props
+
+        const code = this.state.code != null ? this.state.code : this.props.code
 
         return (
             <DraggableCanvasWindow

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import AceEditor from 'react-ace'
-
+import uniqueId from 'lodash/uniqueId'
 import 'brace/mode/java'
 import 'brace/theme/textmate'
 
@@ -10,7 +10,7 @@ import styles from './CodeEditorWindow.pcss'
 
 class CodeEditorWindow extends React.Component {
     state = {
-        editorResetKey: 0,
+        editorResetKey: uniqueId('CodeEditorWindow'),
         code: undefined,
         errors: [],
         sending: false,
@@ -37,9 +37,9 @@ class CodeEditorWindow extends React.Component {
         if (code != null && code !== this.props.code) {
             this.props.onChange(code)
         }
-        this.setState(({ editorResetKey }) => ({
+        this.setState(() => ({
             code: undefined,
-            editorResetKey: editorResetKey + 1,
+            editorResetKey: uniqueId('CodeEditorWindow'),
         }))
     }
 

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -106,7 +106,7 @@ class CodeEditorWindow extends React.Component {
                                 }}
                                 annotations={errors}
                                 editorProps={{ $blockScrolling: true }}
-                                readOnly={readOnly}
+                                readOnly={readOnly || sending}
                             />
                         </div>
                         <DraggableCanvasWindow.Toolbar>

--- a/app/src/editor/canvas/components/CodeEditor/index.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/index.jsx
@@ -65,6 +65,7 @@ export default class CodeEditor extends React.Component {
             code,
             debugMessages,
             onApply,
+            onChange,
             onClearDebug,
             children,
         } = this.props
@@ -81,6 +82,7 @@ export default class CodeEditor extends React.Component {
                         readOnly={readOnly}
                         onClose={this.onCloseEditor}
                         onApply={onApply}
+                        onChange={onChange}
                         onShowDebug={this.onShowDebug}
                     />
                 )}

--- a/app/src/editor/canvas/components/Module.pcss
+++ b/app/src/editor/canvas/components/Module.pcss
@@ -46,7 +46,7 @@
   }
 }
 
-.header {
+.header:not(:last-child) { /* don't show bottom border if no ports */
   border-bottom: 1px solid #EFEFEF;
 }
 

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -243,6 +243,12 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     pushNewDefinition = async (hash, value) => {
         const module = CanvasState.getModule(this.props.canvas, hash)
+        this.replaceCanvas((canvas) => (
+            CanvasState.updateModule(canvas, hash, (current = {}) => ({
+                ...current,
+                ...value,
+            }))
+        ))
 
         // Update the module info, this will throw if anything went wrong.
         const newModule = await sharedServices.getModule({
@@ -252,6 +258,8 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                 ...value,
             },
         })
+
+        if (this.unmounted) { return }
 
         this.setCanvas({ type: 'Update Module' }, (canvas) => (
             CanvasState.updateModule(canvas, hash, () => newModule)

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -243,12 +243,6 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     pushNewDefinition = async (hash, value) => {
         const module = CanvasState.getModule(this.props.canvas, hash)
-        this.replaceCanvas((canvas) => (
-            CanvasState.updateModule(canvas, hash, (current = {}) => ({
-                ...current,
-                ...value,
-            }))
-        ))
 
         // Update the module info, this will throw if anything went wrong.
         const newModule = await sharedServices.getModule({
@@ -261,7 +255,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
         if (this.unmounted) { return }
 
-        this.setCanvas({ type: 'Update Module' }, (canvas) => (
+        this.replaceCanvas((canvas) => (
             CanvasState.updateModule(canvas, hash, () => newModule)
         ))
     }

--- a/app/src/editor/shared/components/modules/Comment.pcss
+++ b/app/src/editor/shared/components/modules/Comment.pcss
@@ -1,7 +1,6 @@
 body .Comment {
   position: relative;
   flex: 1;
-  border: none;
 
   textarea {
     resize: none;

--- a/app/src/editor/shared/components/modules/Custom.jsx
+++ b/app/src/editor/shared/components/modules/Custom.jsx
@@ -19,6 +19,10 @@ export default class CustomModule extends React.Component {
         })
     )
 
+    onChange = (code) => {
+        this.props.api.updateModule(this.props.moduleHash, { code })
+    }
+
     onMessage = (d) => {
         if (d.type === 'debug') {
             this.setState(({ debugMessages }) => ({
@@ -54,6 +58,7 @@ export default class CustomModule extends React.Component {
                     code={module.code || ''}
                     readOnly={isActive}
                     onApply={this.onApply}
+                    onChange={this.onChange}
                     debugMessages={debugMessages}
                     onClearDebug={this.onClearDebug}
                 >


### PR DESCRIPTION
* Currently the code prop is only copied to state on mount. If a new prop code arrives, e.g. after sending or via canvas undo/redo, that update is ignored. Fixed this so it only reads local state until "apply" step is complete, then it'll read from props until an `onChange` happens.
* if you close the editor and open it again before the "apply" is complete, it'll show a flash of the old content stored in the canvas. Fixed it so that it updates the canvas immediately when you hit "apply" so it'll show latest content on subsequent open/close.
* Prevented edits while apply is pending, prevents at least one scenario where the shown code gets out of sync with what's saved.

**update**: Also set it up to work like our other text inputs:

* Persists content to canvas on blur, this should prevent most cases of accidental loss of content.
* Uses in-editor undo/redo while focused, resets on blur (otherwise chaos).

@mikhaelsantos I've added you as a reviewer, when the PR deployment is available, can you confirm or deny that this fixes the issue?

**update**:  PR URL here: ~~https://d2pooulclg9rx7.cloudfront.net~~ ~~https://d2h5tyqzh8rt2j.cloudfront.net~~

**update** use #442 for testing as this builds on top of this and fixes module error handling