### PR TITLE
[PLATFORM-747] Fix ExportCSV module to use new API endpoint

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10976,6 +10976,11 @@
         "schema-utils": "^0.4.5"
       }
     },
+    "file-saver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
+    },
     "file-system-cache": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-1.0.5.tgz",
@@ -11340,8 +11345,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -11362,14 +11366,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11384,20 +11386,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11514,8 +11513,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -11527,7 +11525,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11542,7 +11539,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11550,14 +11546,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -11576,7 +11570,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11657,8 +11650,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11670,7 +11662,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11756,8 +11747,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "optional": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11793,7 +11783,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11813,7 +11802,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11857,14 +11845,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "optional": true
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },

--- a/app/package.json
+++ b/app/package.json
@@ -127,6 +127,7 @@
     "events": "^3.0.0",
     "expect": "^23.5.0",
     "file-loader": "^1.1.9",
+    "file-saver": "^2.0.2",
     "flow-babel-webpack-plugin": "^1.1.1",
     "flow-bin": "^0.96.0",
     "form-serialize": "^0.7.2",

--- a/app/src/editor/shared/components/modules/ExportCSV.jsx
+++ b/app/src/editor/shared/components/modules/ExportCSV.jsx
@@ -3,8 +3,10 @@
 import React from 'react'
 import cx from 'classnames'
 import throttle from 'lodash/throttle'
+import { saveAs } from 'file-saver'
 
 import routes from '$routes'
+import api from '$editor/shared/utils/api'
 import ModuleSubscription from '../ModuleSubscription'
 
 import styles from './ExportCSV.pcss'
@@ -46,6 +48,20 @@ export default class ExportCSVModule extends React.Component<Props, State> {
         }
     }, 250)
 
+    downloadFile = async (url: string, filename: string) => {
+        const result = await api().get(url, {
+            responseType: 'blob',
+            timeout: 30000,
+        })
+        await saveAs(result.data, filename)
+
+        // We need to clear the download link since the file will
+        // be deleted on the server after a succesful download
+        this.setState({
+            link: undefined,
+        })
+    }
+
     render() {
         const { rows, size, link } = this.state
         const downloadUrl = link && routes.downloadCsv({
@@ -64,9 +80,16 @@ export default class ExportCSVModule extends React.Component<Props, State> {
                 {size != null && (
                     <div className={styles.text}>Size: {size} kb</div>
                 )}
-                {downloadUrl && (
+                {downloadUrl && link && (
                     <div className={styles.text}>
-                        <a href={downloadUrl}>Download CSV</a>
+                        <a
+                            href="#"
+                            onClick={() => {
+                                this.downloadFile(downloadUrl, link)
+                            }}
+                        >
+                            Download CSV
+                        </a>
                     </div>
                 )}
             </div>

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -25,7 +25,7 @@
     "docsTutorials": "/docs/tutorials",
     "docsUserPage": "/docs/userpage",
     "docsVisualEditor": "/docs/visual-editor",
-    "downloadCsv": "<streamr>/canvas/downloadCsv?filename=:file",
+    "downloadCsv": "<streamr>/api/v1/canvases/downloadCsv?filename=:file",
     "editProduct": "/marketplace/products/:id/edit",
     "editProfile": "/core/profile/edit",
     "error": "/error",

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -25,7 +25,6 @@
     "docsTutorials": "/docs/tutorials",
     "docsUserPage": "/docs/userpage",
     "docsVisualEditor": "/docs/visual-editor",
-    "downloadCsv": "<streamr>/api/v1/canvases/downloadCsv?filename=:file",
     "editProduct": "/marketplace/products/:id/edit",
     "editProfile": "/core/profile/edit",
     "error": "/error",


### PR DESCRIPTION
With newest e&e, the `/canvas/downloadCsv` endpoint is now under `/api/v1/` so we'll need these changes for download to work.

We need to use https://github.com/eligrey/FileSaver.js/ for saving the file because authentication is needed on the endpoint and therefore we cannot use a simple link.