### PR TITLE
Improve editor drag/drop perf

### DIFF
--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unused-state */
-import React from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 import { getModulePorts } from '../state'
 import styles from './Canvas.pcss'
 import { DragDropContext } from './DragDropContext'
@@ -190,57 +190,32 @@ class Cables extends React.PureComponent {
     }
 }
 
-export default class CablesContainer extends React.PureComponent {
-    static contextType = DragDropContext
-    initialState = {
-        diff: {
+export default function CablesContainer(props) {
+    const dragDrop = useContext(DragDropContext)
+    const [diff, setDiff] = useState(dragDrop.getDiff())
+    const { onMove, offMove, isDragging, data } = dragDrop
+    useEffect(() => {
+        onMove(setDiff)
+        return () => {
+            offMove(setDiff)
+        }
+    }, [onMove, offMove, setDiff])
+
+    useEffect(() => {
+        if (isDragging) { return }
+        // reset
+        setDiff({
             x: 0,
             y: 0,
-        },
-    }
-
-    state = {
-        ...this.initialState,
-    }
-
-    onUpdate = () => {
-        if (!this.context.isDragging) { return }
-        this.setState(({ diff }) => {
-            const newDiff = this.context.getDiff()
-            if (diff.x === newDiff.x && diff.y === newDiff.y) {
-                return null
-            }
-
-            return {
-                diff: newDiff,
-            }
-        }, () => {
-            requestAnimationFrame(this.onUpdate)
         })
-    }
+    }, [isDragging])
 
-    reset() {
-        this.setState(this.initialState)
-    }
-
-    componentDidUpdate(prev) {
-        if (this.context.isDragging && !prev.isDragging) {
-            requestAnimationFrame(this.onUpdate)
-        }
-
-        if (!this.context.isDragging && prev.isDragging) {
-            this.reset()
-        }
-    }
-
-    render() {
-        return (
-            <Cables
-                isDragging={this.context.isDragging}
-                data={this.context.data}
-                diff={this.state.diff}
-                {...this.props}
-            />
-        )
-    }
+    return (
+        <Cables
+            isDragging={isDragging}
+            data={data}
+            diff={diff}
+            {...props}
+        />
+    )
 }

--- a/app/src/editor/canvas/components/DragDropContext.jsx
+++ b/app/src/editor/canvas/components/DragDropContext.jsx
@@ -7,6 +7,8 @@ const DragDropContext = React.createContext({})
 export { DragDropContext }
 
 export class DragDropProvider extends React.PureComponent {
+    moveListeners = new Set()
+
     initialState = {
         isDragging: false,
         isCancelled: undefined,
@@ -33,11 +35,22 @@ export class DragDropProvider extends React.PureComponent {
         if (this.state.isCancelled) { return false }
         // don't setState to avoid rerendering entire context on each mouse move
         this.diff = diff
+        this.moveListeners.forEach((fn) => {
+            fn(diff)
+        })
     }
 
     getDiff = () => (
         this.diff
     )
+
+    onMove = (fn) => {
+        this.moveListeners.add(fn)
+    }
+
+    offMove = (fn) => {
+        this.moveListeners.delete(fn)
+    }
 
     onStart = (data) => {
         if (this.unmounted) { return }
@@ -82,6 +95,8 @@ export class DragDropProvider extends React.PureComponent {
     state = {
         ...this.initialState,
         onStart: this.onStart,
+        onMove: this.onMove,
+        offMove: this.offMove,
         onDrag: this.onDrag,
         onStop: this.onStop,
         getDiff: this.getDiff,


### PR DESCRIPTION
Quick fix I did a week or so back but didn't get around to pushing.
Not critical but noticeably improves module & cable drag/drop perf in the editor. 
Fix was to re-render cables only when a drag occurs, rather than on every animation frame.

To test: 
1. Drag a module/cable around on whatever branch you are currently on.
2. Note it's a bit choppy, especially compared to dragging the module search.
3. Check out this branch. 
4. Drag module/cable around. 
5. Notice dragging is now a lot smoother.
