### PR TITLE
[PLATFORM-778] Detect fields endpoint fix

### DIFF
--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -574,7 +574,7 @@ export const streamFieldsAutodetect = (id: StreamId) => (dispatch: Function) => 
                 fields: data.config.fields,
             },
         }))
-        .then(({ config: { fields } }, err) => {
+        .then(({ config: { fields } }) => {
             if (fields) {
                 dispatch(getStreamFieldAutodetectSuccess(fields))
                 Notification.push({
@@ -582,6 +582,7 @@ export const streamFieldsAutodetect = (id: StreamId) => (dispatch: Function) => 
                     icon: NotificationIcon.CHECKMARK,
                 })
             }
+        }, (err) => {
             if (err) {
                 dispatch(getStreamFieldAutodetectFailure(err))
                 Notification.push({


### PR DESCRIPTION
Error handling that just *works*.

If you want to test, it's the `Autodetect fields` in the Stream Edit page