### PR TITLE
Fix setting double inputs to empty string

### DIFF
--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -44,6 +44,7 @@ const Value = ({ canvas, port, onChange }: Props) => {
     const disabled = isRunning || (!port.canHaveInitialValue && port.connected)
     const type = getPortType(port)
     const isParam = 'defaultValue' in port
+
     // TODO: Ignore when editing.
     const value = (isParam ? (port.value || port.defaultValue) : port.initialValue) || ''
     const commonProps: CommonProps = {

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -646,9 +646,22 @@ export function setPortUserValue(canvas, portId, value) {
 
     const port = getPort(canvas, portId)
 
-    // coerce empty double to undefined
-    if (value === '' && port.type === 'Double') {
-        value = undefined
+    // coerce double to number or undefined if empty or invalid
+    if (port.type === 'Double') {
+        value = value != null ? String(value).trim() : undefined
+        if (value == null || value === '') {
+            value = undefined
+        } else {
+            // swap , for .
+            value = String(value).replace(/,/gm, '.')
+            const num = Number.parseFloat(value)
+            // infinite/NaN = undefined
+            if (Number.isNaN(num) || !Number.isFinite(num)) {
+                value = undefined
+            } else {
+                value = String(num)
+            }
+        }
     }
 
     if (JSON.stringify(port[key]) === JSON.stringify(value)) {

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -630,20 +630,28 @@ export function addModule(canvas, moduleData) {
     }
 }
 
+const PORT_USER_VALUE_KEYS = {
+    [PortTypes.input]: 'initialValue',
+    [PortTypes.param]: 'value',
+    [PortTypes.output]: 'value', // not really user-configurable but whatever
+}
+
 /**
  * Sets initialValue for inputs
  * Sets value for output/params
  */
 
 export function setPortUserValue(canvas, portId, value) {
-    const portType = getPortType(canvas, portId)
-    const key = {
-        [PortTypes.input]: 'initialValue',
-        [PortTypes.param]: 'value',
-        [PortTypes.output]: 'value', // not really user-configurable but whatever
-    }[portType]
+    const key = PORT_USER_VALUE_KEYS[getPortType(canvas, portId)]
 
-    if (JSON.stringify(getPort(canvas, portId)[key]) === JSON.stringify(value)) {
+    const port = getPort(canvas, portId)
+
+    // coerce empty double to undefined
+    if (value === '' && port.type === 'Double') {
+        value = undefined
+    }
+
+    if (JSON.stringify(port[key]) === JSON.stringify(value)) {
         // noop if no change
         return canvas
     }
@@ -655,6 +663,12 @@ export function setPortUserValue(canvas, portId, value) {
             [key]: value,
         }
     })
+}
+
+export function getPortUserValue(canvas, portId) {
+    const key = PORT_USER_VALUE_KEYS[getPortType(canvas, portId)]
+    const port = getPort(canvas, portId)
+    return port[key]
 }
 
 /**

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -279,7 +279,7 @@ describe('Canvas State', () => {
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2,3  '))
                     expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '  -2.3  '))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('-2.3')
                     // tries to parse a number
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2dasd'))
                     expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2')

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -252,15 +252,42 @@ describe('Canvas State', () => {
             })
 
             describe('{set,get}PortUserValue', () => {
-                it('should coerce empty string to undefined for Double type', async () => {
+                it('should coerce numberish values to numbers for Double type', async () => {
                     let canvas = State.emptyCanvas()
                     canvas = State.addModule(canvas, await loadModuleDefinition('Equals'))
                     const [equalsModule] = canvas.modules
                     // params[0] is 'tolerance', of Double type
+                    // coerce empty string to undefined
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, ''))
                     expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(undefined)
+                    // handles commas
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2,3'))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
+                    // handles zero
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '0'))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('0')
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '0.0'))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('0')
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, 0))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('0')
+                    // handles negative numbers
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '-2.3'))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('-2.3')
+                    // ignores whitespace
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2.3 '))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2,3  '))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '  -2.3  '))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
+                    // tries to parse a number
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2dasd'))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2')
+                    // Falls back to undefined if it cannot
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, 'dasd'))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(undefined)
 
-                    // test server accepts state
+                    // test server accepts state with undefined value
                     expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
                 })
             })

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -3,6 +3,8 @@ import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/t
 import * as State from '../state'
 import * as Services from '../services'
 
+import './utils'
+
 const portMatcher = {
     id: expect.any(String),
     name: expect.any(String),
@@ -246,6 +248,20 @@ describe('Canvas State', () => {
                     })
                     expect(canvas.settings.beginDate).toEqual(beginDate)
                     expect(canvas.settings.endDate).toEqual(beginDate)
+                })
+            })
+
+            describe('{set,get}PortUserValue', () => {
+                it('should coerce empty string to undefined for Double type', async () => {
+                    let canvas = State.emptyCanvas()
+                    canvas = State.addModule(canvas, await loadModuleDefinition('Equals'))
+                    const [equalsModule] = canvas.modules
+                    // params[0] is 'tolerance', of Double type
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, ''))
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(undefined)
+
+                    // test server accepts state
+                    expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
                 })
             })
         })


### PR DESCRIPTION
This PR ensures empty double values are saved/sent to the server as `undefined` rather than empty string. Empty string causes a `500` error on server :rage1:

Not sure how this hasn't come up as an issue before as it seems to affect every input/param.

## To Test

1. Add Equals module.
2. Set "tolerance" to any number.
3. Click canvas background to blur input & commit change
4. Select & delete the tolerance value
5. Click canvas background to blur input & commit change (input should be empty)
6. Wait for autosave

## Before

Autosave fails with `500` error:

```js
{
  code: "NumberFormatException"
  message: "empty String"
}
```

![image](https://user-images.githubusercontent.com/43438/61510613-323f5000-aa26-11e9-9e11-9866a40ac96f.png)

Also note this is a frustratingly bad error message as it doesn't indicate which module or port caused the issue. Just terrible.

## After

It saves correctly. 🎆 