### PR TITLE
Prevent "cannot read id on undefined" exception on bad canvas/dasboard load

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/useCanvasLoadCallback.js
+++ b/app/src/editor/canvas/components/CanvasController/useCanvasLoadCallback.js
@@ -21,6 +21,7 @@ export default function useCanvasLoadCallback() {
                 if (!isMountedRef.current) { return }
                 if (!err.response) { throw err } // unexpected error
                 history.replace('/404') // 404
+                return
             }
             // Get permissions and save them temporarily to canvas
             const permissions = await services.getCanvasPermissions({ id: canvas.id })

--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -204,6 +204,7 @@ const DashboardLoader = withRouter(withErrorBoundary(ErrorComponentView)(class D
         } catch (error) {
             if (this.unmounted || this.state.isLoading !== dashboardId) { return }
             this.props.history.replace('/404')
+            return
         }
         // ignore result if unmounted or dashboard changed
         if (this.unmounted || this.state.isLoading !== dashboardId) { return }


### PR DESCRIPTION
Was missing `return` statements after error redirect.