### PR TITLE
[PLATFORM-692] Fix crash if deleting module while dragging

### DIFF
--- a/app/src/editor/canvas/components/DragDropContext.jsx
+++ b/app/src/editor/canvas/components/DragDropContext.jsx
@@ -26,7 +26,12 @@ export class DragDropProvider extends React.PureComponent {
     }
 
     onKeyDown = (event) => {
-        if (this.state.isDragging && event.key === 'Escape') {
+        if (!this.state.isDragging) { return }
+        // all keyboard events should be swallowed while dragging
+        event.preventDefault()
+        event.stopPropagation()
+        event.stopImmediatePropagation()
+        if (event.key === 'Escape') {
             this.onCancel()
         }
     }


### PR DESCRIPTION
Prevents crash if use tries to delete a module while also dragging it. Solution is to disable all keyboard events while dragging, except those explicitly handled by the dragger e.g. escape.