### PR TITLE
[PLATFORM-707] Stream Preview Fix

### DIFF
--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -123,7 +123,9 @@ export class StreamLivePreview extends Component<Props, State> {
         try {
             this.subscription = this.client.subscribe({
                 stream: streamId,
-                resend_last: LOCAL_DATA_LIST_LENGTH,
+                resend: {
+                    last: LOCAL_DATA_LIST_LENGTH,
+                },
             }, (data, metadata) => this.onData({
                 data,
                 metadata,

--- a/app/src/marketplace/components/StreamPreviewPage/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/index.jsx
@@ -38,6 +38,7 @@ type Props = {
 type State = {
     selectedDataPoint: ?DataPoint,
     sidebarVisible: boolean,
+    hasData: boolean,
 }
 
 const addStreamIdCopiedNotification = () => {
@@ -58,6 +59,7 @@ class StreamPreviewPage extends React.Component<Props, State> {
     state = {
         selectedDataPoint: null,
         sidebarVisible: false,
+        hasData: false,
     }
 
     componentDidMount() {
@@ -118,11 +120,18 @@ class StreamPreviewPage extends React.Component<Props, State> {
         })
     }
 
+    hasData = () => {
+        this.setState(() => ({
+            hasData: true,
+        }))
+    }
+
     render() {
         const {
             streams, productId, match: { params: { streamId } }, currentUser,
             authApiKeyId, onClose,
         } = this.props
+        const { hasData } = this.state
         const currentStream = streams && streams.find((s) => s.id === streamId)
         const prevStreamId = this.getPrevStreamId()
         const nextStreamId = this.getNextStreamId()
@@ -174,7 +183,11 @@ class StreamPreviewPage extends React.Component<Props, State> {
                         <h2 className={styles.title}>
                             {currentStream && currentStream.name}
                             <p className={styles.subtitle}>
-                                <Translate value="modal.streamLiveData.liveData" />
+                                {hasData ? (
+                                    <Translate value="modal.streamLiveData.liveData" />
+                                ) :
+                                    <Translate value="modal.streamLiveData.noLiveData" />
+                                }
                             </p>
                         </h2>
                         <div className={styles.body}>
@@ -186,6 +199,7 @@ class StreamPreviewPage extends React.Component<Props, State> {
                                     authApiKeyId={authApiKeyId}
                                     onSelectDataPoint={this.onSelectDataPoint}
                                     selectedDataPoint={this.state.selectedDataPoint}
+                                    hasData={this.hasData}
                                 />
                             )}
                         </div>

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -470,6 +470,9 @@ msgstr "Next"
 msgid "modal##streamLiveData##previous"
 msgstr "Previous"
 
+msgid "modal##streamLiveData##noLiveData"
+msgstr "0 Messages Received"
+
 msgid "modal##web3##installmetamask##message"
 msgstr ""
 "We couldn't find your wallet. Please install <br /> MetaMask or another "

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
@@ -58,6 +58,10 @@ export class PreviewView extends Component<Props, State> {
                     </Row>
                     <Row>
                         <Col xs={12}>
+                            <p className={!hasData && styles.hasData}>
+                                This Stream has no data yet.
+                                Checkout the <Link to={routes.docsGettingStarted()}>Docs</Link> for a guide to push data to your Stream.
+                            </p>
                             <div
                                 className={cx(styles.previewContainer, {
                                     [styles.hasData]: hasData,

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/previewView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/previewView.pcss
@@ -48,4 +48,8 @@
 
 .hasData {
   display: block;
+
+  a {
+    text-decoration: none;
+  }
 }

--- a/app/src/userpages/flowtype/streamr-client-types.js
+++ b/app/src/userpages/flowtype/streamr-client-types.js
@@ -22,7 +22,7 @@ export type SubscriptionOptions = {
     stream?: StreamId,
     apiKey?: string,
     partition?: number,
-    resend_all?: boolean,
+    resend_all?: boolean, // TODO: Update these to new streamr client spec
     resend_last?: number,
     resend_from?: number,
     resend_from_time?: number | Date,


### PR DESCRIPTION
No design for this but this adds a bit more feedback for the user for the Stream Preview inside the Stream Details page and in the product 'view live data' page. 

Also fixed the resend. The old app actually did the resend, what changed is the StreamrClient resend spec.