### PR TITLE
[PLATFORM-539] Chart module resizing

### DIFF
--- a/app/src/editor/i18n/en.po
+++ b/app/src/editor/i18n/en.po
@@ -22,3 +22,45 @@ msgstr "NR"
 
 msgid "editor##module##error"
 msgstr "Whoops. Something has broken down. Please delete the module and try again."
+
+msgid "editor##timeRange##all"
+msgstr "All"
+
+msgid "editor##timeRange##2592000000"
+msgstr "1 month"
+
+msgid "editor##timeRange##604800000"
+msgstr "1 week"
+
+msgid "editor##timeRange##86400000"
+msgstr "1 day"
+
+msgid "editor##timeRange##43200000"
+msgstr "12 hours"
+
+msgid "editor##timeRange##28800000"
+msgstr "8 hours"
+
+msgid "editor##timeRange##14400000"
+msgstr "4 hours"
+
+msgid "editor##timeRange##7200000"
+msgstr "2 hours"
+
+msgid "editor##timeRange##3600000"
+msgstr "1 hour"
+
+msgid "editor##timeRange##1800000"
+msgstr "30 minutes"
+
+msgid "editor##timeRange##900000"
+msgstr "15 minutes"
+
+msgid "editor##timeRange##60000"
+msgstr "1 minute"
+
+msgid "editor##timeRange##15000"
+msgstr "15 seconds"
+
+msgid "editor##timeRange##1000"
+msgstr "1 second"

--- a/app/src/editor/shared/components/Chart/RangeSelect/index.jsx
+++ b/app/src/editor/shared/components/Chart/RangeSelect/index.jsx
@@ -1,15 +1,11 @@
 // @flow
 
-import React from 'react'
+import React, { useCallback } from 'react'
 import cx from 'classnames'
 import { I18n } from 'react-redux-i18n'
 import SvgIcon from '$shared/components/SvgIcon'
 import AutosizedSelect from '$shared/components/AutosizedSelect'
 import styles from './rangeSelect.pcss'
-
-type Props = {
-    className?: ?string,
-}
 
 const ranges = [
     // All
@@ -42,25 +38,44 @@ const ranges = [
     1000,
 ]
 
-const RangeSelect = ({ className }: Props) => (
-    <div className={cx(styles.root, className)}>
-        <AutosizedSelect
-            className={styles.select}
-            onChange={() => {}}
-            value="all"
-        >
-            {ranges.map((range) => (
-                <option key={range} value={range}>
-                    {/* AutosizedSelect's children have to be strings. */}
-                    {I18n.t(`editor.timeRange.${range}`)}
+type Range = number | 'all'
+
+type Props = {
+    className?: ?string,
+    onChange?: ?(Range) => void,
+    value?: Range,
+}
+
+const RangeSelect = ({ className, value, onChange: onChangeProp }: Props) => {
+    const onChange = useCallback((value: string) => {
+        if (onChangeProp) {
+            onChangeProp(value === 'all' ? value : Number.parseInt(value, 10))
+        }
+    }, [onChangeProp])
+
+    return (
+        <div className={cx(styles.root, className)}>
+            <AutosizedSelect
+                className={styles.select}
+                onChange={onChange}
+                value={value}
+            >
+                <option disabled value="">
+                    Range
                 </option>
-            ))}
-        </AutosizedSelect>
-        <SvgIcon
-            name="caretDown"
-            className={styles.caret}
-        />
-    </div>
-)
+                {ranges.map((range) => (
+                    <option key={range} value={range}>
+                        {/* AutosizedSelect's children have to be strings. */}
+                        {I18n.t(`editor.timeRange.${range}`)}
+                    </option>
+                ))}
+            </AutosizedSelect>
+            <SvgIcon
+                name="caretDown"
+                className={styles.caret}
+            />
+        </div>
+    )
+}
 
 export default RangeSelect

--- a/app/src/editor/shared/components/Chart/RangeSelect/index.jsx
+++ b/app/src/editor/shared/components/Chart/RangeSelect/index.jsx
@@ -1,0 +1,66 @@
+// @flow
+
+import React from 'react'
+import cx from 'classnames'
+import { I18n } from 'react-redux-i18n'
+import SvgIcon from '$shared/components/SvgIcon'
+import AutosizedSelect from '$shared/components/AutosizedSelect'
+import styles from './rangeSelect.pcss'
+
+type Props = {
+    className?: ?string,
+}
+
+const ranges = [
+    // All
+    'all',
+    // 1 month
+    2592000000,
+    // 1 week
+    604800000,
+    // 1 day
+    86400000,
+    // 12 hours
+    43200000,
+    // 8 hours
+    28800000,
+    // 4 hours
+    14400000,
+    // 2 hours
+    7200000,
+    // 1 hour
+    3600000,
+    // 30 minutes
+    1800000,
+    // 15 minutes
+    900000,
+    // 1 minute
+    60000,
+    // 15 seconds
+    15000,
+    // 1 second
+    1000,
+]
+
+const RangeSelect = ({ className }: Props) => (
+    <div className={cx(styles.root, className)}>
+        <AutosizedSelect
+            className={styles.select}
+            onChange={() => {}}
+            value="all"
+        >
+            {ranges.map((range) => (
+                <option key={range} value={range}>
+                    {/* AutosizedSelect's children have to be strings. */}
+                    {I18n.t(`editor.timeRange.${range}`)}
+                </option>
+            ))}
+        </AutosizedSelect>
+        <SvgIcon
+            name="caretDown"
+            className={styles.caret}
+        />
+    </div>
+)
+
+export default RangeSelect

--- a/app/src/editor/shared/components/Chart/RangeSelect/index.jsx
+++ b/app/src/editor/shared/components/Chart/RangeSelect/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import cx from 'classnames'
 import { I18n } from 'react-redux-i18n'
 import SvgIcon from '$shared/components/SvgIcon'
@@ -53,6 +53,8 @@ const RangeSelect = ({ className, value, onChange: onChangeProp }: Props) => {
         }
     }, [onChangeProp])
 
+    const isCustomRange: boolean = useMemo(() => !!value && !ranges.includes(value), [value])
+
     return (
         <div className={cx(styles.root, className)}>
             <AutosizedSelect
@@ -63,6 +65,11 @@ const RangeSelect = ({ className, value, onChange: onChangeProp }: Props) => {
                 <option disabled value="">
                     Range
                 </option>
+                {isCustomRange && (
+                    <option disabled value={value}>
+                        Custom
+                    </option>
+                )}
                 {ranges.map((range) => (
                     <option key={range} value={range}>
                         {/* AutosizedSelect's children have to be strings. */}

--- a/app/src/editor/shared/components/Chart/RangeSelect/rangeSelect.pcss
+++ b/app/src/editor/shared/components/Chart/RangeSelect/rangeSelect.pcss
@@ -9,18 +9,18 @@
 }
 
 .select > select {
-  border-radius: calc(0.125 * var(--um));
+  border-radius: 0.125um;
   box-shadow: inset 0 0 0 1px #CDCDCD;
   color: #323232;
-  font-size: calc(0.625 * var(--um));
+  font-size: 0.625um;
   line-height: 1em;
-  padding: 0 calc(1.3125 * var(--um)) 0 calc(0.5 * var(--um));
+  padding: 0 1.3125um 0 0.5um;
 }
 
 .caret {
   position: absolute;
-  right: calc(0.3125 * var(--um));
+  right: 0.3125um;
   top: 50%;
   transform: translateY(-50%);
-  width: calc(0.375 * var(--um));
+  width: 0.375um;
 }

--- a/app/src/editor/shared/components/Chart/RangeSelect/rangeSelect.pcss
+++ b/app/src/editor/shared/components/Chart/RangeSelect/rangeSelect.pcss
@@ -1,0 +1,26 @@
+.root {
+  height: var(--um);
+  position: relative;
+}
+
+.select,
+.select > select {
+  height: 100%;
+}
+
+.select > select {
+  border-radius: calc(0.125 * var(--um));
+  box-shadow: inset 0 0 0 1px #CDCDCD;
+  color: #323232;
+  font-size: calc(0.625 * var(--um));
+  line-height: 1em;
+  padding: 0 calc(1.3125 * var(--um)) 0 calc(0.5 * var(--um));
+}
+
+.caret {
+  position: absolute;
+  right: calc(0.3125 * var(--um));
+  top: 50%;
+  transform: translateY(-50%);
+  width: calc(0.375 * var(--um));
+}

--- a/app/src/editor/shared/components/Chart/approx.js
+++ b/app/src/editor/shared/components/Chart/approx.js
@@ -1,0 +1,35 @@
+export default {
+    'min/max': (points) => {
+        // Smarter data grouping: for all-positive values choose max, for all-negative choose min, for neither choose avg
+        const { min, max, sum } = points.reduce(({ min, max, sum }, point) => ({
+            sum: sum + point,
+            min: Math.min(it, min),
+            max: Math.max(it, max),
+        }), {
+            sum: 0,
+            min: Number.POSITIVE_INFINITY,
+            max: Number.NEGATIVE_INFINITY,
+        })
+
+        if (!points.length && points.hasNulls) {
+            // If original had only nulls, Highcharts expects null
+            return null
+        } else if (!points.length) {
+            // "Ordinary" empty group, Highcharts expects undefined
+            return undefined
+        } else if (min >= 0) {
+            // All positive
+            return max
+        } else if (max <= 0) {
+            // All negative
+            return min
+        }
+        // Mixed positive and negative
+        return sum / points.length
+    },
+    average: 'average',
+    open: 'open',
+    high: 'high',
+    low: 'low',
+    close: 'close',
+}

--- a/app/src/editor/shared/components/Chart/chart.pcss
+++ b/app/src/editor/shared/components/Chart/chart.pcss
@@ -1,0 +1,11 @@
+.root {
+}
+
+.toolbar {
+  box-sizing: content-box;
+  align-items: center;
+  display: flex;
+  height: var(--um);
+  justify-content: flex-end;
+  padding: calc(0.75 * var(--um)) var(--um);
+}

--- a/app/src/editor/shared/components/Chart/chart.pcss
+++ b/app/src/editor/shared/components/Chart/chart.pcss
@@ -7,5 +7,5 @@
   display: flex;
   height: var(--um);
   justify-content: flex-end;
-  padding: calc(0.75 * var(--um)) var(--um);
+  padding: 0.75um 1um;
 }

--- a/app/src/editor/shared/components/Chart/chart.pcss
+++ b/app/src/editor/shared/components/Chart/chart.pcss
@@ -2,8 +2,8 @@
 }
 
 .toolbar {
-  box-sizing: content-box;
   align-items: center;
+  box-sizing: content-box;
   display: flex;
   height: var(--um);
   justify-content: flex-end;

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -37,8 +37,6 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
 
         return Object.values(series).map((payload: any) => ({
             ...payload,
-            type: 'spline',
-            step: undefined,
             data: data[payload.idx] || [],
         }))
     }, [series, datapoints])

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -12,7 +12,7 @@ type Props = {
 const Chart = ({ className }: Props) => (
     <div className={cx(styles.root, className)}>
         <div className={styles.toolbar}>
-            <RangeSelect />
+            <RangeSelect onChange={() => {}} />
         </div>
     </div>
 )

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -34,12 +34,11 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
             ],
         }), {})
 
-        return Object.entries(data).map(([key, data]) => ({
-            id: `series-${key}`,
-            ...series[key],
+        return Object.values(series).map((payload: any) => ({
+            ...payload,
             type: 'spline',
             step: undefined,
-            data,
+            data: data[payload.idx] || [],
         }))
     }, [series, datapoints])
 
@@ -80,11 +79,108 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
 
     useEffect(() => {
         if (chart) {
+            seriesData.forEach((data) => {
+                const series = chart.get(data.id)
+                if (series) {
+                    series.update(data)
+                } else {
+                    chart.addSeries(data)
+                }
+            })
             chart.redraw()
         }
     }, [chart, seriesData])
 
     const { height } = useContext(UiSizeContext)
+
+    useEffect(() => {
+        if (chart) {
+            // 40px = RangeSelect toolbar height
+            chart.setSize(undefined, height > 40 ? (height - 40) : null, false)
+        }
+    }, [height, chart])
+
+    const opts = useMemo(() => ({
+        chart: {
+            animation: false,
+            backgroundColor: null,
+            reflow: false,
+            selectionMarkerFill: 'rgba(0, 0, 0, 0.05)',
+            style: {
+                fontFamily: "'IBM Plex Sans', sans-serif",
+            },
+            zoomType: 'x',
+        },
+        colors: ['#FF5C00', '#0324FF', '#2AC437', '#6240AF'],
+        credits: {
+            enabled: false,
+        },
+        legend: {
+            enabled: true,
+        },
+        navigator: {
+            enabled: true,
+            maskFill: 'rgba(0, 0, 0, 0.05)',
+            outlineWidth: 0,
+            handles: {
+                borderWidth: 1,
+                borderColor: '#A0A0A0',
+                backgroundColor: '#ADADAD',
+                height: 16,
+                width: 8,
+            },
+            series: {
+                type: 'line',
+                // step: true,
+                // dataGrouping: {
+                //     approximation: approximations.average,
+                //     forced: true,
+                //     groupAll: true,
+                //     groupPixelWidth: 4,
+                // },
+            },
+        },
+        plotOptions: {
+            series: {
+                animation: false,
+                // dataGrouping: {
+                //     approximation: approximations[options.dataGrouping],
+                // },
+            },
+        },
+        rangeSelector: {
+            enabled: false,
+        },
+        scrollbar: {
+            enabled: false,
+        },
+        series: [],
+        // series: series.map((s) => ({
+        //     ...s,
+        //     ...seriesData[s.idx],
+        //     id: `series-${s.idx}`,
+        // })),
+        time: {
+            timezoneOffset: new Date().getTimezoneOffset(),
+        },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.96)',
+            padding: 10,
+            borderRadius: 8,
+            style: {
+                boxShadow: '0 0 6px 0 rgba(0, 0, 0, 0.05)',
+                color: '#323232',
+                lineHeight: 1.6,
+            },
+        },
+        xAxis: {
+            ordinal: false,
+            events: {
+                afterSetExtremes: onSetExtremes,
+            },
+        },
+        ...options,
+    }), [onSetExtremes, options])
 
     return (
         <div className={cx(styles.root, className)}>
@@ -100,88 +196,7 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
                 constructorType="stockChart"
                 allowChartUpdate
                 callback={setChart}
-                options={{
-                    chart: {
-                        animation: false,
-                        backgroundColor: null,
-                        height: height > 40 ? (height - 40) : null, // 40px = RangeSelect toolbar height
-                        reflow: false,
-                        selectionMarkerFill: 'rgba(0, 0, 0, 0.05)',
-                        style: {
-                            fontFamily: "'IBM Plex Sans', sans-serif",
-                        },
-                        zoomType: 'x',
-                    },
-                    colors: ['#FF5C00', '#0324FF', '#2AC437', '#6240AF'],
-                    credits: {
-                        enabled: false,
-                    },
-                    legend: {
-                        enabled: true,
-                    },
-                    navigator: {
-                        enabled: true,
-                        maskFill: 'rgba(0, 0, 0, 0.05)',
-                        outlineWidth: 0,
-                        handles: {
-                            borderWidth: 1,
-                            borderColor: '#A0A0A0',
-                            backgroundColor: '#ADADAD',
-                            height: 16,
-                            width: 8,
-                        },
-                        series: {
-                            type: 'line',
-                            // step: true,
-                            // dataGrouping: {
-                            //     approximation: approximations.average,
-                            //     forced: true,
-                            //     groupAll: true,
-                            //     groupPixelWidth: 4,
-                            // },
-                        },
-                    },
-                    plotOptions: {
-                        series: {
-                            animation: false,
-                            // dataGrouping: {
-                            //     approximation: approximations[options.dataGrouping],
-                            // },
-                        },
-                    },
-                    rangeSelector: {
-                        enabled: false,
-                    },
-                    scrollbar: {
-                        enabled: false,
-                    },
-                    series: series.map((s) => ({
-                        ...s,
-                        ...seriesData[s.idx],
-                        id: `series-${s.idx}`,
-                    })),
-                    time: {
-                        timezoneOffset: new Date().getTimezoneOffset(),
-                    },
-                    tooltip: {
-                        backgroundColor: 'rgba(255, 255, 255, 0.96)',
-                        padding: 10,
-                        borderRadius: 8,
-                        style: {
-                            boxShadow: '0 0 6px 0 rgba(0, 0, 0, 0.05)',
-                            color: '#323232',
-                            lineHeight: 1.6,
-                        },
-                    },
-                    xAxis: {
-                        ordinal: false,
-                        events: {
-                            afterSetExtremes: onSetExtremes,
-                        },
-                        range: typeof range === 'number' ? range : undefined,
-                    },
-                    ...options,
-                }}
+                options={opts}
             />
         </div>
     )

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -107,7 +107,13 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
             enabled: false,
         },
         legend: {
+            align: 'left',
             enabled: true,
+            itemStyle: {
+                color: '#323232',
+                fontSize: '10px',
+                fontWeight: '500',
+            },
         },
         navigator: {
             enabled: true,
@@ -120,6 +126,7 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
                 height: 16,
                 width: 8,
             },
+            margin: 12,
             series: {
                 type: 'line',
                 step: true,
@@ -137,6 +144,20 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
                 dataGrouping: {
                     approximation: approximations[options.dataGrouping],
                 },
+                states: {
+                    hover: {
+                        halo: {
+                            attributes: {
+                                fill: 'white',
+                                'fill-opacity': 1,
+                                stroke: 'black',
+                                'stroke-width': 1,
+                                'stroke-opacity': 0.1,
+                            },
+                            size: 8,
+                        },
+                    },
+                },
             },
         },
         rangeSelector: {
@@ -150,19 +171,51 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
             timezoneOffset: new Date().getTimezoneOffset(),
         },
         tooltip: {
+            borderWidth: 0,
             backgroundColor: 'rgba(255, 255, 255, 0.96)',
             padding: 10,
-            borderRadius: 8,
+            borderRadius: 4,
             style: {
                 boxShadow: '0 0 6px 0 rgba(0, 0, 0, 0.05)',
                 color: '#323232',
                 lineHeight: 1.6,
+                fontSize: '10px',
             },
+            useHTML: true,
+            // eslint-disable-next-line func-names, object-shorthand
+            formatter: function () {
+                return this.points.reduce((s, point) => (
+                    `${s}<br/><span style="font-weight: 500;">${point.series.name}</span> ${point.y}`
+                ), `${Highcharts.dateFormat('%A, %b %e, %H:%M:%S', this.x)}`)
+            },
+            outside: true,
         },
         xAxis: {
-            ordinal: false,
+            crosshair: {
+                color: '#EFEFEF',
+            },
             events: {
                 afterSetExtremes: onSetExtremes,
+            },
+            gridLineColor: '#EFEFEF',
+            labels: {
+                style: {
+                    color: '#ADADAD',
+                    fontSize: '10px',
+                },
+                y: 24,
+            },
+            lineColor: '#EFEFEF',
+            ordinal: false,
+            tickWidth: 0,
+        },
+        yAxis: {
+            gridLineColor: '#EFEFEF',
+            labels: {
+                style: {
+                    color: '#ADADAD',
+                    fontSize: '10px',
+                },
             },
         },
         ...options,

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -1,20 +1,100 @@
 // @flow
 
-import React from 'react'
+import React, { useState, useMemo, useEffect, useCallback, useContext } from 'react'
 import cx from 'classnames'
+import Highcharts from 'highcharts/highstock'
+import HighchartsReact from 'highcharts-react-official'
+import ResizeWatcher from '$editor/canvas/components/Resizable/ResizeWatcher'
+import { Context as UiSizeContext } from '$editor/shared/components/UiSizeConstraint'
 import RangeSelect from './RangeSelect'
 import styles from './chart.pcss'
 
-type Props = {
-    className?: ?string,
+type Datapoint = {
+    s: any,
+    x: number,
+    y: number,
 }
 
-const Chart = ({ className }: Props) => (
-    <div className={cx(styles.root, className)}>
-        <div className={styles.toolbar}>
-            <RangeSelect onChange={() => {}} />
+type Props = {
+    className?: ?string,
+    datapoints: Array<Datapoint>,
+    series: any,
+}
+
+const Chart = ({ className, series, datapoints }: Props) => {
+    const [chart, setChart] = useState(null)
+
+    const seriesData = useMemo(() => {
+        const data = datapoints.reduce((memo, { s, x, y }) => ({
+            ...memo,
+            [s]: [
+                ...(memo[s] || []),
+                [x, y],
+            ],
+        }), {})
+
+        return Object.entries(data).map(([key, data]) => ({
+            id: `series-${key}`,
+            ...series[key],
+            type: 'line',
+            data,
+        }))
+    }, [series, datapoints])
+
+    const onResize = useCallback(() => {
+        if (chart) {
+            chart.reflow()
+        }
+    }, [chart])
+
+    useEffect(() => {
+        if (chart) {
+            chart.redraw()
+        }
+    }, [chart, seriesData])
+
+    const { height } = useContext(UiSizeContext)
+
+    return (
+        <div className={cx(styles.root, className)}>
+            <div className={styles.toolbar}>
+                <RangeSelect onChange={() => {}} />
+            </div>
+            <ResizeWatcher onResize={onResize} />
+            <HighchartsReact
+                highcharts={Highcharts}
+                constructorType="stockChart"
+                allowChartUpdate
+                callback={setChart}
+                options={{
+                    chart: {
+                        height: height > 40 ? (height - 40) : null, // 40px = RangeSelect toolbar height
+                        reflow: false,
+                    },
+                    credits: {
+                        enabled: false,
+                    },
+                    legend: {
+                        enabled: true,
+                    },
+                    rangeSelector: {
+                        enabled: false,
+                    },
+                    scrollbar: {
+                        enabled: false,
+                    },
+                    series: series.map((s) => ({
+                        ...s,
+                        ...seriesData[s.idx],
+                        id: `series-${s.idx}`,
+                    })),
+                    time: {
+                        timezoneOffset: new Date().getTimezoneOffset(),
+                    },
+                }}
+            />
         </div>
-    </div>
-)
+    )
+}
 
 export default Chart

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -26,20 +26,12 @@ type Props = {
 const Chart = ({ className, series, datapoints, options }: Props) => {
     const [chart, setChart] = useState(null)
 
-    const seriesData = useMemo(() => {
-        const data = datapoints.reduce((memo, { s, x, y }) => ({
-            ...memo,
-            [s]: [
-                ...(memo[s] || []),
-                [x, y],
-            ],
-        }), {})
-
-        return Object.values(series).map((payload: any) => ({
+    const seriesData = useMemo(() => (
+        Object.values(series).map((payload: any) => ({
             ...payload,
-            data: data[payload.idx] || [],
+            data: datapoints[payload.idx] || [],
         }))
-    }, [series, datapoints])
+    ), [series, datapoints])
 
     const onResize = useCallback(() => {
         if (chart) {

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -36,7 +36,8 @@ const Chart = ({ className, series, datapoints }: Props) => {
         return Object.entries(data).map(([key, data]) => ({
             id: `series-${key}`,
             ...series[key],
-            type: 'line',
+            type: 'spline',
+            step: undefined,
             data,
         }))
     }, [series, datapoints])

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -7,6 +7,7 @@ import HighchartsReact from 'highcharts-react-official'
 import ResizeWatcher from '$editor/canvas/components/Resizable/ResizeWatcher'
 import { Context as UiSizeContext } from '$editor/shared/components/UiSizeConstraint'
 import RangeSelect from './RangeSelect'
+import approximations from './approx'
 import styles from './chart.pcss'
 
 type Datapoint = {
@@ -131,21 +132,21 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
             },
             series: {
                 type: 'line',
-                // step: true,
-                // dataGrouping: {
-                //     approximation: approximations.average,
-                //     forced: true,
-                //     groupAll: true,
-                //     groupPixelWidth: 4,
-                // },
+                step: true,
+                dataGrouping: {
+                    approximation: approximations.average,
+                    forced: true,
+                    groupAll: true,
+                    groupPixelWidth: 4,
+                },
             },
         },
         plotOptions: {
             series: {
                 animation: false,
-                // dataGrouping: {
-                //     approximation: approximations[options.dataGrouping],
-                // },
+                dataGrouping: {
+                    approximation: approximations[options.dataGrouping],
+                },
             },
         },
         rangeSelector: {
@@ -155,11 +156,6 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
             enabled: false,
         },
         series: [],
-        // series: series.map((s) => ({
-        //     ...s,
-        //     ...seriesData[s.idx],
-        //     id: `series-${s.idx}`,
-        // })),
         time: {
             timezoneOffset: new Date().getTimezoneOffset(),
         },

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -1,0 +1,20 @@
+// @flow
+
+import React from 'react'
+import cx from 'classnames'
+import RangeSelect from './RangeSelect'
+import styles from './chart.pcss'
+
+type Props = {
+    className?: ?string,
+}
+
+const Chart = ({ className }: Props) => (
+    <div className={cx(styles.root, className)}>
+        <div className={styles.toolbar}>
+            <RangeSelect />
+        </div>
+    </div>
+)
+
+export default Chart

--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -233,7 +233,7 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
             <HighchartsReact
                 highcharts={Highcharts}
                 constructorType="stockChart"
-                allowChartUpdate
+                allowChartUpdate={false}
                 callback={setChart}
                 options={opts}
             />

--- a/app/src/editor/shared/components/UiSizeConstraint/index.jsx
+++ b/app/src/editor/shared/components/UiSizeConstraint/index.jsx
@@ -34,7 +34,7 @@ const UiSizeConstraint = ({ children, className, minWidth: minWidthProp, minHeig
     const { minHeight } = useContext(SizeConstraintContext)
 
     const value = useMemo(() => ({
-        height: (height - minHeight) + minHeightProp,
+        height: Math.max((height - minHeight), 0) + minHeightProp,
         width,
     }), [height, minHeight, minHeightProp, width])
 

--- a/app/src/editor/shared/components/UiSizeConstraint/index.jsx
+++ b/app/src/editor/shared/components/UiSizeConstraint/index.jsx
@@ -1,11 +1,25 @@
 // @flow
 
-import React, { type Node, useContext } from 'react'
+import React, { type Node, useContext, createContext, useMemo, type Context } from 'react'
 import cx from 'classnames'
 import { Context as ResizableContext } from '$editor/canvas/components/Resizable'
 import { Context as SizeConstraintContext } from '$editor/canvas/components/Resizable/SizeConstraintProvider'
 import Probe from '$editor/canvas/components/Resizable/SizeConstraintProvider/Probe'
 import styles from './uiSizeConstraint.pcss'
+
+type ContextProps = {
+    height: number,
+    width: number,
+}
+
+const defaultContext: ContextProps = {
+    height: -1,
+    width: -1,
+}
+
+const UiSizeContext = (createContext(defaultContext): Context<ContextProps>)
+
+export { UiSizeContext as Context }
 
 type Props = {
     children?: Node,
@@ -16,22 +30,30 @@ type Props = {
 
 const UiSizeConstraint = ({ children, className, minWidth: minWidthProp, minHeight: minHeightProp }: Props) => {
     const { height, width, enabled } = useContext(ResizableContext)
+
     const { minHeight } = useContext(SizeConstraintContext)
 
+    const value = useMemo(() => ({
+        height: (height - minHeight) + minHeightProp,
+        width,
+    }), [height, minHeight, minHeightProp, width])
+
     return (
-        <div
-            className={cx(styles.root, className)}
-            style={enabled ? {
-                height: (height - minHeight) + minHeightProp,
-                minHeight: minHeightProp,
-                minWidth: minWidthProp,
-                width,
-            } : {}}
-        >
-            <Probe group="ModuleHeight" uid="UI" height={minHeightProp} />
-            <Probe group="UiWidth" uid="UI" width={minWidthProp} />
-            {children}
-        </div>
+        <UiSizeContext.Provider value={value}>
+            <div
+                className={cx(styles.root, className)}
+                style={enabled ? {
+                    height: value.height,
+                    minHeight: minHeightProp,
+                    minWidth: minWidthProp,
+                    width: value.width,
+                } : {}}
+            >
+                <Probe group="ModuleHeight" uid="UI" height={minHeightProp} />
+                <Probe group="UiWidth" uid="UI" width={minWidthProp} />
+                {children}
+            </div>
+        </UiSizeContext.Provider>
     )
 }
 

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -288,7 +288,7 @@ export default class ChartModule extends React.Component {
     render() {
         const { className, module } = this.props
         const { options = {} } = module
-        const { title } = this.state
+        const { title, series, datapoints } = this.state
         const seriesData = this.getSeriesData(this.state.datapoints)
 
         return (
@@ -299,107 +299,15 @@ export default class ChartModule extends React.Component {
                     onMessage={this.onMessage}
                     onActiveChange={this.initIfActive}
                 />
+                {!!(options.displayTitle && options.displayTitle.value && title) && (
+                    <h4>{title}</h4>
+                )}
                 <Chart
                     className={styles.chart}
+                    datapoints={datapoints}
+                    options={options}
+                    series={series}
                 />
-                {/* <div className={cx(styles.Chart, className)}>
-                    {!!(options.displayTitle && options.displayTitle.value && title) && (
-                        <h4>{title}</h4>
-                    )}
-                    <RangeDropdown onChange={this.onChangeRange} value={this.state.range} />
-                    <ResizeWatcher onResize={this.onContainerResize} />
-                    {!!this.state.series && (
-                        <div className={styles.inner}>
-                            <HighchartsReact
-                                highcharts={Highcharts}
-                                constructorType="stockChart"
-                                allowChartUpdate={false}
-                                callback={this.onChart}
-                                options={{
-                                    chart: {
-                                        animation: false,
-                                        panning: true,
-                                        spacingBottom: 40,
-                                        backgroundColor: null,
-                                        zoomType: 'x',
-                                        selectionMarkerFill: 'rgba(0, 0, 0, 0.05)',
-                                        style: {
-                                            fontFamily: "'IBM Plex Sans', sans-serif",
-                                        },
-                                    },
-                                    colors: ['#FF5C00', '#0324FF', '#2AC437', '#6240AF'],
-                                    time: {
-                                        timezoneOffset: new Date().getTimezoneOffset(),
-                                    },
-                                    credits: {
-                                        enabled: false,
-                                    },
-                                    xAxis: {
-                                        ordinal: false,
-                                        events: {
-                                            setExtremes: this.setExtremes,
-                                        },
-                                    },
-                                    legend: {
-                                        enabled: true,
-                                    },
-                                    rangeSelector: {
-                                        enabled: false,
-                                    },
-                                    navigator: {
-                                        enabled: true,
-                                        maskFill: 'rgba(0, 0, 0, 0.05)',
-                                        outlineWidth: 0,
-                                        handles: {
-                                            borderWidth: 1,
-                                            borderColor: '#A0A0A0',
-                                            backgroundColor: '#ADADAD',
-                                            height: 16,
-                                            width: 8,
-                                        },
-                                        series: {
-                                            type: 'line',
-                                            step: true,
-                                            dataGrouping: {
-                                                approximation: approximations.average,
-                                                forced: true,
-                                                groupAll: true,
-                                                groupPixelWidth: 4,
-                                            },
-                                        },
-                                    },
-                                    plotOptions: {
-                                        series: {
-                                            animation: false,
-                                            dataGrouping: {
-                                                approximation: approximations[options.dataGrouping],
-                                            },
-                                        },
-                                    },
-                                    scrollbar: {
-                                        enabled: false,
-                                    },
-                                    tooltip: {
-                                        backgroundColor: 'rgba(255, 255, 255, 0.96)',
-                                        padding: 10,
-                                        borderRadius: 8,
-                                        style: {
-                                            boxShadow: '0 0 6px 0 rgba(0, 0, 0, 0.05)',
-                                            color: '#323232',
-                                            lineHeight: 1.6,
-                                        },
-                                    },
-                                    series: this.state.series.map((s) => ({
-                                        ...s,
-                                        ...seriesData[s.idx],
-                                        id: `series-${s.idx}`,
-                                    })),
-                                    ...options,
-                                }}
-                            />
-                        </div>
-                    )}
-                </div> */}
             </UiSizeConstraint>
         )
     }

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -34,9 +34,9 @@ const ChartModule2 = (props) => {
 
     const queuedDatapointsRef = useRef([])
 
-    const [datapoints, setDatapoints] = useState([])
-
     const [series, setSeries] = useState({})
+
+    const [seriesData, setSeriesData] = useState({})
 
     const onSeries = useCallback((payload) => {
         const id = `series-${payload.idx}`
@@ -61,10 +61,13 @@ const ChartModule2 = (props) => {
         const queued = queuedDatapointsRef.current || []
         queuedDatapointsRef.current = []
 
-        setDatapoints((datapoints) => [
-            ...datapoints,
-            ...queued,
-        ])
+        setSeriesData((seriesData) => queued.reduce((memo, { s, x, y }) => ({
+            ...memo,
+            [s]: [
+                ...(memo[s] || []),
+                [x, y],
+            ],
+        }), seriesData))
     }, 250), [])
 
     const onDatapoint = useCallback((payload) => {
@@ -119,7 +122,7 @@ const ChartModule2 = (props) => {
                 />
                 <Chart
                     className={styles.chart}
-                    datapoints={datapoints}
+                    datapoints={seriesData}
                     options={module.options || {}}
                     series={series}
                 />

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -16,59 +16,6 @@ import ResizeWatcher from '$editor/canvas/components/Resizable/ResizeWatcher'
 
 import styles from './Chart.pcss'
 
-const rangeConfig = {
-    All: 'all',
-    '1 month': 30 * 24 * 60 * 60 * 1000,
-    '1 week': 7 * 24 * 60 * 60 * 1000,
-    '1 day': 24 * 60 * 60 * 1000,
-    '12 hours': 12 * 60 * 60 * 1000,
-    '8 hours': 8 * 60 * 60 * 1000,
-    '4 hours': 4 * 60 * 60 * 1000,
-    '2 hours': 2 * 60 * 60 * 1000,
-    '1 hour': 1 * 60 * 60 * 1000,
-    '30 minutes': 30 * 60 * 1000,
-    '15 minutes': 15 * 60 * 1000,
-    '1 minute': 1 * 60 * 1000,
-    '15 seconds': 15 * 1000,
-    '1 second': 1 * 1000,
-}
-
-const approximations = {
-    'min/max': (points) => {
-        // Smarter data grouping: for all-positive values choose max, for all-negative choose min, for neither choose avg
-        let sum = 0
-        let min = Number.POSITIVE_INFINITY
-        let max = Number.NEGATIVE_INFINITY
-
-        points.forEach((it) => {
-            sum += it
-            min = Math.min(it, min)
-            max = Math.max(it, max)
-        })
-
-        if (!points.length && points.hasNulls) {
-            // If original had only nulls, Highcharts expects null
-            return null
-        } else if (!points.length) {
-            // "Ordinary" empty group, Highcharts expects undefined
-            return undefined
-        } else if (min >= 0) {
-            // All positive
-            return max
-        } else if (max <= 0) {
-            // All negative
-            return min
-        }
-        // Mixed positive and negative
-        return sum / points.length
-    },
-    average: 'average',
-    open: 'open',
-    high: 'high',
-    low: 'low',
-    close: 'close',
-}
-
 class MinMax {
     min = Number.POSITIVE_INFINITY
     max = Number.NEGATIVE_INFINITY

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -16,17 +16,6 @@ import ResizeWatcher from '$editor/canvas/components/Resizable/ResizeWatcher'
 
 import styles from './Chart.pcss'
 
-class MinMax {
-    min = Number.POSITIVE_INFINITY
-    max = Number.NEGATIVE_INFINITY
-
-    update(v) {
-        if (v == null) { return }
-        this.min = Math.min(v, this.min)
-        this.max = Math.max(v, this.max)
-    }
-}
-
 const ChartModule2 = (props) => {
     const { isActive, canvas, module } = props
     
@@ -46,6 +35,12 @@ const ChartModule2 = (props) => {
             [id]: {
                 ...(series[id] || {}),
                 ...payload,
+                lineWidth: 1,
+                marker: {
+                    lineColor: undefined,
+                    symbol: 'circle',
+                },
+                showInNavigator: true,
                 id,
             },
         }))
@@ -128,89 +123,6 @@ const ChartModule2 = (props) => {
                 />
         </UiSizeConstraint>
     )
-}
-
-class ChartModule extends React.Component {
-    subscription = React.createRef()
-
-    queuedDatapoints = []
-    state = {
-        title: 'My Chart',
-        datapoints: [],
-        series: [],
-        range: 'all',
-    }
-
-    timeRange = new MinMax()
-    seriesRanges = {}
-
-    onMessage = (m) => {
-        console.log(m)
-    }
-
-    componentWillUnmount() {
-        this.unmounted = true
-    }
-
-    componentDidUpdate(prevProps, prevState) {
-        if (this.chart && prevState.datapoints !== this.state.datapoints) {
-            const seriesData = this.getSeriesData(this.state.datapoints)
-            seriesData.forEach((s) => {
-                const series = this.chart.get(s.id)
-                if (!series) {
-                    this.chart.addSeries(s)
-                } else {
-                    series.setData(s.data, true, true, true)
-                }
-            })
-        }
-        // const { module } = this.props
-        // if (this.chart && JSON.stringify(module.layout) !== JSON.stringify(prevProps.module.layout)) {
-        //     this.resize()
-        // } else {
-        //     this.redraw()
-        // }
-    }
-
-    getSeriesData(datapoints) {
-        const seriesData = {}
-        datapoints.forEach((point) => {
-            seriesData[point.s] = seriesData[point.s] || []
-            seriesData[point.s].push([point.x, point.y])
-        })
-        return Object.entries(seriesData).map(([key, data]) => ({
-            id: `series-${key}`,
-            ...this.state.series[key],
-            type: 'line',
-            data,
-        }))
-    }
-
-    render() {
-        const { className, module } = this.props
-        const { options = {} } = module
-        const { title, series, datapoints } = this.state
-
-        return (
-            <UiSizeConstraint minWidth={300} minHeight={200}>
-                <ModuleSubscription
-                    {...this.props}
-                    ref={this.subscription}
-                    onMessage={this.onMessage}
-                    onActiveChange={this.initIfActive}
-                />
-                {!!(options.displayTitle && options.displayTitle.value && title) && (
-                    <h4>{title}</h4>
-                )}
-                <Chart
-                    className={styles.chart}
-                    datapoints={datapoints}
-                    options={options}
-                    series={series}
-                />
-            </UiSizeConstraint>
-        )
-    }
 }
 
 export default ChartModule2

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -1,13 +1,17 @@
+/* eslint-disable */
+
 import React from 'react'
 import cx from 'classnames'
 import throttle from 'lodash/throttle'
 import debounce from 'lodash/debounce'
 import Highcharts from 'highcharts/highstock'
 
+import Chart from '$editor/shared/components/Chart'
 import HighchartsReact from 'highcharts-react-official'
 import ModuleSubscription from '$editor/shared/components/ModuleSubscription'
 import SvgIcon from '$shared/components/SvgIcon'
 import UiSizeConstraint from '../UiSizeConstraint'
+import ResizeWatcher from '$editor/canvas/components/Resizable/ResizeWatcher'
 
 import styles from './Chart.pcss'
 
@@ -200,6 +204,12 @@ export default class ChartModule extends React.Component {
         }
     }
 
+    onContainerResize = () => {
+        if (this.chart) {
+            this.resize()
+        }
+    }
+
     redraw = () => {
         if (!this.chart) { return }
         let max
@@ -283,107 +293,113 @@ export default class ChartModule extends React.Component {
 
         return (
             <UiSizeConstraint minWidth={300} minHeight={200}>
-                <div className={cx(styles.Chart, className)}>
-                    <ModuleSubscription
-                        {...this.props}
-                        ref={this.subscription}
-                        onMessage={this.onMessage}
-                        onActiveChange={this.initIfActive}
-                    />
+                <ModuleSubscription
+                    {...this.props}
+                    ref={this.subscription}
+                    onMessage={this.onMessage}
+                    onActiveChange={this.initIfActive}
+                />
+                <Chart
+                    className={styles.chart}
+                />
+                {/* <div className={cx(styles.Chart, className)}>
                     {!!(options.displayTitle && options.displayTitle.value && title) && (
                         <h4>{title}</h4>
                     )}
                     <RangeDropdown onChange={this.onChangeRange} value={this.state.range} />
+                    <ResizeWatcher onResize={this.onContainerResize} />
                     {!!this.state.series && (
-                        <HighchartsReact
-                            highcharts={Highcharts}
-                            constructorType="stockChart"
-                            allowChartUpdate={false}
-                            callback={this.onChart}
-                            options={{
-                                chart: {
-                                    animation: false,
-                                    panning: true,
-                                    spacingBottom: 40,
-                                    backgroundColor: null,
-                                    zoomType: 'x',
-                                    selectionMarkerFill: 'rgba(0, 0, 0, 0.05)',
-                                    style: {
-                                        fontFamily: "'IBM Plex', sans-serif",
-                                    },
-                                },
-                                colors: ['#FF5C00', '#0324FF', '#2AC437', '#6240AF'],
-                                time: {
-                                    timezoneOffset: new Date().getTimezoneOffset(),
-                                },
-                                credits: {
-                                    enabled: false,
-                                },
-                                xAxis: {
-                                    ordinal: false,
-                                    events: {
-                                        setExtremes: this.setExtremes,
-                                    },
-                                },
-                                legend: {
-                                    enabled: true,
-                                },
-                                rangeSelector: {
-                                    enabled: false,
-                                },
-                                navigator: {
-                                    enabled: true,
-                                    maskFill: 'rgba(0, 0, 0, 0.05)',
-                                    outlineWidth: 0,
-                                    handles: {
-                                        borderWidth: 1,
-                                        borderColor: '#A0A0A0',
-                                        backgroundColor: '#ADADAD',
-                                        height: 16,
-                                        width: 8,
-                                    },
-                                    series: {
-                                        type: 'line',
-                                        step: true,
-                                        dataGrouping: {
-                                            approximation: approximations.average,
-                                            forced: true,
-                                            groupAll: true,
-                                            groupPixelWidth: 4,
-                                        },
-                                    },
-                                },
-                                plotOptions: {
-                                    series: {
+                        <div className={styles.inner}>
+                            <HighchartsReact
+                                highcharts={Highcharts}
+                                constructorType="stockChart"
+                                allowChartUpdate={false}
+                                callback={this.onChart}
+                                options={{
+                                    chart: {
                                         animation: false,
-                                        dataGrouping: {
-                                            approximation: approximations[options.dataGrouping],
+                                        panning: true,
+                                        spacingBottom: 40,
+                                        backgroundColor: null,
+                                        zoomType: 'x',
+                                        selectionMarkerFill: 'rgba(0, 0, 0, 0.05)',
+                                        style: {
+                                            fontFamily: "'IBM Plex Sans', sans-serif",
                                         },
                                     },
-                                },
-                                scrollbar: {
-                                    enabled: false,
-                                },
-                                tooltip: {
-                                    backgroundColor: 'rgba(255, 255, 255, 0.96)',
-                                    padding: 10,
-                                    borderRadius: 8,
-                                    style: {
-                                        boxShadow: '0 0 6px 0 rgba(0, 0, 0, 0.05)',
-                                        color: '#323232',
-                                        lineHeight: 1.6,
+                                    colors: ['#FF5C00', '#0324FF', '#2AC437', '#6240AF'],
+                                    time: {
+                                        timezoneOffset: new Date().getTimezoneOffset(),
                                     },
-                                },
-                                series: this.state.series.map((s) => ({
-                                    ...s,
-                                    ...seriesData[s.idx],
-                                    id: `series-${s.idx}`,
-                                })),
-                                ...options,
-                            }}
-                        />
+                                    credits: {
+                                        enabled: false,
+                                    },
+                                    xAxis: {
+                                        ordinal: false,
+                                        events: {
+                                            setExtremes: this.setExtremes,
+                                        },
+                                    },
+                                    legend: {
+                                        enabled: true,
+                                    },
+                                    rangeSelector: {
+                                        enabled: false,
+                                    },
+                                    navigator: {
+                                        enabled: true,
+                                        maskFill: 'rgba(0, 0, 0, 0.05)',
+                                        outlineWidth: 0,
+                                        handles: {
+                                            borderWidth: 1,
+                                            borderColor: '#A0A0A0',
+                                            backgroundColor: '#ADADAD',
+                                            height: 16,
+                                            width: 8,
+                                        },
+                                        series: {
+                                            type: 'line',
+                                            step: true,
+                                            dataGrouping: {
+                                                approximation: approximations.average,
+                                                forced: true,
+                                                groupAll: true,
+                                                groupPixelWidth: 4,
+                                            },
+                                        },
+                                    },
+                                    plotOptions: {
+                                        series: {
+                                            animation: false,
+                                            dataGrouping: {
+                                                approximation: approximations[options.dataGrouping],
+                                            },
+                                        },
+                                    },
+                                    scrollbar: {
+                                        enabled: false,
+                                    },
+                                    tooltip: {
+                                        backgroundColor: 'rgba(255, 255, 255, 0.96)',
+                                        padding: 10,
+                                        borderRadius: 8,
+                                        style: {
+                                            boxShadow: '0 0 6px 0 rgba(0, 0, 0, 0.05)',
+                                            color: '#323232',
+                                            lineHeight: 1.6,
+                                        },
+                                    },
+                                    series: this.state.series.map((s) => ({
+                                        ...s,
+                                        ...seriesData[s.idx],
+                                        id: `series-${s.idx}`,
+                                    })),
+                                    ...options,
+                                }}
+                            />
+                        </div>
                     )}
-                </div>
+                </div> */}
             </UiSizeConstraint>
         )
     }

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -14,8 +14,6 @@ import SvgIcon from '$shared/components/SvgIcon'
 import UiSizeConstraint from '../UiSizeConstraint'
 import ResizeWatcher from '$editor/canvas/components/Resizable/ResizeWatcher'
 
-import styles from './Chart.pcss'
-
 const ChartModule2 = (props) => {
     const { isActive, canvas, module } = props
     
@@ -108,7 +106,7 @@ const ChartModule2 = (props) => {
     }, [])
 
     return (
-        <UiSizeConstraint minWidth={300} minHeight={200}>
+        <UiSizeConstraint minWidth={300} minHeight={240}>
                 <ModuleSubscription
                     {...props}
                     onActiveChange={init}
@@ -116,7 +114,6 @@ const ChartModule2 = (props) => {
                     ref={subscriptionRef}
                 />
                 <Chart
-                    className={styles.chart}
                     datapoints={seriesData}
                     options={module.options || {}}
                     series={series}

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -40,6 +40,8 @@ const ChartModule2 = (props) => {
                 },
                 showInNavigator: true,
                 id,
+                xAxis: 0,
+                yAxis: 0,
             },
         }))
     }, [])

--- a/app/src/editor/shared/components/modules/Chart.pcss
+++ b/app/src/editor/shared/components/modules/Chart.pcss
@@ -1,3 +1,0 @@
-.chart {
-  height: 100%;
-}

--- a/app/src/editor/shared/components/modules/Chart.pcss
+++ b/app/src/editor/shared/components/modules/Chart.pcss
@@ -1,26 +1,3 @@
-.Chart {
-
-}
-
-.RangeDropdown {
-  display: flex;
-  align-items: center;
-  margin: 10px;
-  justify-content: flex-end;
-
-  .caret {
-    height: 4px;
-  }
-
-  select {
-    margin-left: auto;
-    background: none;
-    appearance: none;
-    outline: none;
-    border: none;
-    color: #323232;
-    font-size: 10px;
-    letter-spacing: 0;
-    line-height: 20px;
-  }
+.chart {
+  height: 100%;
 }

--- a/app/src/shared/components/AutosizedSelect/autosizedSelect.pcss
+++ b/app/src/shared/components/AutosizedSelect/autosizedSelect.pcss
@@ -1,0 +1,21 @@
+.root {
+  position: relative;
+}
+
+.root select {
+  appearance: none;
+  background-color: transparent;
+  border: 0;
+  outline: 0;
+}
+
+.control {
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.spaceholder {
+  visibility: hidden;
+}

--- a/app/src/shared/components/AutosizedSelect/index.jsx
+++ b/app/src/shared/components/AutosizedSelect/index.jsx
@@ -1,0 +1,63 @@
+// @flow
+
+// TODO: Use it for $editor/canvas/components/Ports/Value/Select. — Mariusz
+
+import React, { useState, useCallback, useEffect, useMemo, type ChildrenArray, type Element } from 'react'
+import cx from 'classnames'
+import styles from './autosizedSelect.pcss'
+
+type Props = {
+    className?: ?string,
+    value: string,
+    onChange: (string) => void,
+    children: ChildrenArray<Element<'option'>>,
+}
+
+const AutosizedSelect = ({
+    children,
+    className,
+    onChange: onChangeProp,
+    value: valueProp,
+    ...props
+}: Props) => {
+    const [value, setValue] = useState(valueProp || '')
+
+    const onChange = useCallback((e: SyntheticInputEvent<EventTarget>) => {
+        const val = e.target.value || ''
+        setValue(val)
+        onChangeProp(val)
+    }, [onChangeProp])
+
+    useEffect(() => {
+        setValue(valueProp || '')
+    }, [valueProp])
+
+    const currentLabel = useMemo(() => {
+        const currentOption = React.Children.toArray(children).find((child) => String(value) === (String(child.props.value) || ''))
+        return currentOption ? currentOption.props.children : null
+    }, [value, children])
+
+    return (
+        <div
+            className={cx(styles.root, className)}
+        >
+            <select
+                className={styles.control}
+                value={value}
+                onChange={onChange}
+                {...props}
+                // Force single selected value. Other cases are unsupported.
+                multiple={false}
+            >
+                {children}
+            </select>
+            <select className={styles.spaceholder}>
+                {!!currentLabel && (
+                    <option>{currentLabel}</option>
+                )}
+            </select>
+        </div>
+    )
+}
+
+export default AutosizedSelect

--- a/app/src/shared/components/AutosizedSelect/index.jsx
+++ b/app/src/shared/components/AutosizedSelect/index.jsx
@@ -8,8 +8,8 @@ import styles from './autosizedSelect.pcss'
 
 type Props = {
     className?: ?string,
-    value: string,
-    onChange: (string) => void,
+    value: any,
+    onChange: (any) => void,
     children: ChildrenArray<Element<'option'>>,
 }
 

--- a/app/src/shared/components/AutosizedSelect/index.jsx
+++ b/app/src/shared/components/AutosizedSelect/index.jsx
@@ -10,7 +10,7 @@ type Props = {
     className?: ?string,
     value: any,
     onChange: (any) => void,
-    children: ChildrenArray<Element<'option'>>,
+    children: ChildrenArray<Element<'option'> | boolean>,
 }
 
 const AutosizedSelect = ({
@@ -33,8 +33,10 @@ const AutosizedSelect = ({
     }, [valueProp])
 
     const currentLabel = useMemo(() => {
-        const currentOption = React.Children.toArray(children).find((child) => String(value) === (String(child.props.value) || ''))
-        return currentOption ? currentOption.props.children : null
+        const currentOption = React.Children.toArray(children).find((child) => (
+            typeof child !== 'boolean' && String(value) === (String(child.props.value) || '')
+        ))
+        return currentOption && typeof currentOption !== 'boolean' ? currentOption.props.children : null
     }, [value, children])
 
     return (


### PR DESCRIPTION
In this PR I make the Chart module resizeable and steer the styling towards the designs, as far as possible.

Few noteworthy things:
- it's mostly running on hooks
- comes with the refactored `RangeSelect` component and nicer ranging
- tried to optimize redrawing so that the resizing is smooth(er)

@mattatgit the styling isn't 100% accurate. The library we're using for this is flexible but has its limitations. I went through a couple of painful styling rounds for this and would say it's 80% of what we planned. Hope that's "good enough" for you, sir.

PS. Guys, ignore the `um` part. There's a separate PR for it. It just happens to be here. :)