### PR TITLE
Whitelist streamr urls for Sentry.

### DIFF
--- a/app/src/analytics.js
+++ b/app/src/analytics.js
@@ -63,6 +63,12 @@ if (process.env.SENTRY_DSN) {
                 dsn: process.env.SENTRY_DSN,
                 release: process.env.VERSION,
                 environment: process.env.SENTRY_ENVIRONMENT,
+                whitelistUrls: [
+                    window.location.origin,
+                    process.env.PLATFORM_PUBLIC_PATH,
+                    process.env.PLATFORM_ORIGIN_URL,
+                    process.env.STREAMR_URL,
+                ].filter(Boolean),
                 debug: true,
             })
         ),


### PR DESCRIPTION
This may resolve the issue where some errors are not being logged in production, when the same error is are being logged successfully in other environments.