### PR TITLE
[PLATFORM-917] Prevent search content jumping as scrollbar appears/disappears

### DIFF
--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -117,7 +117,7 @@
 .SearchPanel .ContentContainer {
   border-top: 1px solid #EFEFEF;
   transform: translateY(1px);
-  overflow: auto;
+  overflow: overlay; /* deprecated, but does what we want */
 
   /* standards compliant but only firefox implements */
   scrollbar-width: thin; /* stylelint-disable-line property-no-unknown */


### PR DESCRIPTION

![module-search-scroll-overlay](https://user-images.githubusercontent.com/43438/59358460-2e514b80-8d5f-11e9-99c6-bf67ac455ee4.gif)

Seems to work, but for how long?
https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/vAcR9UdJwJw

Nah, that's been open since 2012, so probably won't go away before we get:
https://www.w3.org/TR/css-overflow-4/#scollbar-gutter-property