### PR TITLE
[PLATFORM-720] Fix Onboarding menu on mobile

### DIFF
--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -50,13 +50,13 @@ const Port = ({
         setContextMenuTarget(null)
     }, [])
 
-    useGlobalEventWithin('mousedown', {
+    useGlobalEventWithin('mousedown', useMemo(() => ({
         current: contextMenuTarget,
-    }, (within: boolean) => {
+    }), [contextMenuTarget]), useCallback((within: boolean) => {
         if (!within) {
             dismiss()
         }
-    }, Menu.styles.noAutoDismiss)
+    }, [dismiss]), Menu.styles.noAutoDismiss)
 
     useKeyDown(useMemo(() => ({
         Escape: () => {

--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -1,9 +1,11 @@
 // @flow
 
-import React, { useCallback, useState, useEffect, useContext } from 'react'
+import React, { useCallback, useState, useEffect, useContext, useMemo } from 'react'
 import cx from 'classnames'
 import startCase from 'lodash/startCase'
 import EditableText from '$shared/components/EditableText'
+import useGlobalEventWithin from '$shared/hooks/useGlobalEventWithin'
+import useKeyDown from '$shared/hooks/useKeyDown'
 import { DragDropContext } from '../../DragDropContext'
 import Option from '../Option'
 import Plug from '../Plug'
@@ -48,27 +50,25 @@ const Port = ({
         setContextMenuTarget(null)
     }, [])
 
-    const onWindowMouseDown = useCallback((e: SyntheticMouseEvent<EventTarget>) => {
-        if (contextMenuTarget && e.target instanceof Element) {
-            if (e.target.classList.contains(Menu.styles.noAutoDismiss)) {
-                return
-            }
+    useGlobalEventWithin('mousedown', {
+        current: contextMenuTarget,
+    }, (within: boolean) => {
+        if (!within) {
+            dismiss()
+        }
+    }, Menu.styles.noAutoDismiss)
 
-            if (!contextMenuTarget.contains(e.target)) {
+    useKeyDown(useMemo(() => ({
+        Escape: () => {
+            if (contextMenuTarget) {
                 dismiss()
             }
-        }
-    }, [contextMenuTarget, dismiss])
+        },
+    }), [contextMenuTarget, dismiss]))
 
     const onWindowBlur = useCallback(() => {
         const { activeElement } = document
         if (contextMenuTarget && activeElement && activeElement.tagName.toLowerCase() === 'iframe') {
-            dismiss()
-        }
-    }, [contextMenuTarget, dismiss])
-
-    const onGlobalKeyDown = useCallback(({ key }: SyntheticKeyboardEvent<EventTarget>) => {
-        if (contextMenuTarget && key === 'Escape') {
             dismiss()
         }
     }, [contextMenuTarget, dismiss])
@@ -107,16 +107,12 @@ const Port = ({
     )
 
     useEffect(() => {
-        window.addEventListener('mousedown', onWindowMouseDown)
-        window.addEventListener('keydown', onGlobalKeyDown)
         window.addEventListener('blur', onWindowBlur)
 
         return () => {
-            window.removeEventListener('mousedown', onWindowMouseDown)
-            window.removeEventListener('keydown', onGlobalKeyDown)
             window.removeEventListener('blur', onWindowBlur)
         }
-    }, [onWindowMouseDown, onGlobalKeyDown, onWindowBlur])
+    }, [onWindowBlur])
 
     useEffect(() => {
         onSizeChange()

--- a/app/src/shared/components/Onboarding/index.jsx
+++ b/app/src/shared/components/Onboarding/index.jsx
@@ -1,38 +1,66 @@
 // @flow
 
-import React, { type Element, type ChildrenArray } from 'react'
+import React, { type Element as ReactElement, type ChildrenArray, useState, useCallback, useRef } from 'react'
+import useGlobalEventWithin from '$shared/hooks/useGlobalEventWithin'
 import cx from 'classnames'
+import { type Ref } from '$shared/flowtype/common-types'
 import Link from '$shared/components/Link'
 import SvgIcon from '$shared/components/SvgIcon'
 import styles from './onboarding.pcss'
 
 type Props = {
-    children: ChildrenArray<Element<typeof Link> | null>, // – can be a Link (`null` for a separator)
+    children: ChildrenArray<ReactElement<typeof Link> | null>, // – can be a Link (`null` for a separator)
     title?: ?string,
 }
 
-const Onboarding = ({ children, title }: Props) => (
-    <div className={styles.root}>
-        <div className={styles.inner}>
-            <div className={styles.children}>
-                {!!title && (
-                    <div className={styles.label}>
-                        {title}
-                    </div>
-                )}
-                {React.Children.map(children, (child) => child || <div className={styles.separator} />)}
-            </div>
-            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-            <div className={styles.toggle} tabIndex="0">
-                <SvgIcon name="questionMark" className={styles.icon} />
+const Onboarding = ({ children, title }: Props) => {
+    const [open, setOpen] = useState(false)
+
+    const toggle = useCallback(() => {
+        setOpen((current) => !current)
+    }, [setOpen])
+
+    const childrenRef: Ref<Element> = useRef(null)
+
+    useGlobalEventWithin('click', childrenRef, useCallback((within: boolean) => {
+        if (within) {
+            setOpen(false)
+        }
+    }, [setOpen]))
+
+    const rootRef: Ref<Element> = useRef(null)
+
+    useGlobalEventWithin('mousedown focusin touchstart', rootRef, useCallback((within: boolean) => {
+        if (!within) {
+            setOpen(false)
+        }
+    }, [setOpen]))
+
+    return (
+        <div
+            className={cx(styles.root, {
+                [styles.open]: open,
+            })}
+            ref={rootRef}
+        >
+            <div className={styles.inner}>
+                <div
+                    className={styles.children}
+                    ref={childrenRef}
+                >
+                    {!!title && (
+                        <div className={styles.label}>
+                            {title}
+                        </div>
+                    )}
+                    {React.Children.map(children, (child) => child || <div className={styles.separator} />)}
+                </div>
+                <button type="button" className={styles.toggle} onClick={toggle}>
+                    <SvgIcon name="questionMark" className={styles.icon} />
+                </button>
             </div>
         </div>
-        {/* The following element is visible only when `.inner` is/has `:focus-within`. CSS makes
-            it cover the actual popup toggle. Clicking it "steals" focus from whoever has it within
-            `.inner`. This allows us to trick ppl into believing that "?" is a js-driven toggle
-            which it is not. Magic. */}
-        <div className={cx(styles.toggle, styles.focusCatcher)} />
-    </div>
-)
+    )
+}
 
 export default Onboarding

--- a/app/src/shared/components/Onboarding/index.jsx
+++ b/app/src/shared/components/Onboarding/index.jsx
@@ -1,7 +1,8 @@
 // @flow
 
-import React, { type Element as ReactElement, type ChildrenArray, useState, useCallback, useRef } from 'react'
+import React, { type Element as ReactElement, type ChildrenArray, useState, useCallback, useRef, useMemo } from 'react'
 import useGlobalEventWithin from '$shared/hooks/useGlobalEventWithin'
+import useKeyDown from '$shared/hooks/useKeyDown'
 import cx from 'classnames'
 import { type Ref } from '$shared/flowtype/common-types'
 import Link from '$shared/components/Link'
@@ -35,6 +36,14 @@ const Onboarding = ({ children, title }: Props) => {
             setOpen(false)
         }
     }, [setOpen]))
+
+    useKeyDown(useMemo(() => ({
+        Escape: () => {
+            if (open) {
+                setOpen(false)
+            }
+        },
+    }), [open, setOpen]))
 
     return (
         <div

--- a/app/src/shared/components/Onboarding/onboarding.pcss
+++ b/app/src/shared/components/Onboarding/onboarding.pcss
@@ -48,11 +48,11 @@
   visibility: hidden;
 }
 
-.inner:focus-within {
+.open .inner {
   pointer-events: all;
 }
 
-.inner:focus-within .children {
+.open .children {
   opacity: 1;
   transition-delay: 0s, 0s;
   visibility: visible;
@@ -84,21 +84,4 @@
   line-height: calc(1.5 * var(--um));
   padding-left: var(--um);
   text-transform: uppercase;
-}
-
-.focusCatcher {
-  bottom: 0;
-  cursor: pointer;
-  opacity: 0;
-  pointer-events: all;
-  position: absolute;
-  right: 0;
-}
-
-.root .focusCatcher {
-  display: none;
-}
-
-.inner:focus-within + .focusCatcher {
-  display: block;
 }

--- a/app/src/shared/hooks/useGlobalEventWithin.js
+++ b/app/src/shared/hooks/useGlobalEventWithin.js
@@ -1,0 +1,40 @@
+// @flow
+
+import { useEffect } from 'react'
+import { type Ref } from '$shared/flowtype/common-types'
+
+/*
+ * useGlobalEventWithin triggers a `callback` with an argument indicating whether the event happened
+ * within a given element (ref.current) or not.
+ */
+
+export default (eventName: string, ref: Ref<Element>, callback: (boolean) => void, ignoredClassName?: ?string) => {
+    useEffect(() => {
+        const onEvent = (e: any) => {
+            const { current } = ref
+            const { target } = e
+
+            if (!current || !(target instanceof Element)) {
+                return
+            }
+
+            if (ignoredClassName && target.classList.contains(ignoredClassName)) {
+                return
+            }
+
+            callback(current === target || current.contains(target))
+        }
+
+        const eventNames = eventName.split(/\s+/)
+
+        eventNames.forEach((name) => {
+            window.addEventListener(name, onEvent)
+        })
+
+        return () => {
+            eventNames.forEach((name) => {
+                window.removeEventListener(name, onEvent)
+            })
+        }
+    }, [eventName, ref, callback, ignoredClassName])
+}

--- a/app/src/shared/hooks/useKeyDown.js
+++ b/app/src/shared/hooks/useKeyDown.js
@@ -1,0 +1,23 @@
+// @flow
+
+import { useEffect } from 'react'
+
+type Bindings = {
+    [string]: () => void,
+}
+
+export default (bindings: Bindings) => {
+    useEffect(() => {
+        const onKeyDown = (e: SyntheticKeyboardEvent<EventTarget>) => {
+            if (Object.prototype.hasOwnProperty.call(bindings, e.key)) {
+                bindings[e.key]()
+            }
+        }
+
+        window.addEventListener('keydown', onKeyDown)
+
+        return () => {
+            window.removeEventListener('keydown', onKeyDown)
+        }
+    }, [bindings])
+}


### PR DESCRIPTION
It had to be this way. 😢 My js-less component lost its way and it's got a state now.

Cheer up tho! It's not all that bad! 🎉 

I did manage to extract some of that new funcitonality and created 2 new hooks!

1. `useGlobalEventWithin(string, Ref<Element>, (boolean) => void, ?string)` – allows you to trigger a `(boolean) => void` callback when a given ~~error~~ event happens. The callback has 1 argument which indicates whether the event happened inside a given element or outside of it.
2. `useKeyDown({ [string]: () => void })` – sets up a global `keydown` listener for given keys. You give it an object of key bindings e.g. `{ Escape: () => {} }` and it does the rest.

These are all secondary changes. The main issue – Onboarding not working on mobile – has been resolved with the help of them hooks. I also used them for editor's `Port` already. 💥 


![May-24-2019 13-09-19](https://user-images.githubusercontent.com/320066/58323780-4bac8d00-7e25-11e9-98f7-42c0e16389df.gif)
