### PR TITLE
[PLATFORM-626] Fix module connection states after definition load

### DIFF
--- a/app/src/editor/canvas/components/DragDropContext.jsx
+++ b/app/src/editor/canvas/components/DragDropContext.jsx
@@ -149,6 +149,7 @@ class EditorDraggable extends React.PureComponent {
     }
 
     onStart = (event, data) => {
+        if (this.unmounted) { return }
         this.setState({
             initialPosition: data,
         })
@@ -182,6 +183,8 @@ class EditorDraggable extends React.PureComponent {
             }, this.reset)
         }
 
+        if (this.unmounted) { return }
+
         this.setState({
             // ensure this happens after props.onStop
             // so reset can file in onStop
@@ -192,6 +195,7 @@ class EditorDraggable extends React.PureComponent {
     }
 
     onDrag = (event, data) => {
+        if (this.unmounted) { return false }
         // do nothing if cancelled
         if (this.context.isCancelled) {
             return false
@@ -223,11 +227,13 @@ class EditorDraggable extends React.PureComponent {
     }
 
     reset = () => {
+        if (this.unmounted) { return }
         if (!this.state.initialPosition) { return }
         // pump initial position to reset draggable
         this.setState({
             position: this.state.initialPosition,
         }, () => {
+            if (this.unmounted) { return }
             this.setState({
                 position: undefined,
             })

--- a/app/src/editor/canvas/components/PortDragger.jsx
+++ b/app/src/editor/canvas/components/PortDragger.jsx
@@ -38,6 +38,7 @@ class DraggablePort extends React.Component {
     }
 
     connectPorts() {
+        if (this.unmounted) { return }
         const triggeredPorts = []
         const { data } = this.context
         const { sourceId, portId, overId } = data
@@ -96,6 +97,7 @@ class DraggablePort extends React.Component {
     }
 
     disconnectPorts() {
+        if (this.unmounted) { return }
         const { data } = this.context
         const { sourceId, portId } = data
         if (!sourceId) { return } // not connected
@@ -122,6 +124,7 @@ class DraggablePort extends React.Component {
     }
 
     onStartDragPort = () => {
+        if (this.unmounted) { return }
         const { port } = this.props
 
         return {
@@ -158,8 +161,12 @@ export function DragSource({ api, port, onValueChange, className }) {
 
 export class DropTarget extends React.PureComponent {
     static contextType = DragDropContext
+    componentWillUnmount() {
+        this.unmounted = true
+    }
 
     onMouseOverTarget = () => {
+        if (this.unmounted) { return }
         const dragPortInProgress = this.context.isDragging && this.context.data.portId != null
         if (!dragPortInProgress) { return }
         this.context.updateData({
@@ -168,6 +175,7 @@ export class DropTarget extends React.PureComponent {
     }
 
     onMouseOutTarget = () => {
+        if (this.unmounted) { return }
         const dragPortInProgress = this.context.isDragging && this.context.data.portId != null
         if (!dragPortInProgress) { return }
         this.context.updateData({

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -198,35 +198,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         try {
             const moduleData = await canvasController.loadModule(canvas, { hash })
             if (this.unmounted) { return }
-            replace((canvas) => {
-                const prevModule = CanvasState.getModule(canvas, hash)
-                let nextCanvas = CanvasState.updateModule(canvas, hash, () => moduleData)
-                nextCanvas = CanvasState.updateModulePortConnections(nextCanvas, hash)
-                const newModule = CanvasState.getModule(nextCanvas, hash)
-
-                // Restore input connections
-                nextCanvas = newModule.inputs.reduce((nextCanvas, { id, sourceId }) => {
-                    const port = prevModule.inputs.find((p) => id === p.id)
-
-                    if (sourceId && port) {
-                        return CanvasState.connectPorts(nextCanvas, port.id, sourceId)
-                    }
-
-                    return nextCanvas
-                }, nextCanvas)
-
-                nextCanvas = newModule.params.reduce((nextCanvas, { id, sourceId }) => {
-                    const port = prevModule.params.find((p) => id === p.id)
-
-                    if (sourceId && port) {
-                        return CanvasState.connectPorts(nextCanvas, port.id, sourceId)
-                    }
-
-                    return nextCanvas
-                }, nextCanvas)
-
-                return nextCanvas
-            })
+            replace((canvas) => CanvasState.replaceModule(canvas, moduleData))
         } catch (error) {
             console.error(error.message)
             // undo value change

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -306,6 +306,12 @@ export function isPortConnected(canvas, portId) {
     return !!conn.length
 }
 
+export function arePortsConnected(canvas, portIdA, portIdB) {
+    const connA = getConnectedPortIds(canvas, portIdA)
+    const connB = getConnectedPortIds(canvas, portIdB)
+    return connA.includes(portIdB) && connB.includes(portIdA)
+}
+
 export function isPortExported(canvas, portId) {
     if (!hasPort(canvas, portId)) { return false }
     return !!getPort(canvas, portId).export

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -1136,7 +1136,7 @@ export function moduleSearch(moduleCategories, search) {
  * - the port type
  */
 
-function matchPortInOtherCanvas(canvas, prevCanvas, portId) {
+function matchPortInPreviousCanvas(canvas, prevCanvas, portId) {
     const prevPort = getPort(prevCanvas, portId)
     const exactMatch = getPortIfExists(canvas, portId)
     if (exactMatch) { return exactMatch }
@@ -1164,10 +1164,10 @@ export function replaceModule(canvas, moduleData) {
     prevPorts.forEach((prevPort) => {
         const connectedIds = getConnectedPortIds(prevCanvas, prevPort.id)
         if (!connectedIds.length) { return } // nothing to do if no connections
-        const matchedPort = matchPortInOtherCanvas(nextCanvas, prevCanvas, prevPort.id)
+        const matchedPort = matchPortInPreviousCanvas(nextCanvas, prevCanvas, prevPort.id)
         if (!matchedPort) { return } // nothing to do if port no longer exists
         connectedIds.forEach((connectedId) => {
-            const matchedConnectedPort = matchPortInOtherCanvas(nextCanvas, prevCanvas, connectedId)
+            const matchedConnectedPort = matchPortInPreviousCanvas(nextCanvas, prevCanvas, connectedId)
             if (!matchedConnectedPort || !canConnectPorts(nextCanvas, matchedPort.id, matchedConnectedPort.id)) { return }
             // re-connect if possible
             nextCanvas = connectPorts(nextCanvas, matchedPort.id, matchedConnectedPort.id)

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -456,8 +456,11 @@ export function connectPorts(canvas, portIdA, portIdB) {
 
     let nextCanvas = canvas
 
-    if (input.sourceId) {
-        // disconnect existing input connection
+    // disconnect existing input connection
+    // if variadic, delay disconnecting until end
+    // as disconnecting may lead to input we're trying
+    // to connect to being removed before we can connect to it
+    if (input.sourceId && !input.variadic) {
         nextCanvas = disconnectPorts(nextCanvas, input.sourceId, input.id)
     }
 
@@ -498,10 +501,17 @@ export function connectPorts(canvas, portIdA, portIdB) {
     }
 
     // connect output
-    return updatePort(nextCanvas, output.id, (port) => ({
+    nextCanvas = updatePort(nextCanvas, output.id, (port) => ({
         ...port,
         connected: isPortConnected(nextCanvas, output.id),
     }))
+
+    // delayed disconnect output original if input variadic, see above
+    if (input.sourceId && input.variadic && input.sourceId !== output.id) {
+        nextCanvas = disconnectPorts(nextCanvas, input.sourceId, input.id)
+    }
+
+    return nextCanvas
 }
 
 export function movePortConnection(canvas, outputPortId, newInputId, { currentInputId }) {

--- a/app/src/editor/canvas/tests/connection.test.js
+++ b/app/src/editor/canvas/tests/connection.test.js
@@ -115,10 +115,13 @@ describe('Connecting Modules', () => {
         canvas = State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, toLowerCaseIn.id))
         expect(State.isPortConnected(canvas, constantTextOut.id)).toBeTruthy()
         expect(State.isPortConnected(canvas, toLowerCaseIn.id)).toBeTruthy()
+        expect(State.arePortsConnected(canvas, constantTextOut.id, toLowerCaseIn.id)).toBeTruthy()
+        expect(State.arePortsConnected(canvas, toLowerCaseIn.id, constantTextOut.id)).toBeTruthy()
 
         canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, toLowerCaseIn.id))
         expect(State.isPortConnected(canvas, constantTextOut.id)).not.toBeTruthy()
         expect(State.isPortConnected(canvas, toLowerCaseIn.id)).not.toBeTruthy()
+        expect(State.arePortsConnected(canvas, constantTextOut.id, toLowerCaseIn.id)).not.toBeTruthy()
 
         // test server accepts state
         expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
@@ -166,10 +169,12 @@ describe('Connecting Modules', () => {
         canvas = State.updateCanvas(State.connectPorts(canvas, constantTextOut.id, constantTextIn.id))
         expect(State.isPortConnected(canvas, constantTextOut.id)).toBeTruthy()
         expect(State.isPortConnected(canvas, constantTextIn.id)).toBeTruthy()
+        expect(State.arePortsConnected(canvas, constantTextIn.id, constantTextOut.id)).toBeTruthy()
 
         canvas = State.updateCanvas(State.disconnectPorts(canvas, constantTextOut.id, constantTextIn.id))
         expect(State.isPortConnected(canvas, constantTextOut.id)).not.toBeTruthy()
         expect(State.isPortConnected(canvas, constantTextIn.id)).not.toBeTruthy()
+        expect(State.arePortsConnected(canvas, constantTextIn.id, constantTextOut.id)).not.toBeTruthy()
 
         // test server accepts state
         expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)


### PR DESCRIPTION
Ensures connections are restored as well as they can be after loading new module definition.

To test:

1. Connect Constant Text to HTTP Module's body input
2. Change HTTP Module verb to anything else
3. Note connection persists

Alternatively try using anything that uses a Contract type input.