### PR TITLE
[PLATFORM-957] Fix module selector's disappearing & non-clickable results

### DIFF
--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -185,7 +185,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
     searchStreams = debounce(async (value) => {
         // remove 'stream' term from search
         // ensures we can pseudo 'filter results to streams' using "stream searchterm"
-        const streamSearchString = value.replace(/(\s+|^)stream(\s+|$)/g, ' ').trim()
+        const streamSearchString = value.replace(/^streams?\s/g, ' ').trim()
         const params = {
             id: '',
             search: streamSearchString,
@@ -199,13 +199,13 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
 
         if (this.unmounted) { return }
         // throw away results if no longer current
-        if (this.currentSearch.trim() !== value.trim()) { return }
+        if (this.currentSearch !== value) { return }
 
         this.setState({ matchingStreams })
     }, 500)
 
     onChange = async (value: string) => {
-        const trimmedValue = value.trim()
+        const trimmedValue = value.trim().replace(/\s+/g, ' ') // trim & collapse whitespace
         this.currentSearch = trimmedValue
 
         // Search modules

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -117,7 +117,6 @@
 
 .SearchPanel .ContentContainer {
   border-top: 1px solid #EFEFEF;
-  transform: translateY(1px);
   overflow: overlay; /* deprecated, but does what we want */
 
   /* standards compliant but only firefox implements */

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -27,9 +27,8 @@
 
 .SearchPanel .Container {
   height: 100%;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto auto 1fr;
+  display: flex;
+  flex-direction: column;
 }
 
 .SearchPanel .Header {
@@ -118,6 +117,7 @@
 .SearchPanel .ContentContainer {
   border-top: 1px solid #EFEFEF;
   overflow: overlay; /* deprecated, but does what we want */
+  flex: 1;
 
   /* standards compliant but only firefox implements */
   scrollbar-width: thin; /* stylelint-disable-line property-no-unknown */


### PR DESCRIPTION
* Adds two workarounds for a chrome rendering `overflow: overlay` bug causing stream search results to disappear.
* Treat "streams" keyword the same as "stream".

Not entirely sure this fixes the reported issue, as I'm not sure I was able to reproduce, see: https://streamr.atlassian.net/browse/PLATFORM-957
