### PR TITLE
Init analytics before doing anything else.

### DIFF
--- a/app/src/analytics.js
+++ b/app/src/analytics.js
@@ -59,6 +59,7 @@ if (process.env.SENTRY_DSN) {
                 dsn: process.env.SENTRY_DSN,
                 release: process.env.VERSION,
                 environment: process.env.SENTRY_ENVIRONMENT,
+                debug: true,
             })
         ),
         reportError: (error: Error, extra: Object = {}) => {

--- a/app/src/shared/utils/diagnostics.js
+++ b/app/src/shared/utils/diagnostics.js
@@ -1,5 +1,7 @@
 /* Attach global diagnostic object */
 
+import '../../analytics'
+
 const navigator = global.navigator || {}
 
 global.streamr = Object.assign(global.streamr || {}, {

--- a/app/src/shared/utils/diagnostics.js
+++ b/app/src/shared/utils/diagnostics.js
@@ -1,7 +1,8 @@
-/* Attach global diagnostic object */
-
+// You should init the Sentry browser SDK as soon as possible during your application load up, before initializing React
+// https://docs.sentry.io/platforms/javascript/react/
 import '../../analytics'
 
+/* Attach global diagnostic object */
 const navigator = global.navigator || {}
 
 global.streamr = Object.assign(global.streamr || {}, {

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -161,9 +161,9 @@ module.exports = {
         new webpack.EnvironmentPlugin({
             GIT_VERSION: gitRevisionPlugin.version(),
             GIT_BRANCH: gitRevisionPlugin.branch(),
-            SENTRY_ENVIRONMENT: process.env.SENTRY_ENVIRONMENT,
-            SENTRY_DSN: process.env.SENTRY_DSN,
-            VERSION: process.env.VERSION,
+            SENTRY_ENVIRONMENT: process.env.SENTRY_ENVIRONMENT || '',
+            SENTRY_DSN: process.env.SENTRY_DSN || '',
+            VERSION: process.env.VERSION || '',
         }),
         ...(analyze ? [
             new BundleAnalyzerPlugin({


### PR DESCRIPTION
According to https://docs.sentry.io/platforms/javascript/react/:

> You should init the Sentry browser SDK as soon as possible during your application load up, before initializing React

This PR initialises the analytics before doing anything else except loading babel-polyfill due to: 

https://github.com/streamr-dev/streamr-platform/blob/development/app/webpack.config.js#L43

