### PR TITLE
[PLATFORM-712] Gracefully handle embed urls

### DIFF
--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -45,6 +45,7 @@ import ApiPage from '$docs/components/ApiPage'
 
 // Editor
 import CanvasEditor from '$editor/canvas'
+import CanvasEmbed from '$editor/canvas/components/Embed'
 import DashboardEditor from '$editor/dashboard'
 
 import ModalRoot from '$shared/components/ModalRoot'
@@ -149,7 +150,7 @@ const UserpagesRouter = () => ([
 const EditorRouter = () => ([
     <Route exact path="/" component={Products} key="root" />, // edge case for localhost
     <Route exact path={formatPath(editor.canvasEditor, ':id?')} component={CanvasEditorAuth} key="CanvasEditor" />,
-    <Route exact path={formatPath(editor.canvasEmbed, ':id?')} component={CanvasEditorAuth} key="CanvasEmbed" />,
+    <Route exact path={formatPath(editor.canvasEmbed, ':id?')} component={CanvasEmbed} key="CanvasEmbed" />,
     <Route exact path={formatPath(editor.dashboardEditor, ':id?')} component={DashboardEditorAuth} key="DashboardEditor" />,
 ])
 

--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -149,6 +149,7 @@ const UserpagesRouter = () => ([
 const EditorRouter = () => ([
     <Route exact path="/" component={Products} key="root" />, // edge case for localhost
     <Route exact path={formatPath(editor.canvasEditor, ':id?')} component={CanvasEditorAuth} key="CanvasEditor" />,
+    <Route exact path={formatPath(editor.canvasEmbed, ':id?')} component={CanvasEditorAuth} key="CanvasEmbed" />,
     <Route exact path={formatPath(editor.dashboardEditor, ':id?')} component={DashboardEditorAuth} key="DashboardEditor" />,
 ])
 

--- a/app/src/editor/canvas/components/Embed.jsx
+++ b/app/src/editor/canvas/components/Embed.jsx
@@ -1,0 +1,53 @@
+// @flow
+
+import React from 'react'
+import { Container } from 'reactstrap'
+import { Link } from 'react-router-dom'
+import { Translate, I18n } from 'react-redux-i18n'
+
+import BodyClass, { PAGE_SECONDARY } from '$shared/components/BodyClass'
+import EmptyState from '$shared/components/EmptyState'
+import Layout from '$mp/components/Layout'
+import links from '../../../links'
+import pageNotFoundPic from '$shared/assets/images/404_blocks.png'
+import pageNotFoundPic2x from '$shared/assets/images/404_blocks@2x.png'
+import styles from './Embed.pcss'
+
+const CanvasEmbedPage = () => (
+    <Layout className={styles.canvasEmbedPage}>
+        <BodyClass className={PAGE_SECONDARY} />
+        <Container>
+            <EmptyState
+                image={(
+                    <img
+                        src={pageNotFoundPic}
+                        srcSet={`${pageNotFoundPic2x} 2x`}
+                        alt={I18n.t('error.notFound')}
+                    />
+                )}
+                link={(
+                    <React.Fragment>
+                        <Link
+                            to={links.userpages.main}
+                            className="btn btn-special"
+                        >
+                            <Translate value="notFoundPage.coreaApp" />
+                        </Link>
+                        <Link
+                            to={links.root}
+                            className="btn btn-special"
+                        >
+                            <Translate value="notFoundPage.publicSite" />
+                        </Link>
+                    </React.Fragment>
+                )}
+                linkOnMobile
+            >
+                <p>Whoops! Embeds are disabled in the beta for now.</p>
+                <small>We’re working on it, so please check back again soon.</small>
+            </EmptyState>
+        </Container>
+    </Layout>
+)
+
+export default CanvasEmbedPage

--- a/app/src/editor/canvas/components/Embed.jsx
+++ b/app/src/editor/canvas/components/Embed.jsx
@@ -31,7 +31,7 @@ const CanvasEmbedPage = () => (
                             to={links.userpages.main}
                             className="btn btn-special"
                         >
-                            <Translate value="notFoundPage.coreaApp" />
+                            <Translate value="notFoundPage.coreApp" />
                         </Link>
                         <Link
                             to={links.root}

--- a/app/src/editor/canvas/components/Embed.pcss
+++ b/app/src/editor/canvas/components/Embed.pcss
@@ -1,0 +1,4 @@
+.canvasEmbedPage {
+  text-align: center;
+  width: 100%;
+}

--- a/app/src/links.js
+++ b/app/src/links.js
@@ -57,6 +57,7 @@ module.exports = {
     },
     editor: {
         canvasEditor: routes.canvasEditor(),
+        canvasEmbed: routes.canvasEmbed(),
         dashboardEditor: routes.dashboardEditor(),
     },
     community: {

--- a/app/src/marketplace/components/NotFoundPage/index.jsx
+++ b/app/src/marketplace/components/NotFoundPage/index.jsx
@@ -31,7 +31,7 @@ const NotFoundPage = () => (
                             to={links.userpages.main}
                             className="btn btn-special"
                         >
-                            <Translate value="notFoundPage.coreaApp" />
+                            <Translate value="notFoundPage.coreApp" />
                         </Link>
                         <Link
                             to={links.marketplace.main}

--- a/app/src/marketplace/components/NotFoundPage/index.jsx
+++ b/app/src/marketplace/components/NotFoundPage/index.jsx
@@ -26,12 +26,26 @@ const NotFoundPage = () => (
                     />
                 )}
                 link={(
-                    <Link
-                        to={links.marketplace.main}
-                        className="btn btn-special"
-                    >
-                        <Translate value="notFoundPage.top" />
-                    </Link>
+                    <React.Fragment>
+                        <Link
+                            to={links.userpages.main}
+                            className="btn btn-special"
+                        >
+                            <Translate value="notFoundPage.coreaApp" />
+                        </Link>
+                        <Link
+                            to={links.marketplace.main}
+                            className="btn btn-special"
+                        >
+                            <Translate value="notFoundPage.top" />
+                        </Link>
+                        <Link
+                            to={links.root}
+                            className="btn btn-special"
+                        >
+                            <Translate value="notFoundPage.publicSite" />
+                        </Link>
+                    </React.Fragment>
                 )}
                 linkOnMobile
             >

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -539,11 +539,17 @@ msgstr "We couldn’t find anything to match your search"
 
 msgid "notFoundPage##message"
 msgstr ""
-"Whoops! We don’t seem to be able to <br />find your data. Something might have "
-"been moved around or changed."
+"Whoops! We don’t seem to be able to find your data.</br>"
+"<small>Something might have been moved around or changed.<small>"
 
 msgid "notFoundPage##top"
-msgstr "Go to the marketplace top"
+msgstr "Go to marketplace"
+
+msgid "notFoundPage##coreaApp"
+msgstr "Go to core app"
+
+msgid "notFoundPage##publicSite"
+msgstr "Go to public site"
 
 msgid "notifications##productPublished"
 msgstr "Your product has been published"

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -545,7 +545,7 @@ msgstr ""
 msgid "notFoundPage##top"
 msgstr "Go to marketplace"
 
-msgid "notFoundPage##coreaApp"
+msgid "notFoundPage##coreApp"
 msgstr "Go to core app"
 
 msgid "notFoundPage##publicSite"

--- a/app/src/marketplace/styles/pcss/buttons.pcss
+++ b/app/src/marketplace/styles/pcss/buttons.pcss
@@ -142,9 +142,8 @@
 
   .btn.btn-special {
     font-size: 12px;
-    background-color: #FCFBF9;
+    background-color: rgba(255, 255, 255, 0.9);
     display: inline-block;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
     border-radius: 20px;
     padding: 0 1.5em;
     color: var(--greyDark);
@@ -156,13 +155,18 @@
     letter-spacing: 1px;
 
     &:--enter {
-      box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
       color: var(--greyDark);
+      background-color: rgba(255, 255, 255, 1);
       text-decoration: none;
+      transform: scale(1.05);
     }
 
     &:active {
       background-color: var(--white);
+    }
+
+    &[disabled] {
+      opacity: 0.5;
     }
   }
 

--- a/app/src/marketplace/styles/pcss/buttons.pcss
+++ b/app/src/marketplace/styles/pcss/buttons.pcss
@@ -153,6 +153,7 @@
     font-family: 'IBM Plex Sans', sans-serif;
     font-weight: var(--medium);
     letter-spacing: 1px;
+    will-change: transform;
 
     &:--enter {
       color: var(--greyDark);

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -1,5 +1,6 @@
 {
     "canvasEditor": "/canvas/editor",
+    "canvasEmbed": "/canvas/embed",
     "canvases": "/core/canvases",
     "communityGithub": "https://github.com/streamr-dev",
     "communityLinkedin": "https://www.linkedin.com/company/streamr-ltd-/",

--- a/app/src/shared/components/EmptyState/emptyState.pcss
+++ b/app/src/shared/components/EmptyState/emptyState.pcss
@@ -47,7 +47,7 @@
 
       a + a {
         margin-left: 0;
-        margin-top: calc(1 * var(--um));
+        margin-top: var(--um);
       }
     }
   }

--- a/app/src/shared/components/EmptyState/emptyState.pcss
+++ b/app/src/shared/components/EmptyState/emptyState.pcss
@@ -1,6 +1,7 @@
 .emptyState {
   color: var(--greyDark);
   font-size: 16px;
+  font-weight: var(--regular);
   padding: 6em 0;
   text-align: center;
 
@@ -28,10 +29,27 @@
 }
 
 .linkWrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
   margin-top: 1.25em;
 
   a + a {
-    margin-left: 3.25em;
+    margin-left: calc(2 * var(--um));
+  }
+}
+
+@media (--sm-down) {
+  .emptyState {
+    .linkWrapper {
+      flex-direction: column;
+      align-items: center;
+
+      a + a {
+        margin-left: 0;
+        margin-top: calc(1 * var(--um));
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Adds a customised error page for canvas embed urls and updates `NotFound` page to have link buttons for core app and landing page. I also updated `special-btn` style as requested by Matt & Saori.

This page will be displayed until we have implemented embedding.