### PR TITLE
[PLATFORM-914] module options update

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/index.jsx
+++ b/app/src/editor/canvas/components/CanvasController/index.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo } from 'react'
+import React, { useContext, useEffect, useMemo, useCallback, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import LoadingIndicator from '$userpages/components/LoadingIndicator'
 
@@ -36,19 +36,56 @@ function useCanvasLoadEffect() {
     }, [urlId, canvasId, currentCanvasRootId, load, canvas, isPending])
 }
 
+export function useChangedModuleLoader() {
+    const [changed, setChanged] = useState(new Set())
+    const markChanged = useCallback((id) => {
+        setChanged((changed) => {
+            if (changed.has(id)) { return changed }
+            return new Set([...changed, id])
+        })
+    }, [setChanged])
+
+    const loadChanged = useCallback((prevChanged, canvas, updatedCanvas) => {
+        prevChanged.forEach((hash) => {
+            if (changed.has(hash)) {
+                // item changed again, don't update this round
+                return
+            }
+            canvas = CanvasState.updateModule(canvas, hash, () => (
+                CanvasState.getModule(updatedCanvas, hash)
+            ))
+        })
+        return canvas
+    }, [changed])
+
+    const resetChanged = useCallback(() => {
+        const prev = changed
+        setChanged(new Set())
+        return prev
+    }, [changed])
+
+    return useMemo(() => ({
+        resetChanged,
+        markChanged,
+        loadChanged,
+    }), [resetChanged, markChanged, loadChanged])
+}
+
 export function useController() {
     const create = useCanvasCreateCallback()
     const load = useCanvasLoadCallback()
     const remove = useCanvasRemoveCallback()
     const duplicate = useCanvasDuplicateCallback()
     const loadModule = useModuleLoadCallback()
+    const changedLoader = useChangedModuleLoader()
     return useMemo(() => ({
         load,
         create,
         remove,
         duplicate,
         loadModule,
-    }), [load, create, remove, duplicate, loadModule])
+        changedLoader,
+    }), [load, create, remove, duplicate, loadModule, changedLoader])
 }
 
 function useCanvasCreateEffect() {

--- a/app/src/editor/canvas/components/ModuleDragger.jsx
+++ b/app/src/editor/canvas/components/ModuleDragger.jsx
@@ -3,11 +3,11 @@ import React, { useCallback } from 'react'
 import { updateModulePosition } from '../state'
 import { Draggable } from './DragDropContext'
 import ModuleStyles from '$editor/shared/components/Module.pcss'
-import * as CanvasController from './CanvasController'
+import { useController } from './CanvasController'
 import styles from './Module.pcss'
 
 export default function (props) {
-    const canvasController = CanvasController.useController()
+    const canvasController = useController()
     const onStartDragModule = useCallback((hash) => {
         canvasController.changedLoader.markChanged(hash)
     }, [canvasController])

--- a/app/src/editor/canvas/components/ModuleDragger.jsx
+++ b/app/src/editor/canvas/components/ModuleDragger.jsx
@@ -1,11 +1,22 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { updateModulePosition } from '../state'
 import { Draggable } from './DragDropContext'
 import ModuleStyles from '$editor/shared/components/Module.pcss'
+import * as CanvasController from './CanvasController'
 import styles from './Module.pcss'
 
-export default class ModuleDragger extends React.Component {
+export default function (props) {
+    const canvasController = CanvasController.useController()
+    const onStartDragModule = useCallback((hash) => {
+        canvasController.changedLoader.markChanged(hash)
+    }, [canvasController])
+    return (
+        <ModuleDragger {...props} onStartDragModule={onStartDragModule} />
+    )
+}
+
+class ModuleDragger extends React.Component {
     onDropModule = (event, data) => {
         if (this.context.isCancelled) { return }
         if (data.diff.x === 0 && data.diff.y === 0) {
@@ -23,9 +34,16 @@ export default class ModuleDragger extends React.Component {
         ))
     }
 
-    onStartDragModule = () => ({
-        moduleHash: this.props.module.hash,
-    })
+    onStartDragModule = () => {
+        const { module, onStartDragModule } = this.props
+        const moduleHash = module.hash
+        if (onStartDragModule) {
+            onStartDragModule(moduleHash)
+        }
+        return {
+            moduleHash,
+        }
+    }
 
     bounds = {
         top: 0,

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -127,17 +127,20 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 
     async autosave() {
-        const { canvas, runController } = this.props
+        const { canvas, runController, canvasController } = this.props
         if (this.isDeleted) { return } // do not autosave deleted canvases
         if (!runController.isEditable) {
             // do not autosave running/adhoc canvases or if we have no write permission
             return
         }
 
+        const changed = canvasController.changedLoader.resetChanged()
+
         const newCanvas = await services.autosave(canvas)
         if (this.unmounted) { return }
         // ignore new canvas, just extract updated time from it
         this.props.setUpdated(newCanvas.updated)
+        this.props.replace((canvas) => this.props.canvasController.changedLoader.loadChanged(changed, canvas, newCanvas))
     }
 
     removeModule = async ({ hash }) => {
@@ -238,6 +241,8 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         this.setCanvas({ type: 'Set Module Options' }, (canvas) => (
             CanvasState.setModuleOptions(canvas, hash, options)
         ))
+
+        this.props.canvasController.changedLoader.markChanged(hash)
     }
 
     setRunTab = (runTab) => {

--- a/app/src/editor/canvas/state.js
+++ b/app/src/editor/canvas/state.js
@@ -666,9 +666,12 @@ export function setModuleOptions(canvas, moduleHash, newOptions = {}) {
     const { modules } = getIndex(canvas)
     const modulePath = modules[moduleHash]
     return update(modulePath.concat('options'), (options = {}) => (
-        Object.keys(newOptions).reduce((options, key) => (
-            update([key].concat('value'), () => newOptions[key], options)
-        ), options)
+        Object.keys(newOptions).reduce((options, key) => {
+            if (get(options, [key].concat('value')) === newOptions[key]) {
+                return options
+            }
+            return update([key].concat('value'), () => newOptions[key], options)
+        }, options)
     ), canvas)
 }
 


### PR DESCRIPTION
Updates modules after module options set.

To test: change number of inputs in Chart module options. After autosave you should see the inputs change. Making subsequent changes to options or repositioning module should not break things, but will delay change being reflected, it waits until no changes since last change to apply changes from autosave response. 