### PR TITLE
[PLATFORM-878] Update transactions empty state

### DIFF
--- a/app/src/userpages/components/TransactionPage/List/NoTransactions/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/NoTransactions/index.jsx
@@ -2,12 +2,20 @@
 
 import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
+import { Link } from 'react-router-dom'
 
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
 
-const NoTransactionsView = () => (
+import routes from '$routes'
+
+type Props = {
+    accountsExist?: boolean,
+    accountLinked?: boolean,
+}
+
+const NoTransactionsView = ({ accountsExist, accountLinked }: Props) => (
     <EmptyState
         image={(
             <img
@@ -16,9 +24,39 @@ const NoTransactionsView = () => (
                 alt={I18n.t('error.notFound')}
             />
         )}
+        link={(!accountsExist || !accountLinked) && (
+            <Link
+                className="btn btn-special"
+                to={routes.editProfile({}, 'ethereum-accounts')}
+            >
+                <Translate value="userpages.transactions.noAccountsLinked.linkAccount" />
+            </Link>
+        )}
     >
-        <Translate value="userpages.transactions.noTransactions.title" />
-        <Translate value="userpages.transactions.noTransactions.message" tag="small" />
+        {(() => {
+            if (!accountsExist) {
+                return (
+                    <React.Fragment>
+                        <Translate value="userpages.transactions.noAccountsLinked.title" />
+                        <Translate value="userpages.transactions.noAccountsLinked.message" tag="small" />
+                    </React.Fragment>
+                )
+            } else if (!accountLinked) {
+                return (
+                    <React.Fragment>
+                        <Translate value="userpages.transactions.currentAccountNotLinked.title" />
+                        <Translate value="userpages.transactions.currentAccountNotLinked.message" tag="small" />
+                    </React.Fragment>
+                )
+            }
+
+            return (
+                <React.Fragment>
+                    <Translate value="userpages.transactions.noTransactions.title" />
+                    <Translate value="userpages.transactions.noTransactions.message" tag="small" />
+                </React.Fragment>
+            )
+        })()}
     </EmptyState>
 )
 

--- a/app/src/userpages/components/TransactionPage/List/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/index.jsx
@@ -13,7 +13,7 @@ import NoTransactionsView from './NoTransactions'
 import Layout from '$userpages/components/Layout'
 import { selectEthereumIdentities } from '$shared/modules/integrationKey/selectors'
 import type { StoreState } from '$shared/flowtype/store-state'
-import type { TransactionEntityList } from '$shared/flowtype/web3-types'
+import type { TransactionEntityList, Address } from '$shared/flowtype/web3-types'
 import type { IntegrationKeyList } from '$shared/flowtype/integration-key-types'
 import type { ProductEntities } from '$mp/flowtype/product-types'
 import { fetchIntegrationKeys } from '$shared/modules/integrationKey/actions'
@@ -26,6 +26,8 @@ import DropdownActions from '$shared/components/DropdownActions'
 import Meatball from '$shared/components/Meatball'
 import LoadMore from '$mp/components/LoadMore'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
+import { selectAccountId } from '$mp/modules/web3/selectors'
+import { areAddressesEqual } from '$mp/utils/smartContract'
 
 import styles from './list.pcss'
 
@@ -35,6 +37,7 @@ type StateProps = {
     transactions: ?TransactionEntityList,
     products: ProductEntities,
     hasMoreResults: boolean,
+    accountId: ?Address,
 }
 
 type DispatchProps = {
@@ -68,7 +71,19 @@ class TransactionList extends Component<Props> {
     }
 
     render() {
-        const { fetching, transactions, hasMoreResults } = this.props
+        const {
+            fetching,
+            transactions,
+            hasMoreResults,
+            web3Accounts,
+            accountId,
+        } = this.props
+        const accountsExist = !!(web3Accounts && web3Accounts.length)
+        const accountLinked = !!(web3Accounts &&
+            accountId &&
+            web3Accounts.find((account) =>
+                account.json && account.json.address && areAddressesEqual(account.json.address, accountId))
+        )
 
         return (
             <Layout
@@ -80,7 +95,10 @@ class TransactionList extends Component<Props> {
                 <Helmet title={`Streamr Core | ${I18n.t('userpages.title.transactions')}`} />
                 <div className={cx('container', styles.transactionList)}>
                     {!fetching && transactions && transactions.length <= 0 && (
-                        <NoTransactionsView />
+                        <NoTransactionsView
+                            accountsExist={accountsExist}
+                            accountLinked={accountLinked}
+                        />
                     )}
                     {transactions && transactions.length > 0 && (
                         <Table>
@@ -167,6 +185,7 @@ const mapStateToProps = (state: StoreState) => {
     const events = selectTransactionEvents(state) || []
 
     return {
+        accountId: selectAccountId(state),
         transactions: selectVisibleTransactions(state),
         fetching: selectFetching(state),
         web3Accounts: selectEthereumIdentities(state),

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -416,6 +416,21 @@ msgstr "No transactions."
 msgid "userpages##transactions##noTransactions##message"
 msgstr "You haven't made any transactions yet."
 
+msgid "userpages##transactions##noAccountsLinked##linkAccount"
+msgstr "Link account"
+
+msgid "userpages##transactions##noAccountsLinked##title"
+msgstr "Account not linked."
+
+msgid "userpages##transactions##noAccountsLinked##message"
+msgstr "You need to link an Ethereum account to see your transaction history."
+
+msgid "userpages##transactions##currentAccountNotLinked##title"
+msgstr "Account not linked."
+
+msgid "userpages##transactions##currentAccountNotLinked##message"
+msgstr "You need to link the current Ethereum account to see your transaction history."
+
 msgid "userpages##dashboards##createDashboard"
 msgstr "Create dashboard"
 


### PR DESCRIPTION
No accounts linked:
<img width="1046" alt="Screen Shot 2019-06-06 at 15 56 33" src="https://user-images.githubusercontent.com/1064982/59034708-51b65b00-8874-11e9-9155-1f2f9af88a26.png">

One account linked + selected in Metamask, no transactions:
<img width="1019" alt="Screen Shot 2019-06-06 at 15 56 09" src="https://user-images.githubusercontent.com/1064982/59034722-5ed34a00-8874-11e9-939e-3a6cef4ca521.png">

One account linked + another account selected in Metamask, no transactions (text is changed to "link the **current** account"):
<img width="1068" alt="Screen Shot 2019-06-06 at 15 57 04" src="https://user-images.githubusercontent.com/1064982/59034762-7ca0af00-8874-11e9-8140-3e26d6e1ff48.png">

If any of the linked accounts have transactions, then the list is shown and there is no hint that the current account is not linked:
<img width="1350" alt="Screen Shot 2019-06-06 at 15 57 26" src="https://user-images.githubusercontent.com/1064982/59034825-a3f77c00-8874-11e9-959d-7a0c7ec6588e.png">
