### PR TITLE
Fix solidity editor onChange

### DIFF
--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -34,13 +34,13 @@ class CodeEditorWindow extends React.Component {
 
     onBlur = () => {
         const { code } = this.state
-        if (code != null && code !== this.props.code) {
+        if (code != null && code !== this.props.code && this.props.onChange) {
             this.props.onChange(code)
         }
-        this.setState(() => ({
+        this.setState({
             code: undefined,
             editorResetKey: uniqueId('CodeEditorWindow'),
-        }))
+        })
     }
 
     onApply = () => {
@@ -51,7 +51,9 @@ class CodeEditorWindow extends React.Component {
             if (this.unmounted) { return }
             const code = this.state.code != null ? this.state.code : this.props.code
             try {
-                await this.props.onApply(code)
+                if (this.props.onApply) {
+                    await this.props.onApply(code)
+                }
 
                 if (this.unmounted) { return }
 

--- a/app/src/editor/shared/components/modules/Solidity.jsx
+++ b/app/src/editor/shared/components/modules/Solidity.jsx
@@ -26,6 +26,10 @@ export default class SolidityModule extends React.Component {
         })
     )
 
+    onChange = (code) => {
+        this.props.api.updateModule(this.props.moduleHash, { code })
+    }
+
     onDeploy = () => {
         if (!this.state.deploying) {
             this.setState({
@@ -80,6 +84,7 @@ export default class SolidityModule extends React.Component {
                     code={module.code || ''}
                     readOnly={isActive}
                     onApply={this.onApply}
+                    onChange={this.onChange}
                     debugMessages={debugMessages}
                     onClearDebug={this.onClearDebug}
                 >


### PR DESCRIPTION
Solidity editor wasn't persisting code to canvas correctly and was firing errors on blur, both due to missing `onChange` prop. Added `onChange` and prevented crash due to missing `onChange`.