### PR TITLE
[PLATFORM-635] Prevent future timestamps in stream list

### DIFF
--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -347,7 +347,11 @@ class StreamList extends Component<Props, State> {
                                                         />}
                                                     </Table.Th>
                                                     <Table.Td noWrap title={stream.description}>{stream.description}</Table.Td>
-                                                    <Table.Td noWrap>{moment.tz(stream.lastUpdated, timezone).fromNow()}</Table.Td>
+                                                    <Table.Td noWrap>
+                                                        {stream.lastUpdated && (
+                                                            moment.min(moment.tz(stream.lastUpdated, timezone), nowTime).fromNow()
+                                                        )}
+                                                    </Table.Td>
                                                     <Table.Td>
                                                         {stream.lastData && (
                                                             moment.min(moment.tz(stream.lastData, timezone), nowTime).fromNow()
@@ -431,12 +435,16 @@ class StreamList extends Component<Props, State> {
                                                                     {stream.description}
                                                                 </span>
                                                                 <span className={styles.lastUpdatedStreamMobile}>
-                                                                    {moment.tz(stream.lastUpdated, timezone).fromNow()}
+                                                                    {stream.lastUpdated && (
+                                                                        moment.min(moment.tz(stream.lastUpdated, timezone), nowTime).fromNow()
+                                                                    )}
                                                                 </span>
                                                             </div>
                                                             <div>
                                                                 <span className={styles.lastUpdatedStreamTablet}>
-                                                                    {moment.tz(stream.lastUpdated, timezone).fromNow()}
+                                                                    {stream.lastUpdated && (
+                                                                        moment.min(moment.tz(stream.lastUpdated, timezone), nowTime).fromNow()
+                                                                    )}
                                                                 </span>
                                                                 <StatusIcon className={styles.tabletStatusStreamIcon} />
                                                             </div>

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -266,6 +266,7 @@ class StreamList extends Component<Props, State> {
         const { fetching, streams, showStream, filter } = this.props
         const timezone = moment.tz.guess()
         const { dialogTargetStream, activeDialog } = this.state
+        const nowTime = moment.tz(Date.now(), timezone)
 
         return (
             <Layout
@@ -349,7 +350,7 @@ class StreamList extends Component<Props, State> {
                                                     <Table.Td noWrap>{moment.tz(stream.lastUpdated, timezone).fromNow()}</Table.Td>
                                                     <Table.Td>
                                                         {stream.lastData && (
-                                                            moment.tz(stream.lastData, timezone).fromNow()
+                                                            moment.min(moment.tz(stream.lastData, timezone), nowTime).fromNow()
                                                         )}
                                                     </Table.Td>
                                                     <Table.Td className={styles.statusColumn}>


### PR DESCRIPTION
If the user's local time is not exactly accurate, they might see future versions of the verbal descriptions in "Last Data" column on stream list page, like "in a few seconds" or "in a minute".

Added `moment.min` to check that the date is not past the present. If and invalid moment is one of the arguments, nothing is shown.