### PR TITLE
Add workaround for CORE-1718

### DIFF
--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -961,6 +961,23 @@ export function getRelevantCanvasId(canvas) {
 }
 
 /**
+ * Fixes erroneous initialValue of {} back to null.
+ * See https://streamr.atlassian.net/browse/CORE-1718
+ */
+
+export function workaroundInitialValueWeirdness(canvas) {
+    let nextCanvas = canvas
+    canvas.modules.forEach((canvasModule) => {
+        canvasModule.inputs.forEach((port) => {
+            if (port.initialValue !== null && typeof port.initialValue === 'object') {
+                nextCanvas = setPortUserValue(nextCanvas, port.id, null)
+            }
+        })
+    })
+    return nextCanvas
+}
+
+/**
  * Cleanup
  */
 
@@ -968,7 +985,7 @@ export function updateCanvas(canvas, path, fn) {
     if (!canvas || typeof canvas !== 'object') {
         throw new Error(`bad canvas (${typeof canvas})`)
     }
-    return limitLayout(updateVariadic(updatePortConnections(update(path, fn, canvas))))
+    return limitLayout(updateVariadic(updatePortConnections(workaroundInitialValueWeirdness(update(path, fn, canvas)))))
 }
 
 export function moduleCategoriesIndex(modules = [], path = [], index = []) {


### PR DESCRIPTION
Basically, when this sees an initialValue set to an erroneous `{}` instead of `null`, this sets the `initialValue` back to `null`. Possible the underlying bug in CORE-1718 has other victims, we can work around them as they are discovered.

See https://streamr.atlassian.net/browse/CORE-1718
