### PR TITLE
[PLATFORM-486] Redirect to /404 on not found dashboard/canvas.

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/index.jsx
+++ b/app/src/editor/canvas/components/CanvasController/index.jsx
@@ -59,7 +59,7 @@ function useCanvasCreateEffect() {
 
     useEffect(() => {
         if (id || isPending) { return }
-        create()
+        create({ replace: true })
     }, [id, create, isPending])
 }
 

--- a/app/src/editor/canvas/components/CanvasController/useCanvasCreateCallback.jsx
+++ b/app/src/editor/canvas/components/CanvasController/useCanvasCreateCallback.jsx
@@ -12,12 +12,17 @@ export default function useCanvasCreateCallback() {
     const { isPending, wrap } = usePending('CREATE')
     const isMountedRef = useIsMountedRef()
 
-    return useCallback(async () => {
+    return useCallback(async ({ replace = true } = {}) => {
         if (isPending) { return }
         return wrap(async () => {
             const newCanvas = await services.create()
             if (!isMountedRef.current) { return }
-            history.push(`${links.editor.canvasEditor}/${newCanvas.id}`)
+            const dest = `${links.editor.canvasEditor}/${newCanvas.id}`
+            if (replace) {
+                history.replace(dest)
+            } else {
+                history.push(dest)
+            }
         })
     }, [wrap, isPending, history, isMountedRef])
 }

--- a/app/src/editor/canvas/components/CanvasController/useCanvasLoadCallback.js
+++ b/app/src/editor/canvas/components/CanvasController/useCanvasLoadCallback.js
@@ -1,5 +1,6 @@
-import { useCallback } from 'react'
+import { useContext, useCallback } from 'react'
 
+import * as RouterContext from '$editor/shared/components/RouterContext'
 import useIsMountedRef from '$shared/utils/useIsMountedRef'
 import usePending from '$editor/shared/hooks/usePending'
 
@@ -7,17 +8,25 @@ import * as services from '../../services'
 import useCanvasUpdater from './useCanvasUpdater'
 
 export default function useCanvasLoadCallback() {
+    const { history } = useContext(RouterContext.Context)
     const canvasUpdater = useCanvasUpdater()
     const { wrap } = usePending('LOAD')
     const isMountedRef = useIsMountedRef()
     return useCallback(async (canvasId) => (
         wrap(async () => {
-            const canvas = await services.loadRelevantCanvas({ id: canvasId })
+            let canvas
+            try {
+                canvas = await services.loadRelevantCanvas({ id: canvasId })
+            } catch (err) {
+                if (!isMountedRef.current) { return }
+                if (!err.response) { throw err } // unexpected error
+                history.replace('/404') // 404
+            }
             // Get permissions and save them temporarily to canvas
             const permissions = await services.getCanvasPermissions({ id: canvas.id })
             canvas.permissions = permissions
             if (!isMountedRef.current) { return }
             canvasUpdater.replaceCanvas(() => canvas)
         })
-    ), [wrap, canvasUpdater, isMountedRef])
+    ), [wrap, canvasUpdater, history, isMountedRef])
 }


### PR DESCRIPTION
Currently if you try access a canvas or dashboard that doesn't exist, it will keep re-trying to access it forever, essentially starting a DOS attack on the server. It's a bad bug that's easily stumbled upon.

This PR is a quick fix that simply redirects to `/404` whenever loading a canvas or dashboard fails for whatever reason.

Really should use inline, context-aware 404 "pages" for canvas and dashboards, but 404/non-200 handling needs some refactoring as mentioned in https://streamr.atlassian.net/browse/PLATFORM-628