### PR TITLE
Add clean-cache npm script.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,9 @@
     "stylelint-fix": "stylelint src/**/*.css src/**/*.[ps]css --fix",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "chromatic": "CHROMATIC_APP_CODE=exgpyxh1il5 chromatic test --exit-zero-on-changes"
+    "chromatic": "CHROMATIC_APP_CODE=exgpyxh1il5 chromatic test --exit-zero-on-changes",
+    "clear-cache": "npm run clean-cache",
+    "clean-cache": "rm -rf node_modules/.cache; rm -rf .cache; rm -rf dist; jest --clearCache; killall flow; rm -rf /tmp/flow"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Sometimes things get confused. Wiping the various build caches can help.

This PR adds a convenience `npm run clean-cache` script which:

* Wipes the `babel` & `eslint` caches in  `node_modules/.cache`
* Removes built files in `dist`
* Cleans `jest`'s cache
* Kills the `flow` server(s) and wipes the `flow` cache in `/tmp/flow`

Try running this before `npm start` if you're seeing build errors and they don't make no damn sense.