### PR TITLE
[PLATFORM-669] Allow 'reset and start' to start canvas even if canvas not serialized

### DIFF
--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -274,7 +274,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                             <R.DropdownMenu className={cx(styles.RunButtonMenu, styles.RealtimeRunButtonMenu)} right>
                                                 <R.DropdownItem
                                                     onClick={() => canvasStart({ clearState: true })}
-                                                    disabled={!canvas.serialized || !canEdit}
+                                                    disabled={!canEdit}
                                                 >
                                                     Reset &amp; Start
                                                 </R.DropdownItem>

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -169,11 +169,6 @@
   box-shadow: none !important;
 }
 
-.RealtimeRunButtonMenu :global(.dropdown-item) {
-  padding: 0.25rem 0.5rem !important;
-  text-align: center;
-}
-
 .RunButtonMenu {
   font-size: 12px;
   padding: 8px;
@@ -181,12 +176,14 @@
   margin-bottom: 10px;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
   border: none;
+  overflow: hidden;
 
   & :global(.dropdown-item) {
     font-weight: 500;
     letter-spacing: 2px;
     text-transform: uppercase;
     line-height: 1.2;
+    transition: background-color 0.1s;
 
     &:not(:disabled) {
       color: #525252;
@@ -199,11 +196,26 @@
   }
 }
 
+body .RealtimeRunButtonMenu {
+  padding: 0;
+
+  /* stylelint-disable-next-line no-descending-specificity */
+  & :global(.dropdown-item) {
+    padding: 12px 0.5rem;
+    text-align: center;
+  }
+}
+
 .HistoricalRunButtonMenu {
+  /* stylelint-disable-next-line no-descending-specificity */
+  & :global(.dropdown-item) {
+    padding: 0.25rem 16px;
+  }
+
   & :global(.dropdown-item):active,
   & :global(.dropdown-item):hover,
   & :global(.dropdown-item):global(.active) {
-    background: url('../../../shared/assets/images/tick.svg') no-repeat 8px 50%;
+    background: url('../../../shared/assets/images/tick.svg') no-repeat 0 50%;
     outline: none;
     background-color: transparent;
   }


### PR DESCRIPTION
See https://streamr.atlassian.net/browse/PLATFORM-669

Disables the disabling of the "Reset & Start" menu item, since it seems harmless to add even if current canvas is not serialized.

To test: open canvas start button menu in realtime mode, reset and start should always be clickable whether "save state" is enabled or if the canvas has previously run with "save state" enabled i.e. canvas has `serialized: true` flag set
