### PR TITLE
[PLATFORM-791] Fix canvas 404'ing when historical canvas gone away

### DIFF
--- a/app/src/analytics.js
+++ b/app/src/analytics.js
@@ -43,6 +43,10 @@ export class Analytics {
         Object.keys(this.services).forEach((id) => this.services[id].reportError && this.services[id].reportError(error, extra))
     }
 
+    reportWarning = (error: Error, extra: Object = {}) => {
+        Object.keys(this.services).forEach((id) => this.services[id].reportWarning && this.services[id].reportWarning(error, extra))
+    }
+
     getMiddlewares = () => Object.keys(this.services).reduce((result, id) => ([
         ...result,
         ...(this.services[id].getMiddleware ? [this.services[id].getMiddleware()] : []),
@@ -67,6 +71,21 @@ if (process.env.SENTRY_DSN) {
                 if (extra) {
                     scope.setExtras(extra)
                 }
+
+                Sentry.captureException(error)
+            })
+        },
+
+        reportWarning: (error: Error, extra: Object = {}) => {
+            console.warn({
+                error,
+                extra,
+            }) // eslint-disable-line no-console
+            Sentry.withScope((scope) => {
+                if (extra) {
+                    scope.setExtras(extra)
+                }
+                scope.setLevel('warning')
 
                 Sentry.captureException(error)
             })

--- a/app/src/editor/canvas/tests/adhoc.test.js
+++ b/app/src/editor/canvas/tests/adhoc.test.js
@@ -2,15 +2,7 @@ import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
 
 import * as Services from '../services'
 
-const canvasMatcher = {
-    id: expect.any(String),
-    name: expect.any(String),
-    created: expect.any(String),
-    updated: expect.any(String),
-    uiChannel: expect.objectContaining({
-        id: expect.any(String),
-    }),
-}
+import { canvasMatcher } from './utils'
 
 describe('Adhoc Canvases', () => {
     let teardown
@@ -78,7 +70,26 @@ describe('Adhoc Canvases', () => {
             expect(nextLoadedCanvas).toMatchObject({
                 ...parentCanvas,
                 ...canvasMatcher,
+                id: parentCanvas.id, // should have loaded parent canvas
+            })
+        })
+
+        it('will load parent canvas as the "relevant" canvas if adhoc canvas is missing', async () => {
+            const parentCanvas = await Services.create()
+            const adhocCanvas = await Services.createAdhocCanvas(parentCanvas)
+            await Services.deleteCanvas({ id: adhocCanvas.id })
+
+            const loadedCanvas = await Services.loadRelevantCanvas(parentCanvas)
+            expect(loadedCanvas).toMatchCanvas(parentCanvas, {
                 id: parentCanvas.id, // should have loaded adhoc canvas
+            })
+
+            expect(loadedCanvas).not.toHaveProperty('settings.childCanvasId')
+
+            await Services.unlinkParentCanvas(adhocCanvas)
+            const nextLoadedCanvas = await Services.loadRelevantCanvas(parentCanvas)
+            expect(nextLoadedCanvas).toMatchCanvas(parentCanvas, {
+                id: parentCanvas.id, // should still have loaded parent canvas
             })
         })
     })

--- a/app/src/editor/canvas/tests/utils.js
+++ b/app/src/editor/canvas/tests/utils.js
@@ -19,7 +19,7 @@ function matchPorts(ports) {
 }
 
 expect.extend({
-    toMatchCanvas(targetCanvas, sourceCanvas) {
+    toMatchCanvas(targetCanvas, sourceCanvas, additional = {}) {
         expect(targetCanvas).toMatchObject({
             ...sourceCanvas,
             ...canvasMatcher,
@@ -51,6 +51,7 @@ expect.extend({
 
                 return expect.objectContaining(matcher)
             })),
+            ...additional,
         })
 
         return {


### PR DESCRIPTION
Currently the app will continually redirect to a missing historical canvas if the historical canvas ended without unlinking itself from the parent (e.g. user closed tab).

https://streamr.atlassian.net/browse/PLATFORM-791

https://streamr-team.slack.com/archives/G80NM66KS/p1559016138010200

Now it unlinks & loads the original canvas if there's any problem loading the historical canvas.

Hard to test manually, but I put automated tests around it. basically you need to start a historical canvas, delete the historical canvas (not the original) before the app knows the canvas has stopped and to unlink, then try reloading the original canvas, it shouldn't 404. 