### PR TITLE
[PLATFORM-633] Show timestamp column in live stream preview

### DIFF
--- a/app/src/marketplace/components/StreamPreviewPage/InspectorSidebar/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/InspectorSidebar/index.jsx
@@ -48,11 +48,11 @@ const InspectorSidebar = ({ streamId, dataPoint, onStreamIdCopy }: Props) => {
                         <Fragment>
                             <tr>
                                 <th><Translate value="modal.streamLiveData.inspectorSidebar.streamId" /></th>
-                                <td>{dataPoint && dataPoint.metadata.streamId}</td>
+                                <td>{dataPoint && dataPoint.metadata.messageId.streamId}</td>
                             </tr>
                             <tr>
                                 <th><Translate value="modal.streamLiveData.inspectorSidebar.timestamp" /></th>
-                                <td>{dataPoint && formatDateTime(dataPoint.metadata.timestamp, tz)}</td>
+                                <td>{dataPoint && formatDateTime(dataPoint.metadata.messageId.timestamp, tz)}</td>
                             </tr>
                             {/* In theory the data doesn't have to be object. Then we just skip it */}
                             {dataPoint && dataPoint.data && typeof dataPoint.data === 'object' && Object.entries(dataPoint.data).map(([k, v]) => {

--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -21,9 +21,10 @@ import styles from './streamLivePreview.pcss'
 export type DataPoint = {
     data: any,
     metadata: {
-        offset: number,
-        timestamp: number,
-        streamId: StreamId,
+        messageId: {
+            streamId: StreamId,
+            timestamp: number,
+        },
     }
 }
 
@@ -220,14 +221,14 @@ export class StreamLivePreview extends Component<Props, State> {
                                                 <tbody>
                                                     {data.map((d) => (
                                                         <tr
-                                                            key={d.metadata.offset}
+                                                            key={d.metadata.messageId.timestamp}
                                                             onClick={() => this.props.onSelectDataPoint(d)}
                                                         >
                                                             <td className={styles.timestampColumn}>
-                                                                {formatDateTime(d.metadata && d.metadata.timestamp, tz)}
+                                                                {formatDateTime(d.metadata
+                                                                    && d.metadata.messageId && d.metadata.messageId.timestamp, tz)}
                                                             </td>
-                                                        </tr>
-                                                    ))}
+                                                        </tr>))}
                                                 </tbody>
                                             </Table>
                                             <Table className={classnames(
@@ -252,7 +253,7 @@ export class StreamLivePreview extends Component<Props, State> {
                                                 <tbody>
                                                     {data.map((d) => (
                                                         <tr
-                                                            key={d.metadata.offset}
+                                                            key={d.metadata.messageId.timestamp}
                                                             onClick={() => this.props.onSelectDataPoint(d)}
                                                         >
                                                             <td className={styles.messageColumn}>
@@ -304,9 +305,9 @@ export class StreamLivePreview extends Component<Props, State> {
                                     </thead>
                                     <tbody>
                                         {data.map((d) => (
-                                            <tr key={d.metadata.offset} onClick={() => this.props.onSelectDataPoint(d)}>
+                                            <tr key={d.metadata.messageId.timestamp} onClick={() => this.props.onSelectDataPoint(d)}>
                                                 <td className={styles.timestampColumn}>
-                                                    {formatDateTime(d.metadata && d.metadata.timestamp, tz)}
+                                                    {formatDateTime(d.metadata && d.metadata.messageId && d.metadata.messageId.timestamp, tz)}
                                                 </td>
                                                 <td className={styles.messageColumn}>
                                                     <div className={styles.messagePreview}>

--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -219,9 +219,10 @@ export class StreamLivePreview extends Component<Props, State> {
                                                     </tr>
                                                 </thead>
                                                 <tbody>
-                                                    {data.map((d) => (
+                                                    {data.map((d, index) => (
                                                         <tr
-                                                            key={d.metadata.messageId.timestamp}
+                                                            // eslint-disable-next-line react/no-array-index-key
+                                                            key={`${d.metadata.messageId.timestamp}-${index}`}
                                                             onClick={() => this.props.onSelectDataPoint(d)}
                                                         >
                                                             <td className={styles.timestampColumn}>
@@ -251,9 +252,10 @@ export class StreamLivePreview extends Component<Props, State> {
                                                     </tr>
                                                 </thead>
                                                 <tbody>
-                                                    {data.map((d) => (
+                                                    {data.map((d, index) => (
                                                         <tr
-                                                            key={d.metadata.messageId.timestamp}
+                                                            // eslint-disable-next-line react/no-array-index-key
+                                                            key={`${d.metadata.messageId.timestamp}-${index}`}
                                                             onClick={() => this.props.onSelectDataPoint(d)}
                                                         >
                                                             <td className={styles.messageColumn}>
@@ -304,8 +306,12 @@ export class StreamLivePreview extends Component<Props, State> {
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        {data.map((d) => (
-                                            <tr key={d.metadata.messageId.timestamp} onClick={() => this.props.onSelectDataPoint(d)}>
+                                        {data.map((d, index) => (
+                                            <tr
+                                                // eslint-disable-next-line react/no-array-index-key
+                                                key={`${d.metadata.messageId.timestamp}-${index}`}
+                                                onClick={() => this.props.onSelectDataPoint(d)}
+                                            >
                                                 <td className={styles.timestampColumn}>
                                                     {formatDateTime(d.metadata && d.metadata.messageId && d.metadata.messageId.timestamp, tz)}
                                                 </td>

--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -219,10 +219,9 @@ export class StreamLivePreview extends Component<Props, State> {
                                                     </tr>
                                                 </thead>
                                                 <tbody>
-                                                    {data.map((d, index) => (
+                                                    {data.map((d) => (
                                                         <tr
-                                                            // eslint-disable-next-line react/no-array-index-key
-                                                            key={`${d.metadata.messageId.timestamp}-${index}`}
+                                                            key={JSON.stringify(d.metadata.messageId)}
                                                             onClick={() => this.props.onSelectDataPoint(d)}
                                                         >
                                                             <td className={styles.timestampColumn}>
@@ -252,10 +251,9 @@ export class StreamLivePreview extends Component<Props, State> {
                                                     </tr>
                                                 </thead>
                                                 <tbody>
-                                                    {data.map((d, index) => (
+                                                    {data.map((d) => (
                                                         <tr
-                                                            // eslint-disable-next-line react/no-array-index-key
-                                                            key={`${d.metadata.messageId.timestamp}-${index}`}
+                                                            key={JSON.stringify(d.metadata.messageId)}
                                                             onClick={() => this.props.onSelectDataPoint(d)}
                                                         >
                                                             <td className={styles.messageColumn}>
@@ -306,10 +304,9 @@ export class StreamLivePreview extends Component<Props, State> {
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        {data.map((d, index) => (
+                                        {data.map((d) => (
                                             <tr
-                                                // eslint-disable-next-line react/no-array-index-key
-                                                key={`${d.metadata.messageId.timestamp}-${index}`}
+                                                key={JSON.stringify(d.metadata.messageId)}
                                                 onClick={() => this.props.onSelectDataPoint(d)}
                                             >
                                                 <td className={styles.timestampColumn}>


### PR DESCRIPTION
Datapoint schema changed, needed an update on the frontend.

You can use this script to test:

```
const StreamrClient = require('streamr-client')

var API_KEY = 'tester2-api-key'

var client = new StreamrClient({
    url: 'ws://localhost:8890/api/v1/ws',
    restUrl: 'http://localhost/streamr-core/api/v1',
    auth: {
        apiKey: API_KEY,
    },
})

async function pushToStream() {
    const stream = await client.getOrCreateStream({
        id: 'O-gSWcgiRCyStUPuOTaYtQ',
    })

    await client.publish(stream.id, {
        temperature: 25.4,
        humidity: 10,
        happy: true
    })


    setTimeout(async () => {
        const fetchedStream = await client.getStream(stream.id)
        console.log(fetchedStream.config.fields)
    }, 2000)    
}

pushToStream()
```

Should see the timestamps appear:
<img width="746" alt="Screenshot 2019-05-17 at 17 55 30" src="https://user-images.githubusercontent.com/1593398/57936771-3687a980-78cd-11e9-998a-a8be1f5dc374.png">

