### PR TITLE
[PLATFORM-891] Fix adding ethereum identity

### DIFF
--- a/app/src/shared/modules/integrationKey/services.js
+++ b/app/src/shared/modules/integrationKey/services.js
@@ -61,7 +61,11 @@ export const createIdentity = async (name: string): ApiResult<IntegrationKey> =>
         account = await ownWeb3.getDefaultAccount()
         response = await createChallenge(account)
         challenge = response && response.challenge
-        signature = await ownWeb3.eth.personal.sign(challenge, account)
+        signature = await ownWeb3.eth.personal.sign(
+            challenge,
+            account,
+            '', // required, but MetaMask will ignore the password argument here
+        )
     } catch (error) {
         console.warn(error)
         throw new ChallengeFailedError()


### PR DESCRIPTION
Adding an ethereum account is broken in latest development, due to `web3-beta.55` upgrade (#517).

`web3.eth.personal.sign` requires a password but is actually ignored by Metamask so need only to pass empty string.