### PR TITLE
[PLATFORM-704]  Link “Try the Editor” in the footer to the Editor

### DIFF
--- a/app/src/links.js
+++ b/app/src/links.js
@@ -56,8 +56,8 @@ module.exports = {
         settings: '/core/settings',
     },
     editor: {
-        canvasEditor: '/canvas/editor',
-        dashboardEditor: '/dashboard/editor',
+        canvasEditor: routes.canvasEditor(),
+        dashboardEditor: routes.dashboardEditor(),
     },
     community: {
         trello: routes.communityTrello(),

--- a/app/src/marketplace/components/Footer/index.jsx
+++ b/app/src/marketplace/components/Footer/index.jsx
@@ -7,6 +7,7 @@ import FrameFooter, { FooterColumn } from '$shared/components/Footer'
 import type { DispatchProps } from '../../containers/Footer'
 import type { I18nProps } from '../../containers/WithI18n'
 import { formatPath } from '$shared/utils/url'
+import routes from '$routes'
 import links from '../../../links'
 
 type Props = I18nProps & DispatchProps & {
@@ -49,7 +50,7 @@ class Footer extends React.Component<Props> {
                     <a href={links.streamrSystem}>
                         <Translate value="general.streamrSystem" />
                     </a>
-                    <a href={links.tryTheEditor} className="d-none d-lg-inline">
+                    <a href={routes.canvasEditor()} className="d-none d-lg-inline">
                         <Translate value="general.tryTheEditor" />
                     </a>
                 </FooterColumn>

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -1,4 +1,5 @@
 {
+    "canvasEditor": "/canvas/editor",
     "canvases": "/core/canvases",
     "communityGithub": "https://github.com/streamr-dev",
     "communityLinkedin": "https://www.linkedin.com/company/streamr-ltd-/",
@@ -13,6 +14,7 @@
     "contactLabs": "mailto:labs@streamr.com",
     "contactMedia": "mailto:media@streamr.com",
     "createProduct": "/marketplace/products/create",
+    "dashboardEditor": "/dashboard/editor",
     "dashboards": "/core/dashboards",
     "docs": "/docs",
     "docsApi": "/docs/streamr-api",


### PR DESCRIPTION
Other links seem to work just fine. I only re-linked "Try the Editor". It points to the actual editor now.