### PR TITLE
[PLATFORM-489] Add module stacking when using click insert from ModuleSearch

### DIFF
--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -435,6 +435,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     addModule={this.addModule}
                     isOpen={this.state.moduleSearchIsOpen}
                     open={this.moduleSearchOpen}
+                    canvas={canvas}
                 />
             </div>
         )

--- a/app/src/editor/shared/utils/boundingBox.js
+++ b/app/src/editor/shared/utils/boundingBox.js
@@ -1,0 +1,23 @@
+// @flow
+
+type BoundingBox = {
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+}
+
+export const getModuleBoundingBox = (module: any): BoundingBox => {
+    const { layout } = module
+    return {
+        x: (layout && parseInt(layout.position.left, 10)) || 0,
+        y: (layout && parseInt(layout.position.top, 10)) || 0,
+        width: (layout && parseInt(layout.width, 10)) || 0,
+        height: (layout && parseInt(layout.height, 10)) || 0,
+    }
+}
+
+export const doBoxesIntersect = (a: BoundingBox, b: BoundingBox): boolean => (
+    (Math.abs(a.x - b.x) * 2 < (a.width + b.width)) &&
+    (Math.abs(a.y - b.y) * 2 < (a.height + b.height))
+)


### PR DESCRIPTION
When you add modules by clicking an item on the ModuleSearch list, we are now running a simple collision detection algorithm to see if we'd overlap with another module and apply an offset if needed.

Currently we are using a placeholder for the module size (100px * 50px) since we don't know the module size until it has been added to the canvas.