### PR TITLE
[PLATFORM-728] Fix vertical alignment of Table module cells

### DIFF
--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -179,7 +179,11 @@ export default class TableModule extends React.Component {
                                 <tr key={row.id}>
                                     {row.cells.map((item, index) => (
                                         /* eslint-disable-next-line react/no-array-index-key */
-                                        <td key={index}>{item}</td>
+                                        <td key={index}>
+                                            <div className={styles.cell}>
+                                                {item}
+                                            </div>
+                                        </td>
                                     ))}
                                 </tr>
                             ))}

--- a/app/src/editor/shared/components/modules/Table.pcss
+++ b/app/src/editor/shared/components/modules/Table.pcss
@@ -29,4 +29,5 @@
 .table td {
   font-family: 'IBM Plex Sans', sans-serif;
   line-height: 24px;
+  vertical-align: baseline;
 }

--- a/app/src/editor/shared/components/modules/Table.pcss
+++ b/app/src/editor/shared/components/modules/Table.pcss
@@ -31,3 +31,8 @@
   line-height: 24px;
   vertical-align: baseline;
 }
+
+.cell {
+  max-height: calc(5 * 24px); /* 5 lines */
+  overflow-y: auto;
+}


### PR DESCRIPTION
Here's how it looks like with the fix applied:

<img width="1145" alt="Screenshot 2019-06-03 12 26 37" src="https://user-images.githubusercontent.com/320066/58795531-368ce680-85fb-11e9-9151-850254edb9a3.png">

Thoughts?