### PR TITLE
[PLATFORM-719] Add correct texts for mobile empty states in the userpages

### DIFF
--- a/app/src/userpages/components/CanvasPage/List/NoCanvases/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/NoCanvases/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
+import MediaQuery from 'react-responsive'
 
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
@@ -9,6 +10,7 @@ import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
 import noResultIcon from '$shared/assets/images/search_no_result.png'
 import noResultemptyStateIcon2x from '$shared/assets/images/search_no_result@2x.png'
 import type { Filter } from '$userpages/flowtype/common-types'
+import breakpoints from '$app/scripts/breakpoints'
 
 type NoResultsViewProps = {
     onResetFilter: Function,
@@ -29,7 +31,12 @@ const NoCreatedCanvasesView = () => (
         )}
     >
         <Translate value="userpages.canvases.noCreatedCanvases.title" />
-        <Translate value="userpages.canvases.noCreatedCanvases.message" tag="small" />
+        <MediaQuery minWidth={breakpoints.lg.min}>
+            <Translate value="userpages.canvases.noCreatedCanvases.message" tag="small" />
+        </MediaQuery>
+        <MediaQuery maxWidth={breakpoints.lg.min}>
+            <Translate value="userpages.canvases.noCreatedCanvases.messageMobile" tag="small" />
+        </MediaQuery>
     </EmptyState>
 )
 

--- a/app/src/userpages/components/DashboardPage/List/NoDashboards/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/NoDashboards/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
+import MediaQuery from 'react-responsive'
 
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
@@ -9,6 +10,7 @@ import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
 import noResultIcon from '$shared/assets/images/search_no_result.png'
 import noResultemptyStateIcon2x from '$shared/assets/images/search_no_result@2x.png'
 import type { Filter } from '$userpages/flowtype/common-types'
+import breakpoints from '$app/scripts/breakpoints'
 
 type NoResultsViewProps = {
     onResetFilter: Function,
@@ -29,7 +31,12 @@ const NoCreatedDashboardsView = () => (
         )}
     >
         <Translate value="userpages.dashboards.noCreatedDashboards.title" />
-        <Translate value="userpages.dashboards.noCreatedDashboards.message" tag="small" />
+        <MediaQuery minWidth={breakpoints.lg.min}>
+            <Translate value="userpages.dashboards.noCreatedDashboards.message" tag="small" />
+        </MediaQuery>
+        <MediaQuery maxWidth={breakpoints.lg.min}>
+            <Translate value="userpages.dashboards.noCreatedDashboards.messageMobile" tag="small" />
+        </MediaQuery>
     </EmptyState>
 )
 

--- a/app/src/userpages/components/ProductsPage/NoProducts/index.jsx
+++ b/app/src/userpages/components/ProductsPage/NoProducts/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
+import MediaQuery from 'react-responsive'
 
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
@@ -9,6 +10,7 @@ import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
 import noResultIcon from '$shared/assets/images/search_no_result.png'
 import noResultemptyStateIcon2x from '$shared/assets/images/search_no_result@2x.png'
 import type { Filter } from '$userpages/flowtype/common-types'
+import breakpoints from '$app/scripts/breakpoints'
 
 type NoResultsViewProps = {
     onResetFilter: Function,
@@ -29,7 +31,12 @@ const NoCreatedProductsView = () => (
         )}
     >
         <Translate value="userpages.products.noCreatedProducts.title" />
-        <Translate value="userpages.products.noCreatedProducts.message" tag="small" />
+        <MediaQuery minWidth={breakpoints.lg.min}>
+            <Translate value="userpages.products.noCreatedProducts.message" tag="small" />
+        </MediaQuery>
+        <MediaQuery maxWidth={breakpoints.lg.min}>
+            <Translate value="userpages.products.noCreatedProducts.messageMobile" tag="small" />
+        </MediaQuery>
     </EmptyState>
 )
 

--- a/app/src/userpages/components/StreamPage/List/NoStreams/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/NoStreams/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
+import MediaQuery from 'react-responsive'
 
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
@@ -9,6 +10,7 @@ import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
 import noResultIcon from '$shared/assets/images/search_no_result.png'
 import noResultemptyStateIcon2x from '$shared/assets/images/search_no_result@2x.png'
 import type { Filter } from '$userpages/flowtype/common-types'
+import breakpoints from '$app/scripts/breakpoints'
 
 type NoResultsViewProps = {
     onResetFilter: Function,
@@ -29,7 +31,12 @@ const NoCreatedStreamsView = () => (
         )}
     >
         <Translate value="userpages.streams.noCreatedStreams.title" />
-        <Translate value="userpages.streams.noCreatedStreams.message" tag="small" />
+        <MediaQuery minWidth={breakpoints.lg.min}>
+            <Translate value="userpages.streams.noCreatedStreams.message" tag="small" />
+        </MediaQuery>
+        <MediaQuery maxWidth={breakpoints.lg.min}>
+            <Translate value="userpages.streams.noCreatedStreams.messageMobile" tag="small" />
+        </MediaQuery>
     </EmptyState>
 )
 

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -23,6 +23,9 @@ msgstr "You haven't created any canvases yet."
 msgid "userpages##canvases##noCreatedCanvases##message"
 msgstr "Click the button above to create one."
 
+msgid "userpages##canvases##noCreatedCanvases##messageMobile"
+msgstr "Use the desktop app to make one."
+
 msgid "userpages##canvases##noCanvasesResult##title"
 msgstr "No results."
 
@@ -140,6 +143,9 @@ msgstr "You haven’t created any products yet."
 msgid "userpages##products##noCreatedProducts##message"
 msgstr "Click the button above to create one."
 
+msgid "userpages##products##noCreatedProducts##messageMobile"
+msgstr "Use the desktop app to make one."
+
 msgid "userpages##products##noProductsResult##title"
 msgstr "No results."
 
@@ -244,6 +250,9 @@ msgstr "You haven't created any streams yet."
 
 msgid "userpages##streams##noCreatedStreams##message"
 msgstr "Click the button above to create one."
+
+msgid "userpages##streams##noCreatedStreams##messageMobile"
+msgstr "Use the desktop app to make one."
 
 msgid "userpages##streams##noStreamsResult##title"
 msgstr "No results."
@@ -415,6 +424,9 @@ msgstr "You haven’t created any dashboards yet."
 
 msgid "userpages##dashboards##noCreatedDashboards##message"
 msgstr "Click the button above to create one."
+
+msgid "userpages##dashboards##noCreatedDashboards##messageMobile"
+msgstr "Use the desktop app to make one."
 
 msgid "userpages##dashboards##noDashboardsResult##title"
 msgstr "No results."


### PR DESCRIPTION
Currently empty state views for the userpages are showing text `Click the button above to create one` even though on mobile we hide the `Create` button. This PR fixes that by using media query and showing a different text: `Use the desktop app to make one`.