### PR TITLE
[PLATFORM-735] Module's hamburger visibility

### DIFF
--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -19,6 +19,7 @@ import ModuleStyles from '$editor/shared/components/Module.pcss'
 import Resizable from './Resizable'
 import styles from './Module.pcss'
 import isModuleResizable from '$editor/canvas/utils/isModuleResizable'
+import SvgIcon from '$shared/components/SvgIcon'
 
 class CanvasModule extends React.PureComponent {
     static contextType = RunController.Context
@@ -157,14 +158,14 @@ class CanvasModule extends React.PureComponent {
                     >
                         {isRunning && !!module.canRefresh && (
                             <ModuleHeaderButton
-                                icon="refresh"
                                 className={ModuleStyles.dragCancel}
                                 onFocus={this.onFocusOptionsButton}
                                 onClick={this.onRefreshModule}
-                            />
+                            >
+                                <SvgIcon name="refresh" />
+                            </ModuleHeaderButton>
                         )}
                         <ModuleHeaderButton
-                            icon="hamburger"
                             className={ModuleStyles.dragCancel}
                             onClick={this.onTriggerOptions}
                             onFocus={this.onHamburgerButtonFocus}
@@ -172,7 +173,9 @@ class CanvasModule extends React.PureComponent {
                                 /* hacky. allows delete to work when this focussed */
                                 module.hash
                             )}
-                        />
+                        >
+                            <SvgIcon name="hamburger" />
+                        </ModuleHeaderButton>
                     </ModuleHeader>
                     <Ports
                         api={api}

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -19,7 +19,6 @@ import ModuleStyles from '$editor/shared/components/Module.pcss'
 import Resizable from './Resizable'
 import styles from './Module.pcss'
 import isModuleResizable from '$editor/canvas/utils/isModuleResizable'
-import SvgIcon from '$shared/components/SvgIcon'
 
 class CanvasModule extends React.PureComponent {
     static contextType = RunController.Context
@@ -162,7 +161,10 @@ class CanvasModule extends React.PureComponent {
                                 onFocus={this.onFocusOptionsButton}
                                 onClick={this.onRefreshModule}
                             >
-                                <SvgIcon name="refresh" />
+                                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    {/* eslint-disable-next-line max-len */}
+                                    <path d="M8.76 14.75a4.25 4.25 0 0 0 7.133-1.04.75.75 0 0 1 1.372.605 5.75 5.75 0 0 1-9.515 1.558V17a.75.75 0 1 1-1.5 0v-3a.75.75 0 0 1 .75-.75h3a.75.75 0 1 1 0 1.5H8.76zm7.49-6.623V7a.75.75 0 1 1 1.5 0v3a.75.75 0 0 1-.75.75h-3a.75.75 0 1 1 0-1.5h1.24a4.25 4.25 0 0 0-7.143 1.064.75.75 0 1 1-1.376-.596 5.75 5.75 0 0 1 9.529-1.591z" />
+                                </svg>
                             </ModuleHeaderButton>
                         )}
                         <ModuleHeaderButton

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -174,7 +174,11 @@ class CanvasModule extends React.PureComponent {
                                 module.hash
                             )}
                         >
-                            <SvgIcon name="hamburger" />
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <g fill="none" fillRule="evenodd" stroke="#000000" strokeLinecap="round" strokeWidth="1.5">
+                                    <path d="M7 16h10M7 12h10M7 8h10" />
+                                </g>
+                            </svg>
                         </ModuleHeaderButton>
                     </ModuleHeader>
                     <Ports

--- a/app/src/editor/shared/components/ModuleHeader/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/index.jsx
@@ -64,7 +64,11 @@ const ModuleHeader = ({
                         </EditableText>
                     </div>
                 </div>
-                {children}
+                {!!children && (
+                    <div className={styles.buttons}>
+                        {children}
+                    </div>
+                )}
             </div>
         </Fragment>
     )

--- a/app/src/editor/shared/components/ModuleHeader/moduleHeader.pcss
+++ b/app/src/editor/shared/components/ModuleHeader/moduleHeader.pcss
@@ -27,3 +27,23 @@
 .limitedWidth {
   max-width: calc(100% - 24px);
 }
+
+.buttons {
+  display: flex;
+  opacity: 0;
+  padding: calc(0.5 * var(--um));
+  transition: 200ms linear;
+  transition-delay: 200s, 0s;
+  transition-property: visibility, opacity;
+  visibility: hidden;
+}
+
+.root:--enter .buttons {
+  opacity: 1;
+  transition-delay: 0s, 0s;
+  visibility: visible;
+}
+
+.buttons button {
+  display: block;
+}

--- a/app/src/editor/shared/components/ModuleHeaderButton/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeaderButton/index.jsx
@@ -1,23 +1,21 @@
 // @flow
 
-import React from 'react'
+import React, { type Node } from 'react'
 import cx from 'classnames'
 import styles from './moduleHeaderButton.pcss'
 
-import SvgIcon, { type IconName } from '$shared/components/SvgIcon'
-
 type Props = {
-    icon: IconName,
-    className?: string,
+    children: Node,
+    className?: ?string,
 }
 
-const ModuleHeaderButton = ({ icon, className, ...props }: Props) => (
+const ModuleHeaderButton = ({ children, className, ...props }: Props) => (
     <button
         className={cx(styles.root, className)}
         type="button"
         {...props}
     >
-        <SvgIcon name={icon} />
+        {children}
     </button>
 )
 

--- a/app/src/editor/shared/components/ModuleHeaderButton/moduleHeaderButton.pcss
+++ b/app/src/editor/shared/components/ModuleHeaderButton/moduleHeaderButton.pcss
@@ -4,10 +4,10 @@
   background: none;
   border: 0;
   box-sizing: content-box;
-  font-size: var(--um);
   flex-shrink: 0;
+  font-size: var(--um);
   height: 1.5em;
-  padding: 0.5em;
+  padding: 0;
   width: 1.5em;
 }
 

--- a/app/src/editor/shared/components/ModuleHeaderButton/moduleHeaderButton.pcss
+++ b/app/src/editor/shared/components/ModuleHeaderButton/moduleHeaderButton.pcss
@@ -4,10 +4,11 @@
   background: none;
   border: 0;
   box-sizing: content-box;
+  font-size: var(--um);
   flex-shrink: 0;
-  height: 24px;
-  padding: 8px;
-  width: 12px;
+  height: 1.5em;
+  padding: 0.5em;
+  width: 1.5em;
 }
 
 .root:--enter,
@@ -18,8 +19,6 @@
 .root svg {
   display: block;
   opacity: 0.2;
-  width: 10px;
-  height: 10px;
 }
 
 .root:--enter svg {


### PR DESCRIPTION
A couple of things happen here.

- Tweaked the icons. They're 24x24 again, and are custom for the header – I re-exported them. I'm not sure if I'm a fan of the one-for-all `SvgIcon` solution anymore. 😕 
- Buttons are no longer `40x40` – didn't work for multiple buttons. Button section is `n • 24px` wide and `24px` high, plus the section is surrounded with `padding: 8px`.

Preview

![May-24-2019 14-50-06](https://user-images.githubusercontent.com/320066/58335226-655bcd80-7e41-11e9-8f26-7391bd4441a5.gif)
