### PR TITLE
[PLATFORM-709] Flush user data on logout

### DIFF
--- a/app/src/auth/components/LogoutPage/index.jsx
+++ b/app/src/auth/components/LogoutPage/index.jsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 import { connect } from 'react-redux'
 
 import { post } from '$shared/utils/api'
-import useIsMountedRef from '$shared/utils/useIsMountedRef'
+import useIsMounted from '$shared/hooks/useIsMounted'
 import useOnMount from '$shared/utils/useOnMount'
 import { logout as logoutAction } from '$shared/modules/user/actions'
 import ErrorPageView from '$mp/components/ErrorPageView'
@@ -19,18 +19,18 @@ type Props = DispatchProps & {}
 const LogoutPage = ({ logout }: Props) => {
     const [error, setError] = useState(null)
 
-    const mountedRef = useIsMountedRef()
+    const isMounted = useIsMounted()
 
     useOnMount(() => {
         post(routes.externalLogout())
             .then(
                 () => {
-                    if (mountedRef.current) {
+                    if (isMounted()) {
                         logout()
                     }
                 },
                 (e) => {
-                    if (mountedRef.current) {
+                    if (isMounted()) {
                         setError(e)
                     }
                 },

--- a/app/src/auth/components/LogoutPage/index.jsx
+++ b/app/src/auth/components/LogoutPage/index.jsx
@@ -1,12 +1,11 @@
 // @flow
 
-import React, { useState, useContext } from 'react'
+import React, { useState } from 'react'
 import { connect } from 'react-redux'
 
 import { post } from '$shared/utils/api'
 import useIsMountedRef from '$shared/utils/useIsMountedRef'
 import useOnMount from '$shared/utils/useOnMount'
-import SessionContext from '../../contexts/Session'
 import { logout as logoutAction } from '$shared/modules/user/actions'
 import ErrorPageView from '$mp/components/ErrorPageView'
 import routes from '$routes'
@@ -19,7 +18,6 @@ type Props = DispatchProps & {}
 
 const LogoutPage = ({ logout }: Props) => {
     const [error, setError] = useState(null)
-    const { setSessionToken } = useContext(SessionContext)
 
     const mountedRef = useIsMountedRef()
 
@@ -27,9 +25,8 @@ const LogoutPage = ({ logout }: Props) => {
         post(routes.externalLogout())
             .then(
                 () => {
-                    if (setSessionToken && mountedRef.current) {
+                    if (mountedRef.current) {
                         logout()
-                        setSessionToken(null)
                     }
                 },
                 (e) => {

--- a/app/src/shared/modules/user/actions.js
+++ b/app/src/shared/modules/user/actions.js
@@ -35,11 +35,13 @@ import {
     DELETE_USER_ACCOUNT_FAILURE,
 } from './constants'
 import routes from '$routes'
+import { clearStorage } from '$shared/utils/storage'
 
 // Logout
 export const resetUserData: ReduxActionCreator = createAction(RESET_USER_DATA)
 
 export const logout = () => (dispatch: Function) => {
+    clearStorage()
     dispatch(resetUserData())
     dispatch(replace(routes.root()))
 }

--- a/app/src/shared/modules/user/actions.js
+++ b/app/src/shared/modules/user/actions.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { createAction } from 'redux-actions'
-import { replace } from 'react-router-redux'
 
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
@@ -34,7 +33,6 @@ import {
     DELETE_USER_ACCOUNT_SUCCESS,
     DELETE_USER_ACCOUNT_FAILURE,
 } from './constants'
-import routes from '$routes'
 import { clearStorage } from '$shared/utils/storage'
 
 // Logout
@@ -43,7 +41,8 @@ export const resetUserData: ReduxActionCreator = createAction(RESET_USER_DATA)
 export const logout = () => (dispatch: Function) => {
     clearStorage()
     dispatch(resetUserData())
-    dispatch(replace(routes.root()))
+
+    window.location.href = process.env.PLATFORM_ORIGIN_URL
 }
 
 // Fetching user data

--- a/app/src/shared/test/modules/user/actions.test.js
+++ b/app/src/shared/test/modules/user/actions.test.js
@@ -1,7 +1,6 @@
 import assert from 'assert-diff'
 import sinon from 'sinon'
 import mockStore from '$testUtils/mockStoreProvider'
-import { CALL_HISTORY_METHOD } from 'react-router-redux'
 
 import * as actions from '$shared/modules/user/actions'
 import * as constants from '$shared/modules/user/constants'
@@ -106,15 +105,6 @@ describe('user - actions', () => {
             const expectedActions = [
                 {
                     type: constants.RESET_USER_DATA,
-                },
-                {
-                    type: CALL_HISTORY_METHOD,
-                    payload: {
-                        method: 'replace',
-                        args: [
-                            '/',
-                        ],
-                    },
                 },
             ]
             assert.deepStrictEqual(store.getActions(), expectedActions)

--- a/app/src/shared/utils/storage.js
+++ b/app/src/shared/utils/storage.js
@@ -33,3 +33,13 @@ const storageAvailable = (type: string): boolean => {
 export const isLocalStorageAvailable = () => storageAvailable('localStorage')
 
 export const isSessionStorageAvailable = () => storageAvailable('sessionStorage')
+
+export const clearStorage = () => {
+    if (isLocalStorageAvailable()) {
+        localStorage.clear()
+    }
+
+    if (isSessionStorageAvailable()) {
+        sessionStorage.clear()
+    }
+}


### PR DESCRIPTION
The aim of this PR is to flush all user data on logout. The store gets forgotten because we pretty much redirect away from the app (`window.location=`), and `sessionStorage` and `localStorage` are cleared up manually in `logout` action.

Guys, let me know if you think it's gonna do the trick. Thanks!

PS. @timoxley check out the `useIsMounted` hook I made! 🍰 

---

Tickets addressed in this PR:

- [`PLATFORM-709`](https://streamr.atlassian.net/browse/PLATFORM-709)
- [`PLATFORM-601`](https://streamr.atlassian.net/browse/PLATFORM-601)