### PR TITLE
[PLATFORM-662] Show module warning notifications

### DIFF
--- a/app/src/editor/canvas/hooks/useCanvasNotifications.jsx
+++ b/app/src/editor/canvas/hooks/useCanvasNotifications.jsx
@@ -67,7 +67,6 @@ export function pushErrorNotification(error) {
 
 export function pushWarningNotification(warning) {
     console.warn(warning) // eslint-disable-line no-console
-    // eslint-disable-next-line react/no-danger
     Notification.push({
         title: warning.message || 'Warning',
         icon: NotificationIcon.WARNING,
@@ -77,7 +76,6 @@ export function pushWarningNotification(warning) {
 
 export function pushInfoNotification(info) {
     console.info(info) // eslint-disable-line no-console
-    // eslint-disable-next-line react/no-danger
     Notification.push({
         title: info.message || 'Info',
         icon: NotificationIcon.INFO,

--- a/app/src/editor/canvas/hooks/useCanvasNotifications.jsx
+++ b/app/src/editor/canvas/hooks/useCanvasNotifications.jsx
@@ -65,6 +65,26 @@ export function pushErrorNotification(error) {
     })
 }
 
+export function pushWarningNotification(warning) {
+    console.warn(warning) // eslint-disable-line no-console
+    // eslint-disable-next-line react/no-danger
+    Notification.push({
+        title: warning.message || 'Warning',
+        icon: NotificationIcon.WARNING,
+        warning,
+    })
+}
+
+export function pushInfoNotification(info) {
+    console.info(info) // eslint-disable-line no-console
+    // eslint-disable-next-line react/no-danger
+    Notification.push({
+        title: info.message || 'Info',
+        icon: NotificationIcon.INFO,
+        info,
+    })
+}
+
 export default function useCanvasNotifications(canvas = {}) {
     useAutosaveNotification(services.autosave, canvas)
     useCanvasRunNotification(canvas)

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -29,7 +29,7 @@ import CanvasToolbar from './components/Toolbar'
 import CanvasStatus from './components/Status'
 import ModuleSearch from './components/ModuleSearch'
 
-import useCanvasNotifications, { pushErrorNotification } from './hooks/useCanvasNotifications'
+import useCanvasNotifications, { pushErrorNotification, pushWarningNotification } from './hooks/useCanvasNotifications'
 
 import * as services from './services'
 import * as CanvasState from './state'
@@ -347,6 +347,21 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         return this.loadSelf()
     }
 
+    onWarningMessage = ({ msg = '', hash, ...opts } = {}) => {
+        if (hash != null) {
+            const module = CanvasState.getModule(this.props.canvas, hash)
+            if (module) {
+                const moduleName = module.displayName || module.name
+                msg = `${moduleName}: ${msg}`
+            }
+        }
+        pushWarningNotification({
+            message: msg,
+            hash,
+            ...opts,
+        })
+    }
+
     render() {
         const { canvas, runController } = this.props
         if (!canvas) {
@@ -369,6 +384,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     resendTo={canvas.adhoc ? resendTo : undefined}
                     isActive={runController.isActive}
                     onDoneMessage={this.onDoneMessage}
+                    onWarningMessage={this.onWarningMessage}
                     onErrorMessage={this.onErrorMessage}
                 />
                 <Canvas

--- a/app/src/shared/components/Notifications/BasicNotification/basic.pcss
+++ b/app/src/shared/components/Notifications/BasicNotification/basic.pcss
@@ -13,8 +13,7 @@
   margin-right: 16px;
 }
 
-.error {
+.iconSize {
   width: 20px;
   height: 20px;
-  margin-right: 16px;
 }

--- a/app/src/shared/components/Notifications/BasicNotification/index.jsx
+++ b/app/src/shared/components/Notifications/BasicNotification/index.jsx
@@ -23,6 +23,13 @@ const BasicNotification = ({ title, icon }: Props) => (
         {icon && icon === NotificationIcon.ERROR &&
             <SvgIcon name="error" className={styles.error} />
         }
+        {icon && icon === NotificationIcon.WARNING && (
+            <SvgIcon name="warning" className={styles.icon} />
+        )}
+        {icon && icon === NotificationIcon.INFO &&
+            /* warning icon for now */
+            <SvgIcon name="warning" className={styles.icon} />
+        }
         <span className={styles.title}>{title}</span>
     </div>
 )

--- a/app/src/shared/components/Notifications/BasicNotification/index.jsx
+++ b/app/src/shared/components/Notifications/BasicNotification/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react'
+import cx from 'classnames'
 import Spinner from '$shared/components/Spinner'
 import SvgIcon from '$shared/components/SvgIcon'
 import { NotificationIcon } from '$shared/utils/constants'
@@ -21,14 +22,14 @@ const BasicNotification = ({ title, icon }: Props) => (
             <Spinner size="small" className={styles.icon} />
         }
         {icon && icon === NotificationIcon.ERROR &&
-            <SvgIcon name="error" className={styles.error} />
+            <SvgIcon name="error" className={cx(styles.icon, styles.iconSize)} />
         }
         {icon && icon === NotificationIcon.WARNING && (
-            <SvgIcon name="warning" className={styles.icon} />
+            <SvgIcon name="warning" size="small" className={cx(styles.icon, styles.iconSize)} />
         )}
         {icon && icon === NotificationIcon.INFO &&
             /* warning icon for now */
-            <SvgIcon name="warning" className={styles.icon} />
+            <SvgIcon name="warning" size="small" className={cx(styles.icon, styles.iconSize)} />
         }
         <span className={styles.title}>{title}</span>
     </div>

--- a/app/src/shared/utils/constants.js
+++ b/app/src/shared/utils/constants.js
@@ -77,6 +77,8 @@ export const integrationKeyServices = {
 export const NotificationIcon = {
     CHECKMARK: 'checkmark',
     ERROR: 'error',
+    WARNING: 'warning',
+    INFO: 'info',
     SPINNER: 'spinner',
 }
 


### PR DESCRIPTION
Shows canvas notifications any time there's a "module warning" or "notification" event on the canvas main uiChannel.

To test: make a canvas something like this, start then stop:

![image](https://user-images.githubusercontent.com/43438/58018988-f88dbe00-7b36-11e9-9d6c-ec1fb6e3c773.png)

I haven't yet figured out (or even looked very hard TBH) a way to trigger "notification" type events.

See https://streamr.atlassian.net/browse/PLATFORM-662 for more info. I added a new comment regarding the hopelessness of our situation.