### PR TITLE
[PLATFORM-713] begin/end dates

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.jsx",
   "scripts": {
     "start": "webpack-dev-server --hot",
-    "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack",
+    "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack --progress --profile",
     "test": "NODE_ENV=test jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/* ./src/editor/canvas/tests/*",
     "flow": "flow",
     "flow-stop": "flow stop",

--- a/app/src/editor/canvas/components/CanvasController/Run.jsx
+++ b/app/src/editor/canvas/components/CanvasController/Run.jsx
@@ -136,7 +136,20 @@ function useRunController(canvas = EMPTY) {
 
     const isPending = !!(isStopping || isStarting || isAnyPending)
 
+    // controls whether user can currently start/stop canvas
+    const canChangeRunState = (
+        !isPending && // no pending
+        hasWritePermission && ( // has write perms
+            // check historical settings ok if historical
+            !isHistorical ||
+            // don't prevent stopping running canvas if not valid
+            isRunning ||
+            CanvasState.isHistoricalRunValid(canvas)
+        )
+    )
+
     return useMemo(() => ({
+        canChangeRunState,
         isStarting,
         isStopping,
         isPending,
@@ -151,7 +164,7 @@ function useRunController(canvas = EMPTY) {
         stop,
         exit,
     }), [canvas, isPending, isStarting, isActive, isRunning, isHistorical, isEditable,
-        hasSharePermission, hasWritePermission, isStopping, start, stop, exit])
+        hasSharePermission, hasWritePermission, isStopping, start, stop, exit, canChangeRunState])
 }
 
 export default function RunControllerProvider({ children, canvas }) {

--- a/app/src/editor/canvas/components/CanvasController/Run.jsx
+++ b/app/src/editor/canvas/components/CanvasController/Run.jsx
@@ -87,18 +87,26 @@ function useRunController(canvas = EMPTY) {
         replaceCanvas(() => newCanvas)
     }, [subscriptionStatus, startPending, createAdhocPending, isHistorical, isMountedRef, replaceCanvas])
 
+    const unlinkParent = useCallback((canvas) => (
+        unlinkPending.wrap(() => services.unlinkParentCanvas(canvas))
+    ), [unlinkPending])
+
     const stop = useCallback(async (canvas) => {
         setIsStopping(true)
         return stopPending.wrap(() => services.stop(canvas))
-            .catch((err) => {
+            .catch(async (err) => {
                 if (isStateNotAllowedError(err)) {
-                    return // trying to stop an already stopped canvas, ignore
+                    if (!canvas.adhoc) { return } // trying to stop an already stopped canvas, ignore
+                    const parent = await unlinkParent(canvas) // ensure adhoc canvas gets unlinked
+                    if (!isMountedRef.current) { return }
+                    replaceCanvas(() => parent)
+                    return
                 }
 
                 if (isMountedRef.current) { setIsStopping(false) }
                 throw err
             })
-    }, [stopPending, setIsStopping, isMountedRef])
+    }, [stopPending, setIsStopping, isMountedRef, unlinkParent, replaceCanvas])
 
     const exit = useCallback(async (canvas) => {
         const newCanvas = await exitPending.wrap(() => services.loadParentCanvas(canvas))
@@ -108,8 +116,8 @@ function useRunController(canvas = EMPTY) {
 
     const unlinkAdhocOnStop = useCallback(async (isRunning) => {
         if (isRunning || !canvas.adhoc) { return }
-        await unlinkPending.wrap(() => services.unlinkParentCanvas(canvas))
-    }, [canvas, unlinkPending])
+        await unlinkParent(canvas)
+    }, [canvas, unlinkParent])
 
     useCanvasStateChangeEffect(canvas, unlinkAdhocOnStop)
 

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -108,7 +108,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
 
         const runController = this.context
         const { runButtonDropdownOpen, canvasSearchIsOpen } = this.state
-        const { isRunning, isActive, isPending, hasWritePermission } = runController
+        const { isRunning, isActive, hasWritePermission, canChangeRunState } = runController
         const canEdit = runController.isEditable
         const canShare = runController.hasSharePermission
         const { settings = {} } = canvas
@@ -211,7 +211,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     })}
                                 >
                                     <R.Button
-                                        disabled={!!isPending || !hasWritePermission}
+                                        disabled={!canChangeRunState}
                                         onClick={() => {
                                             if (isRunning) {
                                                 return canvasStop()
@@ -236,7 +236,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                             toggle={this.onToggleRunButtonMenu}
                                             className={styles.RunDropdownButton}
                                         >
-                                            <R.DropdownToggle disabled={!canEdit} caret>
+                                            <R.DropdownToggle disabled={!canChangeRunState} caret>
                                                 {!runButtonDropdownOpen && (
                                                     <SvgIcon name="caretUp" />
                                                 )}
@@ -246,6 +246,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                             </R.DropdownToggle>
                                             <R.DropdownMenu
                                                 className={cx(styles.RunButtonMenu, styles.HistoricalRunButtonMenu)}
+                                                disabled={!canChangeRunState}
                                                 right
                                             >
                                                 <R.DropdownItem

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -279,10 +279,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     setHistorical = (update = {}) => {
         this.setCanvas({ type: 'Set Historical Range' }, (canvas) => (
-            CanvasState.updateCanvas(canvas, 'settings', (settings = {}) => ({
-                ...settings,
-                ...update,
-            }))
+            CanvasState.setHistoricalRange(canvas, update)
         ))
     }
 

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -677,6 +677,39 @@ export function limitLayout(canvas) {
 }
 
 /**
+ * Ensures historical 'beingDate' is before 'endDate'
+ */
+
+export function setHistoricalRange(canvas, update = {}) {
+    const { settings = {} } = canvas
+    let { beginDate, endDate } = settings
+    if (update.beginDate) {
+        beginDate = update.beginDate // eslint-disable-line prefer-destructuring
+        if (endDate && Date.parse(update.beginDate) > Date.parse(endDate)) {
+            endDate = beginDate
+        }
+    }
+
+    if (update.endDate) {
+        endDate = update.endDate // eslint-disable-line prefer-destructuring
+        if (beginDate && Date.parse(beginDate) > Date.parse(update.endDate)) {
+            beginDate = endDate
+        }
+    }
+
+    if (beginDate === settings.beginDate && endDate === settings.endDate) { return canvas }
+
+    return updateCanvas({
+        ...canvas,
+        settings: {
+            ...canvas.settings,
+            beginDate: new Date(beginDate).toISOString(),
+            endDate: new Date(endDate).toISOString(),
+        },
+    })
+}
+
+/**
  * Variadic Port Handling
  */
 

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -697,14 +697,12 @@ export function setHistoricalRange(canvas, update = {}) {
         }
     }
 
-    if (beginDate === settings.beginDate && endDate === settings.endDate) { return canvas }
-
     return updateCanvas({
         ...canvas,
         settings: {
             ...canvas.settings,
-            beginDate: new Date(beginDate).toISOString(),
-            endDate: new Date(endDate).toISOString(),
+            beginDate: beginDate ? new Date(beginDate).toISOString() : canvas.settings.beginDate,
+            endDate: endDate ? new Date(endDate).toISOString() : canvas.settings.endDate,
         },
     })
 }

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -677,7 +677,7 @@ export function limitLayout(canvas) {
 }
 
 /**
- * Ensures historical 'beingDate' is before 'endDate'
+ * Ensures historical 'beginDate' is before 'endDate'
  */
 
 export function setHistoricalRange(canvas, update = {}) {
@@ -705,6 +705,12 @@ export function setHistoricalRange(canvas, update = {}) {
             endDate: endDate ? new Date(endDate).toISOString() : canvas.settings.endDate,
         },
     })
+}
+
+export function isHistoricalRunValid(canvas = {}) {
+    const { settings = {} } = canvas
+    const { beginDate, endDate } = settings
+    return !!(beginDate && endDate && Date.parse(beginDate) <= Date.parse(endDate))
 }
 
 /**

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -202,6 +202,52 @@ describe('Canvas State', () => {
                     expect(() => State.arePortsOfSameModule(canvasWithTwoModules, 'missing', port.id)).toThrowError(State.MissingEntityError)
                 })
             })
+
+            describe('setHistoricalRange', () => {
+                const earlyDate = new Date(Date.now() - 9999999).toISOString()
+                const lateDate = new Date().toISOString()
+                it('should set endDate to beginDate when beginDate < endDate', () => {
+                    let canvas = State.emptyCanvas()
+                    const beginDate = earlyDate
+                    const endDate = lateDate
+                    canvas = State.setHistoricalRange(canvas, {
+                        beginDate,
+                    })
+                    canvas = State.setHistoricalRange(canvas, {
+                        endDate,
+                    })
+                    expect(canvas.settings.beginDate).toEqual(beginDate)
+                    expect(canvas.settings.endDate).toEqual(endDate)
+                })
+
+                it('should set beginDate to endDate when beginDate < endDate & beginDate last set', () => {
+                    const endDate = earlyDate
+                    const beginDate = lateDate
+                    let canvas = State.emptyCanvas()
+                    canvas = State.setHistoricalRange(canvas, {
+                        beginDate,
+                    })
+                    canvas = State.setHistoricalRange(canvas, {
+                        endDate,
+                    })
+                    expect(canvas.settings.beginDate).toEqual(endDate)
+                    expect(canvas.settings.endDate).toEqual(endDate)
+                })
+
+                it('should set endDate to beginDate when beginDate < endDate & endDate last set', () => {
+                    const endDate = earlyDate
+                    const beginDate = lateDate
+                    let canvas = State.emptyCanvas()
+                    canvas = State.setHistoricalRange(canvas, {
+                        endDate,
+                    })
+                    canvas = State.setHistoricalRange(canvas, {
+                        beginDate,
+                    })
+                    expect(canvas.settings.beginDate).toEqual(beginDate)
+                    expect(canvas.settings.endDate).toEqual(beginDate)
+                })
+            })
         })
     })
 })

--- a/app/src/shared/components/WithCalendar/index.jsx
+++ b/app/src/shared/components/WithCalendar/index.jsx
@@ -102,7 +102,7 @@ class WithCalendar extends React.Component<Props, State> {
             const isOpen = typeof open === 'boolean' ? open : !state.open
             let date = isOpen ? state.date : undefined
             if (!state.open && isOpen) {
-                date = this.props.date // eslint-disable-line prefer-destructuring
+                date = this.props.date || new Date() // eslint-disable-line prefer-destructuring
             }
             return {
                 open: isOpen,
@@ -136,8 +136,9 @@ class WithCalendar extends React.Component<Props, State> {
     }
 
     render() {
-        const { date, open } = this.state
+        const { open } = this.state
         const { disabled, className, wrapperClassname } = this.props
+        const date = open ? this.state.date : this.props.date
 
         return (
             <div ref={this.rootRef} className={cx(styles.root, className)}>

--- a/app/src/shared/components/WithCalendar/index.jsx
+++ b/app/src/shared/components/WithCalendar/index.jsx
@@ -26,7 +26,7 @@ type Props = WithCalendarProps & {
 
 type State = {
     open: boolean,
-    date: Date,
+    date: ?Date,
 }
 
 class WithCalendar extends React.Component<Props, State> {
@@ -38,7 +38,7 @@ class WithCalendar extends React.Component<Props, State> {
 
     state = {
         open: false,
-        date: this.props.date || new Date(),
+        date: undefined,
     }
 
     componentDidMount() {
@@ -98,9 +98,17 @@ class WithCalendar extends React.Component<Props, State> {
     rootRef: Ref<HTMLDivElement> = React.createRef()
 
     toggle = (open?: boolean) => {
-        this.setState((state) => ({
-            open: typeof open === 'boolean' ? open : !state.open,
-        }))
+        this.setState((state) => {
+            const isOpen = typeof open === 'boolean' ? open : !state.open
+            let date = isOpen ? state.date : undefined
+            if (!state.open && isOpen) {
+                date = this.props.date // eslint-disable-line prefer-destructuring
+            }
+            return {
+                open: isOpen,
+                date,
+            }
+        })
     }
 
     children(): React.Node {
@@ -113,7 +121,8 @@ class WithCalendar extends React.Component<Props, State> {
             wrapperClassname,
             ...props
         } = this.props
-        const { date } = this.state
+
+        const date = this.state.open ? this.state.date : this.props.date
 
         if (typeof children === 'function') {
             return children({


### PR DESCRIPTION
Prevents selecting a begin/from date later than end/to date.

If begin > end, it will set the other date to the value that was just set. This feels reasonable when I played around with it.

Also set it up to block starting of a canvas if invalid to/from dates are set, but also to be able to recover in the case that one has (i.e. unlinks from parent if fails to stop adhoc canvas).

----

Also there was yet another subtle bug caused by copying props to state but not updating state when props change (in this case calendar UI wouldn't update when selected date changed). This is killing me, we need a lint rule or something.