### PR TITLE
[PLATFORM-475] Share session across tabs, redirect to login on auth failure

### DIFF
--- a/app/src/auth/components/SessionProvider/index.jsx
+++ b/app/src/auth/components/SessionProvider/index.jsx
@@ -5,7 +5,7 @@
 import React, { type Node } from 'react'
 
 import Context, { type Props as State } from '$auth/contexts/Session'
-import { isSessionStorageAvailable } from '$shared/utils/storage'
+import { isLocalStorageAvailable } from '$shared/utils/storage'
 
 const SESSION_TOKEN_KEY = 'session.token'
 
@@ -13,7 +13,7 @@ type Props = {
     children: Node,
 }
 
-const storage = isSessionStorageAvailable() ? sessionStorage : null
+const storage = isLocalStorageAvailable() ? window.localStorage : null
 
 class SessionProvider extends React.Component<Props, State> {
     static token(): ?string {

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -1,0 +1,41 @@
+/**
+ * Redirect to login when axios calls fail to authenticate.
+ */
+
+import axios from 'axios'
+import routes from '$routes'
+
+const meURL = `${process.env.STREAMR_API_URL}/users/me`
+
+function shouldRedirect(error) {
+    if (error.response && error.response.status === 401) {
+        const url = new window.URL(error.config.url)
+        const me = new window.URL(meURL)
+        // shouldn't redirect if hitting /users/me api, 401 normal, signals logged out
+        if (me.pathname === url.pathname && me.origin === url.origin && error.config.method === 'get') { return false }
+        // ignore redirect to login logic for login route
+        return window.location.pathname !== routes.login()
+    }
+    return false
+}
+
+function getRedirect() {
+    let redirect = window.location.href.slice(window.location.origin.length)
+    // never redirect back to login after logging in
+    redirect = (redirect && redirect !== routes.login()) ? redirect : undefined
+    return redirect
+}
+
+// add global axios interceptor
+// redirect to login page on 401 response
+axios.interceptors.response.use((response) => response, (error) => {
+    if (shouldRedirect(error)) {
+        const redirect = getRedirect()
+        window.location = routes.login(redirect ? {
+            redirect,
+        } : {})
+    }
+    // always throw error anyway
+    // caller shouldn't succeed
+    throw error
+})

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -8,6 +8,7 @@ import routes from '$routes'
 const meURL = `${process.env.STREAMR_API_URL}/users/me`
 
 function shouldRedirect(error) {
+    if (window.location.pathname === routes.logout()) { return true }
     // ignore redirect to login logic for login route
     if (window.location.pathname === routes.login()) { return false }
     if (error.response && error.response.status === 401) {
@@ -24,8 +25,11 @@ function shouldRedirect(error) {
 
 function getRedirect() {
     let redirect = window.location.href.slice(window.location.origin.length)
+    const redirectPath = window.location.pathname
     // never redirect back to login after logging in
-    redirect = (redirect && redirect !== routes.login()) ? redirect : undefined
+    redirect = (redirect && redirectPath !== routes.login()) ? redirect : undefined
+    // never redirect to logout after logging in
+    redirect = (redirect && redirectPath !== routes.logout()) ? redirect : undefined
     return redirect
 }
 

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -8,7 +8,6 @@ import routes from '$routes'
 const meURL = `${process.env.STREAMR_API_URL}/users/me`
 
 function shouldRedirect(error) {
-    if (window.location.pathname === routes.logout()) { return true }
     // ignore redirect to login logic for login route
     if (window.location.pathname === routes.login()) { return false }
     if (error.response && error.response.status === 401) {
@@ -42,10 +41,16 @@ export default function installInterceptor(instance = axios) {
     // redirect to login page on 401 response
     instance.interceptors.response.use((response) => response, async (error) => {
         if (shouldRedirect(error)) {
-            const redirect = getRedirect()
-            window.location = routes.login(redirect ? {
-                redirect,
-            } : {})
+            const redirectPath = window.location.pathname
+            if (redirectPath === routes.logout()) {
+                // if user is on logout route, just redirect to root
+                window.location = routes.root()
+            } else {
+                const redirect = getRedirect()
+                window.location = routes.login(redirect ? {
+                    redirect,
+                } : {})
+            }
             await wait(3000) // stall a moment to let redirect happen
         }
         // always throw error anyway

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -33,15 +33,20 @@ function getRedirect() {
     return redirect
 }
 
+function wait(delay) {
+    return new Promise((resolve) => setTimeout(resolve, delay))
+}
+
 export default function installInterceptor(instance = axios) {
     // add global axios interceptor
     // redirect to login page on 401 response
-    instance.interceptors.response.use((response) => response, (error) => {
+    instance.interceptors.response.use((response) => response, async (error) => {
         if (shouldRedirect(error)) {
             const redirect = getRedirect()
             window.location = routes.login(redirect ? {
                 redirect,
             } : {})
+            await wait(3000) // stall a moment to let redirect happen
         }
         // always throw error anyway
         // caller shouldn't succeed

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -29,16 +29,20 @@ function getRedirect() {
     return redirect
 }
 
-// add global axios interceptor
-// redirect to login page on 401 response
-axios.interceptors.response.use((response) => response, (error) => {
-    if (shouldRedirect(error)) {
-        const redirect = getRedirect()
-        window.location = routes.login(redirect ? {
-            redirect,
-        } : {})
-    }
-    // always throw error anyway
-    // caller shouldn't succeed
-    throw error
-})
+export default function installInterceptor(instance = axios) {
+    // add global axios interceptor
+    // redirect to login page on 401 response
+    instance.interceptors.response.use((response) => response, (error) => {
+        if (shouldRedirect(error)) {
+            const redirect = getRedirect()
+            window.location = routes.login(redirect ? {
+                redirect,
+            } : {})
+        }
+        // always throw error anyway
+        // caller shouldn't succeed
+        throw error
+    })
+
+    return instance
+}

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -4,8 +4,9 @@
 
 import axios from 'axios'
 import routes from '$routes'
+import { formatApiUrl } from '$shared/utils/url'
 
-const meURL = `${process.env.STREAMR_API_URL}/users/me`
+const meURL = formatApiUrl('users', 'me')
 
 function shouldRedirect(error) {
     // ignore redirect to login logic for login route

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -8,13 +8,16 @@ import routes from '$routes'
 const meURL = `${process.env.STREAMR_API_URL}/users/me`
 
 function shouldRedirect(error) {
+    // ignore redirect to login logic for login route
+    if (window.location.pathname === routes.login()) { return false }
     if (error.response && error.response.status === 401) {
         const url = new window.URL(error.config.url)
         const me = new window.URL(meURL)
         // shouldn't redirect if hitting /users/me api, 401 normal, signals logged out
-        if (me.pathname === url.pathname && me.origin === url.origin && error.config.method === 'get') { return false }
-        // ignore redirect to login logic for login route
-        return window.location.pathname !== routes.login()
+        if (me.pathname === url.pathname && me.origin === url.origin && error.config.method === 'get') {
+            return false
+        }
+        return true
     }
     return false
 }

--- a/app/src/docs/components/ApiPage/index.jsx
+++ b/app/src/docs/components/ApiPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const ApiPage = () => (
     <DocsLayout subNav={subNav.api}>
-        <Helmet>
-            <title>Streamr Docs | Streamr API</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Streamr API" />
         <ApiContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/GettingStartedPage/index.jsx
+++ b/app/src/docs/components/GettingStartedPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const GettingStartedPage = () => (
     <DocsLayout subNav={subNav.gettingStarted}>
-        <Helmet>
-            <title>Streamr Docs | Getting Started</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Getting Started" />
         <GettingStartedContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/IntroductionPage/index.jsx
+++ b/app/src/docs/components/IntroductionPage/index.jsx
@@ -8,9 +8,7 @@ import IntroductionContent from '$docs/content/introduction.mdx'
 
 const IntroductionPage = () => (
     <DocsLayout>
-        <Helmet>
-            <title>Streamr Docs | Introduction</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Introduction" />
         <IntroductionContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/MarketplacePage/index.jsx
+++ b/app/src/docs/components/MarketplacePage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const MarketplacePage = () => (
     <DocsLayout subNav={subNav.marketplace}>
-        <Helmet>
-            <title>Streamr Docs | Marketplace</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Marketplace" />
         <MarketplacePageContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/StreamrEnginePage/index.jsx
+++ b/app/src/docs/components/StreamrEnginePage/index.jsx
@@ -8,9 +8,7 @@ import StreamrEngineContent from '$docs/content/streamrEngine.mdx'
 
 const StreamrEnginePage = () => (
     <DocsLayout>
-        <Helmet>
-            <title>Streamr Docs | Streamr Engine</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Streamr Engine" />
         <StreamrEngineContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/TutorialsPage/index.jsx
+++ b/app/src/docs/components/TutorialsPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const TutorialsPage = () => (
     <DocsLayout subNav={subNav.tutorials}>
-        <Helmet>
-            <title>Streamr Docs | Tutorials</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Tutorials" />
         <TutorialsContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/UserPage/index.jsx
+++ b/app/src/docs/components/UserPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const UserPages = () => (
     <DocsLayout subNav={subNav.userPages}>
-        <Helmet>
-            <title>Streamr Docs | User Pages</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | User Pages" />
         <UserPageContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/VisualEditorPage/index.jsx
+++ b/app/src/docs/components/VisualEditorPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const VisualEditorPage = () => (
     <DocsLayout subNav={subNav.visualEditor}>
-        <Helmet>
-            <title>Streamr Docs | Visual Editor</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Visual Editor" />
         <VisualEditorContent />
     </DocsLayout>
 )

--- a/app/src/editor/shared/utils/api.js
+++ b/app/src/editor/shared/utils/api.js
@@ -2,13 +2,14 @@
 
 import axios from 'axios'
 import getAuthorizationHeader from '$shared/utils/getAuthorizationHeader'
+import loginInterceptor from '$auth/utils/loginInterceptor'
 
 export default () => (
-    axios.create({
+    loginInterceptor(axios.create({
         headers: {
             ...getAuthorizationHeader(),
             'Content-Type': 'application/json',
         },
         withCredentials: true,
-    })
+    }))
 )

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -7,7 +7,6 @@ import { Provider } from 'react-redux'
 import App from './app'
 import GlobalInfoWatcher from './marketplace/containers/GlobalInfoWatcher'
 import store from './store'
-import './setup'
 
 const root = document.getElementById('root')
 

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -257,9 +257,7 @@ export class ProductPage extends Component<Props, State> {
 
         return !!product && (
             <Layout>
-                <Helmet>
-                    <title>{`${product.name} | ${I18n.t('general.title.suffix')}`}</title>
-                </Helmet>
+                <Helmet title={`${product.name} | ${I18n.t('general.title.suffix')}`} />
                 <ProductPageComponent
                     product={product}
                     streams={streams}

--- a/app/src/marketplace/containers/Products/index.jsx
+++ b/app/src/marketplace/containers/Products/index.jsx
@@ -80,9 +80,7 @@ export class Products extends Component<Props, State> {
 
         return (
             <Layout>
-                <Helmet>
-                    <title>{I18n.t('general.title.suffix')}</title>
-                </Helmet>
+                <Helmet title={I18n.t('general.title.suffix')} />
                 <ActionBar
                     filter={filter}
                     categories={categories}

--- a/app/src/newdocs/components/DocsPages/API/index.jsx
+++ b/app/src/newdocs/components/DocsPages/API/index.jsx
@@ -9,9 +9,7 @@ import ApiContent from '$newdocs/content/api.mdx'
 
 const API = () => (
     <DocsLayout subNav={subNav.api}>
-        <Helmet>
-            <title>Streamr Docs | Streamr API</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Streamr API" />
         <ApiContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Canvases/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Canvases/index.jsx
@@ -9,9 +9,7 @@ import CanvasesContent from '$newdocs/content/canvases.mdx'
 
 const Canvases = () => (
     <DocsLayout subNav={subNav.canvases}>
-        <Helmet>
-            <title>Streamr Docs | Canvases</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Canvases" />
         <CanvasesContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Core/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Core/index.jsx
@@ -9,9 +9,7 @@ import CoreContent from '$newdocs/content/core.mdx'
 
 const Core = () => (
     <DocsLayout subNav={subNav.core}>
-        <Helmet>
-            <title>Streamr Docs | Core</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Core" />
         <CoreContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Dashboards/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Dashboards/index.jsx
@@ -9,9 +9,7 @@ import DashboardsContent from '$newdocs/content/dashboards.mdx'
 
 const Dashboards = () => (
     <DocsLayout subNav={subNav.dashboards}>
-        <Helmet>
-            <title>Streamr Docs | Dashboards</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Dashboards" />
         <DashboardsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/DataToken/index.jsx
+++ b/app/src/newdocs/components/DocsPages/DataToken/index.jsx
@@ -9,9 +9,7 @@ import DataTokenContent from '$newdocs/content/dataToken.mdx'
 
 const DataToken = () => (
     <DocsLayout subNav={subNav.dataToken}>
-        <Helmet>
-            <title>Streamr Docs | DATA Token</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | DATA Token" />
         <DataTokenContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/GettingStarted/index.jsx
+++ b/app/src/newdocs/components/DocsPages/GettingStarted/index.jsx
@@ -9,9 +9,7 @@ import GettingStartedContent from '$newdocs/content/gettingStarted.mdx'
 
 const GettingStarted = () => (
     <DocsLayout subNav={subNav.gettingStarted}>
-        <Helmet>
-            <title>Streamr Docs | Getting Started</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Getting Started" />
         <GettingStartedContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Introduction/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Introduction/index.jsx
@@ -9,9 +9,7 @@ import IntroductionContent from '$newdocs/content/introduction.mdx'
 
 const Introduction = () => (
     <DocsLayout subNav={subNav.introduction}>
-        <Helmet>
-            <title>Streamr Docs | Introduction</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Introduction" />
         <IntroductionContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Marketplace/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Marketplace/index.jsx
@@ -9,9 +9,7 @@ import MarketplacePageContent from '$newdocs/content/marketplace.mdx'
 
 const Marketplace = () => (
     <DocsLayout subNav={subNav.marketplace}>
-        <Helmet>
-            <title>Streamr Docs | Marketplace</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Marketplace" />
         <MarketplacePageContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Products/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Products/index.jsx
@@ -9,9 +9,7 @@ import ProductsContent from '$newdocs/content/products.mdx'
 
 const Products = () => (
     <DocsLayout subNav={subNav.products}>
-        <Helmet>
-            <title>Streamr Docs | Products</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Products" />
         <ProductsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/RunningNode/index.jsx
+++ b/app/src/newdocs/components/DocsPages/RunningNode/index.jsx
@@ -9,9 +9,7 @@
 
 // const RunningNode = () => (
 //     <DocsLayout subNav={subNav.runningNode}>
-//         <Helmet>
-//             <title>Streamr Docs | Running a Node</title>
-//         </Helmet>
+//         <Helmet title="Streamr Docs | Running a Node" />
 //         <RunningNodeContent />
 //     </DocsLayout>
 // )

--- a/app/src/newdocs/components/DocsPages/SDKs/index.jsx
+++ b/app/src/newdocs/components/DocsPages/SDKs/index.jsx
@@ -9,9 +9,7 @@ import SDKsContent from '$newdocs/content/SDKs.mdx'
 
 const SDKs = () => (
     <DocsLayout subNav={subNav.SDKs}>
-        <Helmet>
-            <title>Streamr Docs | SDKs</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | SDKs" />
         <SDKsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Streams/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Streams/index.jsx
@@ -9,9 +9,7 @@ import StreamsContent from '$newdocs/content/streams.mdx'
 
 const Streams = () => (
     <DocsLayout subNav={subNav.streams}>
-        <Helmet>
-            <title>Streamr Docs | Streams</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Streams" />
         <StreamsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/TechnicalNotes/index.jsx
+++ b/app/src/newdocs/components/DocsPages/TechnicalNotes/index.jsx
@@ -10,9 +10,7 @@ import TechnicalNotesContent from '$newdocs/content/technical.mdx'
 
 const TechnicalNotes = () => (
     <DocsLayout subNav={subNav.technicalNotes}>
-        <Helmet>
-            <title>Streamr Docs | Technical Notes</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Technical Notes" />
         <TechnicalNotesContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Tutorials/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Tutorials/index.jsx
@@ -9,9 +9,7 @@ import TutorialsContent from '$newdocs/content/tutorials.mdx'
 
 const Tutorials = () => (
     <DocsLayout subNav={subNav.tutorials}>
-        <Helmet>
-            <title>Streamr Docs | Tutorials</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Tutorials" />
         <TutorialsContent />
     </DocsLayout>
 )

--- a/app/src/setup.js
+++ b/app/src/setup.js
@@ -1,7 +1,9 @@
 // @flow
 
 import BN from 'bignumber.js'
-import '$auth/utils/loginInterceptor'
+import loginInterceptor from '$auth/utils/loginInterceptor'
+
+loginInterceptor()
 
 BN.config({
     DECIMAL_PLACES: 18,

--- a/app/src/setup.js
+++ b/app/src/setup.js
@@ -2,6 +2,23 @@
 
 import BN from 'bignumber.js'
 
+import axios from 'axios'
+import routes from '$routes'
+
+// add global axios interceptor
+// redirect to login page on 401 response
+axios.interceptors.response.use((response) => response, (error) => {
+    if (error.response && error.response.status === 401 && window.location.pathname !== routes.login()) {
+        let redirect = window.location.href.slice(window.location.origin.length)
+        redirect = (redirect && redirect !== '/' && redirect !== routes.login()) ? redirect : undefined
+        window.location = routes.login(redirect ? {
+            redirect,
+        } : {})
+    }
+    // otherwise ignore
+    throw error
+})
+
 BN.config({
     DECIMAL_PLACES: 18,
 })

--- a/app/src/setup.js
+++ b/app/src/setup.js
@@ -1,23 +1,7 @@
 // @flow
 
 import BN from 'bignumber.js'
-
-import axios from 'axios'
-import routes from '$routes'
-
-// add global axios interceptor
-// redirect to login page on 401 response
-axios.interceptors.response.use((response) => response, (error) => {
-    if (error.response && error.response.status === 401 && window.location.pathname !== routes.login()) {
-        let redirect = window.location.href.slice(window.location.origin.length)
-        redirect = (redirect && redirect !== '/' && redirect !== routes.login()) ? redirect : undefined
-        window.location = routes.login(redirect ? {
-            redirect,
-        } : {})
-    }
-    // otherwise ignore
-    throw error
-})
+import '$auth/utils/loginInterceptor'
 
 BN.config({
     DECIMAL_PLACES: 18,

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -38,6 +38,8 @@ module.exports = {
     entry: [
         // forcibly print diagnostics upfront
         path.resolve(root, 'src', 'shared', 'utils', 'diagnostics.js'),
+        // always load setup first
+        path.resolve(root, 'src', 'setup.js'),
         path.resolve(root, 'src', 'index.jsx'),
     ],
     output: {


### PR DESCRIPTION
Converts session provider to use `window.localStorage` instead of `window.sessionStorage`. This fixes the core issue of needing to login when you open multiple tabs.
To handle the logout case I've added a redirect to the login page (and back to current page) on detecting a 401 response from any API endpoint as discussed.

There may be issues with this change should any API responses respond with a 401 and a redirect to login is not appropriate. I couldn't see any references to a 401 status checks in the existing code, but it's possible that there's some non-discriminating error handler that will no longer be run due to this interceptor. Perhaps not.