### PR TITLE
[PLATFORM-654] Share dialog texts

### DIFF
--- a/app/src/userpages/components/ShareDialog/shareDialog.pcss
+++ b/app/src/userpages/components/ShareDialog/shareDialog.pcss
@@ -6,7 +6,7 @@
 }
 
 .dialog {
-  width: 464px;
+  width: 475px;
 }
 
 .content {

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -680,10 +680,10 @@ msgid "modal##shareResource##anonymousAccess"
 msgstr "Who can access this?"
 
 msgid "modal##shareResource##onlyInvited"
-msgstr "Only people you've invited"
+msgstr "Private — only people you’ve invited"
 
 msgid "modal##shareResource##withLink"
-msgstr "Anyone with the link and people you've invited"
+msgstr "Public — viewable by anyone with the link or via the API"
 
 msgid "modal##shareResource##enterEmailAddress"
 msgstr "Enter email address"


### PR DESCRIPTION
Update share dialog options:

> Option 1 old: Anyone you've invited
> Option 1 new: Private — only people you’ve invited
> Option 2 old: Anyone with the link and anyone you invited 
> Option 2 new: Public — viewable by anyone with the link or via the API