### PR TITLE
[PLATFORM-631] Make `/u` the new default post-login location

### DIFF
--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -133,7 +133,6 @@ const DocsRouter = () => ([
 ])
 
 const UserpagesRouter = () => ([
-    <Route exact path={userpages.main} component={StreamListViewAuth} key="RootStreamListView" />,
     <Route exact path={userpages.canvases} component={CanvasListAuth} key="CanvasesCanvasList" />,
     <Route exact path={userpages.profile} component={ProfilePageAuth} key="ProfilePage" />,
     <Route exact path={userpages.dashboards} component={DashboardListAuth} key="DashboardList" />,
@@ -143,6 +142,7 @@ const UserpagesRouter = () => ([
     <Route exact path={userpages.transactions} component={TransactionListAuth} key="TransactionList" />,
     <Route exact path={userpages.purchases} component={PurchasesPageAuth} key="PurchasesPage" />,
     <Route exact path={userpages.products} component={ProductsPageAuth} key="ProductsPage" />,
+    <Redirect from={userpages.main} to={userpages.streams} component={StreamListViewAuth} key="StreamListViewRedirect" />,
 ])
 
 const EditorRouter = () => ([

--- a/app/src/marketplace/utils/auth.js
+++ b/app/src/marketplace/utils/auth.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useEffect } from 'react'
+import { Component } from 'react'
 import { connectedRouterRedirect } from 'redux-auth-wrapper/history4/redirect'
 import locationHelperBuilder from 'redux-auth-wrapper/history4/locationHelper'
 
@@ -14,11 +14,22 @@ type Props = {
     redirectPath: string,
 }
 
-const FailureComponent = (props: Props) => {
-    useEffect(() => {
-        props.redirect(props, props.redirectPath)
-    }, [props])
-    return null
+class FailureComponent extends Component<Props> {
+    componentWillMount() {
+        this.redirect()
+    }
+
+    componentDidUpdate() {
+        this.redirect()
+    }
+
+    redirect() {
+        this.props.redirect(this.props, this.props.redirectPath)
+    }
+
+    render() {
+        return null
+    }
 }
 
 export const userIsAuthenticated = connectedRouterRedirect({

--- a/app/src/marketplace/utils/auth.js
+++ b/app/src/marketplace/utils/auth.js
@@ -23,7 +23,7 @@ export const userIsNotAuthenticated = connectedRouterRedirect({
     authenticatingSelector,
     // This sends the user either to the query param route if we have one, or to
     // the landing page if none is specified and the user is already logged in
-    redirectPath: (state, ownProps) => locationHelper.getRedirectQueryParam(ownProps) || '/',
+    redirectPath: (state, ownProps) => locationHelper.getRedirectQueryParam(ownProps) || routes.streams(),
     // This prevents us from adding the query parameter when we send the user away from the login page
     allowRedirectBack: false,
     // If selector is true, wrapper will not redirect

--- a/app/src/marketplace/utils/auth.js
+++ b/app/src/marketplace/utils/auth.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { useEffect } from 'react'
 import { connectedRouterRedirect } from 'redux-auth-wrapper/history4/redirect'
 import locationHelperBuilder from 'redux-auth-wrapper/history4/locationHelper'
 
@@ -7,6 +8,18 @@ import { selectUserData, isAuthenticating as authenticatingSelector } from '$sha
 import routes from '$routes'
 
 const locationHelper = locationHelperBuilder({})
+
+type Props = {
+    redirect: Function,
+    redirectPath: string,
+}
+
+const FailureComponent = (props: Props) => {
+    useEffect(() => {
+        props.redirect(props, props.redirectPath)
+    }, [props])
+    return null
+}
 
 export const userIsAuthenticated = connectedRouterRedirect({
     authenticatingSelector,
@@ -31,4 +44,5 @@ export const userIsNotAuthenticated = connectedRouterRedirect({
     authenticatedSelector: (state) => !selectUserData(state),
     // A nice display name for this check
     wrapperDisplayName: 'UserIsNotAuthenticated',
+    FailureComponent,
 })

--- a/app/src/shared/components/MobileNav/index.jsx
+++ b/app/src/shared/components/MobileNav/index.jsx
@@ -32,7 +32,7 @@ const mapStateToProps = (state): StateProps => ({
 const MobileNav = compose(
     connect(mapStateToProps),
     withRouter,
-)(({ currentUser, location, className }: Props) => {
+)(({ currentUser, location: { pathname: redirect }, className }: Props) => {
     const [open, setOpen] = useState(false)
 
     const toggle = useCallback(() => {
@@ -126,9 +126,9 @@ const MobileNav = compose(
                             <li>
                                 <Link
                                     className={styles.link}
-                                    to={routes.login({
-                                        redirect: location.pathname,
-                                    })}
+                                    to={routes.login(redirect !== '/' ? {
+                                        redirect,
+                                    } : {})}
                                 >
                                     <Translate value="general.signIn" />
                                 </Link>

--- a/app/src/shared/components/Nav/index.jsx
+++ b/app/src/shared/components/Nav/index.jsx
@@ -33,7 +33,7 @@ const mapStateToProps = (state): StateProps => ({
 const Nav = compose(
     connect(mapStateToProps),
     withRouter,
-)(({ currentUser, location, className }: Props) => (
+)(({ currentUser, location: { pathname: redirect }, className }: Props) => (
     <nav
         className={cx(styles.root, className)}
     >
@@ -100,9 +100,9 @@ const Nav = compose(
             )}
             {!currentUser && (
                 <LinkItem
-                    to={routes.login({
-                        redirect: location.pathname,
-                    })}
+                    to={routes.login(redirect !== '/' ? {
+                        redirect,
+                    } : {})}
                     className={Nav.styles.link}
                 >
                     <Translate value="general.signIn" />

--- a/app/src/shared/modules/user/reducer.js
+++ b/app/src/shared/modules/user/reducer.js
@@ -98,6 +98,13 @@ const reducer: (UserState) => UserState = handleActions({
         deleteUserAccountError: action.payload.error,
     }),
 
-}, initialState)
+}, {
+    ...initialState,
+    // Loading the site always triggers fetching the user. `userIsAuthenticated` gets
+    // called almost at a routing level (before any `getUserData` calls) which will
+    // cause the login page to flash for a split second. In order to prevent that we
+    // start off with `fetchingUserData` set to `true`.
+    fetchingUserData: true,
+})
 
 export default reducer

--- a/app/src/shared/test/modules/user/reducer.test.js
+++ b/app/src/shared/test/modules/user/reducer.test.js
@@ -5,7 +5,10 @@ import * as constants from '$shared/modules/user/constants'
 
 describe('user - reducer', () => {
     it('has initial state', () => {
-        assert.deepStrictEqual(reducer(undefined, {}), initialState)
+        assert.deepStrictEqual(reducer(undefined, {}), {
+            ...initialState,
+            fetchingUserData: true,
+        })
     })
 
     describe('USER_DATA', () => {


### PR DESCRIPTION
I make `/u` the new default and remove `redirect` param from login routes if its value is `/`. Note that you can still tell it to take you to `/` after login. You'd have to do it by hand tho.