### PR TITLE
[PLATFORM-527] Fix jumping calendars in the toolbar

### DIFF
--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -396,6 +396,7 @@ body .RealtimeRunButtonMenu {
 .CalendarWrapper {
   bottom: 50px;
   left: 50%;
+  min-height: 361px; /* Height of 6 rows/weeks. */
   transform: translate(-50%, 0);
 }
 

--- a/app/src/shared/components/Calendar/calendar.pcss
+++ b/app/src/shared/components/Calendar/calendar.pcss
@@ -11,7 +11,7 @@
 
   &,
   button {
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
   }
 
   button {
@@ -25,7 +25,7 @@
   .react-calendar__navigation {
     height: 28px;
     line-height: 20px;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     margin-bottom: 21px;
 
     .react-calendar__navigation__label {


### PR DESCRIPTION
In this PR I force the calendar to persist its vertical position for months with different number of displayed weeks, i.e.

![May-31-2019 15-47-45](https://user-images.githubusercontent.com/320066/58710073-cf352380-83bb-11e9-9bcd-a289ddb42e91.gif)

@mattatgit please note that the same happens when you're in year view and decade view.