### PR TITLE
Add workaround for react-helmet + useEffect bug.

### DIFF
--- a/app/src/docs/components/ApiPage/index.jsx
+++ b/app/src/docs/components/ApiPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const ApiPage = () => (
     <DocsLayout subNav={subNav.api}>
-        <Helmet>
-            <title>Streamr Docs | Streamr API</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Streamr API" />
         <ApiContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/GettingStartedPage/index.jsx
+++ b/app/src/docs/components/GettingStartedPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const GettingStartedPage = () => (
     <DocsLayout subNav={subNav.gettingStarted}>
-        <Helmet>
-            <title>Streamr Docs | Getting Started</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Getting Started" />
         <GettingStartedContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/IntroductionPage/index.jsx
+++ b/app/src/docs/components/IntroductionPage/index.jsx
@@ -8,9 +8,7 @@ import IntroductionContent from '$docs/content/introduction.mdx'
 
 const IntroductionPage = () => (
     <DocsLayout>
-        <Helmet>
-            <title>Streamr Docs | Introduction</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Introduction" />
         <IntroductionContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/MarketplacePage/index.jsx
+++ b/app/src/docs/components/MarketplacePage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const MarketplacePage = () => (
     <DocsLayout subNav={subNav.marketplace}>
-        <Helmet>
-            <title>Streamr Docs | Marketplace</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Marketplace" />
         <MarketplacePageContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/StreamrEnginePage/index.jsx
+++ b/app/src/docs/components/StreamrEnginePage/index.jsx
@@ -8,9 +8,7 @@ import StreamrEngineContent from '$docs/content/streamrEngine.mdx'
 
 const StreamrEnginePage = () => (
     <DocsLayout>
-        <Helmet>
-            <title>Streamr Docs | Streamr Engine</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Streamr Engine" />
         <StreamrEngineContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/TutorialsPage/index.jsx
+++ b/app/src/docs/components/TutorialsPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const TutorialsPage = () => (
     <DocsLayout subNav={subNav.tutorials}>
-        <Helmet>
-            <title>Streamr Docs | Tutorials</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Tutorials" />
         <TutorialsContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/UserPage/index.jsx
+++ b/app/src/docs/components/UserPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const UserPages = () => (
     <DocsLayout subNav={subNav.userPages}>
-        <Helmet>
-            <title>Streamr Docs | User Pages</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | User Pages" />
         <UserPageContent />
     </DocsLayout>
 )

--- a/app/src/docs/components/VisualEditorPage/index.jsx
+++ b/app/src/docs/components/VisualEditorPage/index.jsx
@@ -9,9 +9,7 @@ import { subNav } from '../DocsLayout/Navigation/navLinks'
 
 const VisualEditorPage = () => (
     <DocsLayout subNav={subNav.visualEditor}>
-        <Helmet>
-            <title>Streamr Docs | Visual Editor</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Visual Editor" />
         <VisualEditorContent />
     </DocsLayout>
 )

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -257,9 +257,7 @@ export class ProductPage extends Component<Props, State> {
 
         return !!product && (
             <Layout>
-                <Helmet>
-                    <title>{`${product.name} | ${I18n.t('general.title.suffix')}`}</title>
-                </Helmet>
+                <Helmet title={`${product.name} | ${I18n.t('general.title.suffix')}`} />
                 <ProductPageComponent
                     product={product}
                     streams={streams}

--- a/app/src/marketplace/containers/Products/index.jsx
+++ b/app/src/marketplace/containers/Products/index.jsx
@@ -80,9 +80,7 @@ export class Products extends Component<Props, State> {
 
         return (
             <Layout>
-                <Helmet>
-                    <title>{I18n.t('general.title.suffix')}</title>
-                </Helmet>
+                <Helmet title={I18n.t('general.title.suffix')} />
                 <ActionBar
                     filter={filter}
                     categories={categories}

--- a/app/src/newdocs/components/DocsPages/API/index.jsx
+++ b/app/src/newdocs/components/DocsPages/API/index.jsx
@@ -9,7 +9,7 @@ import ApiContent from '$newdocs/content/api.mdx'
 
 const API = () => (
     <DocsLayout subNav={subNav.api}>
-        <Helmet title="Streamr Docs | Streamr API" />
+        <Helmet title="Streamr API | Streamr Docs" />
         <ApiContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/API/index.jsx
+++ b/app/src/newdocs/components/DocsPages/API/index.jsx
@@ -9,9 +9,7 @@ import ApiContent from '$newdocs/content/api.mdx'
 
 const API = () => (
     <DocsLayout subNav={subNav.api}>
-        <Helmet>
-            <title>Streamr Docs | Streamr API</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Streamr API" />
         <ApiContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Canvases/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Canvases/index.jsx
@@ -9,9 +9,7 @@ import CanvasesContent from '$newdocs/content/canvases.mdx'
 
 const Canvases = () => (
     <DocsLayout subNav={subNav.canvases}>
-        <Helmet>
-            <title>Streamr Docs | Canvases</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Canvases" />
         <CanvasesContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Canvases/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Canvases/index.jsx
@@ -9,7 +9,7 @@ import CanvasesContent from '$newdocs/content/canvases.mdx'
 
 const Canvases = () => (
     <DocsLayout subNav={subNav.canvases}>
-        <Helmet title="Streamr Docs | Canvases" />
+        <Helmet title="Canvases | Streamr Docs" />
         <CanvasesContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Core/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Core/index.jsx
@@ -9,9 +9,7 @@ import CoreContent from '$newdocs/content/core.mdx'
 
 const Core = () => (
     <DocsLayout subNav={subNav.core}>
-        <Helmet>
-            <title>Streamr Docs | Core</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Core" />
         <CoreContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Core/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Core/index.jsx
@@ -9,7 +9,7 @@ import CoreContent from '$newdocs/content/core.mdx'
 
 const Core = () => (
     <DocsLayout subNav={subNav.core}>
-        <Helmet title="Streamr Docs | Core" />
+        <Helmet title="Core | Streamr Docs" />
         <CoreContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Dashboards/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Dashboards/index.jsx
@@ -9,7 +9,7 @@ import DashboardsContent from '$newdocs/content/dashboards.mdx'
 
 const Dashboards = () => (
     <DocsLayout subNav={subNav.dashboards}>
-        <Helmet title="Streamr Docs | Dashboards" />
+        <Helmet title="Dashboards | Streamr Docs" />
         <DashboardsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Dashboards/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Dashboards/index.jsx
@@ -9,9 +9,7 @@ import DashboardsContent from '$newdocs/content/dashboards.mdx'
 
 const Dashboards = () => (
     <DocsLayout subNav={subNav.dashboards}>
-        <Helmet>
-            <title>Streamr Docs | Dashboards</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Dashboards" />
         <DashboardsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/DataToken/index.jsx
+++ b/app/src/newdocs/components/DocsPages/DataToken/index.jsx
@@ -9,9 +9,7 @@ import DataTokenContent from '$newdocs/content/dataToken.mdx'
 
 const DataToken = () => (
     <DocsLayout subNav={subNav.dataToken}>
-        <Helmet>
-            <title>Streamr Docs | DATA Token</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | DATA Token" />
         <DataTokenContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/DataToken/index.jsx
+++ b/app/src/newdocs/components/DocsPages/DataToken/index.jsx
@@ -9,7 +9,7 @@ import DataTokenContent from '$newdocs/content/dataToken.mdx'
 
 const DataToken = () => (
     <DocsLayout subNav={subNav.dataToken}>
-        <Helmet title="Streamr Docs | DATA Token" />
+        <Helmet title="DATA Token | Streamr Docs" />
         <DataTokenContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/GettingStarted/index.jsx
+++ b/app/src/newdocs/components/DocsPages/GettingStarted/index.jsx
@@ -9,7 +9,7 @@ import GettingStartedContent from '$newdocs/content/gettingStarted.mdx'
 
 const GettingStarted = () => (
     <DocsLayout subNav={subNav.gettingStarted}>
-        <Helmet title="Streamr Docs | Getting Started" />
+        <Helmet title="Getting Started | Streamr Docs" />
         <GettingStartedContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/GettingStarted/index.jsx
+++ b/app/src/newdocs/components/DocsPages/GettingStarted/index.jsx
@@ -9,9 +9,7 @@ import GettingStartedContent from '$newdocs/content/gettingStarted.mdx'
 
 const GettingStarted = () => (
     <DocsLayout subNav={subNav.gettingStarted}>
-        <Helmet>
-            <title>Streamr Docs | Getting Started</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Getting Started" />
         <GettingStartedContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Introduction/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Introduction/index.jsx
@@ -9,7 +9,7 @@ import IntroductionContent from '$newdocs/content/introduction.mdx'
 
 const Introduction = () => (
     <DocsLayout subNav={subNav.introduction}>
-        <Helmet title="Streamr Docs | Introduction" />
+        <Helmet title="Introduction | Streamr Docs" />
         <IntroductionContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Introduction/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Introduction/index.jsx
@@ -9,9 +9,7 @@ import IntroductionContent from '$newdocs/content/introduction.mdx'
 
 const Introduction = () => (
     <DocsLayout subNav={subNav.introduction}>
-        <Helmet>
-            <title>Streamr Docs | Introduction</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Introduction" />
         <IntroductionContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Marketplace/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Marketplace/index.jsx
@@ -9,7 +9,7 @@ import MarketplacePageContent from '$newdocs/content/marketplace.mdx'
 
 const Marketplace = () => (
     <DocsLayout subNav={subNav.marketplace}>
-        <Helmet title="Streamr Docs | Marketplace" />
+        <Helmet title="Marketplace | Streamr Docs" />
         <MarketplacePageContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Marketplace/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Marketplace/index.jsx
@@ -9,9 +9,7 @@ import MarketplacePageContent from '$newdocs/content/marketplace.mdx'
 
 const Marketplace = () => (
     <DocsLayout subNav={subNav.marketplace}>
-        <Helmet>
-            <title>Streamr Docs | Marketplace</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Marketplace" />
         <MarketplacePageContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Products/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Products/index.jsx
@@ -9,9 +9,7 @@ import ProductsContent from '$newdocs/content/products.mdx'
 
 const Products = () => (
     <DocsLayout subNav={subNav.products}>
-        <Helmet>
-            <title>Streamr Docs | Products</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Products" />
         <ProductsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Products/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Products/index.jsx
@@ -9,7 +9,7 @@ import ProductsContent from '$newdocs/content/products.mdx'
 
 const Products = () => (
     <DocsLayout subNav={subNav.products}>
-        <Helmet title="Streamr Docs | Products" />
+        <Helmet title="Products | Streamr Docs" />
         <ProductsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/RunningNode/index.jsx
+++ b/app/src/newdocs/components/DocsPages/RunningNode/index.jsx
@@ -9,9 +9,7 @@
 
 // const RunningNode = () => (
 //     <DocsLayout subNav={subNav.runningNode}>
-//         <Helmet>
-//             <title>Streamr Docs | Running a Node</title>
-//         </Helmet>
+//         <Helmet title="Streamr Docs | Running a Node" />
 //         <RunningNodeContent />
 //     </DocsLayout>
 // )

--- a/app/src/newdocs/components/DocsPages/RunningNode/index.jsx
+++ b/app/src/newdocs/components/DocsPages/RunningNode/index.jsx
@@ -9,7 +9,7 @@
 
 // const RunningNode = () => (
 //     <DocsLayout subNav={subNav.runningNode}>
-//         <Helmet title="Streamr Docs | Running a Node" />
+//         <Helmet title="Running a Node | Streamr Docs" />
 //         <RunningNodeContent />
 //     </DocsLayout>
 // )

--- a/app/src/newdocs/components/DocsPages/SDKs/index.jsx
+++ b/app/src/newdocs/components/DocsPages/SDKs/index.jsx
@@ -9,7 +9,7 @@ import SDKsContent from '$newdocs/content/SDKs.mdx'
 
 const SDKs = () => (
     <DocsLayout subNav={subNav.SDKs}>
-        <Helmet title="Streamr Docs | SDKs" />
+        <Helmet title="SDKs | Streamr Docs" />
         <SDKsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/SDKs/index.jsx
+++ b/app/src/newdocs/components/DocsPages/SDKs/index.jsx
@@ -9,9 +9,7 @@ import SDKsContent from '$newdocs/content/SDKs.mdx'
 
 const SDKs = () => (
     <DocsLayout subNav={subNav.SDKs}>
-        <Helmet>
-            <title>Streamr Docs | SDKs</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | SDKs" />
         <SDKsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Streams/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Streams/index.jsx
@@ -9,9 +9,7 @@ import StreamsContent from '$newdocs/content/streams.mdx'
 
 const Streams = () => (
     <DocsLayout subNav={subNav.streams}>
-        <Helmet>
-            <title>Streamr Docs | Streams</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Streams" />
         <StreamsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Streams/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Streams/index.jsx
@@ -9,7 +9,7 @@ import StreamsContent from '$newdocs/content/streams.mdx'
 
 const Streams = () => (
     <DocsLayout subNav={subNav.streams}>
-        <Helmet title="Streamr Docs | Streams" />
+        <Helmet title="Streams | Streamr Docs" />
         <StreamsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/TechnicalNotes/index.jsx
+++ b/app/src/newdocs/components/DocsPages/TechnicalNotes/index.jsx
@@ -10,7 +10,7 @@ import TechnicalNotesContent from '$newdocs/content/technical.mdx'
 
 const TechnicalNotes = () => (
     <DocsLayout subNav={subNav.technicalNotes}>
-        <Helmet title="Streamr Docs | Technical Notes" />
+        <Helmet title="Technical Notes | Streamr Docs" />
         <TechnicalNotesContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/TechnicalNotes/index.jsx
+++ b/app/src/newdocs/components/DocsPages/TechnicalNotes/index.jsx
@@ -10,9 +10,7 @@ import TechnicalNotesContent from '$newdocs/content/technical.mdx'
 
 const TechnicalNotes = () => (
     <DocsLayout subNav={subNav.technicalNotes}>
-        <Helmet>
-            <title>Streamr Docs | Technical Notes</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Technical Notes" />
         <TechnicalNotesContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Tutorials/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Tutorials/index.jsx
@@ -9,7 +9,7 @@ import TutorialsContent from '$newdocs/content/tutorials.mdx'
 
 const Tutorials = () => (
     <DocsLayout subNav={subNav.tutorials}>
-        <Helmet title="Streamr Docs | Tutorials" />
+        <Helmet title="Tutorials | Streamr Docs" />
         <TutorialsContent />
     </DocsLayout>
 )

--- a/app/src/newdocs/components/DocsPages/Tutorials/index.jsx
+++ b/app/src/newdocs/components/DocsPages/Tutorials/index.jsx
@@ -9,9 +9,7 @@ import TutorialsContent from '$newdocs/content/tutorials.mdx'
 
 const Tutorials = () => (
     <DocsLayout subNav={subNav.tutorials}>
-        <Helmet>
-            <title>Streamr Docs | Tutorials</title>
-        </Helmet>
+        <Helmet title="Streamr Docs | Tutorials" />
         <TutorialsContent />
     </DocsLayout>
 )


### PR DESCRIPTION
Fixes this `react-helmet` "Uncaught RangeError: Maximum call stack size exceeded" issue reported by @fonty1:

![image](https://user-images.githubusercontent.com/43438/61680535-7d19da00-ad3c-11e9-9c43-4b19512f652d.png)

See:
* https://github.com/nfl/react-helmet/issues/437
* https://github.com/nfl/react-helmet/issues/373

## tl;dr

Never use `<Helmet><title>`, use `<Helmet title="" />` instead

----

@fonty1 also I think the docs titles are probably back to front? It should have the current doc name first, rather than "Streamr Docs"

e.g. 
"Introduction | Streamr Docs" vs
"Streamr Docs | Introduction". 

 i.e. most significant bit first.

Otherwise if you have a bunch of docs tabs open (especially likely for docs) all you'll see is "Streamr Docs …", "Streamr Docs …", "Streamr Docs …", "Streamr Docs …". The other page titles are also around the other way, so should probably change just for consistency if nothing else. 