### PR TITLE
[PLATFORM-758] Don't perform variadic handling on subcanvases

### DIFF
--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -678,10 +678,12 @@ export function limitLayout(canvas) {
 function hasVariadicPort(canvas, moduleHash, type) {
     if (!type) { throw new Error('type missing') }
     const canvasModule = getModule(canvas, moduleHash)
+    if (isSubCanvasModule(canvasModule)) { return false } // no variadic behaviour for subcanvas
     return canvasModule[type].some(({ variadic }) => variadic)
 }
 
 function getVariadicPorts(canvas, moduleHash, type) {
+    if (!hasVariadicPort(canvas, moduleHash, type)) { return [] }
     if (!type) { throw new Error('type missing') }
     const canvasModule = getModule(canvas, moduleHash)
     return canvasModule[type].filter(({ variadic }) => variadic)
@@ -795,6 +797,10 @@ function updateVariadics(canvas, moduleHash, type) {
         })
     })
     return nextCanvas
+}
+
+function isSubCanvasModule(moduleData) {
+    return moduleData.jsModule === 'CanvasModule'
 }
 
 function addVariadic(canvas, moduleHash, type, config = {}) {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -95,8 +95,8 @@ export function emptyCanvas(config = {}) {
 
 export const defaultModuleLayout = {
     position: {
-        top: 0,
-        left: 0,
+        top: '0px',
+        left: '0px',
     },
     width: '250px',
     height: '150px',

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -395,7 +395,7 @@ function disconnectInput(canvas, portId) {
     return updatePort(canvas, portId, (port) => {
         const newPort = {
             ...port,
-            sourceId: null,
+            sourceId: undefined,
             connected: false,
         }
 

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -306,6 +306,11 @@ export function isPortConnected(canvas, portId) {
     return !!conn.length
 }
 
+export function isPortExported(canvas, portId) {
+    if (!hasPort(canvas, portId)) { return false }
+    return !!getPort(canvas, portId).export
+}
+
 export function updatePort(canvas, portId, fn) {
     const { ports } = getIndex(canvas)
     return update(ports[portId], fn, canvas)
@@ -722,7 +727,7 @@ function removeAdditionalVariadics(canvas, moduleHash, type) {
         // do nothing
     } else {
         const lastConnected = variadics.slice().reverse().find(({ id }) => (
-            isPortConnected(canvas, id)
+            isPortConnected(canvas, id) || isPortExported(canvas, id)
         ))
 
         // remove all variadics after last connected variadic + 1 placeholder
@@ -922,8 +927,8 @@ function updateVariadicModuleForType(canvas, moduleHash, type) {
         throw new Error('no last variadic port') // should not happen
     }
 
-    if (isPortConnected(canvas, lastVariadicPort.id)) {
-        // add new port if last variadic port is connected
+    if (isPortConnected(canvas, lastVariadicPort.id) || isPortExported(canvas, lastVariadicPort.id)) {
+        // add new port if last variadic port is connected or exported
         return addVariadic(canvas, moduleHash, type)
     }
 

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -991,7 +991,13 @@ export function updateCanvas(canvas, path, fn) {
     if (!canvas || typeof canvas !== 'object') {
         throw new Error(`bad canvas (${typeof canvas})`)
     }
-    return limitLayout(updateVariadic(updatePortConnections(workaroundInitialValueWeirdness(update(path, fn, canvas)))))
+
+    if (fn && path) { // path & fn optional
+        // if we call update without a path + fn
+        // so let's skip update call altogether
+        canvas = update(path, fn, canvas)
+    }
+    return limitLayout(updateVariadic(updatePortConnections(workaroundInitialValueWeirdness(canvas))))
 }
 
 export function moduleCategoriesIndex(modules = [], path = [], index = []) {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -367,11 +367,6 @@ export function canConnectPorts(canvas, portIdA, portIdB) {
         return false
     }
 
-    const moduleA = getModuleForPort(canvas, portIdA)
-    const moduleB = getModuleForPort(canvas, portIdB)
-    // cannot connect module to self
-    if (moduleA.hash === moduleB.hash) { return false }
-
     const [output, input] = getOutputInputPorts(canvas, portIdA, portIdB)
 
     if (!input.canConnect || !output.canConnect) { return false }

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -818,8 +818,9 @@ function addVariadic(canvas, moduleHash, type, config = {}) {
             displayName: `in${index}`,
             requiresConnection: false,
         }
+        // linkedOutput name is same as input name
         if (resetMask.variadic.linkedOutput) {
-            resetMask.variadic.linkedOutput = `endpoint-${uuid.v4()}`
+            resetMask.variadic.linkedOutput = resetMask.name
         }
     } else {
         resetMask = {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -880,11 +880,6 @@ function handleVariadicPairs(canvas, moduleHash) {
         if (!linkedOutputPort) {
             newCanvas = addVariadic(newCanvas, moduleHash, 'outputs', {
                 name: inputPort.variadic.linkedOutput,
-                canConnect: true,
-                connected: false,
-                export: false,
-                jsClass: 'VariadicOutput',
-                type: 'Object',
             })
             linkedOutputPort = findLinkedVariadicPort(newCanvas, inputPort.id)
         }

--- a/app/src/editor/canvas/tests/canvas.test.js
+++ b/app/src/editor/canvas/tests/canvas.test.js
@@ -161,7 +161,6 @@ describe('Canvas Module', () => {
             export: true,
         }), subcanvas)
         await Services.saveNow(State.updateCanvas(subcanvas))
-
         let canvas = await Services.create()
         canvas = State.addModule(canvas, await loadModuleDefinition('Canvas'))
         let canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
@@ -169,14 +168,18 @@ describe('Canvas Module', () => {
         // select the subcanvas
         const canvasPort = State.findModulePort(canvas, canvasModule.hash, (p) => p.name === 'canvas')
 
-        canvas = State.updateCanvas(await Services.saveNow(State.updateCanvas(State.updatePort(canvas, canvasPort.id, (port) => ({
+        canvas = await Services.saveNow(State.updateCanvas(State.updatePort(canvas, canvasPort.id, (port) => ({
             ...port,
             value: subcanvas.id,
-        })))))
+        }))))
 
+        canvas = State.updateCanvas(canvas)
         canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
 
         expect(passThrough.inputs.every(({ name }) => !!canvasModule.inputs.find((p) => p.name === name))).toBeTruthy()
+
+        // should not create any outputs
+        expect(canvasModule.outputs).toEqual([])
     })
 
     it('works when exported inputs are variadic & connected', async () => {

--- a/app/src/editor/canvas/tests/canvas.test.js
+++ b/app/src/editor/canvas/tests/canvas.test.js
@@ -90,13 +90,62 @@ describe('Canvas Module', () => {
             value: subcanvas.id,
         }))
 
-        canvas = State.updateCanvas(await Services.saveNow(canvas))
-
+        canvas = await Services.saveNow(State.updateCanvas(canvas))
+        canvas = State.updateCanvas(canvas)
         canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
 
         expect(clock.params.every(({ name }) => !!canvasModule.params.find((p) => p.name === name))).toBeTruthy()
         expect(clock.inputs.every(({ name }) => !!canvasModule.inputs.find((p) => p.name === name))).toBeTruthy()
         expect(clock.outputs.every(({ name }) => !!canvasModule.outputs.find((p) => p.name === name))).toBeTruthy()
+    })
+
+    it('"fixes" subcanvas connection states', async () => {
+        // exported ports show connection status from the subcanvas
+        // rather than the connection status in the canvas it's loaded into
+        // sourceId will reference a port that on the subcanvas that doesn't exist
+        // on the parent canvas
+        // note nothing can be done in the case that an exported port is connected to
+        // another exported port, since the port will actually exist in the current canvas
+
+        let subcanvas = await Services.create()
+        subcanvas = State.addModule(subcanvas, await loadModuleDefinition('Constant'))
+        subcanvas = State.addModule(subcanvas, await loadModuleDefinition('Abs'))
+
+        const constant = subcanvas.modules.find((m) => m.name === 'Constant')
+        const constantOut = State.findModulePort(subcanvas, constant.hash, (p) => p.name === 'out')
+        const abs = subcanvas.modules.find((m) => m.name === 'Abs')
+        const absIn = State.findModulePort(subcanvas, abs.hash, (p) => p.name === 'in')
+
+        subcanvas = State.updateCanvas(State.connectPorts(subcanvas, constantOut.id, absIn.id))
+        subcanvas = State.setPortOptions(subcanvas, absIn.id, {
+            export: true,
+        })
+
+        await Services.saveNow(subcanvas)
+
+        let canvas = await State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Canvas'))
+        let canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
+
+        // select the subcanvas
+        const canvasPort = State.findModulePort(canvas, canvasModule.hash, (p) => p.name === 'canvas')
+        canvas = State.updatePort(canvas, canvasPort.id, (port) => ({
+            ...port,
+            value: subcanvas.id,
+        }))
+
+        canvas = State.updateCanvas(canvas)
+
+        const serverCanvasBeforeFix = await Services.create(canvas)
+        // wrap in updateCanvas to get the "fix"
+        canvas = State.updateCanvas(serverCanvasBeforeFix)
+
+        canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
+        const exportedAbsIn = canvasModule.inputs[0]
+        expect(State.isPortConnected(canvas, exportedAbsIn.id)).not.toBeTruthy()
+        const serverCanvasAfterFix = await Services.saveNow(canvas)
+        // ensure the "fix" didn't mutate canvas
+        expect(serverCanvasAfterFix).toMatchCanvas(serverCanvasBeforeFix)
     })
 
     it('works when exported inputs are variadic', async () => {
@@ -138,14 +187,14 @@ describe('Canvas Module', () => {
         subcanvas = State.addModule(subcanvas, await loadModuleDefinition('Abs'))
 
         const passThrough = subcanvas.modules.find((m) => m.name === 'PassThrough')
-        const constant1 = subcanvas.modules.find((m) => m.name === 'Constant')
+        const constant = subcanvas.modules.find((m) => m.name === 'Constant')
         const abs = subcanvas.modules.find((m) => m.name === 'Abs')
-        // connect constant1 to passthrough
-        const constant1Out = State.findModulePort(subcanvas, constant1.hash, (p) => p.name === 'out')
+        // connect constant to passthrough
+        const constantOut = State.findModulePort(subcanvas, constant.hash, (p) => p.name === 'out')
         const passThroughIn1 = State.findModulePort(subcanvas, passThrough.hash, (p) => p.longName === 'PassThrough.in1')
-        subcanvas = State.updateCanvas(State.connectPorts(subcanvas, constant1Out.id, passThroughIn1.id))
+        subcanvas = State.updateCanvas(State.connectPorts(subcanvas, constantOut.id, passThroughIn1.id))
 
-        // connect passthrough to constant2
+        // connect passthrough to abs
         const passThroughOut1 = State.findModulePort(subcanvas, passThrough.hash, (p) => p.longName === 'PassThrough.out1')
         const absIn = State.findModulePort(subcanvas, abs.hash, (p) => p.name === 'in')
         subcanvas = State.updateCanvas(State.connectPorts(subcanvas, passThroughOut1.id, absIn.id))

--- a/app/src/editor/canvas/tests/canvas.test.js
+++ b/app/src/editor/canvas/tests/canvas.test.js
@@ -3,6 +3,8 @@ import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/t
 import * as State from '../state'
 import * as Services from '../services'
 
+import './utils'
+
 describe('Canvas Module', () => {
     let teardown
 
@@ -37,7 +39,11 @@ describe('Canvas Module', () => {
         subcanvas = clock.outputs.reduce((subcanvas, { id }) => State.setPortOptions(subcanvas, id, {
             export: true,
         }), subcanvas)
-        await Services.saveNow(subcanvas)
+
+        expect(State.updateCanvas(await Services.saveNow(subcanvas))).toMatchCanvas({
+            ...subcanvas,
+            hasExports: true,
+        })
 
         // create main canvas and check that the created canvas shows up
         let canvas = State.emptyCanvas()
@@ -79,15 +85,90 @@ describe('Canvas Module', () => {
         // select the subcanvas
         const canvasPort = State.findModulePort(canvas, canvasModule.hash, (p) => p.name === 'canvas')
 
-        canvas = await Services.saveNow(State.updatePort(canvas, canvasPort.id, (port) => ({
+        canvas = State.updatePort(canvas, canvasPort.id, (port) => ({
             ...port,
             value: subcanvas.id,
-        })))
+        }))
+
+        canvas = State.updateCanvas(await Services.saveNow(canvas))
 
         canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
 
         expect(clock.params.every(({ name }) => !!canvasModule.params.find((p) => p.name === name))).toBeTruthy()
         expect(clock.inputs.every(({ name }) => !!canvasModule.inputs.find((p) => p.name === name))).toBeTruthy()
         expect(clock.outputs.every(({ name }) => !!canvasModule.outputs.find((p) => p.name === name))).toBeTruthy()
+    })
+
+    it('works when exported inputs are variadic', async () => {
+        // Create a subcanvas
+        let subcanvas = await Services.create()
+        subcanvas = State.addModule(subcanvas, await loadModuleDefinition('PassThrough'))
+        subcanvas = State.addModule(subcanvas, await loadModuleDefinition('Constant'))
+
+        const passThrough = subcanvas.modules.find((m) => m.name === 'PassThrough')
+
+        // export inputs
+        subcanvas = passThrough.inputs.reduce((subcanvas, { id }) => State.setPortOptions(subcanvas, id, {
+            export: true,
+        }), subcanvas)
+        await Services.saveNow(State.updateCanvas(subcanvas))
+
+        let canvas = await Services.create()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Canvas'))
+        let canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
+
+        // select the subcanvas
+        const canvasPort = State.findModulePort(canvas, canvasModule.hash, (p) => p.name === 'canvas')
+
+        canvas = State.updateCanvas(await Services.saveNow(State.updateCanvas(State.updatePort(canvas, canvasPort.id, (port) => ({
+            ...port,
+            value: subcanvas.id,
+        })))))
+
+        canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
+
+        expect(passThrough.inputs.every(({ name }) => !!canvasModule.inputs.find((p) => p.name === name))).toBeTruthy()
+    })
+
+    it('works when exported inputs are variadic & connected', async () => {
+        // Create a subcanvas
+        let subcanvas = await Services.create({ name: 'Sub Canvas' })
+        subcanvas = State.addModule(subcanvas, await loadModuleDefinition('PassThrough'))
+        subcanvas = State.addModule(subcanvas, await loadModuleDefinition('Constant'))
+        subcanvas = State.addModule(subcanvas, await loadModuleDefinition('Abs'))
+
+        const passThrough = subcanvas.modules.find((m) => m.name === 'PassThrough')
+        const constant1 = subcanvas.modules.find((m) => m.name === 'Constant')
+        const abs = subcanvas.modules.find((m) => m.name === 'Abs')
+        // connect constant1 to passthrough
+        const constant1Out = State.findModulePort(subcanvas, constant1.hash, (p) => p.name === 'out')
+        const passThroughIn1 = State.findModulePort(subcanvas, passThrough.hash, (p) => p.longName === 'PassThrough.in1')
+        subcanvas = State.updateCanvas(State.connectPorts(subcanvas, constant1Out.id, passThroughIn1.id))
+
+        // connect passthrough to constant2
+        const passThroughOut1 = State.findModulePort(subcanvas, passThrough.hash, (p) => p.longName === 'PassThrough.out1')
+        const absIn = State.findModulePort(subcanvas, abs.hash, (p) => p.name === 'in')
+        subcanvas = State.updateCanvas(State.connectPorts(subcanvas, passThroughOut1.id, absIn.id))
+
+        // export passthrough input
+        subcanvas = State.setPortOptions(subcanvas, passThroughIn1.id, {
+            export: true,
+        })
+        await Services.saveNow(State.updateCanvas(subcanvas))
+        let canvas = await Services.create({ name: 'Parent Canvas' })
+        canvas = State.addModule(canvas, await loadModuleDefinition('Canvas'))
+        let canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
+
+        // select the subcanvas
+        const canvasPort = State.findModulePort(canvas, canvasModule.hash, (p) => p.name === 'canvas')
+
+        canvas = State.updateCanvas(await Services.saveNow(State.updateCanvas(State.updatePort(canvas, canvasPort.id, (port) => ({
+            ...port,
+            value: subcanvas.id,
+        })))))
+
+        canvasModule = canvas.modules.find((m) => m.jsModule === 'CanvasModule')
+
+        expect(passThrough.inputs.every(({ name }) => !!canvasModule.inputs.find((p) => p.name === name))).toBeTruthy()
     })
 })

--- a/app/src/editor/canvas/tests/connection.test.js
+++ b/app/src/editor/canvas/tests/connection.test.js
@@ -2,6 +2,7 @@ import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/t
 
 import * as State from '../state'
 import * as Services from '../services'
+import './utils'
 
 describe('Connecting Modules', () => {
     let teardown
@@ -26,6 +27,9 @@ describe('Connecting Modules', () => {
         expect(() => {
             State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, 'missingportid'))
         }).toThrow()
+
+        // test server accepts state
+        expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
     })
 
     it('will not error if disconnecting from missing port (assumes port removed)', async () => {
@@ -49,6 +53,9 @@ describe('Connecting Modules', () => {
         expect(State.isPortConnected(canvas, constantTextOut.id)).toBeTruthy()
         expect(State.isPortConnected(canvas, toLowerCaseIn.id)).toBeTruthy()
         expect(canvas).toEqual(canvasBefore)
+
+        // test server accepts state
+        expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
     })
 
     it('will not error if disconnecting ports that are not connected', async () => {
@@ -82,6 +89,9 @@ describe('Connecting Modules', () => {
         canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, toUpperCaseIn.id))
         expect(State.isPortConnected(canvas, toLowerCaseIn.id)).toBeTruthy()
         expect(State.isPortConnected(canvas, toUpperCaseIn.id)).not.toBeTruthy()
+
+        // test server accepts state
+        expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
     })
 
     it('can connect & disconnect compatible modules', async () => {
@@ -109,6 +119,9 @@ describe('Connecting Modules', () => {
         canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, toLowerCaseIn.id))
         expect(State.isPortConnected(canvas, constantTextOut.id)).not.toBeTruthy()
         expect(State.isPortConnected(canvas, toLowerCaseIn.id)).not.toBeTruthy()
+
+        // test server accepts state
+        expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
     })
 
     it('can not connect incompatible modules', async () => {
@@ -131,6 +144,8 @@ describe('Connecting Modules', () => {
         expect(() => {
             State.updateCanvas(State.connectPorts(canvas, randomNumberOut.id, toLowerCaseIn.id))
         }).toThrow()
+        // test server accepts state
+        expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
     })
 
     it('can connect ports to self', async () => {
@@ -155,5 +170,8 @@ describe('Connecting Modules', () => {
         canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, constantTextIn.id))
         expect(State.isPortConnected(canvas, constantTextOut.id)).not.toBeTruthy()
         expect(State.isPortConnected(canvas, constantTextIn.id)).not.toBeTruthy()
+
+        // test server accepts state
+        expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
     })
 })

--- a/app/src/editor/canvas/tests/connection.test.js
+++ b/app/src/editor/canvas/tests/connection.test.js
@@ -132,4 +132,28 @@ describe('Connecting Modules', () => {
             State.updateCanvas(State.connectPorts(canvas, randomNumberOut.id, toLowerCaseIn.id))
         }).toThrow()
     })
+
+    it('can connect ports to self', async () => {
+        // connect ConstantText out to ToLowerCase
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+        const constantText = canvas.modules.find((m) => m.name === 'ConstantText')
+        expect(constantText).toBeTruthy()
+        const constantTextOut = State.findModulePort(canvas, constantText.hash, (p) => p.name === 'out')
+        const constantTextIn = State.findModulePort(canvas, constantText.hash, (p) => p.name === 'str')
+        expect(constantTextOut).toBeTruthy()
+        expect(constantTextIn).toBeTruthy()
+
+        // canConnect should be true
+        expect(State.canConnectPorts(canvas, constantTextOut.id, constantTextIn.id)).toBeTruthy()
+
+        // connectPorts should connect
+        canvas = State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, constantTextIn.id))
+        expect(State.isPortConnected(canvas, constantTextOut.id)).toBeTruthy()
+        expect(State.isPortConnected(canvas, constantTextIn.id)).toBeTruthy()
+
+        canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, constantTextIn.id))
+        expect(State.isPortConnected(canvas, constantTextOut.id)).not.toBeTruthy()
+        expect(State.isPortConnected(canvas, constantTextIn.id)).not.toBeTruthy()
+    })
 })

--- a/app/src/editor/canvas/tests/connection.test.js
+++ b/app/src/editor/canvas/tests/connection.test.js
@@ -1,0 +1,135 @@
+import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/tests/utils'
+
+import * as State from '../state'
+import * as Services from '../services'
+
+describe('Connecting Modules', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setupAuthorizationHeader()
+    }, 60000)
+
+    afterAll(async () => {
+        await Services.deleteAllCanvases()
+        await teardown()
+    })
+
+    it('will error if connecting to missing port', async () => {
+        // connect ConstantText out to some missing port id
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+        const constantText = canvas.modules.find((m) => m.name === 'ConstantText')
+        expect(constantText).toBeTruthy()
+        const constantTextOut = State.findModulePort(canvas, constantText.hash, (p) => p.name === 'out')
+        expect(constantTextOut).toBeTruthy()
+        expect(() => {
+            State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, 'missingportid'))
+        }).toThrow()
+    })
+
+    it('will not error if disconnecting from missing port (assumes port removed)', async () => {
+        // connect ConstantText out to ToLowerCase, but try disconnect missing
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('ToLowerCase'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('ToUpperCase'))
+        const constantText = canvas.modules.find((m) => m.name === 'ConstantText')
+        const toLowerCase = canvas.modules.find((m) => m.name === 'ToLowerCase')
+        expect(constantText).toBeTruthy()
+        expect(toLowerCase).toBeTruthy()
+        const constantTextOut = State.findModulePort(canvas, constantText.hash, (p) => p.name === 'out')
+        const toLowerCaseIn = State.findModulePort(canvas, toLowerCase.hash, (p) => p.name === 'text')
+        expect(constantTextOut).toBeTruthy()
+        expect(toLowerCaseIn).toBeTruthy()
+
+        canvas = State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, toLowerCaseIn.id))
+        const canvasBefore = canvas
+        canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, 'missingportid'))
+        expect(State.isPortConnected(canvas, constantTextOut.id)).toBeTruthy()
+        expect(State.isPortConnected(canvas, toLowerCaseIn.id)).toBeTruthy()
+        expect(canvas).toEqual(canvasBefore)
+    })
+
+    it('will not error if disconnecting ports that are not connected', async () => {
+        // connect ConstantText out to ToLowerCase, but try disconnect missing
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('ToLowerCase'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('ToUpperCase'))
+        const constantText = canvas.modules.find((m) => m.name === 'ConstantText')
+        const toLowerCase = canvas.modules.find((m) => m.name === 'ToLowerCase')
+        const toUpperCase = canvas.modules.find((m) => m.name === 'ToUpperCase')
+        expect(constantText).toBeTruthy()
+        expect(toLowerCase).toBeTruthy()
+        expect(toUpperCase).toBeTruthy()
+        const constantTextOut = State.findModulePort(canvas, constantText.hash, (p) => p.name === 'out')
+        const toLowerCaseIn = State.findModulePort(canvas, toLowerCase.hash, (p) => p.name === 'text')
+        const toUpperCaseIn = State.findModulePort(canvas, toUpperCase.hash, (p) => p.name === 'text')
+        expect(constantTextOut).toBeTruthy()
+        expect(toLowerCaseIn).toBeTruthy()
+        expect(toUpperCaseIn).toBeTruthy()
+
+        canvas = State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, toLowerCaseIn.id))
+        expect(State.isPortConnected(canvas, constantTextOut.id)).toBeTruthy()
+
+        const canvasBefore = canvas
+        canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, toUpperCaseIn.id))
+        expect(canvas).toEqual(canvasBefore)
+        canvas = State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, toUpperCaseIn.id))
+        expect(State.isPortConnected(canvas, toLowerCaseIn.id)).toBeTruthy()
+        expect(State.isPortConnected(canvas, toUpperCaseIn.id)).toBeTruthy()
+        canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, toUpperCaseIn.id))
+        expect(State.isPortConnected(canvas, toLowerCaseIn.id)).toBeTruthy()
+        expect(State.isPortConnected(canvas, toUpperCaseIn.id)).not.toBeTruthy()
+    })
+
+    it('can connect & disconnect compatible modules', async () => {
+        // connect ConstantText out to ToLowerCase
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('ToLowerCase'))
+        const constantText = canvas.modules.find((m) => m.name === 'ConstantText')
+        const toLowerCase = canvas.modules.find((m) => m.name === 'ToLowerCase')
+        expect(constantText).toBeTruthy()
+        expect(toLowerCase).toBeTruthy()
+        const constantTextOut = State.findModulePort(canvas, constantText.hash, (p) => p.name === 'out')
+        const toLowerCaseIn = State.findModulePort(canvas, toLowerCase.hash, (p) => p.name === 'text')
+        expect(constantTextOut).toBeTruthy()
+        expect(toLowerCaseIn).toBeTruthy()
+
+        // canConnect should be true
+        expect(State.canConnectPorts(canvas, constantTextOut.id, toLowerCaseIn.id)).toBeTruthy()
+
+        // connectPorts should connect
+        canvas = State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, toLowerCaseIn.id))
+        expect(State.isPortConnected(canvas, constantTextOut.id)).toBeTruthy()
+        expect(State.isPortConnected(canvas, toLowerCaseIn.id)).toBeTruthy()
+
+        canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, toLowerCaseIn.id))
+        expect(State.isPortConnected(canvas, constantTextOut.id)).not.toBeTruthy()
+        expect(State.isPortConnected(canvas, toLowerCaseIn.id)).not.toBeTruthy()
+    })
+
+    it('can not connect incompatible modules', async () => {
+        // connect ConstantText out to ToLowerCase
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('RandomNumber'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('ToLowerCase'))
+        const randomNumber = canvas.modules.find((m) => m.name === 'RandomNumber')
+        const toLowerCase = canvas.modules.find((m) => m.name === 'ToLowerCase')
+        expect(randomNumber).toBeTruthy()
+        expect(toLowerCase).toBeTruthy()
+        const randomNumberOut = State.findModulePort(canvas, randomNumber.hash, (p) => p.name === 'out')
+        const toLowerCaseIn = State.findModulePort(canvas, toLowerCase.hash, (p) => p.name === 'text')
+        expect(randomNumberOut).toBeTruthy()
+        expect(toLowerCaseIn).toBeTruthy()
+        // canConnect should not be true
+        expect(State.canConnectPorts(canvas, randomNumberOut.id, toLowerCaseIn.id)).not.toBeTruthy()
+
+        // connectPorts should error
+        expect(() => {
+            State.updateCanvas(State.connectPorts(canvas, randomNumberOut.id, toLowerCaseIn.id))
+        }).toThrow()
+    })
+})

--- a/app/src/editor/canvas/tests/services.test.js
+++ b/app/src/editor/canvas/tests/services.test.js
@@ -3,16 +3,7 @@ import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/t
 
 import * as Services from '../services'
 import * as State from '../state'
-
-const canvasMatcher = {
-    id: expect.any(String),
-    name: expect.any(String),
-    created: expect.any(String),
-    updated: expect.any(String),
-    uiChannel: expect.objectContaining({
-        id: expect.any(String),
-    }),
-}
+import { canvasMatcher } from './utils'
 
 describe('Canvas Services', () => {
     let teardown

--- a/app/src/editor/canvas/tests/services.test.js
+++ b/app/src/editor/canvas/tests/services.test.js
@@ -48,6 +48,21 @@ describe('Canvas Services', () => {
             const canvas2 = await Services.create()
             expect(canvas.name).not.toEqual(canvas2.name)
         })
+
+        it('can take canvas name', async () => {
+            const name1 = `test${uniqueId()}`
+            const name2 = `test${uniqueId()}`
+            const canvas1 = await Services.create({ name: name1 })
+            await Services.create({ name: name1 })
+            const canvas3 = await Services.create({ name: name2 })
+            expect(canvas1).toMatchObject({
+                name: name1,
+            })
+
+            expect(canvas3).toMatchObject({
+                name: name2,
+            })
+        })
     })
 
     describe('loadCanvas', () => {

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -37,6 +37,13 @@ describe('Canvas State', () => {
         })
     })
 
+    describe('updateCanvas', () => {
+        it('does not add "undefined" the string as a key', () => {
+            const canvas = State.updateCanvas(State.emptyCanvas())
+            expect('undefined' in canvas).not.toBeTruthy()
+        })
+    })
+
     describe('getModule/findModule', () => {
         let canvas
 

--- a/app/src/editor/canvas/tests/utils.js
+++ b/app/src/editor/canvas/tests/utils.js
@@ -1,0 +1,61 @@
+export const canvasMatcher = {
+    id: expect.any(String),
+    name: expect.any(String),
+    created: expect.any(String),
+    updated: expect.any(String),
+    uiChannel: expect.objectContaining({
+        id: expect.any(String),
+    }),
+}
+
+function matchPorts(ports) {
+    return expect.objectContaining(ports.map((port) => {
+        const portMatcher = { ...port }
+        if (port.sourceId == null) { delete portMatcher.sourceId }
+        if (port.value == null) { delete portMatcher.value }
+
+        return expect.objectContaining(portMatcher)
+    }))
+}
+
+expect.extend({
+    toMatchCanvas(targetCanvas, sourceCanvas) {
+        expect(targetCanvas).toMatchObject({
+            ...sourceCanvas,
+            ...canvasMatcher,
+            modules: expect.objectContaining(sourceCanvas.modules.map((m, i) => {
+                const source = sourceCanvas.modules[i]
+                let matcher = source
+                if (source.uiChannel) {
+                    matcher = {
+                        ...matcher,
+                        uiChannel: expect.objectContaining({
+                            id: expect.any(String),
+                        }),
+                    }
+                }
+
+                if (source.inputs) {
+                    matcher.inputs = matchPorts(source.inputs)
+                }
+                if (source.params) {
+                    matcher.params = matchPorts(source.params)
+                }
+                if (source.outputs) {
+                    matcher.outputs = matchPorts(source.outputs)
+                }
+
+                if (matcher.tableConfig) {
+                    matcher.tableConfig = expect.anything()
+                }
+
+                return expect.objectContaining(matcher)
+            })),
+        })
+
+        return {
+            pass: true,
+            message: () => '',
+        }
+    },
+})

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -92,6 +92,29 @@ describe('Variadic Port Handling', () => {
             expect(savedCanvas).toMatchCanvas(canvas)
         })
 
+        it('can add/remove variadic inputs on export', async () => {
+            let canvas = State.emptyCanvas()
+            canvas = State.addModule(canvas, await loadModuleDefinition('Table'))
+            let table = canvas.modules.find((m) => m.name === 'Table')
+            expect(table.inputs.length).toBe(1)
+
+            // export input
+            canvas = State.updateCanvas(State.setPortOptions(canvas, table.inputs[0].id, {
+                export: true,
+            }))
+            table = canvas.modules.find((m) => m.name === 'Table')
+            // exporting input should add new variadic
+            expect(table.inputs.length).toBe(2)
+
+            // de-export input
+            canvas = State.updateCanvas(State.setPortOptions(canvas, table.inputs[0].id, {
+                export: false,
+            }))
+            table = canvas.modules.find((m) => m.name === 'Table')
+            // de-exporting input should remove variadic
+            expect(table.inputs.length).toBe(1)
+        })
+
         it('can move connections', async () => {
             // connect constant to a table (table has variadic inputs)
             let canvas = State.emptyCanvas()

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -3,6 +3,8 @@ import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/t
 import * as State from '../state'
 import * as Services from '../services'
 
+import './utils'
+
 describe('Variadic Port Handling', () => {
     let teardown
 
@@ -84,6 +86,10 @@ describe('Variadic Port Handling', () => {
 
             // first is now last
             expect(firstVariadicPort.variadic.isLast).toBeTruthy()
+
+            // test server accepts state
+            const savedCanvas = State.updateCanvas(await Services.create(canvas))
+            expect(savedCanvas).toMatchCanvas(canvas)
         })
 
         it('can move connections', async () => {
@@ -118,6 +124,9 @@ describe('Variadic Port Handling', () => {
             expect(State.isPortConnected(canvas, tableIn2.id)).toBeTruthy()
             // table.in2 should still exist, and be connected
             expect(State.isPortConnected(canvas, tableIn1.id)).not.toBeTruthy()
+
+            // test server accepts state
+            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
 
         it('updates index/displayName based on initial config index', async () => {
@@ -142,6 +151,9 @@ describe('Variadic Port Handling', () => {
             const addIn4 = State.findModulePort(canvas, add.hash, (p) => p.variadic && p.variadic.index === 4)
             expect(addIn4).toBeTruthy()
             expect(addIn4.displayName).toBe('in4')
+
+            // test server accepts state
+            expect(State.updateCanvas(State.updateCanvas(await Services.create(canvas)))).toMatchCanvas(canvas)
         })
     })
 
@@ -187,6 +199,9 @@ describe('Variadic Port Handling', () => {
 
             // first is now last
             expect(firstVariadicPort.variadic.isLast).toBeTruthy()
+
+            // test server accepts state
+            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
     })
 
@@ -231,6 +246,9 @@ describe('Variadic Port Handling', () => {
 
             // check new output is gone
             expect(State.getPortIfExists(canvas, passThroughOut2.id)).toBeUndefined()
+
+            // test server accepts state
+            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
 
         it('disconnects output when input is disconnected', async () => {
@@ -260,6 +278,9 @@ describe('Variadic Port Handling', () => {
             expect(State.isPortConnected(canvas, passThroughOut1.id)).not.toBeTruthy()
             // valueText.in should be disconnected
             expect(State.isPortConnected(canvas, valueTextIn.id)).not.toBeTruthy()
+
+            // test server accepts state
+            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
 
         it('updates downstream connection status as output ports removed', async () => {
@@ -294,6 +315,9 @@ describe('Variadic Port Handling', () => {
             canvas = State.updateCanvas(State.disconnectPorts(canvas, constantOut.id, passThroughIn1.id))
             // table in1 should be disconnected
             expect(State.isPortConnected(canvas, tableIn1.id)).not.toBeTruthy()
+
+            // test server accepts state
+            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
 
         it('updates downstream connection status as output ports removed in special order', async () => {
@@ -337,6 +361,9 @@ describe('Variadic Port Handling', () => {
             expect(State.isPortConnected(canvas, tableIn1.id)).not.toBeTruthy()
             expect(State.getPortIfExists(canvas, tableIn2.id)).toBeUndefined()
             expect(State.getPortIfExists(canvas, tableIn3.id)).toBeUndefined()
+
+            // test server accepts state
+            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
 
         it('uses input type as output type when trying to connect linked output', async () => {
@@ -371,6 +398,9 @@ describe('Variadic Port Handling', () => {
             expect(() => {
                 State.updateCanvas(State.connectPorts(canvas, passThroughOut2.id, addIn2.id))
             }).toThrow()
+
+            // test server accepts state
+            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
     })
 })

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -211,13 +211,21 @@ describe('Variadic Port Handling', () => {
             expect(State.isPortConnected(canvas, constantOut.id)).toBeTruthy()
             expect(State.isPortConnected(canvas, passThroughIn1.id)).toBeTruthy()
 
-            // check a new output is created
+            // check a new input & output is created
+            const passThroughIn2 = State.findModulePort(canvas, passThrough.hash, (p) => p.displayName === 'in2')
+            expect(passThroughIn2).toBeTruthy()
             const passThroughOut2 = State.findModulePort(canvas, passThrough.hash, (p) => p.displayName === 'out2')
             expect(passThroughOut2).toBeTruthy()
+
             // new output is last
             expect(passThroughOut2.variadic.isLast).toBeTruthy()
             // new output is not connected
             expect(State.isPortConnected(canvas, passThroughOut2.id)).not.toBeTruthy()
+            // output name is same as input name
+            // (not sure if this is necessary but it matches old editor behaviour)
+            expect(passThroughOut2.name).toBe(passThroughIn2.name)
+            // input variadic.linkedOutput is output name
+            expect(passThroughIn2.variadic.linkedOutput).toBe(passThroughOut2.name)
             // disconnecting should remove new output
             canvas = State.updateCanvas(State.disconnectPorts(canvas, constantOut.id, passThroughIn1.id))
 


### PR DESCRIPTION
Fixes an issue preventing a production canvas from working. 

See: https://streamr.atlassian.net/browse/PLATFORM-758

Production canvas in question rendering locally with the fixes in this PR:

![image](https://user-images.githubusercontent.com/43438/58380163-6aa34e80-7fe0-11e9-8a5a-c50747d0fc81.png)

To test: 

1. Create a new canvas (canvas 1)
2. Add the PassThrough module
3. Export the input on the PassThrough (bonus: note it adds a new placeholder input)
4. Create another new canvas.
5. Add canvas module.
6. Select canvas 1 as subcanvas. 
7. Note it doesn't break. 

Current `development` breaks at step 7 with same error as reported in JIRA ticket.

Alternatively you could start the app pointed at the production endpoints:

```
STREAMR_API_URL=https://www.streamr.com/api/v1
STREAMR_WS_URL=wss://www.streamr.com/api/v1/ws
STREAMR_URL=https://www.streamr.com
```

And test that the production canvas:

https://www.streamr.com/canvas/editor/DJ2Ds4ZbRfaXuZ5jC4r7xA-whrguaeTgiaB4tKTqJvxg

works locally:

http://localhost/canvas/editor/DJ2Ds4ZbRfaXuZ5jC4r7xA-whrguaeTgiaB4tKTqJvxg

----

The problem was treating exported, linked variadic ports on a subcanvas as normal linked variadics. Unlike the old UI, linked variadic handling is now "automatic": whenever it sees an input with a `linkedOutput`, it will try to create that output if one does not exist. So when it sees the subcanvas module's variadic input, it can't find the associated output because it exists in the subcanvas modules rather than in the current canvas modules, which then causes an error in the UI because the module isn't configured to handle adding/removing variadic ports. 

The key fix here was to **disable all variadic behaviour when dealing with an embedded subcanvas.** 
323c9b4

In the process of trying to nail down exactly what the problem was, I added a bunch of canvas/variadic tests and thus this PR also includes some minor canvas handling & behaviour fixes:

* Modules can now connect to ports on themselves. We don't currently display this very well but it's not forbidden by the backend implementation so we should allow it.
* Now adds an empty variadic port after exporting last variadic port. This matches old UI behaviour, previously only happened on connection.
* Fixed issue where canvases ended up with a key "undefined" with a value `undefined`
* Fixed `requiresConnection` flag being set on `port.variadic` instead of `port`.
* Improved port longName generation.
* Made linked input/output ports share the same name. Worked before but this matches old UI behaviour.
