### PR TITLE
Possible fix to staging login recursive rendering issue

### DIFF
--- a/app/src/shared/components/FormControl/index.jsx
+++ b/app/src/shared/components/FormControl/index.jsx
@@ -41,7 +41,7 @@ type State = {
     lastKnownError: string,
 }
 
-class FormControl extends React.Component<Props, State> {
+class FormControl extends React.PureComponent<Props, State> {
     state = {
         focused: false,
         autoCompleted: false,


### PR DESCRIPTION
Makes shared FormControl extend PureComponent to prevent pointless/recursive setState calls.

Possible fix for recursive rendering issue on staging.