### PR TITLE
Fix ethereum login

### DIFF
--- a/app/src/auth/components/EthereumLogin/index.jsx
+++ b/app/src/auth/components/EthereumLogin/index.jsx
@@ -55,6 +55,8 @@ const EthereumLogin = ({ onBackClick }: Props) => {
         const token: ?string = await (async () => {
             try {
                 return await getSessionToken({
+                    // TODO: this is a hack, we pass an instance of the web3 injected by Metamask directly because the wrapped object
+                    // in web3-beta.55 does not work (https://github.com/MetaMask/metamask-extension/issues/6080).
                     provider: window.web3.currentProvider,
                 })
             } catch (e) {

--- a/app/src/auth/components/EthereumLogin/index.jsx
+++ b/app/src/auth/components/EthereumLogin/index.jsx
@@ -55,7 +55,7 @@ const EthereumLogin = ({ onBackClick }: Props) => {
         const token: ?string = await (async () => {
             try {
                 return await getSessionToken({
-                    provider: web3.currentProvider,
+                    provider: window.web3.currentProvider,
                 })
             } catch (e) {
                 if (mountedRef.current) {


### PR DESCRIPTION
Fixes ethereum login in `development` by passing the instance of the `web3` injected by Metamask directly to the `StreamrClient` as the used provider. Using the wrapped provider does not work for some reason `web3-beta.55` (https://github.com/MetaMask/metamask-extension/issues/6080).

This will work for now as the `validateWeb()` helper takes care of approving the usage and Metamask injects the provider. In the (near) future though, Metamask will stop injecting its `web3`.

We should move to `ether.js` soon because `web3` is a mess.