### PR TITLE
[PLATFORM-691] Add branch name & commit into sidebar version header.

### DIFF
--- a/app/src/editor/shared/components/Sidebar/Header.jsx
+++ b/app/src/editor/shared/components/Sidebar/Header.jsx
@@ -13,7 +13,20 @@ export type Props = {
 }
 
 const Header = ({ title, onClose }: Props) => {
-    const { version } = global.streamr.info()
+    const { version, branch } = global.streamr.info()
+    const isMaster = branch === 'master'
+    // version e.g. v2.0.5-926-g7e20dd2eb
+    const [versionNumber, , hash] = version.split('-')
+
+    // hash minus leading 'g', not shown on master
+    const displayHash = isMaster ? '' : hash.slice(1)
+
+    // don't show branch if master
+    let displayBranch = branch === 'master' ? '' : branch
+
+    // replace hyphen in branch name with non-breaking hyphen
+    displayBranch = branch.replace(/-/g, '‑')
+
     return (
         <div className={cx(styles.header)}>
             <div className={styles.titleRow}>
@@ -27,7 +40,7 @@ const Header = ({ title, onClose }: Props) => {
                 </button>
             </div>
             <div className={styles.appInfo}>
-                Streamr App {version}
+                Streamr App {[versionNumber, displayBranch, displayHash].filter(Boolean).join(' ')}
             </div>
         </div>
     )

--- a/app/src/editor/shared/components/Sidebar/sidebar.pcss
+++ b/app/src/editor/shared/components/Sidebar/sidebar.pcss
@@ -70,6 +70,8 @@
     letter-spacing: 1px;
     line-height: 16px;
     text-transform: uppercase;
+    word-break: break-word;
+    overflow-wrap: break-word;
   }
 
   .content {


### PR DESCRIPTION
Automatically picks up the branch name & commit hash from git. It's currently baked in by webpack at build time so you'll need to restart webpack to see this change in a local branch. Should probably fix it eventually so webpack updates these vars each build but this is good enough for now.

See https://streamr.atlassian.net/browse/PLATFORM-691 for detail.

----

Applying these changes on top of the `beta` branch would look like this (screenshot from cherry-picked commit and rebuilt beta branch):

![image](https://user-images.githubusercontent.com/43438/57906283-0bd92900-78ac-11e9-8d8e-39342af65fff.png)

And on a PR branch: 

![image](https://user-images.githubusercontent.com/43438/57906288-109ddd00-78ac-11e9-8413-9f206d3d9dfe.png)

Note it auto-splits branch and hash onto multiple lines, but this shouldn't ever need to happen for stuff end users see as those branch names aren't so long.

Hides the commit hash & branch name for the eventual deployment on `master`. Could drop the commit hash entirely if it's too ugly, but IMO hash could help us confirm exactly which commit we're looking at.

