### PR TITLE
[PLATFORM-632] Streams list jams the browser if the user has many streams

### DIFF
--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -17,7 +17,7 @@ import type { Stream, StreamId } from '$shared/flowtype/stream-types'
 
 import SvgIcon from '$shared/components/SvgIcon'
 import links from '$shared/../links'
-import { getStreams, updateFilter, deleteStream, getStreamStatus } from '$userpages/modules/userPageStreams/actions'
+import { getStreams, updateFilter, deleteStream, getStreamStatus, cancelStreamStatusFetch } from '$userpages/modules/userPageStreams/actions'
 import { selectStreams, selectFetching, selectFilter } from '$userpages/modules/userPageStreams/selectors'
 import { getFilters } from '$userpages/utils/constants'
 import Table from '$shared/components/Table'
@@ -75,6 +75,7 @@ export type DispatchProps = {
     copyToClipboard: (string) => void,
     getStreamPermissions: (id: StreamId) => void,
     refreshStreamStatus: (id: StreamId) => Promise<void>,
+    cancelStreamStatusFetch: () => void,
 }
 
 type Props = StateProps & DispatchProps
@@ -145,6 +146,10 @@ class StreamList extends Component<Props, State> {
             updateFilter(this.defaultFilter)
         }
         getStreams()
+    }
+
+    componentWillUnmount() {
+        this.props.cancelStreamStatusFetch()
     }
 
     onSearchChange = (value: string) => {
@@ -480,6 +485,7 @@ const mapDispatchToProps = (dispatch) => ({
     copyToClipboard: (text) => copy(text),
     getStreamPermissions: (id: StreamId) => dispatch(getResourcePermissions('STREAM', id)),
     refreshStreamStatus: (id: StreamId) => dispatch(getStreamStatus(id)),
+    cancelStreamStatusFetch,
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(StreamList)

--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -285,9 +285,14 @@ export const updateStreamStatus = (id: StreamId) => (dispatch: Function) => (
 )
 
 export const updateStreamStatuses = (ids: StreamIdList) => (dispatch: Function) => {
-    ids.forEach((id: StreamId) => (
-        dispatch(updateStreamStatus(id))
-    ))
+    ids.reduce(async (previous, id) => {
+        try {
+            await previous
+        } catch (e) {
+            // do nothing
+        }
+        return dispatch(updateStreamStatus(id))
+    }, Promise.resolve())
 }
 
 export const getStreams = () => (dispatch: Function, getState: Function) => {


### PR DESCRIPTION
Quick fix to run status update calls in series instead of firing everything at once. Let's add paging in a separate issue.