### PR TITLE
[PLATFORM-629] Update moduleErrors handling

### DIFF
--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -61,17 +61,15 @@ class CodeEditorWindow extends React.Component {
                 })
             } catch (e) {
                 if (this.unmounted) { return }
+                if (!e.moduleErrors) { throw e } // unexpected error
                 this.setState({
                     sending: false,
-                    errors: e.moduleErrors.reduce((allErrors, o) => ([
-                        ...allErrors,
-                        ...o.payload.errors.map(({ line, msg }) => ({
-                            row: line - 1,
-                            column: 1,
-                            text: msg,
-                            type: 'error',
-                        })),
-                    ]), []),
+                    errors: e.moduleErrors.map(({ line, message }) => ({
+                        row: line - 1,
+                        column: 1,
+                        text: message,
+                        type: 'error',
+                    })),
                 })
             }
         })


### PR DESCRIPTION
Updates the code editor's handling of `moduleErrors`. More to do to get proper flagging/handling of canvas.moduleErrors but the original ticket is about fixing existing moduleErrors usage.

Builds on top of #427, but not setting that as base yet so we get a PR deployment.
Relevant commit in 2e894c2

To test:

1. *make sure you're using up-to-date engine and editor docker environment.*
2. add java module
3. edit code
4. add syntax error
5. apply
6. see appropriate error message in code editor

![image](https://user-images.githubusercontent.com/43438/57847912-3a062c80-780a-11e9-85be-de00f9d6cf78.png)
