### PR TITLE
[PLATFORM-576] Dynamic "Add module" button tooltip

### DIFF
--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -97,6 +97,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
             canvasExit,
             newCanvas,
             setSpeed,
+            moduleSearchIsOpen,
         } = this.props
 
         if (!canvas) {
@@ -184,7 +185,13 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     isOpen={canvasSearchIsOpen}
                                     open={this.canvasSearchOpen}
                                 />
-                                <Tooltip value="Add module">
+                                <Tooltip
+                                    value={moduleSearchIsOpen ? (
+                                        'Hide module panel'
+                                    ) : (
+                                        'Show module panel'
+                                    )}
+                                >
                                     <R.Button
                                         className={styles.ToolbarButton}
                                         onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -193,8 +193,10 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     )}
                                 >
                                     <R.Button
-                                        className={styles.ToolbarButton}
-                                        onClick={() => this.props.moduleSearchOpen(!this.props.moduleSearchIsOpen)}
+                                        className={cx(styles.ToolbarButton, styles.AddButton, {
+                                            [styles.active]: !!moduleSearchIsOpen,
+                                        })}
+                                        onClick={() => this.props.moduleSearchOpen(!moduleSearchIsOpen)}
                                         disabled={!canEdit}
                                     >
                                         <SvgIcon name="plus" className={styles.icon} />

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -407,3 +407,9 @@ body .RealtimeRunButtonMenu {
 .DashboardButtons {
   justify-content: flex-end;
 }
+
+.AddButton.active,
+.AddButton.active:global(.btn) {
+  /* TODO: Refactor to get rid of !important. */
+  color: #323232 !important;
+}


### PR DESCRIPTION
In this PR I make the tooltip display different copy for when the module panel is open and close. I also use different color for the "+" icon for both states.

---

- [x] [`PLATFORM-576`](https://streamr.atlassian.net/browse/PLATFORM-576) – Update Add Module Panel show / hide button and tooltip