### PR TITLE
Fix connection issue with exported passthrough 

### DIFF
--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -6,6 +6,8 @@ import startCase from 'lodash/startCase'
 import EditableText from '$shared/components/EditableText'
 import useGlobalEventWithin from '$shared/hooks/useGlobalEventWithin'
 import useKeyDown from '$shared/hooks/useKeyDown'
+
+import { isPortInvisible } from '../../../state'
 import { DragDropContext } from '../../DragDropContext'
 import Option from '../Option'
 import Plug from '../Plug'
@@ -118,10 +120,14 @@ const Port = ({
         onSizeChange()
     }, [port.value, onSizeChange])
 
+    const isInvisible = isPortInvisible(canvas, port.id)
+
     return (
         <div
             className={cx(styles.root, {
                 [styles.dragInProgress]: !!dragInProgress,
+                [styles.dragInProgress]: !!dragInProgress,
+                [styles.isInvisible]: isInvisible,
             })}
         >
             {!!contextMenuTarget && (

--- a/app/src/editor/canvas/components/Ports/Port/port.pcss
+++ b/app/src/editor/canvas/components/Ports/Port/port.pcss
@@ -1,6 +1,7 @@
 .root {
   align-items: flex-start;
   display: flex;
+  transition: opacity 0.05s;
 }
 
 .root:not(.dragInProgress):hover .portOption {
@@ -10,4 +11,8 @@
 
 .spaceholder {
   flex-grow: 1;
+}
+
+.isInvisible {
+  opacity: 0;
 }

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -371,7 +371,11 @@ function getPortValueType(canvas, portId) {
     return getPortValueType(canvas, connectedOutId)
 }
 
-function linkedOutputConnectionsDisabled(canvas, outputPortId) {
+export function isPortInvisible(canvas, portId) {
+    return linkedOutputConnectionsDisabled(canvas, portId)
+}
+
+export function linkedOutputConnectionsDisabled(canvas, outputPortId) {
     if (!getIsOutput(canvas, outputPortId)) { return false }
     const outputPort = getPort(canvas, outputPortId)
     if (!isVariadicPort(outputPort)) { return false }

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -951,7 +951,8 @@ function handleVariadicPairs(canvas, moduleHash) {
             linkedOutputPort = findLinkedVariadicPort(newCanvas, inputPort.id)
         }
         // if input is not connected, neither should the output
-        if (!isPortConnected(newCanvas, inputPort.id)) {
+        // can't know if input is connected for exported ports, so ignore this check when input is exported
+        if (!isPortConnected(newCanvas, inputPort.id) && !isPortExported(newCanvas, inputPort.id)) {
             newCanvas = disconnectAllFromPort(newCanvas, linkedOutputPort.id)
         }
     })

--- a/app/src/editor/canvas/tests/connection.test.js
+++ b/app/src/editor/canvas/tests/connection.test.js
@@ -127,6 +127,32 @@ describe('Connecting Modules', () => {
         expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
     })
 
+    it('disconnects previous after connecting new', async () => {
+        // connect ConstantText out to ToLowerCase
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('ToLowerCase'))
+        const [
+            constantText1,
+            constantText2,
+            toLowerCase,
+        ] = canvas.modules
+
+        canvas = State.updateCanvas(State.connectPorts(canvas, constantText1.outputs[0].id, toLowerCase.inputs[0].id))
+        expect(State.arePortsConnected(canvas, constantText1.outputs[0].id, toLowerCase.inputs[0].id)).toBeTruthy()
+        canvas = State.updateCanvas(State.connectPorts(canvas, constantText2.outputs[0].id, toLowerCase.inputs[0].id))
+        // new connection is connected
+        expect(State.arePortsConnected(canvas, constantText2.outputs[0].id, toLowerCase.inputs[0].id)).toBeTruthy()
+        expect(State.isPortConnected(canvas, toLowerCase.inputs[0].id)).toBeTruthy()
+        // old is disconnected
+        expect(State.arePortsConnected(canvas, constantText1.outputs[0].id, toLowerCase.inputs[0].id)).not.toBeTruthy()
+        expect(State.isPortConnected(canvas, constantText1.outputs[0].id)).not.toBeTruthy()
+
+        // test server accepts state
+        expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
+    })
+
     it('can not connect incompatible modules', async () => {
         // connect ConstantText out to ToLowerCase
         let canvas = State.emptyCanvas()

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -462,5 +462,32 @@ describe('Variadic Port Handling', () => {
             // test server accepts state
             expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
+
+        it('can connect linked output when input exported', async () => {
+            let canvas = State.emptyCanvas()
+            canvas = State.addModule(canvas, await loadModuleDefinition('PassThrough'))
+            canvas = State.addModule(canvas, await loadModuleDefinition('Label'))
+            let passthrough = canvas.modules.find((m) => m.name === 'PassThrough')
+            let label = canvas.modules.find((m) => m.name === 'Label')
+
+            // export input
+            canvas = State.updateCanvas(State.setPortOptions(canvas, passthrough.inputs[0].id, {
+                export: true,
+            }))
+
+            canvas = State.updateCanvas(State.connectPorts(canvas, passthrough.outputs[0].id, label.inputs[0].id))
+
+            passthrough = canvas.modules.find((m) => m.name === 'PassThrough')
+            label = canvas.modules.find((m) => m.name === 'Label')
+
+            expect(State.arePortsConnected(canvas, passthrough.outputs[0].id, label.inputs[0].id)).toBeTruthy()
+
+            // de-export input
+            canvas = State.updateCanvas(State.setPortOptions(canvas, passthrough.inputs[0].id, {
+                export: false,
+            }))
+
+            expect(State.arePortsConnected(canvas, passthrough.outputs[0].id, label.inputs[0].id)).not.toBeTruthy()
+        })
     })
 })


### PR DESCRIPTION
A user reported an issue whereby they could not connect a passthrough output.
In this case the input was not connected so the connection was prevented by sanitising code that disconnects a linked output's connections when the linked input is disconnected. This is normally a valid operation, however in this case **the linked input was exported** so the actual connection state is unknown. Linked output ports with an exported linked input should be able to be connected. This PR fixes that (see 0cfcc01)

I have confirmed that this fixes the issue with the production canvas.

Also added some additional fixes and tests:

* Show red 'can't connect' state when trying to connect a linked output whose input is not connected or exported (d94d7a693)
* All connections deemed invalid will be disconnected automatically. (4983f4c08)
* Linked outputs will now be disconnected if the "type" of the linked input changes and this is incompatible with the current connection. Previously the port that was disconnected was left in a weird semi-connected state. (4983f4c08)
* Added a test that verifies connection state is correctly updated when there's recursive connections (ce828f71c)

#### To test exported input linked output

1. Add a PassThrough & a ConstantText
2. Try connecting output of the PassThrough to the ConstantText
3. This should show a red box on the ConstantText input and not be permitted
4. Export the PassThrough input
5. Re-Try connecting output of the PassThrough to the ConstantText
6. This should show a green box on the ConstantText input and be permitted
7. Un-export the PassThrough input.
8. Connection should disappear

![connect-linked-export](https://user-images.githubusercontent.com/43438/60948376-5d8ab680-a325-11e9-9090-d66a63783dd8.gif)


#### To test disconnection on type change

(following on from previous setup)

1. Add another Constant Text module
2. Add a Constant
3. Connect the output of one of the ConstantText modules to the input of the PassThrough
3. Connect the input to the other ConstantText module to the output of the PassThrough
4. This should work. You should have two connections.
5. Now replace the ConstantText -> PassThrough connection with Constant -> PassThrough 
6. The connection from the output of the PassThrough to the other ConstantText should disappear.

![connect-type-change](https://user-images.githubusercontent.com/43438/60948377-5d8ab680-a325-11e9-8428-d6269d880144.gif)