### PR TITLE
Ensure added modules are offset from module closest to ModuleSearch

### DIFF
--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -39,16 +39,32 @@ class CanvasModule extends React.PureComponent {
         this.unmounted = true
     }
 
+    onSelection() {
+        if (!this.el.current) { return }
+        this.el.current.scrollIntoView({
+            behavior: 'smooth',
+            block: 'start',
+            inline: 'nearest',
+        })
+        // no direct access to normal focus ref, have to go via parentElement
+        this.el.current.parentElement.focus()
+    }
+
+    componentDidMount() {
+        const { module, selectedModuleHash } = this.props
+        const isSelected = module.hash === selectedModuleHash
+        // scroll into view on mount if selected
+        if (isSelected) {
+            this.onSelection()
+        }
+    }
+
     componentDidUpdate(prevProps) {
         const { module, selectedModuleHash } = this.props
         const isSelected = module.hash === selectedModuleHash
         // scroll into view if selection status changed
-        if (this.el.current && isSelected && module.hash !== prevProps.selectedModuleHash) {
-            this.el.current.scrollIntoView({
-                behavior: 'smooth',
-                block: 'start',
-                inline: 'nearest',
-            })
+        if (isSelected && module.hash !== prevProps.selectedModuleHash) {
+            this.onSelection()
         }
     }
 

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -39,6 +39,19 @@ class CanvasModule extends React.PureComponent {
         this.unmounted = true
     }
 
+    componentDidUpdate(prevProps) {
+        const { module, selectedModuleHash } = this.props
+        const isSelected = module.hash === selectedModuleHash
+        // scroll into view if selection status changed
+        if (this.el.current && isSelected && module.hash !== prevProps.selectedModuleHash) {
+            this.el.current.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+                inline: 'nearest',
+            })
+        }
+    }
+
     static getDerivedStateFromProps(props) {
         if (!props.module) {
             return null
@@ -147,7 +160,7 @@ class CanvasModule extends React.PureComponent {
                 data-modulehash={module.hash}
                 {...props}
             >
-                <div className={styles.body}>
+                <div className={styles.body} ref={this.el}>
                     <Probe group="ModuleHeight" height="auto" />
                     <ModuleHeader
                         className={cx(styles.header, ModuleStyles.dragHandle)}

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -8,7 +8,7 @@ import cx from 'classnames'
 import type { Stream } from '$shared/flowtype/stream-types'
 import SvgIcon from '$shared/components/SvgIcon'
 import { type Ref } from '$shared/flowtype/common-types'
-import { getModuleBoundingBox } from '$editor/shared/utils/boundingBox'
+import { getModuleBoundingBox, findNonOverlappingPosition } from '$editor/shared/utils/boundingBox'
 
 import { getModuleCategories, getStreams } from '../services'
 import { moduleSearch } from '../state'
@@ -273,24 +273,6 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         return modules
     }
 
-    findNonOverlappingPosition = (myBB: any, stackOffset: number) => {
-        this.props.canvas.modules.forEach((m) => {
-            const otherBB = getModuleBoundingBox(m)
-            const xDiff = myBB.x - otherBB.x
-            const yDiff = myBB.y - otherBB.y
-            if ((xDiff < stackOffset && yDiff < stackOffset)) {
-                myBB.x += (stackOffset - xDiff) // align to offset "grid"
-                myBB.y += (stackOffset - yDiff) // align to offset "grid"
-                return this.findNonOverlappingPosition(myBB, stackOffset)
-            }
-        })
-
-        return {
-            x: myBB.x,
-            y: myBB.y,
-        }
-    }
-
     getPositionForClickInsert = () => {
         const canvasElement = document.querySelector(`.${CanvasStyles.Modules}`)
 
@@ -320,8 +302,8 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         }
 
         const stackOffset = 16 // pixels
-
-        const pos = this.findNonOverlappingPosition(myBB, stackOffset)
+        const boundingBoxes = this.props.canvas.modules.map((m) => getModuleBoundingBox(m))
+        const pos = findNonOverlappingPosition(myBB, boundingBoxes, stackOffset)
         return pos
     }
 

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -286,25 +286,20 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         const selfRect = this.selfRef.current.getBoundingClientRect()
         const canvasRect = canvasElement.getBoundingClientRect()
 
-        // Align module to the top right corner of ModuleSearch with a 32px offset
-        const position = {
+        const myBB = {
+            // Align module to the top right corner of ModuleSearch with a 32px offset
             x: (selfRect.right - canvasRect.left - 20) + 32,
             y: selfRect.top - canvasRect.top - 20,
-        }
-
-        const myBB = {
-            x: position.x,
-            y: position.y,
             // TODO: It would be nice to use actual module size here but we know
             //       it only after the module has been added to the canvas
             width: 100,
             height: 50,
         }
 
-        const stackOffset = 16 // pixels
         const boundingBoxes = this.props.canvas.modules.map((m) => getModuleBoundingBox(m))
-        const pos = findNonOverlappingPosition(myBB, boundingBoxes, stackOffset)
-        return pos
+
+        const stackOffset = 16 // pixels
+        return findNonOverlappingPosition(myBB, boundingBoxes, stackOffset)
     }
 
     renderMenu = () => {

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -165,6 +165,19 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         ))
     }
 
+    addAndSelectModule = async (...args) => {
+        this.latestAdd = ((this.latestAdd + 1) || 0)
+        const currentAdd = this.latestAdd
+        await this.addModule(...args)
+        if (this.unmounted) { return }
+        const { canvas } = this.props
+        // assume last module is most recently added
+        const newModule = canvas.modules[canvas.modules.length - 1]
+        // only select if still latest
+        if (this.latestAdd !== currentAdd || !newModule) { return }
+        this.selectModule(newModule)
+    }
+
     duplicateCanvas = async () => {
         const { canvas, canvasController } = this.props
         await canvasController.duplicate(canvas)
@@ -409,7 +422,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     )}
                 </Sidebar>
                 <ModuleSearch
-                    addModule={this.addModule}
+                    addModule={this.addAndSelectModule}
                     isOpen={this.state.moduleSearchIsOpen}
                     open={this.moduleSearchOpen}
                     canvas={canvas}

--- a/app/src/editor/shared/utils/boundingBox.js
+++ b/app/src/editor/shared/utils/boundingBox.js
@@ -39,7 +39,14 @@ export const findNonOverlappingPosition = (
         return distA - distB
     })
 
-    const closest = boundingBoxes[0]
+    // only consider boxes to the right/bottom of first box,
+    // within an allowance of stackOffset
+    const possibleBoxes = initial ? boundingBoxes.filter((bb) => (
+        currentBB.x - bb.x <= stackOffset &&
+        currentBB.y - bb.y <= stackOffset
+    )) : boundingBoxes
+
+    const closest = possibleBoxes[0]
 
     // no items
     if (!closest) { return currentBB }

--- a/app/src/editor/shared/utils/boundingBox.js
+++ b/app/src/editor/shared/utils/boundingBox.js
@@ -18,6 +18,53 @@ export const getModuleBoundingBox = (module: any): BoundingBox => {
 }
 
 export const doBoxesIntersect = (a: BoundingBox, b: BoundingBox): boolean => (
-    (Math.abs(a.x - b.x) * 2 < (a.width + b.width)) &&
-    (Math.abs(a.y - b.y) * 2 < (a.height + b.height))
+    ((Math.abs(a.x - b.x) * 2) < (a.width + b.width)) &&
+    ((Math.abs(a.y - b.y) * 2) < (a.height + b.height))
 )
+
+const dist = (a: BoundingBox, b: BoundingBox): number => (
+    Math.sqrt(((b.x - a.x) ** 2) + ((b.y - a.y) ** 2))
+)
+
+export const findNonOverlappingPosition = (
+    currentBB: BoundingBox,
+    boundingBoxes: BoundingBox[],
+    stackOffset: number,
+    initial: boolean = true,
+): BoundingBox => {
+    // always sort based on passed in bounding box
+    boundingBoxes.sort((a, b) => {
+        const distA = dist(a, currentBB)
+        const distB = dist(b, currentBB)
+        return distA - distB
+    })
+
+    const closest = boundingBoxes[0]
+
+    // no items
+    if (!closest) { return currentBB }
+
+    function toStackBB(bb) {
+        return {
+            ...bb,
+            width: stackOffset,
+            height: stackOffset,
+        }
+    }
+
+    const isOverlapping = initial
+        ? doBoxesIntersect(closest, currentBB) // use full module sizes for first check
+        : doBoxesIntersect(toStackBB(closest), toStackBB(currentBB)) // otherwise only check overlap in stackOffset increments
+
+    if (!isOverlapping) {
+        return currentBB
+    }
+
+    const nextBB = {
+        ...currentBB,
+        x: closest.x + stackOffset,
+        y: closest.y + stackOffset,
+    }
+
+    return findNonOverlappingPosition(nextBB, boundingBoxes, stackOffset, false)
+}


### PR DESCRIPTION
## Before
![before-module-offset](https://user-images.githubusercontent.com/43438/61027292-62fd0500-a3e8-11e9-8634-c932be664ff7.gif)

## After
![after-module-offset](https://user-images.githubusercontent.com/43438/61027238-3cd76500-a3e8-11e9-99fa-a74921c245b3.gif)

### Update

Also set it to select the module after adding, this ensures it always renders on top:

![after-module-selection](https://user-images.githubusercontent.com/43438/61028223-bcfeca00-a3ea-11e9-9574-374aa1cef31d.gif)


Please test, try break.

Break = module appears at same position as another module or somewhere that isn't *near* the modulesearch box, or otherwise hidden. 