### PR TITLE
[PLATFORM-494] Editor Search Panel Keyboard controls

### DIFF
--- a/app/src/editor/canvas/components/CanvasSearch.jsx
+++ b/app/src/editor/canvas/components/CanvasSearch.jsx
@@ -36,38 +36,35 @@ export default connect((state) => ({
             name.toLowerCase().includes(search)
         )) : otherCanvases
         return (
-            <React.Fragment>
-                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-                <div className={styles.Overlay} onClick={() => this.props.open(false)} hidden={!this.props.isOpen} />
-                <SearchPanel
-                    placeholder="Search or select a canvas"
-                    className={styles.CanvasSearch}
-                    onChange={this.onChange}
-                    isOpen={this.props.isOpen}
-                    open={this.props.open}
-                    dragDisabled
-                    headerHidden
-                    minHeight={352}
-                    maxHeight={352}
-                    defaultHeight={352}
-                >
+            <SearchPanel
+                placeholder="Search or select a canvas"
+                className={styles.CanvasSearch}
+                onChange={this.onChange}
+                isOpen={this.props.isOpen}
+                open={this.props.open}
+                dragDisabled
+                headerHidden
+                minHeight={352}
+                maxHeight={352}
+                defaultHeight={352}
+                closeOnBlur
+            >
 
-                    {canvases.map((canvas, index) => (
-                        /* eslint-disable react/no-array-index-key */
-                        <SearchRow
-                            key={index}
-                            className={styles.CanvasSearchRow}
-                            component={Link}
-                            refName="innerRef"
-                            to={`${links.editor.canvasEditor}/${canvas.id}`}
-                        >
-                            <span className={cx(styles.canvasState, styles[canvas.state.toLowerCase()])} />
-                            {startCase(canvas.name)}
-                        </SearchRow>
-                        /* eslint-enable react/no-array-index-key */
-                    ))}
-                </SearchPanel>
-            </React.Fragment>
+                {canvases.map((canvas, index) => (
+                    /* eslint-disable react/no-array-index-key */
+                    <SearchRow
+                        key={index}
+                        className={styles.CanvasSearchRow}
+                        component={Link}
+                        refName="innerRef"
+                        to={`${links.editor.canvasEditor}/${canvas.id}`}
+                    >
+                        <span className={cx(styles.canvasState, styles[canvas.state.toLowerCase()])} />
+                        {startCase(canvas.name)}
+                    </SearchRow>
+                    /* eslint-enable react/no-array-index-key */
+                ))}
+            </SearchPanel>
         )
     }
 })

--- a/app/src/editor/canvas/components/CanvasSearch.jsx
+++ b/app/src/editor/canvas/components/CanvasSearch.jsx
@@ -51,13 +51,20 @@ export default connect((state) => ({
                     maxHeight={352}
                     defaultHeight={352}
                 >
-                    {canvases.map((canvas) => (
-                        <SearchRow key={canvas.id} className={styles.CanvasSearchRow}>
-                            <Link to={`${links.editor.canvasEditor}/${canvas.id}`}>
-                                <span className={cx(styles.canvasState, styles[canvas.state.toLowerCase()])} />
-                                {startCase(canvas.name)}
-                            </Link>
+
+                    {canvases.map((canvas, index) => (
+                        /* eslint-disable react/no-array-index-key */
+                        <SearchRow
+                            key={index}
+                            className={styles.CanvasSearchRow}
+                            component={Link}
+                            refName="innerRef"
+                            to={`${links.editor.canvasEditor}/${canvas.id}`}
+                        >
+                            <span className={cx(styles.canvasState, styles[canvas.state.toLowerCase()])} />
+                            {startCase(canvas.name)}
                         </SearchRow>
+                        /* eslint-enable react/no-array-index-key */
                     ))}
                 </SearchPanel>
             </React.Fragment>

--- a/app/src/editor/canvas/components/CanvasSearch.pcss
+++ b/app/src/editor/canvas/components/CanvasSearch.pcss
@@ -37,14 +37,3 @@ body .CanvasSearch {
   text-decoration: none;
   color: #323232;
 }
-
-.Overlay {
-  pointer-events: auto;
-  position: fixed;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  opacity: 0;
-  z-index: 2;
-}

--- a/app/src/editor/canvas/components/CanvasSearch.pcss
+++ b/app/src/editor/canvas/components/CanvasSearch.pcss
@@ -29,7 +29,6 @@ body .CanvasSearch {
 
 .CanvasSearch a {
   color: #323232;
-  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -1,5 +1,10 @@
 // @flow
 
+// Need to use index-based keys otherwise transitions get messed up.
+// With normal id-based keys and index-based selection higlight,
+// the highlight will flicker when the item at same index changes selection state
+/* eslint-disable react/no-array-index-key */
+
 import React from 'react'
 import startCase from 'lodash/startCase'
 import debounce from 'lodash/debounce'
@@ -57,14 +62,13 @@ export class ModuleMenuCategory extends React.PureComponent<MenuCategoryProps, M
                     className={cx(styles.Category, {
                         [styles.active]: !!isExpanded,
                     })}
-                    key={category.name}
                     onClick={() => !isDisabled && this.toggle()}
                     disabled={isDisabled}
                 >
                     {category.name}
                 </SearchRow>
-                {isExpanded && category.modules.map((m) => (
-                    <ModuleMenuItem key={m.id} module={m} addModule={addModule} />
+                {isExpanded && category.modules.map((m, index) => (
+                    <ModuleMenuItem module={m} key={index} addModule={addModule} />
                 ))}
             </React.Fragment>
         )
@@ -341,11 +345,11 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                 {matchingModules.length > 0 && (
                     <SearchRow className={styles.SearchCategory} disabled>Modules</SearchRow>
                 )}
-                {matchingModules.map((m) => (
+                {matchingModules.map((m, index) => (
                     /* TODO: follow the disabled jsx-a11y recommendations below to add keyboard support */
                     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events */
                     <SearchRow
-                        key={m.id}
+                        key={index}
                         className={cx(styles.ModuleItem, styles.WithCategory)}
                         draggable
                         onDragStart={(e) => { onDragStart(e, m.id, m.name) }}
@@ -358,10 +362,10 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                 {matchingStreams.length > 0 && (
                     <SearchRow className={styles.SearchCategory} disabled>Streams</SearchRow>
                 )}
-                {matchingStreams.map((stream) => (
+                {matchingStreams.map((stream, index) => (
                     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events */
                     <SearchRow
-                        key={stream.id}
+                        key={index}
                         className={styles.StreamItem}
                         draggable
                         onDragStart={(e) => { onDragStart(e, STREAM_MODULE_ID, stream.name, stream.id) }}

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -389,6 +389,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                     isOpen={isOpen}
                     open={open}
                     panelRef={this.selfRef}
+                    resetOnDefault
                     renderDefault={() => this.renderMenu()}
                 >
                     {!!isSearching && this.renderSearchResults()}

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -30,6 +30,7 @@ const categoryMapping = {
 type MenuCategoryProps = {
     category: CategoryType,
     addModule: (id: number, x: ?number, y: ?number, streamId: ?string) => void,
+    disabled?: boolean,
 }
 
 type MenuCategoryState = {
@@ -46,8 +47,9 @@ export class ModuleMenuCategory extends React.PureComponent<MenuCategoryProps, M
     }
 
     render() {
-        const { category, addModule } = this.props
+        const { category, addModule, disabled } = this.props
         const { isExpanded } = this.state
+        const isDisabled = disabled || !category.modules.length // disable if no modules
         return (
             <React.Fragment>
                 {/* eslint-disable-next-line */}
@@ -56,7 +58,8 @@ export class ModuleMenuCategory extends React.PureComponent<MenuCategoryProps, M
                         [styles.active]: !!isExpanded,
                     })}
                     key={category.name}
-                    onClick={() => this.toggle()}
+                    onClick={() => !isDisabled && this.toggle()}
+                    disabled={isDisabled}
                 >
                     {category.name}
                 </SearchRow>
@@ -336,7 +339,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
         return (
             <React.Fragment>
                 {matchingModules.length > 0 && (
-                    <SearchRow className={styles.SearchCategory}>Modules</SearchRow>
+                    <SearchRow className={styles.SearchCategory} disabled>Modules</SearchRow>
                 )}
                 {matchingModules.map((m) => (
                     /* TODO: follow the disabled jsx-a11y recommendations below to add keyboard support */
@@ -353,7 +356,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                     </SearchRow>
                 ))}
                 {matchingStreams.length > 0 && (
-                    <SearchRow className={styles.SearchCategory}>Streams</SearchRow>
+                    <SearchRow className={styles.SearchCategory} disabled>Streams</SearchRow>
                 )}
                 {matchingStreams.map((stream) => (
                     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events */

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -5,7 +5,7 @@
 // the highlight will flicker when the item at same index changes selection state
 /* eslint-disable react/no-array-index-key */
 
-import React from 'react'
+import React, { useState, useCallback } from 'react'
 import startCase from 'lodash/startCase'
 import debounce from 'lodash/debounce'
 import cx from 'classnames'
@@ -38,41 +38,37 @@ type MenuCategoryProps = {
     disabled?: boolean,
 }
 
-type MenuCategoryState = {
-    isExpanded: boolean,
-}
+export function ModuleMenuCategory(props: MenuCategoryProps) {
+    const { category, addModule, disabled } = props
+    const isDisabled = disabled || !category.modules.length // disable if no modules
+    const [isExpanded, setIsExpanded] = useState(false)
 
-export class ModuleMenuCategory extends React.PureComponent<MenuCategoryProps, MenuCategoryState> {
-    state = {
-        isExpanded: false,
-    }
+    const toggle = useCallback(() => {
+        setIsExpanded((isExpanded) => !isExpanded)
+    }, [setIsExpanded])
 
-    toggle = () => {
-        this.setState(({ isExpanded }) => ({ isExpanded: !isExpanded }))
-    }
+    const onClick = useCallback(() => {
+        if (isDisabled) { return }
+        toggle()
+    }, [isDisabled, toggle])
 
-    render() {
-        const { category, addModule, disabled } = this.props
-        const { isExpanded } = this.state
-        const isDisabled = disabled || !category.modules.length // disable if no modules
-        return (
-            <React.Fragment>
-                {/* eslint-disable-next-line */}
-                <SearchRow
-                    className={cx(styles.Category, {
-                        [styles.active]: !!isExpanded,
-                    })}
-                    onClick={() => !isDisabled && this.toggle()}
-                    disabled={isDisabled}
-                >
-                    {category.name}
-                </SearchRow>
-                {isExpanded && category.modules.map((m, index) => (
-                    <ModuleMenuItem module={m} key={index} addModule={addModule} />
-                ))}
-            </React.Fragment>
-        )
-    }
+    return (
+        <React.Fragment>
+            {/* eslint-disable-next-line */}
+            <SearchRow
+                className={cx(styles.Category, {
+                    [styles.active]: !!isExpanded,
+                })}
+                onClick={onClick}
+                disabled={isDisabled}
+            >
+                {category.name}
+            </SearchRow>
+            {isExpanded && category.modules.map((m, index) => (
+                <ModuleMenuItem module={m} key={index} addModule={addModule} />
+            ))}
+        </React.Fragment>
+    )
 }
 
 const onDragStart = (e: any, moduleId: number, moduleName: string, streamId?: string) => {

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -29,10 +29,6 @@ body .SearchCategory {
   letter-spacing: 1px;
 }
 
-body .SearchCategory:hover {
-  background: transparent;
-}
-
 .ModuleSearch .ModuleItem {
   display: flex;
   align-items: center;

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -41,24 +41,10 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
         })
     }
 
-    onKeyDown = (event) => {
-        if (this.state.canvasSearchIsOpen && event.code === 'Escape') {
-            this.canvasSearchOpen(false)
-        }
-    }
-
     getOnChangeHistorical = (key) => (value) => {
         this.props.setHistorical({
             [key]: value,
         })
-    }
-
-    componentDidMount() {
-        window.addEventListener('keydown', this.onKeyDown)
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('keydown', this.onKeyDown)
     }
 
     onToggleRunButtonMenu = () => {

--- a/app/src/editor/canvas/index.pcss
+++ b/app/src/editor/canvas/index.pcss
@@ -28,7 +28,7 @@
 .CanvasToolbar {
   grid-area: footer;
   width: 100vw;
-  z-index: 11; /* show over connections */
+  z-index: 13; /* show over connections & module search */
   min-height: 80px;
 }
 

--- a/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
+++ b/app/src/editor/dashboard/components/DashboardModuleSearch.jsx
@@ -2,6 +2,8 @@
  * Popup canvas/module searcher for adding new items to a dashboard.
  */
 
+/* eslint-disable react/no-array-index-key */
+
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import startCase from 'lodash/startCase'
 import groupBy from 'lodash/groupBy'
@@ -49,9 +51,9 @@ function DashboardModuleSearchItem({
                 {canvas.name}
             </SearchRow>
             {/* rows of matching canvas modules */}
-            {!!isExpanded && modules.map((m) => (
+            {!!isExpanded && modules.map((m, index) => (
                 <SearchRow
-                    key={m.hash}
+                    key={index}
                     onClick={() => onSelect(canvas.id, m)}
                     className={cx(styles.UIModule, {
                         [styles.isOnDashboard]: isOnDashboard(canvas.id, m),
@@ -126,11 +128,11 @@ class DashboardModuleSearch extends React.PureComponent {
                 isOpen
                 open={modalApi.open}
             >
-                {Object.entries(availableDashboardModules).map(([canvasId, modules]) => {
+                {Object.entries(availableDashboardModules).map(([canvasId, modules], index) => {
                     const canvas = canvases.find(({ id }) => id === canvasId)
                     return (
                         <DashboardModuleSearchItem
-                            key={canvas.id}
+                            key={index}
                             canvas={canvas}
                             modules={modules}
                             onSelect={this.onSelect}

--- a/app/src/editor/dashboard/components/DashboardModuleSearch.pcss
+++ b/app/src/editor/dashboard/components/DashboardModuleSearch.pcss
@@ -19,11 +19,6 @@
   border-top: 1px solid #EFEFEF;
 }
 
-.UIModule:hover,
-.CanvasName:hover {
-  background: #F8F8F8;
-}
-
 .Circle {
   display: block;
   width: 8px;

--- a/app/src/editor/shared/components/SearchPanel/ListBox.jsx
+++ b/app/src/editor/shared/components/SearchPanel/ListBox.jsx
@@ -1,0 +1,110 @@
+import React, { useState, useCallback, useMemo, useRef, useContext } from 'react'
+import uniqueId from 'lodash/uniqueId'
+
+// onKeyDown handler fire callback on Enter/Spacebar
+function useOnKeyDownConfirm(onClick) {
+    return useCallback((event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            onClick(event)
+        }
+    }, [onClick])
+}
+
+function useId(prefix) {
+    const idRef = useRef()
+    if (!idRef.current) {
+        idRef.current = uniqueId(prefix)
+    }
+
+    return idRef.current
+}
+
+const ListContext = React.createContext()
+
+export function ListOption({ onClick, ...props }) {
+    const listContext = useContext(ListContext)
+    const parentId = listContext.id
+    const id = useId([parentId, 'ListOption'].join('.'))
+    const { setSelected } = listContext
+    const onFocus = useCallback(() => {
+        setSelected(id)
+    }, [id, setSelected])
+
+    return (
+        <div
+            id={id}
+            role="option"
+            aria-selected={String(listContext.isSelected(id))}
+            tabIndex="0"
+            onClick={onClick}
+            onKeyDown={useOnKeyDownConfirm(onClick) /* treat enter/spacebar as onClick */}
+            onFocus={onFocus}
+            {...props}
+        />
+    )
+}
+
+export const ListBox = React.forwardRef((props, ref) => {
+    const id = useId('ListBox')
+
+    const [selection, setSelected] = useState()
+    const isSelected = useCallback((id) => (
+        selection === id
+    ), [selection])
+
+    const selectNext = useCallback(() => {
+        const options = Array.from(ref.current.querySelectorAll('[role=option]'))
+        const ids = options.map((el) => el.id)
+        const currentIndex = ids.indexOf(selection)
+        const nextIndex = (currentIndex + 1) % ids.length
+        const next = options[nextIndex]
+        if (!next) { return }
+        next.focus()
+    }, [ref, selection])
+
+    const selectPrev = useCallback(() => {
+        const options = Array.from(ref.current.querySelectorAll('[role=option]'))
+        const ids = options.map((el) => el.id)
+        const currentIndex = ids.indexOf(selection)
+        const prevIndex = (ids.length + (currentIndex - 1)) % ids.length
+        const prev = options[prevIndex]
+        if (!prev) { return }
+        prev.focus()
+    }, [ref, selection])
+
+    const listContext = useMemo(() => ({
+        id,
+        selection,
+        isSelected,
+        selectPrev,
+        selectNext,
+        setSelected,
+    }), [id, selection, isSelected, setSelected, selectNext, selectPrev])
+
+    const onKeyDown = useCallback((event) => {
+        if (event.key === 'ArrowDown') {
+            event.preventDefault()
+            selectNext()
+        }
+        if (event.key === 'ArrowUp') {
+            event.preventDefault()
+            selectPrev()
+        }
+    }, [selectNext, selectPrev])
+
+    return (
+        <ListContext.Provider value={listContext}>
+            <div
+                id={id}
+                tabIndex="0"
+                role="listbox"
+                ref={ref}
+                aria-activedescendant={selection}
+                onKeyDown={onKeyDown}
+                {...props}
+            />
+        </ListContext.Provider>
+    )
+})
+

--- a/app/src/editor/shared/components/SearchPanel/ListBox.jsx
+++ b/app/src/editor/shared/components/SearchPanel/ListBox.jsx
@@ -111,8 +111,16 @@ function clamp(value, min, max) {
     return Math.max(min, Math.min(max, value))
 }
 
-export const useListBoxOnKeyDownCallback = (listContext) => (
-    useCallback((event) => {
+function useOptionalRef(externalRef) {
+    // allow ref prop to be optional
+    const internalRef = useRef()
+    return externalRef || internalRef
+}
+
+export const useListBoxOnKeyDownCallback = (externalListContextRef) => {
+    const listContextRef = useOptionalRef(externalListContextRef)
+    return useCallback((event) => {
+        const listContext = listContextRef.current
         if (!listContext) { return }
         if (event.currentTarget !== event.target && event.currentTarget !== window) { return } // ignore bubbled
         if (event.key === 'ArrowDown') {
@@ -134,13 +142,12 @@ export const useListBoxOnKeyDownCallback = (listContext) => (
                 el.click()
             }
         }
-    }, [listContext])
-)
+    }, [listContextRef])
+}
 
 function useListBoxContext(externalRef) {
     // allow ref prop to be optional
-    const internalRef = useRef()
-    const ref = externalRef || internalRef
+    const ref = useOptionalRef(externalRef)
 
     // ListBox needs unique id so ListOptions can have ListBox-scoped ids
     // So aria-activedescendant={selectedId} is valid
@@ -237,7 +244,7 @@ export const ListBox = React.forwardRef(({ listContextRef, ...props }, ref) => {
         listContextRef.current = listContext
     }
 
-    const onKeyDown = useListBoxOnKeyDownCallback(listContext)
+    const onKeyDown = useListBoxOnKeyDownCallback(listContextRef)
 
     const [isOver, setIsOver] = useState(false)
 

--- a/app/src/editor/shared/components/SearchPanel/ListBox.jsx
+++ b/app/src/editor/shared/components/SearchPanel/ListBox.jsx
@@ -93,6 +93,16 @@ export const ListBox = React.forwardRef((props, ref) => {
         }
     }, [selectNext, selectPrev])
 
+    // select first item when container focussed
+    const onFocus = useCallback((event) => {
+        if (event.currentTarget !== event.target) { return } // ignore bubbled
+        event.preventDefault()
+        event.stopPropagation()
+        const item = ref.current.querySelector('[role=option]')
+        if (!item) { return }
+        item.focus()
+    }, [ref])
+
     return (
         <ListContext.Provider value={listContext}>
             <div
@@ -100,6 +110,7 @@ export const ListBox = React.forwardRef((props, ref) => {
                 tabIndex="0"
                 role="listbox"
                 ref={ref}
+                onFocus={onFocus}
                 aria-activedescendant={selection}
                 onKeyDown={onKeyDown}
                 {...props}

--- a/app/src/editor/shared/components/SearchPanel/ListBox.jsx
+++ b/app/src/editor/shared/components/SearchPanel/ListBox.jsx
@@ -15,6 +15,11 @@ function useId(...prefixes) {
         idRef.current = uniqueId(prefix)
     }
 
+    // unset on unmount
+    useEffect(() => () => {
+        idRef.current = undefined
+    }, [])
+
     return idRef.current
 }
 
@@ -49,10 +54,10 @@ export function ListOption({
         setSelected(id)
     }, [setSelected, id])
 
-    /* treat enter/spacebar as onClick */
+    /* treat enter/spacebar/rightarrow as onClick */
     const onKeyDown = useCallback((event) => {
         if (!elRef.current) { return }
-        if (event.key === 'Enter' || event.key === ' ') {
+        if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowRight') {
             event.preventDefault()
             elRef.current.click()
         }
@@ -65,8 +70,11 @@ export function ListOption({
         const nextIsSelected = listContext.isSelected(id)
         // do nothing if no change
         if (nextIsSelected === isSelected) { return }
+        setIsSelected(nextIsSelected)
+    }, [setIsSelected, listContext, isSelected, id, elRef])
 
-        if (!nextIsSelected) {
+    useEffect(() => {
+        if (!isSelected) {
             // ensure blurred when selectedIndex leaves element
             if (document.activeElement === elRef.current) {
                 elRef.current.blur()
@@ -80,9 +88,7 @@ export function ListOption({
                 inline: 'nearest',
             })
         }
-
-        setIsSelected(nextIsSelected)
-    }, [setIsSelected, listContext, isSelected, id, elRef])
+    }, [isSelected, id, elRef])
 
     const refProp = {
         [refName]: elRef, // dynamic ref
@@ -107,42 +113,19 @@ export function ListOption({
     )
 }
 
+/**
+ * Clamp value between min & max
+ * If max < min, min = max
+ */
 function clamp(value, min, max) {
+    if (max < min) { max = min } // don't allow max < min
     return Math.max(min, Math.min(max, value))
 }
 
-function useOptionalRef(externalRef) {
+export function useOptionalRef(externalRef) {
     // allow ref prop to be optional
     const internalRef = useRef()
     return externalRef || internalRef
-}
-
-export const useListBoxOnKeyDownCallback = (externalListContextRef) => {
-    const listContextRef = useOptionalRef(externalListContextRef)
-    return useCallback((event) => {
-        const listContext = listContextRef.current
-        if (!listContext) { return }
-        if (event.currentTarget !== event.target && event.currentTarget !== window) { return } // ignore bubbled
-        if (event.key === 'ArrowDown') {
-            event.stopPropagation()
-            event.preventDefault()
-            listContext.selectNext()
-        }
-        if (event.key === 'ArrowUp') {
-            event.stopPropagation()
-            event.preventDefault()
-            listContext.selectPrev()
-        }
-
-        if (event.key === 'Enter') {
-            event.stopPropagation()
-            event.preventDefault()
-            const el = listContext.getSelectedEl()
-            if (el) {
-                el.click()
-            }
-        }
-    }, [listContextRef])
 }
 
 function useListBoxContext(externalRef) {
@@ -153,21 +136,23 @@ function useListBoxContext(externalRef) {
     // So aria-activedescendant={selectedId} is valid
     const id = useId('ListBox')
 
-    const [selectedIndex, setSelectedState] = useState(0)
+    const [selectedIndex, setSelectedIndexState] = useState(0)
 
     /**
      * Move selectedIndex forward or backwards with wrap around.
      */
     const adjustSelectedIndex = useCallback((amount = 0) => {
         if (!ref.current) { return }
-        const options = ref.current.querySelectorAll(OPTION_SELECTOR)
-        setSelectedState((index = 0) => {
+
+        setSelectedIndexState((index = 0) => {
+            const options = ref.current.querySelectorAll(OPTION_SELECTOR)
+            if (!options.length) { return 0 } // ignore if no options
             // ensure movement relative to current list bounds
             index = clamp(index, 0, options.length - 1)
             // starting at options.length enables backwards wrap around
             return (options.length + index + amount) % options.length
         })
-    }, [setSelectedState, ref])
+    }, [setSelectedIndexState, ref])
 
     const selectNext = useCallback(() => {
         adjustSelectedIndex(1)
@@ -209,8 +194,8 @@ function useListBoxContext(externalRef) {
         const options = Array.from(ref.current.querySelectorAll(OPTION_SELECTOR))
         const ids = options.map((el) => el.id)
         const selectedIndex = ids.indexOf(id)
-        setSelectedState(clamp(selectedIndex, 0, ids.length - 1))
-    }, [ref, setSelectedState])
+        setSelectedIndexState(clamp(selectedIndex, 0, ids.length - 1))
+    }, [ref, setSelectedIndexState])
 
     /**
      * Build list context API
@@ -234,40 +219,81 @@ function useListBoxContext(externalRef) {
     ])
 }
 
-export const ListBox = React.forwardRef(({ listContextRef, ...props }, ref) => {
-    const listContext = useListBoxContext(ref)
+export const useListBoxOnKeyDownCallback = (externalListContextRef) => {
+    const listContextRef = useOptionalRef(externalListContextRef)
+    return useCallback((event) => {
+        const listContext = listContextRef.current
+        if (!listContext) { return }
+        if (event.currentTarget !== event.target && event.currentTarget !== window) { return } // ignore bubbled
+        if (event.key === 'ArrowDown') {
+            event.stopPropagation()
+            event.preventDefault()
+            listContext.selectNext()
+        }
+        if (event.key === 'ArrowUp') {
+            event.stopPropagation()
+            event.preventDefault()
+            listContext.selectPrev()
+        }
 
-    /**
-     * Provide ref to context API for parent to control
-     */
-    if (listContextRef) {
-        listContextRef.current = listContext
-    }
+        if (event.key === 'Enter') {
+            event.stopPropagation()
+            event.preventDefault()
+            const el = listContext.getSelectedEl()
+            if (el) {
+                el.click()
+            }
+        }
+    }, [listContextRef])
+}
+
+export function useListBoxInteraction(listContextRef) {
+    const [isInteractive, setIsInteractive] = useState(false)
 
     const onKeyDown = useListBoxOnKeyDownCallback(listContextRef)
-
-    const [isOver, setIsOver] = useState(false)
 
     /**
      * Attach keyboard handlers whenever mouse over listbox
      */
-    const onMouseEnter = useCallback(() => {
-        if (isOver) { return }
-        setIsOver(true)
-    }, [setIsOver, isOver])
+    const enable = useCallback(() => {
+        if (isInteractive) { return }
+        setIsInteractive(true)
+    }, [setIsInteractive, isInteractive])
 
-    const onMouseLeave = useCallback(() => {
-        if (!isOver) { return }
-        setIsOver(false)
-    }, [setIsOver, isOver])
+    const disable = useCallback(() => {
+        if (!isInteractive) { return }
+        setIsInteractive(false)
+    }, [setIsInteractive, isInteractive])
 
     useEffect(() => {
-        if (!isOver) { return }
+        if (!isInteractive) { return }
         window.addEventListener('keydown', onKeyDown)
         return () => {
             window.removeEventListener('keydown', onKeyDown)
         }
-    }, [isOver, onKeyDown])
+    }, [isInteractive, onKeyDown])
+
+    return useMemo(() => ({
+        enable,
+        disable,
+        onKeyDown,
+    }), [enable, disable, onKeyDown])
+}
+
+export const ListBox = React.forwardRef(({ listContextRef: externalListContextRef, ...props }, ref) => {
+    const listContext = useListBoxContext(ref)
+    const listContextRef = useOptionalRef(externalListContextRef)
+
+    /**
+     * Provide ref to context API for parent to control
+     */
+    listContextRef.current = listContext
+    useEffect(() => () => {
+        // unset on unmount
+        listContextRef.current = undefined
+    }, [listContextRef])
+
+    const { onKeyDown } = useListBoxInteraction(listContextRef)
 
     const selectedEl = listContext.getSelectedEl()
 
@@ -280,8 +306,6 @@ export const ListBox = React.forwardRef(({ listContextRef, ...props }, ref) => {
                 ref={ref}
                 aria-activedescendant={selectedEl && selectedEl.id}
                 onKeyDown={onKeyDown}
-                onMouseEnter={onMouseEnter}
-                onMouseLeave={onMouseLeave}
                 {...props}
             />
         </ListContext.Provider>

--- a/app/src/editor/shared/components/SearchPanel/ListBox.jsx
+++ b/app/src/editor/shared/components/SearchPanel/ListBox.jsx
@@ -110,15 +110,19 @@ export const ListBox = React.forwardRef((props, ref) => {
         }
     }, [selectNext, selectPrev])
 
-    // select first item when container focussed
+    // select current/first item when container focussed
     const onFocus = useCallback((event) => {
         if (event.currentTarget !== event.target) { return } // ignore bubbled
+        const options = Array.from(ref.current.querySelectorAll(OPTION_SELECTOR))
+        const ids = options.map((el) => el.id)
+        // selected item or first if no selection
+        const currentIndex = Math.max(0, ids.indexOf(selection))
+        const current = options[currentIndex]
+        if (!current) { return }
         event.preventDefault()
         event.stopPropagation()
-        const item = ref.current.querySelector(OPTION_SELECTOR)
-        if (!item) { return }
-        item.focus()
-    }, [ref])
+        current.focus()
+    }, [ref, selection])
 
     return (
         <ListContext.Provider value={listContext}>

--- a/app/src/editor/shared/components/SearchPanel/ListBox.jsx
+++ b/app/src/editor/shared/components/SearchPanel/ListBox.jsx
@@ -116,18 +116,20 @@ export const useListBoxOnKeyDownCallback = (listContext) => (
         if (!listContext) { return }
         if (event.currentTarget !== event.target && event.currentTarget !== window) { return } // ignore bubbled
         if (event.key === 'ArrowDown') {
+            event.stopPropagation()
             event.preventDefault()
             listContext.selectNext()
         }
         if (event.key === 'ArrowUp') {
+            event.stopPropagation()
             event.preventDefault()
             listContext.selectPrev()
         }
 
         if (event.key === 'Enter') {
-            const el = listContext.getSelectedEl()
             event.stopPropagation()
             event.preventDefault()
+            const el = listContext.getSelectedEl()
             if (el) {
                 el.click()
             }

--- a/app/src/editor/shared/components/SearchPanel/ListBox.jsx
+++ b/app/src/editor/shared/components/SearchPanel/ListBox.jsx
@@ -154,9 +154,9 @@ function useListBoxContext(externalRef) {
     const adjustSelectedIndex = useCallback((amount = 0) => {
         if (!ref.current) { return }
         const options = ref.current.querySelectorAll(OPTION_SELECTOR)
-        setSelectedState((index) => {
+        setSelectedState((index = 0) => {
             // ensure movement relative to current list bounds
-            index = clamp(index, 0, options.length)
+            index = clamp(index, 0, options.length - 1)
             // starting at options.length enables backwards wrap around
             return (options.length + index + amount) % options.length
         })
@@ -202,7 +202,7 @@ function useListBoxContext(externalRef) {
         const options = Array.from(ref.current.querySelectorAll(OPTION_SELECTOR))
         const ids = options.map((el) => el.id)
         const selectedIndex = ids.indexOf(id)
-        setSelectedState(clamp(selectedIndex, 0, ids.length))
+        setSelectedState(clamp(selectedIndex, 0, ids.length - 1))
     }, [ref, setSelectedState])
 
     /**

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -180,11 +180,9 @@
 }
 
 .SearchRow:active,
-.SearchRow:focus {
-  outline: none;
-}
-
+.SearchRow:focus,
 .SearchRow:hover {
+  outline: none;
   background: #F8F8F8;
 }
 

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -180,10 +180,11 @@
   border-bottom: none;
 }
 
-.SearchRow:active,
-.SearchRow:focus,
-.SearchRow:hover {
+.SearchRow:focus {
   outline: none;
+}
+
+.SearchRow[aria-selected=true] {
   background: #F8F8F8;
 }
 

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -38,6 +38,7 @@
   height: 40px;
   padding: 0 12px;
   border-bottom: 1px solid #EFEFEF;
+  flex-shrink: 0;
 }
 
 .SearchPanel .Header button {
@@ -89,7 +90,7 @@
 .SearchPanel .Input {
   font-size: 14px;
   font-weight: var(--regular);
-  line-height: 1;
+  line-height: normal;
   text-align: left;
   letter-spacing: 0;
   padding-right: 16px;
@@ -117,6 +118,7 @@
 .SearchPanel .ContentContainer {
   flex: 1;
   border-top: 1px solid #EFEFEF;
+  overflow: auto; /* fallback for firefox */
   overflow: overlay; /* deprecated, but does what we want */
   scroll-behavior: smooth;
 
@@ -184,6 +186,10 @@
   transition: background 0.1s, color 0.1s;
 }
 
+.SearchRow:first-child {
+  border-top: none;
+}
+
 .SearchRow:last-child {
   border-bottom: none;
 }
@@ -214,7 +220,7 @@
   grid-row-gap: 2px;
   font-family: var(--mono);
   font-size: 12px;
-  line-height: 1;
+  line-height: normal;
   font-weight: var(--medium);
   text-align: center;
   align-items: center;

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -149,7 +149,7 @@
 }
 
 .SearchPanel .Content {
-  height: stretch;
+  height: min-content;
   color: #525252;
   font-size: 12px;
   font-family: var(--sans);
@@ -158,6 +158,14 @@
   text-transform: uppercase;
   letter-spacing: 1px;
   line-height: 32px;
+}
+
+.SearchPanel .Content:focus {
+  outline: none;
+}
+
+.SearchPanel.isExpanded .Content {
+  height: stretch;
 }
 
 /**

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -115,9 +115,10 @@
 }
 
 .SearchPanel .ContentContainer {
+  flex: 1;
   border-top: 1px solid #EFEFEF;
   overflow: overlay; /* deprecated, but does what we want */
-  flex: 1;
+  scroll-behavior: smooth;
 
   /* standards compliant but only firefox implements */
   scrollbar-width: thin; /* stylelint-disable-line property-no-unknown */

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -149,7 +149,7 @@
 }
 
 .SearchPanel .Content {
-  height: min-content;
+  height: stretch;
   color: #525252;
   font-size: 12px;
   font-family: var(--sans);

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -205,16 +205,7 @@ export function SearchPanel(props) {
         return children
     }, [children, isSearching, isExpanded, renderDefault])
 
-    const onInputKeyDown = useListBoxOnKeyDownCallback(listContextRef.current)
-
-    const onFocusCapture = useCallback((event) => {
-        event.persist()
-        // bounce focus back up to input if container gets focus from an internal item
-        if (event.target === contentRef.current && event.relatedTarget !== inputRef.current) {
-            event.stopPropagation()
-            inputRef.current.focus()
-        }
-    }, [inputRef, contentRef])
+    const onInputKeyDown = useListBoxOnKeyDownCallback(listContextRef)
 
     const { width, height, posX, posY } = layout
 
@@ -292,7 +283,7 @@ export function SearchPanel(props) {
                                 setLayout({})
                             }}
                         >
-                            <ListBox listContextRef={listContextRef} ref={contentRef} className={styles.Content} onFocusCapture={onFocusCapture}>
+                            <ListBox listContextRef={listContextRef} ref={contentRef} className={styles.Content}>
                                 {internalContent}
                             </ListBox>
                         </div>

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -6,7 +6,7 @@ import SvgIcon from '$shared/components/SvgIcon'
 
 import styles from './SearchPanel.pcss'
 
-import { ListBox, ListOption } from './ListBox'
+import { ListBox, ListOption, useListBoxOnKeyDownCallback } from './ListBox'
 
 export function SearchRow({ className, ...props }) {
     return (
@@ -205,29 +205,7 @@ export function SearchPanel(props) {
         return children
     }, [children, isSearching, isExpanded, renderDefault])
 
-    const onInputKeyDown = useCallback((event) => {
-        if (event.currentTarget !== event.target) { return } // ignore bubbled
-        // select next item on arrow down
-        if (event.key === 'ArrowDown') {
-            event.preventDefault()
-            event.stopPropagation()
-            listContextRef.current.selectNext()
-        }
-
-        // select prev item on arrow up
-        if (event.key === 'ArrowUp') {
-            event.preventDefault()
-            event.stopPropagation()
-            listContextRef.current.selectPrev()
-        }
-
-        if (event.key === 'Enter') {
-            const el = listContextRef.current.getSelectedEl()
-            if (el) {
-                el.click()
-            }
-        }
-    }, [listContextRef])
+    const onInputKeyDown = useListBoxOnKeyDownCallback(listContextRef.current)
 
     const onFocusCapture = useCallback((event) => {
         event.persist()

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -6,7 +6,7 @@ import SvgIcon from '$shared/components/SvgIcon'
 
 import styles from './SearchPanel.pcss'
 
-import { ListBox, ListOption, useListBoxOnKeyDownCallback } from './ListBox'
+import { ListBox, ListOption, useListBoxInteraction, useOptionalRef } from './ListBox'
 
 export function SearchRow({ className, ...props }) {
     return (
@@ -48,6 +48,7 @@ export function SearchPanel(props) {
     const listContextRef = useRef()
     const contentRef = useRef()
     const inputRef = useRef()
+    const panelRef = useOptionalRef(props.panelRef)
 
     const [isExpanded, setExpanded] = useState(true)
     const [hasFocus, setHasFocus] = useState(false)
@@ -213,7 +214,7 @@ export function SearchPanel(props) {
         open(false)
     }, [open, closeOnBlur])
 
-    const onInputKeyDown = useListBoxOnKeyDownCallback(listContextRef)
+    const listBoxInteraction = useListBoxInteraction(listContextRef)
 
     const { width, height, posX, posY } = layout
 
@@ -234,7 +235,9 @@ export function SearchPanel(props) {
                     [styles.isExpanded]: isExpanded,
                 })}
                 hidden={!isOpen}
-                ref={props.panelRef}
+                ref={panelRef}
+                onMouseEnter={() => listBoxInteraction.enable()}
+                onMouseLeave={() => listBoxInteraction.disable()}
                 onBlur={onBlur}
             >
                 <ResizableBox
@@ -262,13 +265,13 @@ export function SearchPanel(props) {
                         )}
                         <div className={styles.Input}>
                             <input
+                                onKeyDown={listBoxInteraction.onKeyDown}
                                 ref={inputRef}
                                 placeholder={placeholder}
                                 value={search}
                                 onChange={onChange}
                                 onFocus={onInputFocus}
                                 onBlur={onInputBlur}
-                                onKeyDown={onInputKeyDown}
                             />
                             <button
                                 type="button"

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -6,14 +6,25 @@ import SvgIcon from '$shared/components/SvgIcon'
 
 import styles from './SearchPanel.pcss'
 
-export function SearchRow({ className, ...props }) {
+// onKeyDown handler fire callback on Enter/Spacebar
+function useOnKeyDownConfirm(onClick) {
+    return useCallback((event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            onClick(event)
+        }
+    }, [onClick])
+}
+
+export function SearchRow({ className, onClick, ...props }) {
     return (
-        /* eslint-disable-next-line jsx-a11y/click-events-have-key-events */
         <div
             className={cx(styles.SearchRow, className)}
             role="option"
             aria-selected="false"
             tabIndex="0"
+            onClick={onClick}
+            onKeyDown={useOnKeyDownConfirm(onClick) /* treat enter/spacebar as onClick */}
             {...props}
         />
     )

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -42,6 +42,7 @@ export function SearchPanel(props) {
         scrollPadding,
         dragDisabled,
         headerHidden,
+        resetOnDefault, /* if true will reset listbox when switching between default render */
         renderDefault,
     } = props
 
@@ -198,14 +199,16 @@ export function SearchPanel(props) {
         })
     }, [setLayout])
 
+    const shouldRenderDefault = !!(!isSearching && isExpanded && renderDefault)
+
     const internalContent = useMemo(() => {
         // empty content if not searching and not expanded
         if (!isSearching && !isExpanded) { return null }
         // show default if not searching and expanded
-        if (!isSearching && isExpanded && renderDefault) { return renderDefault() }
+        if (shouldRenderDefault) { return renderDefault() }
         // show children otherwise
         return children
-    }, [children, isSearching, isExpanded, renderDefault])
+    }, [children, isSearching, isExpanded, renderDefault, shouldRenderDefault])
 
     // close on blur if prop set
     const onBlur = useCallback((event) => {
@@ -295,7 +298,12 @@ export function SearchPanel(props) {
                                 setLayout({})
                             }}
                         >
-                            <ListBox listContextRef={listContextRef} ref={contentRef} className={styles.Content}>
+                            <ListBox
+                                key={String(!!(shouldRenderDefault && resetOnDefault))}
+                                listContextRef={listContextRef}
+                                ref={contentRef}
+                                className={styles.Content}
+                            >
                                 {internalContent}
                             </ListBox>
                         </div>

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -6,7 +6,7 @@ import SvgIcon from '$shared/components/SvgIcon'
 
 import styles from './SearchPanel.pcss'
 
-import { ListBox, ListOption, OPTION_SELECTOR } from './ListBox'
+import { ListBox, ListOption } from './ListBox'
 
 export function SearchRow({ className, ...props }) {
     return (
@@ -44,6 +44,7 @@ export function SearchPanel(props) {
         renderDefault,
     } = props
 
+    const listContextRef = useRef()
     const contentRef = useRef()
     const inputRef = useRef()
 
@@ -206,27 +207,27 @@ export function SearchPanel(props) {
 
     const onInputKeyDown = useCallback((event) => {
         if (event.currentTarget !== event.target) { return } // ignore bubbled
-        // select first item on arrow down
-        if (event.key === 'ArrowDown' && contentRef.current) {
+        // select next item on arrow down
+        if (event.key === 'ArrowDown') {
             event.preventDefault()
             event.stopPropagation()
-            const [firstItem] = contentRef.current.querySelectorAll(OPTION_SELECTOR)
-            if (firstItem) {
-                firstItem.focus()
-            }
+            listContextRef.current.selectNext()
         }
 
-        // select last item on arrow up
-        if (event.key === 'ArrowUp' && contentRef.current) {
+        // select prev item on arrow up
+        if (event.key === 'ArrowUp') {
             event.preventDefault()
             event.stopPropagation()
-            const items = Array.from(contentRef.current.querySelectorAll(OPTION_SELECTOR))
-            const lastItem = items.pop()
-            if (lastItem) {
-                lastItem.focus()
+            listContextRef.current.selectPrev()
+        }
+
+        if (event.key === 'Enter') {
+            const el = listContextRef.current.getSelectedEl()
+            if (el) {
+                el.click()
             }
         }
-    }, [contentRef])
+    }, [listContextRef])
 
     const onFocusCapture = useCallback((event) => {
         event.persist()
@@ -313,7 +314,7 @@ export function SearchPanel(props) {
                                 setLayout({})
                             }}
                         >
-                            <ListBox ref={contentRef} className={styles.Content} onFocusCapture={onFocusCapture}>
+                            <ListBox listContextRef={listContextRef} ref={contentRef} className={styles.Content} onFocusCapture={onFocusCapture}>
                                 {internalContent}
                             </ListBox>
                         </div>

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -6,25 +6,12 @@ import SvgIcon from '$shared/components/SvgIcon'
 
 import styles from './SearchPanel.pcss'
 
-// onKeyDown handler fire callback on Enter/Spacebar
-function useOnKeyDownConfirm(onClick) {
-    return useCallback((event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault()
-            onClick(event)
-        }
-    }, [onClick])
-}
+import { ListBox, ListOption } from './ListBox'
 
-export function SearchRow({ className, onClick, ...props }) {
+export function SearchRow({ className, ...props }) {
     return (
-        <div
+        <ListOption
             className={cx(styles.SearchRow, className)}
-            role="option"
-            aria-selected="false"
-            tabIndex="0"
-            onClick={onClick}
-            onKeyDown={useOnKeyDownConfirm(onClick) /* treat enter/spacebar as onClick */}
             {...props}
         />
     )
@@ -288,9 +275,9 @@ export function SearchPanel(props) {
                                 setLayout({})
                             }}
                         >
-                            <div ref={contentRef} role="listbox" className={styles.Content}>
+                            <ListBox ref={contentRef} className={styles.Content}>
                                 {internalContent}
-                            </div>
+                            </ListBox>
                         </div>
                     </div>
                 </ResizableBox>

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -6,7 +6,7 @@ import SvgIcon from '$shared/components/SvgIcon'
 
 import styles from './SearchPanel.pcss'
 
-import { ListBox, ListOption } from './ListBox'
+import { ListBox, ListOption, OPTION_SELECTOR } from './ListBox'
 
 export function SearchRow({ className, ...props }) {
     return (
@@ -129,12 +129,6 @@ export function SearchPanel(props) {
             if (event.key === 'Escape') {
                 open(false)
             }
-            // select result list on arrow down
-            if (event.key === 'ArrowDown' && contentRef.current) {
-                event.preventDefault()
-                event.stopPropagation()
-                contentRef.current.focus()
-            }
         }
     }, [isOpen, hasFocus, open])
 
@@ -210,6 +204,30 @@ export function SearchPanel(props) {
         return children
     }, [children, isSearching, isExpanded, renderDefault])
 
+    const onInputKeyDown = useCallback((event) => {
+        if (event.currentTarget !== event.target) { return } // ignore bubbled
+        // select first item on arrow down
+        if (event.key === 'ArrowDown' && contentRef.current) {
+            event.preventDefault()
+            event.stopPropagation()
+            const [firstItem] = contentRef.current.querySelectorAll(OPTION_SELECTOR)
+            if (firstItem) {
+                firstItem.focus()
+            }
+        }
+
+        // select last item on arrow up
+        if (event.key === 'ArrowUp' && contentRef.current) {
+            event.preventDefault()
+            event.stopPropagation()
+            const items = contentRef.current.querySelectorAll(OPTION_SELECTOR)
+            const lastItem = items.pop()
+            if (lastItem) {
+                lastItem.focus()
+            }
+        }
+    }, [contentRef])
+
     const { width, height, posX, posY } = layout
 
     return (
@@ -262,6 +280,7 @@ export function SearchPanel(props) {
                                 onChange={onChange}
                                 onFocus={onInputFocus}
                                 onBlur={onInputBlur}
+                                onKeyDown={onInputKeyDown}
                             />
                             <button
                                 type="button"

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -228,6 +228,15 @@ export function SearchPanel(props) {
         }
     }, [contentRef])
 
+    const onFocusCapture = useCallback((event) => {
+        event.persist()
+        // bounce focus back up to input if container gets focus from an internal item
+        if (event.target === contentRef.current && event.relatedTarget !== inputRef.current) {
+            event.stopPropagation()
+            inputRef.current.focus()
+        }
+    }, [inputRef, contentRef])
+
     const { width, height, posX, posY } = layout
 
     return (
@@ -285,6 +294,7 @@ export function SearchPanel(props) {
                             <button
                                 type="button"
                                 className={styles.ClearButton}
+                                tabIndex="-1"
                                 onClick={clear}
                                 hidden={search === ''}
                             >
@@ -303,7 +313,7 @@ export function SearchPanel(props) {
                                 setLayout({})
                             }}
                         >
-                            <ListBox ref={contentRef} className={styles.Content}>
+                            <ListBox ref={contentRef} className={styles.Content} onFocusCapture={onFocusCapture}>
                                 {internalContent}
                             </ListBox>
                         </div>

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -220,7 +220,7 @@ export function SearchPanel(props) {
         if (event.key === 'ArrowUp' && contentRef.current) {
             event.preventDefault()
             event.stopPropagation()
-            const items = contentRef.current.querySelectorAll(OPTION_SELECTOR)
+            const items = Array.from(contentRef.current.querySelectorAll(OPTION_SELECTOR))
             const lastItem = items.pop()
             if (lastItem) {
                 lastItem.focus()

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -30,6 +30,7 @@ export function SearchPanel(props) {
     const {
         open,
         isOpen,
+        closeOnBlur,
         bounds,
         placeholder,
         minWidth,
@@ -205,6 +206,13 @@ export function SearchPanel(props) {
         return children
     }, [children, isSearching, isExpanded, renderDefault])
 
+    // close on blur if prop set
+    const onBlur = useCallback((event) => {
+        if (event.currentTarget.contains(event.relatedTarget)) { return }
+        if (!closeOnBlur || !open) { return }
+        open(false)
+    }, [open, closeOnBlur])
+
     const onInputKeyDown = useListBoxOnKeyDownCallback(listContextRef)
 
     const { width, height, posX, posY } = layout
@@ -227,6 +235,7 @@ export function SearchPanel(props) {
                 })}
                 hidden={!isOpen}
                 ref={props.panelRef}
+                onBlur={onBlur}
             >
                 <ResizableBox
                     className={styles.ResizableBox}

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -124,8 +124,17 @@ export function SearchPanel(props) {
     /* Minimise/Focus Handling */
 
     const onKeyDown = useCallback((event) => {
-        if (isOpen && event.key === 'Escape' && hasFocus) {
-            open(false)
+        if (isOpen && hasFocus) {
+            // close on esc
+            if (event.key === 'Escape') {
+                open(false)
+            }
+            // select result list on arrow down
+            if (event.key === 'ArrowDown' && contentRef.current) {
+                event.preventDefault()
+                event.stopPropagation()
+                contentRef.current.focus()
+            }
         }
     }, [isOpen, hasFocus, open])
 


### PR DESCRIPTION
Works for Canvas, Module & Dashboard search panels in the editor.

* Up/Down to change selection.
* Enter to confirm selection.
* First item selected by default.
* Selection loops around when at start/end of list.
* Focus stays in search box (if it was focused).
* Keyboard controls are responsive when mouse hovered over the list.
* Scrolls to selected item when selection changes.
* Smooth scrolling in Chrome/Firefox (Safari needs polyfill)


There's a warning in console about invalid ref propType due to outdated `react-router-dom`, attempting to upgrade. **update**: nope, cascading updates needed. We can live with the warning.

