### PR TITLE
Move UndoContext to shared

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/useCanvas.jsx
+++ b/app/src/editor/canvas/components/CanvasController/useCanvas.jsx
@@ -1,8 +1,8 @@
 import { useContext } from 'react'
 
-import UndoContainer from '$editor/shared/components/UndoContainer'
+import { Context as UndoContext } from '$shared/components/UndoContextProvider'
 
 export default function useCanvas() {
-    const { state } = useContext(UndoContainer.Context)
+    const { state } = useContext(UndoContext)
     return state
 }

--- a/app/src/editor/canvas/components/CanvasController/useCanvasUpdater.jsx
+++ b/app/src/editor/canvas/components/CanvasController/useCanvasUpdater.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, useContext } from 'react'
 
 import useIsMountedRef from '$shared/utils/useIsMountedRef'
-import UndoContainer from '$editor/shared/components/UndoContainer'
+import { Context as UndoContext } from '$shared/components/UndoContextProvider'
 
 import * as CanvasState from '../../state'
 
@@ -22,7 +22,7 @@ function canvasUpdater(fn) {
 }
 
 export default function useCanvasUpdater() {
-    const { push, replace } = useContext(UndoContainer.Context)
+    const { push, replace } = useContext(UndoContext)
 
     const setCanvas = useMountedCallback((action, fn, done) => {
         push(action, canvasUpdater(fn), done)

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -8,7 +8,8 @@ import ErrorComponentView from '$shared/components/ErrorComponentView'
 
 import links from '../../links'
 
-import UndoContainer, { UndoControls } from '$editor/shared/components/UndoContainer'
+import UndoControls from '$editor/shared/components/UndoControls'
+import * as UndoContext from '$shared/components/UndoContextProvider'
 import Subscription from '$editor/shared/components/Subscription'
 import * as SubscriptionStatus from '$editor/shared/components/SubscriptionStatus'
 import { ClientProvider } from '$editor/shared/components/Client'
@@ -452,7 +453,7 @@ const CanvasEdit = withRouter(({ canvas, ...props }) => {
 
 const CanvasEditWrap = () => {
     const { replaceCanvas, setCanvas } = useCanvasUpdater()
-    const { undo } = useContext(UndoContainer.Context)
+    const { undo } = useContext(UndoContext.Context)
     const canvas = useCanvas()
     if (!canvas) {
         return (
@@ -484,12 +485,12 @@ function isDisabled({ state: canvas }) {
 
 const CanvasContainer = withRouter(withErrorBoundary(ErrorComponentView)((props) => (
     <ClientProvider>
-        <UndoContainer key={props.match.params.id}>
+        <UndoContext.Provider key={props.match.params.id}>
             <UndoControls disabled={isDisabled} />
             <CanvasController.Provider>
                 <CanvasEditWrap />
             </CanvasController.Provider>
-        </UndoContainer>
+        </UndoContext.Provider>
     </ClientProvider>
 )))
 

--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -6,7 +6,8 @@ import Layout from '$mp/components/Layout'
 import withErrorBoundary from '$shared/utils/withErrorBoundary'
 import LoadingIndicator from '$userpages/components/LoadingIndicator'
 import ErrorComponentView from '$shared/components/ErrorComponentView'
-import UndoContainer, { UndoControls } from '$editor/shared/components/UndoContainer'
+import UndoControls from '$editor/shared/components/UndoControls'
+import { Context as UndoContext, Provider as UndoContextProvider } from '$shared/components/UndoContextProvider'
 import { ClientProvider } from '$editor/shared/components/Client'
 import * as sharedServices from '$editor/shared/services'
 
@@ -164,7 +165,7 @@ const DashboardEdit = withRouter(class DashboardEdit extends Component {
 })
 
 const DashboardLoader = withRouter(withErrorBoundary(ErrorComponentView)(class DashboardLoader extends React.PureComponent {
-    static contextType = UndoContainer.Context
+    static contextType = UndoContext
     state = { isLoading: false }
 
     componentDidMount() {
@@ -228,7 +229,7 @@ const DashboardLoader = withRouter(withErrorBoundary(ErrorComponentView)(class D
 }))
 
 const DashboardEditWrap = () => (
-    <UndoContainer.Consumer>
+    <UndoContext.Consumer>
         {({ state: dashboard, push, replace }) => (
             <DashboardEdit
                 key={dashboard.id}
@@ -237,11 +238,11 @@ const DashboardEditWrap = () => (
                 dashboard={dashboard}
             />
         )}
-    </UndoContainer.Consumer>
+    </UndoContext.Consumer>
 )
 
 function DashboardLoadingIndicator() {
-    const { state } = useContext(UndoContainer.Context)
+    const { state } = useContext(UndoContext)
     return (
         <LoadingIndicator className={styles.LoadingIndicator} loading={!state} />
     )
@@ -250,13 +251,13 @@ function DashboardLoadingIndicator() {
 export default withRouter((props) => (
     <Layout className={styles.layout} footer={false}>
         <ClientProvider>
-            <UndoContainer key={props.match.params.id}>
+            <UndoContextProvider key={props.match.params.id}>
                 <UndoControls />
                 <DashboardLoadingIndicator />
                 <DashboardLoader>
                     <DashboardEditWrap />
                 </DashboardLoader>
-            </UndoContainer>
+            </UndoContextProvider>
         </ClientProvider>
     </Layout>
 ))

--- a/app/src/editor/shared/components/UndoControls.jsx
+++ b/app/src/editor/shared/components/UndoControls.jsx
@@ -1,0 +1,56 @@
+/* eslint-disable react/no-unused-state */
+
+import React from 'react'
+
+import { Context as UndoContext } from '$shared/components/UndoContextProvider'
+
+export default class UndoControls extends React.Component {
+    static contextType = UndoContext
+
+    onKeyDown = (event) => {
+        let { disabled } = this.props
+        if (typeof disabled === 'function') {
+            disabled = disabled(this.context)
+        }
+        if (disabled) { return } // noop if disabled
+
+        // ignore if focus is in an input, select, textarea, etc
+        if (document.activeElement) {
+            const tagName = document.activeElement.tagName.toLowerCase()
+            if (tagName === 'input'
+                || tagName === 'select'
+                || tagName === 'textarea'
+                || document.activeElement.isContentEditable
+            ) {
+                return
+            }
+        }
+
+        const metaKey = event.ctrlKey || event.metaKey
+        if (!metaKey) { return } // all shortcuts require meta key
+
+        if (event.code === 'KeyZ') {
+            if (!event.shiftKey) { // Meta+Z – Undo
+                this.context.undo()
+            } else { // Meta+Shift+Z – Redo
+                this.context.redo()
+            }
+        }
+
+        if (event.code === 'KeyY') { // Meta+Y – Redo (windows style)
+            this.context.redo()
+        }
+    }
+
+    componentDidMount() {
+        window.addEventListener('keydown', this.onKeyDown)
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('keydown', this.onKeyDown)
+    }
+
+    render() {
+        return this.props.children || null
+    }
+}

--- a/app/src/shared/test/components/UndoContext.test.jsx
+++ b/app/src/shared/test/components/UndoContext.test.jsx
@@ -1,34 +1,36 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import UndoContainer from '../components/UndoContainer'
+import * as UndoContext from '$shared/components/UndoContextProvider'
 
-describe('UndoContainer', () => {
+describe('UndoContext', () => {
     describe('initialState', () => {
         it('does not need a value', () => {
             mount((
-                <UndoContainer>
-                    <UndoContainer.Consumer>
+                <UndoContext.Provider>
+                    <UndoContext.Context.Consumer>
                         {(props) => {
                             expect(props.state).toBe(undefined)
                             return null
                         }}
-                    </UndoContainer.Consumer>
-                </UndoContainer>
+                    </UndoContext.Context.Consumer>
+                </UndoContext.Provider>
             ))
         })
 
         it('can take a value', () => {
-            const initialState = { initial: true }
+            const initialState = {
+                initial: true,
+            }
             let props
             mount((
-                <UndoContainer initialState={initialState}>
-                    <UndoContainer.Consumer>
+                <UndoContext.Provider initialState={initialState}>
+                    <UndoContext.Context.Consumer>
                         {(containerProps) => {
                             props = containerProps
                             return null
                         }}
-                    </UndoContainer.Consumer>
-                </UndoContainer>
+                    </UndoContext.Context.Consumer>
+                </UndoContext.Provider>
             ))
             expect(props.state).toEqual(initialState)
         })
@@ -37,14 +39,14 @@ describe('UndoContainer', () => {
             it('will not undo past initial state, redo does nothing', async () => {
                 let props
                 mount((
-                    <UndoContainer>
-                        <UndoContainer.Consumer>
+                    <UndoContext.Provider>
+                        <UndoContext.Context.Consumer>
                             {(containerProps) => {
                                 props = containerProps
                                 return null
                             }}
-                        </UndoContainer.Consumer>
-                    </UndoContainer>
+                        </UndoContext.Context.Consumer>
+                    </UndoContext.Provider>
                 ))
                 const initialProps = props
                 await props.undo()
@@ -57,22 +59,28 @@ describe('UndoContainer', () => {
 
     describe('push/undo/redo', () => {
         it('can push new state', async () => {
-            const initialState = { initial: true }
-            const nextState = { next: true }
+            const initialState = {
+                initial: true,
+            }
+            const nextState = {
+                next: true,
+            }
             let props
             mount((
-                <UndoContainer initialState={initialState}>
-                    <UndoContainer.Consumer>
+                <UndoContext.Provider initialState={initialState}>
+                    <UndoContext.Context.Consumer>
                         {(containerProps) => {
                             props = containerProps
                             return null
                         }}
-                    </UndoContainer.Consumer>
-                </UndoContainer>
+                    </UndoContext.Context.Consumer>
+                </UndoContext.Provider>
             ))
 
             const initialProps = props
-            const action = { type: 'action' }
+            const action = {
+                type: 'action',
+            }
             await props.push(action, (prevState) => {
                 expect(prevState).toEqual(initialState) // history pointer should not change
                 return nextState
@@ -83,18 +91,22 @@ describe('UndoContainer', () => {
         })
 
         it('push/replace does nothing if return null/same', async () => {
-            const initialState = { initial: true }
-            const action = { type: 'action' }
+            const initialState = {
+                initial: true,
+            }
+            const action = {
+                type: 'action',
+            }
             let props
             mount((
-                <UndoContainer initialState={initialState}>
-                    <UndoContainer.Consumer>
+                <UndoContext.Provider initialState={initialState}>
+                    <UndoContext.Context.Consumer>
                         {(containerProps) => {
                             props = containerProps
                             return null
                         }}
-                    </UndoContainer.Consumer>
-                </UndoContainer>
+                    </UndoContext.Context.Consumer>
+                </UndoContext.Provider>
             ))
 
             const initialProps = props
@@ -111,22 +123,28 @@ describe('UndoContainer', () => {
         })
 
         it('can undo then redo after pushing state', async () => {
-            const initialState = { initial: true }
-            const nextState = { next: true }
+            const initialState = {
+                initial: true,
+            }
+            const nextState = {
+                next: true,
+            }
             let props
             mount((
-                <UndoContainer initialState={initialState}>
-                    <UndoContainer.Consumer>
+                <UndoContext.Provider initialState={initialState}>
+                    <UndoContext.Context.Consumer>
                         {(containerProps) => {
                             props = containerProps
                             return null
                         }}
-                    </UndoContainer.Consumer>
-                </UndoContainer>
+                    </UndoContext.Context.Consumer>
+                </UndoContext.Provider>
             ))
 
             const initialProps = props
-            const action = { type: 'action' }
+            const action = {
+                type: 'action',
+            }
             // add item
             await props.push(action, (prevState) => {
                 expect(prevState).toEqual(initialState) // history pointer should not change
@@ -149,7 +167,9 @@ describe('UndoContainer', () => {
             // undo
             await props.undo()
             // replace redo with new history
-            const action2 = { type: 'action2' }
+            const action2 = {
+                type: 'action2',
+            }
             await props.push(action2, () => nextState)
             expect(props.pointer).toBe(initialProps.pointer + 1)
             expect(props.action).toEqual(action2)
@@ -158,18 +178,22 @@ describe('UndoContainer', () => {
     })
 
     it('can replace initial state', async () => {
-        const initialState = { initial: true }
-        const replaceState = { replaced: true }
+        const initialState = {
+            initial: true,
+        }
+        const replaceState = {
+            replaced: true,
+        }
         let props
         mount((
-            <UndoContainer>
-                <UndoContainer.Consumer initialState={initialState}>
+            <UndoContext.Provider>
+                <UndoContext.Context.Consumer initialState={initialState}>
                     {(containerProps) => {
                         props = containerProps
                         return null
                     }}
-                </UndoContainer.Consumer>
-            </UndoContainer>
+                </UndoContext.Context.Consumer>
+            </UndoContext.Provider>
         ))
 
         const initialProps = props
@@ -179,25 +203,33 @@ describe('UndoContainer', () => {
     })
 
     it('can replace top item after push', async () => {
-        const initialState = { initial: true }
-        const nextState = { next: true }
+        const initialState = {
+            initial: true,
+        }
+        const nextState = {
+            next: true,
+        }
         let props
         mount((
-            <UndoContainer initialState={initialState}>
-                <UndoContainer.Consumer>
+            <UndoContext.Provider initialState={initialState}>
+                <UndoContext.Context.Consumer>
                     {(containerProps) => {
                         props = containerProps
                         return null
                     }}
-                </UndoContainer.Consumer>
-            </UndoContainer>
+                </UndoContext.Context.Consumer>
+            </UndoContext.Provider>
         ))
 
         const initialProps = props
-        const action = { type: 'action' }
+        const action = {
+            type: 'action',
+        }
         await props.push(action, () => nextState)
 
-        const replaceState = { replaced: true }
+        const replaceState = {
+            replaced: true,
+        }
         await props.replace(() => replaceState)
         expect(props.pointer).toBe(initialProps.pointer + 1)
         expect(props.action).toEqual(action)
@@ -205,20 +237,26 @@ describe('UndoContainer', () => {
     })
 
     it('can reset history', async () => {
-        const initialState = { initial: true }
-        const nextState = { next: true }
-        const action = { type: 'action' }
+        const initialState = {
+            initial: true,
+        }
+        const nextState = {
+            next: true,
+        }
+        const action = {
+            type: 'action',
+        }
 
         let props
         mount((
-            <UndoContainer initialState={initialState}>
-                <UndoContainer.Consumer>
+            <UndoContext.Provider initialState={initialState}>
+                <UndoContext.Context.Consumer>
                     {(containerProps) => {
                         props = containerProps
                         return null
                     }}
-                </UndoContainer.Consumer>
-            </UndoContainer>
+                </UndoContext.Context.Consumer>
+            </UndoContext.Provider>
         ))
 
         const initialProps = props


### PR DESCRIPTION
Moving `UndoContext` under `shared` so it can be used outside of the editor.
