### PR TITLE
[PLATFORM-730] Longer ids for the rescue!(?)

### DIFF
--- a/app/src/editor/shared/components/Preview/ModulePreview/Chart/index.jsx
+++ b/app/src/editor/shared/components/Preview/ModulePreview/Chart/index.jsx
@@ -27,7 +27,7 @@ const Chart = ({ height, width, y }: Props) => {
                     <defs>
                         <pattern
                             height="66"
-                            id="tile"
+                            id="Chart-tile"
                             patternUnits="userSpaceOnUse"
                             width="112"
                         >
@@ -43,7 +43,7 @@ const Chart = ({ height, width, y }: Props) => {
                         </pattern>
                     </defs>
                     <svg viewBox="0 0 11200 66" preserveAspectRatio="xMinYMid slice">
-                        <rect width="100%" height="100%" fill="url(#tile)" />
+                        <rect width="100%" height="100%" fill="url(#Chart-tile)" />
                     </svg>
                 </svg>
             </svg>

--- a/app/src/editor/shared/components/Preview/ModulePreview/Table/index.jsx
+++ b/app/src/editor/shared/components/Preview/ModulePreview/Table/index.jsx
@@ -16,7 +16,7 @@ const Table = ({ width, height, ...props }: Props) => (
     >
         <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
             <defs>
-                <pattern id="paragraph" width="100%" height="16" patternUnits="userSpaceOnUse">
+                <pattern id="Table-paragraph" width="100%" height="16" patternUnits="userSpaceOnUse">
                     <g fill="#d8d8d8">
                         <rect width="15" rx="1" height="4" />
                         <rect width="19" rx="1" height="4" y="8" />
@@ -25,7 +25,7 @@ const Table = ({ width, height, ...props }: Props) => (
                     </g>
                 </pattern>
             </defs>
-            <rect width="100%" height="100%" fill="url(#paragraph)" />
+            <rect width="100%" height="100%" fill="url(#Table-paragraph)" />
         </svg>
     </svg>
 )

--- a/app/src/marketplace/components/Modal/SetPriceDialog/PaymentRateEditor/FixedPriceSelector/index.jsx
+++ b/app/src/marketplace/components/Modal/SetPriceDialog/PaymentRateEditor/FixedPriceSelector/index.jsx
@@ -29,13 +29,10 @@ const Icon = () => (
         viewBox="0 0 16 16"
         xmlns="http://www.w3.org/2000/svg"
     >
-        <g id="Create-product-+-Publish-flows" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-            <g id="Set-Price-01" transform="translate(-615.000000, -552.000000)" fill="#C3C3C3" fillRule="nonzero">
-                <g id="Question-icon" transform="translate(615.000000, 552.000000)">
-                    <path
-                        d={path}
-                        id="Shape-Copy-3"
-                    />
+        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+            <g transform="translate(-615.000000, -552.000000)" fill="#C3C3C3" fillRule="nonzero">
+                <g transform="translate(615.000000, 552.000000)">
+                    <path d={path} />
                 </g>
             </g>
         </g>

--- a/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
+++ b/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
@@ -29,8 +29,8 @@ export type Props = {
 
 const KeylockIconSvg = () => (
     <svg width="9px" height="12px" viewBox="0 0 9 12">
-        <g id="Product-Detail-Views" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-            <g id="Product-Detail-Page-/-Purchases" transform="translate(-221.000000, -682.000000)" fill="#525252" fillRule="nonzero">
+        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+            <g transform="translate(-221.000000, -682.000000)" fill="#525252" fillRule="nonzero">
                 <path
                     d="M229.5,686 L229,686 L229,685.5 C229,683.57 227.43,682 225.5,682 C223.57,682
                 222,683.57 222,685.5 L222,686 L221.5,686 C221.224,686 221,686.224 221,686.5 L221,693.5
@@ -40,7 +40,6 @@ const KeylockIconSvg = () => (
                 225.775,692.001 225.499,692.001 C225.223,692.001 225,691.777 225,691.501 L225,689.847 C224.706,689.672
                 224.5,689.365 224.5,689 C224.5,688.448 224.948,688 225.5,688 C226.052,688 226.5,688.448 226.5,689
                 C226.5,689.365 226.293,689.672 226,689.847 Z"
-                    id="Keylock-icon"
                 />
             </g>
         </g>

--- a/app/src/marketplace/components/Table/CollapseRow/index.jsx
+++ b/app/src/marketplace/components/Table/CollapseRow/index.jsx
@@ -57,10 +57,9 @@ class CollapseRow extends React.Component<Props, State> {
                     })}
                     >
                         <svg width="13px" height="7px" viewBox="0 0 13 7">
-                            <g id="Product-Detail-Views" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                                <g id="Product-view-/-Mobile" strokeWidth="1" transform="translate(-335.000000, -740.000000)" stroke="#525252">
+                            <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                                <g strokeWidth="1" transform="translate(-335.000000, -740.000000)" stroke="#525252">
                                     <polyline
-                                        id="Path-2"
                                         transform="translate(341.656854, 740.656854) rotate(45.000000) translate(-341.656854, -740.656854) "
                                         points="345.656854 736.656854 345.656854 744.656854 337.656854 744.656854"
                                     />

--- a/app/src/shared/components/SvgIcon/ImageUploadIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/ImageUploadIcon/index.jsx
@@ -16,37 +16,32 @@ const ImageUploadIcon = ({ color, className }: Props) => (
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 52 52"
     >
-        <g id="-Symbols" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinejoin="round">
+        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinejoin="round">
             <g
-                id="Image-Uploader-Default"
                 transform="translate(-217.000000, -136.000000)"
                 stroke={color}
                 strokeWidth="2"
             >
-                <g id="Group-12">
-                    <g id="Group-11" transform="translate(0.000000, 137.000000)">
-                        <g id="Group-9" transform="translate(218.000000, 0.000000)">
-                            <g id="Image-upload-icon">
+                <g>
+                    <g transform="translate(0.000000, 137.000000)">
+                        <g transform="translate(218.000000, 0.000000)">
+                            <g>
                                 <rect
-                                    id="Rectangle-path"
                                     x="0.0472589792"
                                     y="0.0472589792"
                                     width="40.8589792"
                                     height="40.831758"
                                 />
-                                <path d="M0.0744801512,31.805293 L40.9062382,31.805293" id="Shape" />
+                                <path d="M0.0744801512,31.805293 L40.9062382,31.805293" />
                                 <polyline
-                                    id="Shape"
                                     strokeLinecap="round"
                                     points="17.6888469 45.415879 43.5240076 49.952741 49.952741 13.3402647 45.415879 12.5440454"
                                 />
                                 <polygon
-                                    id="Shape"
                                     points="28.4026465 15.926276 21.5973535 27.268431 15.926276
                                     25 11.389414 31.805293 34.073724 31.805293"
                                 />
                                 <polygon
-                                    id="Shape"
                                     strokeLinecap="round"
                                     points="18.194707 15.3591682 13.657845 18.194707 9.12098299
                                     15.3591682 9.12098299 10.8223062 13.657845 7.98676749 18.194707 10.8223062"

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -255,14 +255,14 @@ const sources = {
     profileMan: (
         <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
             <defs>
-                <circle id="a" cx="40" cy="40" r="40" />
+                <circle id="profileMan-a" cx="40" cy="40" r="40" />
             </defs>
             <g fill="none" fillRule="evenodd">
-                <mask id="b" fill="#fff">
-                    <use href="#a" />
+                <mask id="profileMan-b" fill="#fff">
+                    <use href="#profileMan-a" />
                 </mask>
-                <use fill="#EFEFEF" href="#a" />
-                <g opacity=".503" mask="url(#b)" stroke="#525252" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5">
+                <use fill="#EFEFEF" href="#profileMan-a" />
+                <g opacity=".503" mask="url(#profileMan-b)" stroke="#525252" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5">
                     <g transform="translate(20 17)">
                         <ellipse cx="20.5" cy="11" rx="10.762" ry="10.5" />
                         <path d="M11.226 5.668c3.367 3.408 8.01 5.333 12.861 5.332 2.433 0 4.84-.483 7.073-1.422M.512 45.5C.512 34.73 9.462 26 20.5 26c11.039 0 19.987 8.73 19.987 19.5" />

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -185,12 +185,11 @@ const sources = {
                 <g transform="translate(-505.000000, -2598.000000)" stroke="#0324FF" strokeWidth="1.5">
                     <path
                         d="M517,2614.5 C516.792893,2614.5 516.625,2614.66789 516.625,2614.875 C516.625,2615.08211 516.792893,2615.25 517,2615.25 C517.207107,2615.25 517.375,2615.08211 517.375,2614.875 C517.375,2614.66789 517.207107,2614.5 517,2614.5"
-                        id="Path"
                         strokeLinecap="round"
                         strokeLinejoin="round"
                     />
-                    <path d="M517,2611.5 L517,2603.25" id="Path" strokeLinecap="round" />
-                    <circle id="Oval" cx="517" cy="2610" r="11.25" />
+                    <path d="M517,2611.5 L517,2603.25" strokeLinecap="round" />
+                    <circle cx="517" cy="2610" r="11.25" />
                 </g>
             </g>
         </svg>
@@ -254,20 +253,12 @@ const sources = {
     ),
     profileMan: (
         <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-                <circle id="profileMan-a" cx="40" cy="40" r="40" />
-            </defs>
             <g fill="none" fillRule="evenodd">
-                <mask id="profileMan-b" fill="#fff">
-                    <use href="#profileMan-a" />
-                </mask>
-                <use fill="#EFEFEF" href="#profileMan-a" />
-                <g opacity=".503" mask="url(#profileMan-b)" stroke="#525252" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5">
-                    <g transform="translate(20 17)">
-                        <ellipse cx="20.5" cy="11" rx="10.762" ry="10.5" />
-                        <path d="M11.226 5.668c3.367 3.408 8.01 5.333 12.861 5.332 2.433 0 4.84-.483 7.073-1.422M.512 45.5C.512 34.73 9.462 26 20.5 26c11.039 0 19.987 8.73 19.987 19.5" />
-                        <path d="M12.813 27.498V29c0 4.142 3.441 7.5 7.687 7.5s7.688-3.358 7.688-7.5v-1.502" />
-                    </g>
+                <circle fill="#EFEFEF" fillRule="nonzero" cx="40" cy="40" r="40" />
+                <g opacity="0.5">
+                    <ellipse stroke="#525252" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" cx="40.5" cy="28" rx="10.762" ry="10.5" />
+                    <path d="M32.813 44.498V46c0 4.142 3.441 7.5 7.687 7.5s7.688-3.358 7.688-7.5v-1.502" stroke="#525252" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M31.226 22.668c3.367 3.408 8.01 5.333 12.861 5.332 2.433 0 4.84-.483 7.073-1.422M20.512 62.5c0-10.77 8.95-19.5 19.988-19.5 11.039 0 19.987 8.73 19.987 19.5" stroke="#525252" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                 </g>
             </g>
         </svg>


### PR DESCRIPTION
**tl;dr** Chrome exposes elements with ids as `window` properties, i.e. `<div id=“a”></div>` is accessible via `window.a`. Longer ids are less likely to cause conflicts with… browser extensions.

I don't feel like it's a proper solution to the problem. Why? The exception tells us that `indexOf` is not a function. It means that `a[b].target.className` is somehow defined. Here's what Chrome thinks `window.a` is on core pages:

<img width="617" alt="Screenshot 2019-05-28 18 06 05" src="https://user-images.githubusercontent.com/320066/58496864-ffda4a80-817a-11e9-828c-994a9e52894c.png">

_(`window.b` is part of the same svg, so `a[b]` kinda makes sense.)_

I'd treat this PR as an attempt to solve the issue rather than the actual fix. Hope that's good enough.

FYI, [an article](https://medium.com/@amir.harel/a-b-target-classname-indexof-is-not-a-function-at-least-not-mine-8e52f7be64ca) what helped me identify the issue