### PR TITLE
[PLATFORM-570] Module titles vs min. module widths

### DIFF
--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -149,7 +149,7 @@ const Port = ({
                 <EditableText
                     disabled={!!isRunning}
                     editing={editingName}
-                    onChange={onNameChange}
+                    onCommit={onNameChange}
                     setEditing={setEditingName}
                 >
                     {port.displayName || startCase(port.name)}

--- a/app/src/editor/canvas/components/Ports/Value/Text/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Text/index.jsx
@@ -30,7 +30,7 @@ const Text = ({
             disabled={disabled}
             editing={editing}
             editOnFocus
-            onChange={onChange}
+            onCommit={onChange}
             setEditing={setEditing}
         >
             {value}

--- a/app/src/editor/canvas/components/Resizable/SizeConstraintProvider/Probe/probe.pcss
+++ b/app/src/editor/canvas/components/Resizable/SizeConstraintProvider/Probe/probe.pcss
@@ -1,7 +1,9 @@
 .root {
   height: 100%;
+  left: 0;
   pointer-events: none;
   position: absolute;
+  top: 0;
   width: 100%;
 }
 

--- a/app/src/editor/canvas/components/Resizable/SizeConstraintProvider/index.jsx
+++ b/app/src/editor/canvas/components/Resizable/SizeConstraintProvider/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { type Node, type Context, createContext, useMemo, useState, useCallback } from 'react'
+import debounce from 'lodash/debounce'
 
 type ContextProps = {
     minHeight: number,
@@ -69,9 +70,9 @@ const SizeConstraintProvider = ({ children }: Props) => {
         }))
     }, [setDim])
 
-    const refreshProbes = useCallback(() => {
+    const refreshProbes = useCallback(debounce(() => {
         setProbeRefreshCount((count) => count + 1)
-    }, [])
+    }, 200), [])
 
     const { minWidth, minHeight } = useMemo(() => ({
         minHeight: Object.values(dim.heights).reduce((min, group) => (

--- a/app/src/editor/canvas/components/Resizable/index.jsx
+++ b/app/src/editor/canvas/components/Resizable/index.jsx
@@ -15,14 +15,14 @@ type Size = {
 type ContextProps = {
     enabled: boolean,
     height: number,
-    toggleHandle: (?boolean) => void,
+    setShowHandle: (?boolean) => void,
     width: number,
 }
 
 const defaultContext: ContextProps = {
     enabled: false,
     height: 0,
-    toggleHandle: () => {},
+    setShowHandle: () => {},
     width: 0,
 }
 
@@ -116,7 +116,7 @@ const Resizable = ({
     const value = useMemo(() => ({
         ...size,
         enabled: true,
-        toggleHandle: setShowHandle,
+        setShowHandle,
     }), [size])
 
     useEffect(() => {

--- a/app/src/editor/canvas/components/Resizable/index.jsx
+++ b/app/src/editor/canvas/components/Resizable/index.jsx
@@ -140,6 +140,9 @@ const Resizable = ({
     commitRef.current = commit
 
     useEffect(() => {
+        // We're using refs because we only want this effect to run when either
+        // minWidth or minHeight change.
+
         const commit: (any) => void = (commitRef.current: any)
         const updatePreviousSize: () => void = (updatePreviousSizeRef.current: any)
 

--- a/app/src/editor/canvas/components/Resizable/index.jsx
+++ b/app/src/editor/canvas/components/Resizable/index.jsx
@@ -15,12 +15,14 @@ type Size = {
 type ContextProps = {
     enabled: boolean,
     height: number,
+    toggleHandle: (?boolean) => void,
     width: number,
 }
 
 const defaultContext: ContextProps = {
     enabled: false,
     height: 0,
+    toggleHandle: () => {},
     width: 0,
 }
 
@@ -47,6 +49,8 @@ const Resizable = ({
     ...props
 }: Props) => {
     const { minWidth, minHeight } = useContext(SizeConstraintContext)
+
+    const [showHandle, setShowHandle] = useState(true)
 
     const [size, setSize] = useState({
         height,
@@ -112,6 +116,7 @@ const Resizable = ({
     const value = useMemo(() => ({
         ...size,
         enabled: true,
+        toggleHandle: setShowHandle,
     }), [size])
 
     useEffect(() => {
@@ -169,11 +174,13 @@ const Resizable = ({
                 }}
             >
                 {children}
-                <Handle
-                    beforeDrag={prepare}
-                    onDrag={preview}
-                    onDrop={commit}
-                />
+                {!!showHandle && (
+                    <Handle
+                        beforeDrag={prepare}
+                        onDrag={preview}
+                        onDrop={commit}
+                    />
+                )}
             </div>
         </ResizeableContext.Provider>
     ) : (

--- a/app/src/editor/canvas/components/Resizable/index.jsx
+++ b/app/src/editor/canvas/components/Resizable/index.jsx
@@ -133,17 +133,11 @@ const Resizable = ({
         }
     }, [width, height])
 
-    const updatePreviousSizeRef: Ref<Function> = useRef(updatePreviousSize)
+    const updatePreviousSizeRef: Ref<Function> = useRef()
+    updatePreviousSizeRef.current = updatePreviousSize
 
-    useEffect(() => {
-        updatePreviousSizeRef.current = updatePreviousSize
-    }, [updatePreviousSize])
-
-    const commitRef: Ref<Function> = useRef(commit)
-
-    useEffect(() => {
-        commitRef.current = commit
-    }, [commit])
+    const commitRef: Ref<Function> = useRef()
+    commitRef.current = commit
 
     useEffect(() => {
         const commit: (any) => void = (commitRef.current: any)

--- a/app/src/editor/canvas/components/Resizable/index.jsx
+++ b/app/src/editor/canvas/components/Resizable/index.jsx
@@ -121,6 +121,36 @@ const Resizable = ({
         })
     }, [width, height])
 
+    const updatePreviousSize = useCallback(() => {
+        previousSize.current = {
+            height,
+            width,
+        }
+    }, [width, height])
+
+    const updatePreviousSizeRef: Ref<Function> = useRef(updatePreviousSize)
+
+    useEffect(() => {
+        updatePreviousSizeRef.current = updatePreviousSize
+    }, [updatePreviousSize])
+
+    const commitRef: Ref<Function> = useRef(commit)
+
+    useEffect(() => {
+        commitRef.current = commit
+    }, [commit])
+
+    useEffect(() => {
+        const commit: (any) => void = (commitRef.current: any)
+        const updatePreviousSize: () => void = (updatePreviousSizeRef.current: any)
+
+        updatePreviousSize()
+        commit({
+            dx: 0,
+            dy: 0,
+        })
+    }, [minWidth, minHeight, updatePreviousSize])
+
     return enabled ? (
         <ResizeableContext.Provider value={value}>
             <div

--- a/app/src/editor/canvas/components/Resizable/index.jsx
+++ b/app/src/editor/canvas/components/Resizable/index.jsx
@@ -154,7 +154,7 @@ const Resizable = ({
             dx: 0,
             dy: 0,
         })
-    }, [minWidth, minHeight, updatePreviousSize])
+    }, [minWidth, minHeight])
 
     return enabled ? (
         <ResizeableContext.Provider value={value}>

--- a/app/src/editor/shared/components/ModuleHeader/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/index.jsx
@@ -1,9 +1,10 @@
 // @flow
 
-import React, { useState, type Node, Fragment } from 'react'
+import React, { useState, type Node, Fragment, useContext, useCallback } from 'react'
 import cx from 'classnames'
 import EditableText from '$shared/components/EditableText'
 import Probe from '$editor/canvas/components/Resizable/SizeConstraintProvider/Probe'
+import { Context as SizeConstraintContext } from '$editor/canvas/components/Resizable/SizeConstraintProvider'
 import styles from './moduleHeader.pcss'
 
 type Props = {
@@ -25,6 +26,12 @@ const ModuleHeader = ({
     ...props
 }: Props) => {
     const [editing, setEditing] = useState(false)
+
+    const { refreshProbes } = useContext(SizeConstraintContext)
+
+    const onChange = useCallback(() => {
+        refreshProbes()
+    }, [refreshProbes])
 
     return (
         <Fragment>
@@ -49,6 +56,7 @@ const ModuleHeader = ({
                             disabled={!editable}
                             editing={editing}
                             onCommit={onLabelChange}
+                            onChange={onChange}
                             probe={(
                                 <Probe uid="name" group="ModuleHeader" width="auto" />
                             )}

--- a/app/src/editor/shared/components/ModuleHeader/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/index.jsx
@@ -34,13 +34,13 @@ const ModuleHeader = ({
         refreshProbes()
     }, [refreshProbes])
 
-    const { toggleHandle } = useContext(ResizableContext)
+    const { setShowHandle } = useContext(ResizableContext)
 
     useEffect(() => {
         refreshProbes()
         // Hide resize handle during editing.
-        toggleHandle(!editing)
-    }, [editing, toggleHandle, refreshProbes])
+        setShowHandle(!editing)
+    }, [editing, setShowHandle, refreshProbes])
 
     return (
         <Fragment>

--- a/app/src/editor/shared/components/ModuleHeader/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/index.jsx
@@ -57,7 +57,7 @@ const ModuleHeader = ({
                             })}
                             disabled={!editable}
                             editing={editing}
-                            onChange={onLabelChange}
+                            onCommit={onLabelChange}
                             setEditing={setEditing}
                         >
                             {label}

--- a/app/src/editor/shared/components/ModuleHeader/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/index.jsx
@@ -1,10 +1,11 @@
 // @flow
 
-import React, { useState, type Node, Fragment, useContext, useCallback } from 'react'
+import React, { useState, type Node, Fragment, useContext, useCallback, useEffect } from 'react'
 import cx from 'classnames'
 import EditableText from '$shared/components/EditableText'
 import Probe from '$editor/canvas/components/Resizable/SizeConstraintProvider/Probe'
 import { Context as SizeConstraintContext } from '$editor/canvas/components/Resizable/SizeConstraintProvider'
+import { Context as ResizableContext } from '$editor/canvas/components/Resizable'
 import styles from './moduleHeader.pcss'
 
 type Props = {
@@ -32,6 +33,13 @@ const ModuleHeader = ({
     const onChange = useCallback(() => {
         refreshProbes()
     }, [refreshProbes])
+
+    const { toggleHandle } = useContext(ResizableContext)
+
+    // Hide resize handle during editing.
+    useEffect(() => {
+        toggleHandle(!editing)
+    }, [editing, toggleHandle])
 
     return (
         <Fragment>

--- a/app/src/editor/shared/components/ModuleHeader/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/index.jsx
@@ -36,10 +36,11 @@ const ModuleHeader = ({
 
     const { toggleHandle } = useContext(ResizableContext)
 
-    // Hide resize handle during editing.
     useEffect(() => {
+        refreshProbes()
+        // Hide resize handle during editing.
         toggleHandle(!editing)
-    }, [editing, toggleHandle])
+    }, [editing, toggleHandle, refreshProbes])
 
     return (
         <Fragment>

--- a/app/src/editor/shared/components/ModuleHeader/index.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/index.jsx
@@ -28,29 +28,20 @@ const ModuleHeader = ({
 
     return (
         <Fragment>
-            {/*
-                ModuleHeader's minWidth is always 92px. The way we calculate the number:
-                - 24px for expand/collapse placeholder
-                - 40px for the hamburger menu button
-                - 1.75um for EditableText (1um = 16px) - makes `Title` display as `T…`
-            */}
-            <Probe group="ModuleHeader" width={92} />
             <div
                 className={cx(styles.root, className)}
                 {...props}
             >
                 {/* TODO: Replace the following line with the actual toggle. This here is just a placeholder. */}
-                <div className={styles.expandToggle} />
+                <div className={styles.expandToggle}>
+                    <Probe uid="toggle" group="ModuleHeader" width="auto" />
+                </div>
                 <div
                     className={cx(styles.name, {
                         [styles.limitedWidth]: !!(limitWidth && editing),
                     })}
                 >
-                    <div
-                        className={cx({
-                            [styles.idle]: !editing,
-                        })}
-                    >
+                    <div className={styles.inner}>
                         <EditableText
                             className={cx({
                                 [styles.limitedWidth]: !!limitWidth,
@@ -58,6 +49,9 @@ const ModuleHeader = ({
                             disabled={!editable}
                             editing={editing}
                             onCommit={onLabelChange}
+                            probe={(
+                                <Probe uid="name" group="ModuleHeader" width="auto" />
+                            )}
                             setEditing={setEditing}
                         >
                             {label}
@@ -66,6 +60,7 @@ const ModuleHeader = ({
                 </div>
                 {!!children && (
                     <div className={styles.buttons}>
+                        <Probe uid="buttons" group="ModuleHeader" width="auto" />
                         {children}
                     </div>
                 )}

--- a/app/src/editor/shared/components/ModuleHeader/moduleHeader.pcss
+++ b/app/src/editor/shared/components/ModuleHeader/moduleHeader.pcss
@@ -4,7 +4,6 @@
   font-size: 12px;
   font-weight: var(--medium);
   justify-content: space-between;
-  min-width: 92px; /* 24px + 40px + 1.75um (um = 16px)  */
 }
 
 .name {
@@ -12,15 +11,14 @@
   position: relative;
 }
 
-.idle {
-  position: absolute;
-  transform: translateY(-50%);
-  width: 100%;
+.inner {
+  max-width: calc(32 * var(--um));
 }
 
 .expandToggle {
   flex-shrink: 0;
   height: 40px;
+  position: relative;
   width: 24px;
 }
 
@@ -32,6 +30,7 @@
   display: flex;
   opacity: 0;
   padding: calc(0.5 * var(--um));
+  position: relative;
   transition: 200ms linear;
   transition-delay: 200s, 0s;
   transition-property: visibility, opacity;

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -54,11 +54,8 @@ const EditableText = ({
         setHasFocus(true)
     }, [setHasFocus])
 
-    const onChange = useCallback((e: SyntheticInputEvent<EventTarget>) => {
-        setValue(e.target.value)
-    }, [])
-
-    const onValueChange = useCallback((val: string) => {
+    const onChange = useCallback(({ target: { value: val } }: SyntheticInputEvent<EventTarget>) => {
+        setValue(val)
         if (onChangeProp) {
             onChangeProp(val)
         }
@@ -111,7 +108,6 @@ const EditableText = ({
                             onChange={onChange}
                             onCommit={onCommit}
                             onFocus={onFocus}
-                            onValueChange={onValueChange}
                             placeholder={placeholder}
                             revertOnEsc
                             selectAllOnFocus

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -14,7 +14,7 @@ type Props = {
     disabled?: boolean,
     editing?: boolean,
     editOnFocus?: boolean,
-    onChange?: (string) => void,
+    onCommit: (string) => void,
     onModeChange?: ?(boolean) => void,
     placeholder?: ?string,
     setEditing: (boolean) => void,
@@ -27,7 +27,7 @@ const EditableText = ({
     disabled,
     editing,
     editOnFocus,
-    onChange: onChangeProp,
+    onCommit,
     onModeChange,
     placeholder,
     setEditing,
@@ -49,6 +49,7 @@ const EditableText = ({
     const onFocus = useCallback(() => {
         setHasFocus(true)
     }, [setHasFocus])
+
     const onChange = useCallback((e: SyntheticInputEvent<EventTarget>) => {
         setValue(e.target.value)
     }, [setValue])
@@ -97,7 +98,7 @@ const EditableText = ({
                             flushHistoryOnBlur
                             onBlur={onBlur}
                             onChange={onChange}
-                            onCommit={onChangeProp}
+                            onCommit={onCommit}
                             onFocus={onFocus}
                             placeholder={placeholder}
                             revertOnEsc

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useState, useCallback, Fragment, useEffect, useRef } from 'react'
+import React, { useState, useCallback, Fragment, useEffect, useRef, type Node } from 'react'
 import cx from 'classnames'
 import { type Ref } from '$shared/flowtype/common-types'
 import ModuleHeader from '$editor/shared/components/ModuleHeader'
@@ -17,6 +17,7 @@ type Props = {
     onCommit: (string) => void,
     onModeChange?: ?(boolean) => void,
     placeholder?: ?string,
+    probe?: Node,
     setEditing: (boolean) => void,
 }
 
@@ -30,6 +31,7 @@ const EditableText = ({
     onCommit,
     onModeChange,
     placeholder,
+    probe,
     setEditing,
     ...props
 }: Props) => {
@@ -89,6 +91,7 @@ const EditableText = ({
             } : {})}
         >
             <span className={styles.inner}>
+                {probe}
                 {editing && !disabled ? (
                     <Fragment>
                         <TextControl

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -14,7 +14,8 @@ type Props = {
     disabled?: boolean,
     editing?: boolean,
     editOnFocus?: boolean,
-    onCommit: (string) => void,
+    onChange?: (string) => void,
+    onCommit?: (string) => void,
     onModeChange?: ?(boolean) => void,
     placeholder?: ?string,
     probe?: Node,
@@ -28,6 +29,7 @@ const EditableText = ({
     disabled,
     editing,
     editOnFocus,
+    onChange: onChangeProp,
     onCommit,
     onModeChange,
     placeholder,
@@ -54,7 +56,13 @@ const EditableText = ({
 
     const onChange = useCallback((e: SyntheticInputEvent<EventTarget>) => {
         setValue(e.target.value)
-    }, [setValue])
+    }, [])
+
+    const onValueChange = useCallback((val: string) => {
+        if (onChangeProp) {
+            onChangeProp(val)
+        }
+    }, [onChangeProp])
 
     const initialRender: Ref<boolean> = useRef(true)
 
@@ -103,6 +111,7 @@ const EditableText = ({
                             onChange={onChange}
                             onCommit={onCommit}
                             onFocus={onFocus}
+                            onValueChange={onValueChange}
                             placeholder={placeholder}
                             revertOnEsc
                             selectAllOnFocus

--- a/app/src/shared/components/TextControl/index.jsx
+++ b/app/src/shared/components/TextControl/index.jsx
@@ -15,6 +15,7 @@ type Props = {
     onCommit?: ?(string) => void,
     onFocus?: ?(SyntheticInputEvent<EventTarget>) => void,
     onKeyDown?: ?(SyntheticKeyboardEvent<EventTarget>) => void,
+    onValueChange?: ?(string) => void,
     revertOnEsc?: boolean,
     selectAllOnFocus?: boolean,
     tag?: 'input' | 'textarea',
@@ -35,6 +36,7 @@ const TextControl = ({
     onCommit,
     onFocus: onFocusProp,
     onKeyDown: onKeyDownProp,
+    onValueChange,
     revertOnEsc,
     selectAllOnFocus,
     tag,
@@ -142,6 +144,12 @@ const TextControl = ({
             commit()
         }
     }, [immediateCommit, commit])
+
+    useEffect(() => {
+        if (onValueChange) {
+            onValueChange(String(value))
+        }
+    }, [value, onValueChange])
 
     return (
         <Tag

--- a/app/src/shared/components/TextControl/index.jsx
+++ b/app/src/shared/components/TextControl/index.jsx
@@ -15,7 +15,6 @@ type Props = {
     onCommit?: ?(string) => void,
     onFocus?: ?(SyntheticInputEvent<EventTarget>) => void,
     onKeyDown?: ?(SyntheticKeyboardEvent<EventTarget>) => void,
-    onValueChange?: ?(string) => void,
     revertOnEsc?: boolean,
     selectAllOnFocus?: boolean,
     tag?: 'input' | 'textarea',
@@ -36,7 +35,6 @@ const TextControl = ({
     onCommit,
     onFocus: onFocusProp,
     onKeyDown: onKeyDownProp,
-    onValueChange,
     revertOnEsc,
     selectAllOnFocus,
     tag,
@@ -144,12 +142,6 @@ const TextControl = ({
             commit()
         }
     }, [immediateCommit, commit])
-
-    useEffect(() => {
-        if (onValueChange) {
-            onValueChange(String(value))
-        }
-    }, [value, onValueChange])
 
     return (
         <Tag


### PR DESCRIPTION
In this PR I make module titles take part in module size constraining. It makes the thing respect multiple buttons in the module title bar (`ModuleHeader`) and dynamic size of the actial title.

It's kind of a new situation cause usually the resizing comes from the outside (user drags the resize handler thus controls the size). Here we have a situation where component inside of the module box tells the box what's the current min size and the module box acts accordingly.

Anyway, long story short, looks like I got it! Let me know what you think (go, try to break it). 💃 

---

Tickets addressed in this PR:
- [`PLATFORM-570`](https://streamr.atlassian.net/browse/PLATFORM-570) Minimum module size should take module name into account
- [`PLATFORM-689`](https://streamr.atlassian.net/browse/PLATFORM-689) Switcher Module Title not visible (another case of the same issue)