### PR TITLE
[PLATFORM-649] Add autoZoom

### DIFF
--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -64,10 +64,15 @@ type State = {
 
 export default class Map extends React.Component<Props, State> {
     ref: Ref<LeafletMap> = React.createRef()
+    unmounted: boolean = false
 
     state = {
         touched: false,
         bounds: null,
+    }
+
+    componentWillUnmount() {
+        this.unmounted = true
     }
 
     onResize = () => {
@@ -92,6 +97,9 @@ export default class Map extends React.Component<Props, State> {
             bounds = L.latLngBounds(positions)
         }
 
+        if (this.unmounted) {
+            return
+        }
         this.setState({
             bounds,
         })

--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -38,6 +38,7 @@ type Props = {
     minZoom: number,
     maxZoom: number,
     zoom: number,
+    autoZoom: boolean,
     traceColor: string,
     traceWidth: number,
     markers: { [string]: Marker },
@@ -74,6 +75,7 @@ export default class Map extends React.Component<Props> {
             minZoom,
             maxZoom,
             zoom,
+            autoZoom,
             traceColor,
             traceWidth,
             markers,
@@ -105,6 +107,12 @@ export default class Map extends React.Component<Props> {
         const markerArray: Array<Marker> = Object
             .values(markers)
 
+        let bounds = null
+        if (autoZoom && markerArray.length > 0) {
+            const positions = markerArray.map((m) => [m.lat, m.long])
+            bounds = L.latLngBounds(positions)
+        }
+
         return (
             <UiSizeConstraint minWidth={368} minHeight={224}>
                 <div className={cx(className)}>
@@ -117,6 +125,7 @@ export default class Map extends React.Component<Props> {
                         maxZoom={maxZoom}
                         crs={isImageMap ? L.CRS.Simple : L.CRS.EPSG3857}
                         preferCanvas
+                        bounds={bounds}
                     >
                         <ResizeWatcher onResize={this.onResize} />
                         {isHeatmap && (

--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -58,6 +58,7 @@ type Props = {
 
 export default class Map extends React.Component<Props> {
     ref: Ref<LeafletMap> = React.createRef()
+    touched: boolean = false
 
     onResize = () => {
         const { current: map } = this.ref
@@ -65,6 +66,10 @@ export default class Map extends React.Component<Props> {
         if (map) {
             map.leafletElement.invalidateSize(false)
         }
+    }
+
+    markTouched = () => {
+        this.touched = true
     }
 
     render() {
@@ -108,14 +113,20 @@ export default class Map extends React.Component<Props> {
             .values(markers)
 
         let bounds = null
-        if (autoZoom && markerArray.length > 0) {
+        if (autoZoom && markerArray.length > 0 && !this.touched) {
             const positions = markerArray.map((m) => [m.lat, m.long])
             bounds = L.latLngBounds(positions)
         }
 
         return (
             <UiSizeConstraint minWidth={368} minHeight={224}>
-                <div className={cx(className)}>
+                <div
+                    className={cx(className)}
+                    onMouseDown={this.markTouched}
+                    onKeyDown={this.markTouched}
+                    onWheel={this.markTouched}
+                    role="presentation"
+                >
                     <LeafletMap
                         ref={this.ref}
                         center={mapCenter}

--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -139,7 +139,7 @@ export default class Map extends React.Component<Props> {
                         bounds={bounds}
                     >
                         <ResizeWatcher onResize={this.onResize} />
-                        {isHeatmap && (
+                        {isHeatmap && markerArray.length > 0 && (
                             <HeatmapLayer
                                 fitBoundsOnLoad={false}
                                 fitBoundsOnUpdate={false}

--- a/app/src/editor/shared/components/modules/Map.jsx
+++ b/app/src/editor/shared/components/modules/Map.jsx
@@ -277,6 +277,7 @@ export default class MapModule extends React.PureComponent<Props, State> {
                     minZoom={this.getModuleOption('minZoom', 2)}
                     maxZoom={this.getModuleOption('maxZoom', 18)}
                     zoom={this.getModuleOption('zoom', 12)}
+                    autoZoom={this.getModuleOption('autoZoom', false)}
                     /* For Map */
                     traceColor={this.getModuleParam('traceColor', '#FFFFFF')}
                     traceWidth={this.getModuleOption('traceWidth', 2)}


### PR DESCRIPTION
If module has option `autoZoom` enabled the Map will now zoom so that current viewport covers all markers.