### PR TITLE
Vertically center text in canvas search rows

### DIFF
--- a/app/src/editor/canvas/components/CanvasSearch.pcss
+++ b/app/src/editor/canvas/components/CanvasSearch.pcss
@@ -23,6 +23,8 @@ body .CanvasSearch {
 .CanvasSearchRow {
   padding: 0 16px;
   border-bottom: none;
+  display: flex;
+  align-items: center;
 }
 
 .CanvasSearch a {


### PR DESCRIPTION
Not sure when this regressed but here's a fix.

## Before

![image](https://user-images.githubusercontent.com/43438/60866376-c9ecb380-a25a-11e9-830e-a697c9f39a72.png)

## After

![image](https://user-images.githubusercontent.com/43438/60866404-de30b080-a25a-11e9-8de1-818607529e55.png)
