### PR TITLE
[PLATFORM-718] No autosave on unmount after deleting a dashboard or canvas

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/useUpdatedTime.js
+++ b/app/src/editor/canvas/components/CanvasController/useUpdatedTime.js
@@ -1,0 +1,24 @@
+import { useState, useMemo, useCallback, useEffect } from 'react'
+
+export default function useUpdatedTime(updated) {
+    const updatedTime = (new Date(updated)).getTime()
+    const [lastUpdated, setUpdatedState] = useState(updatedTime)
+
+    const setUpdated = useCallback((updated) => {
+        const nextUpdatedUpdated = (new Date(updated)).getTime()
+        setUpdatedState((lastUpdated) => {
+            const updated = Math.max(lastUpdated || nextUpdatedUpdated, nextUpdatedUpdated)
+            if (lastUpdated === updated) { return lastUpdated }
+            return updated
+        })
+    }, [setUpdatedState])
+
+    useEffect(() => {
+        setUpdated(updatedTime)
+    }, [setUpdated, updatedTime])
+
+    return useMemo(() => [
+        lastUpdated,
+        setUpdated,
+    ], [lastUpdated, setUpdated])
+}

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -23,6 +23,7 @@ import * as CanvasController from './components/CanvasController'
 import * as RunController from './components/CanvasController/Run'
 import useCanvas from './components/CanvasController/useCanvas'
 import useCanvasUpdater from './components/CanvasController/useCanvasUpdater'
+import useUpdatedTime from './components/CanvasController/useUpdatedTime'
 
 import Canvas from './components/Canvas'
 import CanvasToolbar from './components/Toolbar'
@@ -38,26 +39,11 @@ import styles from './index.pcss'
 
 const { RunStates } = CanvasState
 
-const UpdatedTime = new Map()
-
-function setUpdated(canvas) {
-    const canvasUpdated = new Date(canvas.updated)
-    const updated = Math.max(UpdatedTime.get(canvas.id) || canvasUpdated, canvasUpdated)
-    UpdatedTime.set(canvas.id, updated)
-    return updated
-}
-
 const CanvasEditComponent = class CanvasEdit extends Component {
     state = {
         moduleSearchIsOpen: this.props.runController.isEditable,
         moduleSidebarIsOpen: false,
         keyboardShortcutIsOpen: false,
-    }
-
-    static getDerivedStateFromProps(props) {
-        return {
-            updated: setUpdated(props.canvas),
-        }
     }
 
     setCanvas = (action, fn, done) => {
@@ -151,7 +137,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         const newCanvas = await services.autosave(canvas)
         if (this.unmounted) { return }
         // ignore new canvas, just extract updated time from it
-        this.setState({ updated: setUpdated(newCanvas) }) // call setState to trigger rerender, but actual updated value comes from gDSFP
+        this.props.setUpdated(newCanvas.updated)
     }
 
     removeModule = async ({ hash }) => {
@@ -404,7 +390,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     pushNewDefinition={this.pushNewDefinition}
                 >
                     {runController.hasWritePermission ? (
-                        <CanvasStatus updated={this.state.updated} />
+                        <CanvasStatus updated={this.props.updated} />
                     ) : (
                         <CannotSaveStatus />
                     )}
@@ -461,6 +447,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 const CanvasEdit = withRouter(({ canvas, ...props }) => {
     const runController = useContext(RunController.Context)
     const canvasController = CanvasController.useController()
+    const [updated, setUpdated] = useUpdatedTime(canvas.updated)
     useCanvasNotifications(canvas)
 
     return (
@@ -469,6 +456,8 @@ const CanvasEdit = withRouter(({ canvas, ...props }) => {
             canvas={canvas}
             runController={runController}
             canvasController={canvasController}
+            updated={updated}
+            setUpdated={setUpdated}
         />
     )
 })

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -36,8 +36,6 @@ import * as CanvasState from './state'
 
 import styles from './index.pcss'
 
-const DELETED = Symbol('deleted')
-
 const { RunStates } = CanvasState
 
 const UpdatedTime = new Map()
@@ -135,7 +133,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     async autostart() {
         const { canvas, runController } = this.props
-        if (canvas[DELETED]) { return } // do not autostart deleted canvases
+        if (this.isDeleted) { return } // do not autostart deleted canvases
         if (canvas.adhoc && !runController.isActive) {
             // do not autostart running/non-adhoc canvases
             return this.canvasStart()
@@ -144,7 +142,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     async autosave() {
         const { canvas, runController } = this.props
-        if (canvas[DELETED]) { return } // do not autosave deleted canvases
+        if (this.isDeleted) { return } // do not autosave deleted canvases
         if (!runController.isEditable) {
             // do not autosave running/adhoc canvases or if we have no write permission
             return
@@ -185,7 +183,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     deleteCanvas = async () => {
         const { canvas, canvasController } = this.props
-        canvas[DELETED] = true
+        this.isDeleted = true
         await canvasController.remove(canvas)
     }
 

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -36,6 +36,8 @@ import * as CanvasState from './state'
 
 import styles from './index.pcss'
 
+const DELETED = Symbol('deleted')
+
 const { RunStates } = CanvasState
 
 const UpdatedTime = new Map()
@@ -133,6 +135,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     async autostart() {
         const { canvas, runController } = this.props
+        if (canvas[DELETED]) { return } // do not autostart deleted canvases
         if (canvas.adhoc && !runController.isActive) {
             // do not autostart running/non-adhoc canvases
             return this.canvasStart()
@@ -141,6 +144,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     async autosave() {
         const { canvas, runController } = this.props
+        if (canvas[DELETED]) { return } // do not autosave deleted canvases
         if (!runController.isEditable) {
             // do not autosave running/adhoc canvases or if we have no write permission
             return
@@ -181,6 +185,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     deleteCanvas = async () => {
         const { canvas, canvasController } = this.props
+        canvas[DELETED] = true
         await canvasController.remove(canvas)
     }
 

--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -22,8 +22,6 @@ import * as services from './services'
 
 import styles from './index.pcss'
 
-const DELETED = Symbol('deleted')
-
 const DashboardEdit = withRouter(class DashboardEdit extends Component {
     setDashboard = (action, fn, done) => {
         this.props.push(action, (dashboard) => {
@@ -68,7 +66,7 @@ const DashboardEdit = withRouter(class DashboardEdit extends Component {
 
     async autosave() {
         const { dashboard } = this.props
-        if (dashboard[DELETED]) { return } // do not autosave deleted dashboards
+        if (this.isDeleted) { return } // do not autosave deleted dashboards
         await services.autosave(dashboard)
     }
 
@@ -100,7 +98,7 @@ const DashboardEdit = withRouter(class DashboardEdit extends Component {
 
     deleteDashboard = async () => {
         const { dashboard } = this.props
-        dashboard[DELETED] = true
+        this.isDeleted = true
         await services.deleteDashboard(dashboard)
         if (this.unmounted) { return }
         this.props.history.push(links.userpages.dashboards)

--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -22,6 +22,8 @@ import * as services from './services'
 
 import styles from './index.pcss'
 
+const DELETED = Symbol('deleted')
+
 const DashboardEdit = withRouter(class DashboardEdit extends Component {
     setDashboard = (action, fn, done) => {
         this.props.push(action, (dashboard) => {
@@ -66,6 +68,7 @@ const DashboardEdit = withRouter(class DashboardEdit extends Component {
 
     async autosave() {
         const { dashboard } = this.props
+        if (dashboard[DELETED]) { return } // do not autosave deleted dashboards
         await services.autosave(dashboard)
     }
 
@@ -97,6 +100,7 @@ const DashboardEdit = withRouter(class DashboardEdit extends Component {
 
     deleteDashboard = async () => {
         const { dashboard } = this.props
+        dashboard[DELETED] = true
         await services.deleteDashboard(dashboard)
         if (this.unmounted) { return }
         this.props.history.push(links.userpages.dashboards)


### PR DESCRIPTION
See https://streamr.atlassian.net/browse/PLATFORM-718

Autosave wasn't properly cleaned up after deleting a dashboard or canvas, specifically, it tries to autosave just before unmounting the canvas/dashboard, even if it's unmounting because the canvas/dashboard was deleted.

To test:

1. Create a Canvas/Dashboard
2. Open Dev Console
3. Delete the Canvas/Dashboard

Note that it:
* redirects back to the canvases/dashboards page
* canvas/dashboard is gone, and
* there's no 404 errors in the console

I want to get the autosave out of `canvas/index.jsx` and into hooks so it can be tested in isolation but when I started refactoring it out there was a bit too much so I cut my losses and present this PR with a minor piece of transitional refactoring.
