### PR TITLE
Fix text editing after double-clicking then clicking module header.

### DIFF
--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -3,7 +3,7 @@
 import React, { useState, useCallback, Fragment, useEffect, useRef, type Node } from 'react'
 import cx from 'classnames'
 import { type Ref } from '$shared/flowtype/common-types'
-import ModuleHeader from '$editor/shared/components/ModuleHeader'
+import ModuleStyles from '$editor/shared/components/Module.pcss'
 import TextControl from '../TextControl'
 import styles from './editableText.pcss'
 
@@ -85,7 +85,7 @@ const EditableText = ({
                 [styles.idle]: !editing,
                 [styles.disabled]: disabled,
                 [styles.blank]: (editing && !value) || (!editing && !children),
-                [ModuleHeader.styles.dragCancel]: !!editing,
+                [ModuleStyles.dragCancel]: !!editing,
             })}
             onDoubleClick={startEditing}
             {...((editOnFocus && !disabled) ? {


### PR DESCRIPTION
Currently double-clicking module header, then clicking it again does not allow editing. Due to module dragCancel class reference being missing. This fixes it.