### PR TITLE
Module exception handling

### DIFF
--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -205,12 +205,17 @@ function ModuleError(props) {
         className,
         selectedModuleHash,
         moduleSidebarIsOpen,
-        onPort,
         layout,
+        onPort,
+        error,
+        style,
         ...restProps
     } = props
 
     const isSelected = module.hash === selectedModuleHash
+    const errorObj = (error && error.error) ? error.error : error
+    const moduleLayout = layout || module.layout
+    const errorMessage = (errorObj.stack || errorObj.message || '').trim()
 
     return (
         <div
@@ -218,6 +223,11 @@ function ModuleError(props) {
             className={cx(className, styles.CanvasModule, ModuleStyles.ModuleBase, ModuleStyles.dragHandle, styles.ModuleError, {
                 [ModuleStyles.isSelected]: isSelected,
             })}
+            style={{
+                width: moduleLayout.width,
+                minHeight: moduleLayout.height,
+                ...style,
+            }}
             role="rowgroup"
             tabIndex="0"
             data-modulehash={module.hash}
@@ -227,11 +237,18 @@ function ModuleError(props) {
                 <ModuleHeader
                     className={cx(styles.header, styles.hasError)}
                     editable={false}
-                    label={module.displayName || module.name}
+                    label={`${module.displayName || module.name} Error`}
                 />
             </div>
             <div className={cx(styles.canvasModuleUI, styles.ModuleErrorContent)}>
-                <Translate value="error.general" />
+                <div>
+                    <Translate value="editor.module.error" />
+                </div>
+                {!!errorMessage && (
+                    <div className={styles.errorMessage}>
+                        {errorMessage}
+                    </div>
+                )}
             </div>
             <div className={ModuleStyles.selectionDecorator} />
         </div>

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -198,30 +198,50 @@ class CanvasModule extends React.PureComponent {
 
 // try render module error in-place
 function ModuleError(props) {
-    const { module } = props
-    const { layout } = module
+    const {
+        api,
+        module,
+        canvas,
+        className,
+        selectedModuleHash,
+        moduleSidebarIsOpen,
+        onPort,
+        layout,
+        ...restProps
+    } = props
+
+    const isSelected = module.hash === selectedModuleHash
+
     return (
         <div
-            className={cx(styles.Module)}
-            style={{
-                top: layout.position.top,
-                left: layout.position.left,
-                minHeight: layout.height,
-                minWidth: layout.width,
-            }}
+            onFocus={() => api.selectModule({ hash: module.hash })}
+            className={cx(className, styles.CanvasModule, ModuleStyles.ModuleBase, ModuleStyles.dragHandle, styles.ModuleError, {
+                [ModuleStyles.isSelected]: isSelected,
+            })}
+            role="rowgroup"
+            tabIndex="0"
+            data-modulehash={module.hash}
+            {...restProps}
         >
-            <div className={styles.moduleHeader}>
-                {module.displayName || module.name}
+            <div className={styles.body}>
+                <ModuleHeader
+                    className={cx(styles.header, styles.hasError)}
+                    editable={false}
+                    label={module.displayName || module.name}
+                />
             </div>
-            <div className={styles.ports}>
+            <div className={cx(styles.canvasModuleUI, styles.ModuleErrorContent)}>
                 <Translate value="error.general" />
             </div>
+            <div className={ModuleStyles.selectionDecorator} />
         </div>
     )
 }
 
+const CanvasModuleWithErrorBoundary = withErrorBoundary(ModuleError)(CanvasModule)
+
 export default withErrorBoundary(ModuleError)((props) => (
     <ModuleDragger module={props.module} api={props.api}>
-        <CanvasModule {...props} />
+        <CanvasModuleWithErrorBoundary {...props} />
     </ModuleDragger>
 ))

--- a/app/src/editor/canvas/components/Module.pcss
+++ b/app/src/editor/canvas/components/Module.pcss
@@ -58,6 +58,29 @@
   position: relative;
 }
 
+.ModuleError {
+  overflow: hidden;
+}
+
 .ModuleErrorContent {
-  padding: 8px;
+  min-width: 248px;
+  font-size: 10px;
+  color: #323232;
+  line-height: 2;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+.ModuleErrorContent > * {
+  padding: 10px 24px;
+}
+
+.errorMessage {
+  color: #525252;
+  background: #F8F8F8;
+  max-height: 15vh;
+  overflow: auto;
+  white-space: pre-wrap;
+  text-overflow: ellipsis;
+  font-family: var(--mono);
+  font-size: 8px;
 }

--- a/app/src/editor/canvas/components/Module.pcss
+++ b/app/src/editor/canvas/components/Module.pcss
@@ -50,6 +50,14 @@
   border-bottom: 1px solid #EFEFEF;
 }
 
+.header.hasError {
+  border-bottom: 1px solid #FF0F2D;
+}
+
 .body {
   position: relative;
+}
+
+.ModuleErrorContent {
+  padding: 8px;
 }

--- a/app/src/editor/i18n/en.po
+++ b/app/src/editor/i18n/en.po
@@ -19,3 +19,6 @@ msgstr "No Repeat"
 
 msgid "editor##module##portOption##noRepeat##abbr"
 msgstr "NR"
+
+msgid "editor##module##error"
+msgstr "Whoops. Something has broken down. Please delete the module and try again."


### PR DESCRIPTION
When canvas modules crash, there's currently no way to remove them. This fixes that by rendering the error message as a stub module that can be selected and deleted.

![image](https://user-images.githubusercontent.com/43438/57914291-edc9f380-78c0-11e9-9eef-d282e2c602f0.png)

Idea is that this is a response to errors like https://github.com/streamr-dev/streamr-platform/pull/444 

Mock: 

![image](https://user-images.githubusercontent.com/43438/57915706-ee17be00-78c3-11e9-8c8b-37e85471a7ac.png)

https://app.goabstract.com/projects/667a5970-5f1f-11e9-bf62-2556403415af/branches/e81395ea-cee8-4dc8-95f8-badab055aa60/commits/bc9c29c3fbd56c88266ec01cf9a22634702d2cfe/files/632368C4-4D71-4548-97F3-468F89D29073/layers/0A6DD9FA-8B20-4503-BC11-03793EECCEB3?mode=build&selected=1488291044-FDE65107-D110-4521-8F6A-9D46A79C021B

Mild deviation from mock, with approval from matt: exception message rendered as monospace, exception message area is scrollable.

If you add a `throw new Error('oops')` into `canvas/components/Module.jsx` it should look something like so:
![image](https://user-images.githubusercontent.com/43438/58020068-ab5f1b80-7b39-11e9-9e48-4120e096516c.png)

Modules should be able to be moved around and deleted.
