### PR TITLE
[PLATFORM-978] Update stream list after creating stream

### DIFF
--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -17,7 +17,14 @@ import type { Stream, StreamId } from '$shared/flowtype/stream-types'
 
 import SvgIcon from '$shared/components/SvgIcon'
 import links from '$shared/../links'
-import { getStreams, updateFilter, deleteStream, getStreamStatus, cancelStreamStatusFetch } from '$userpages/modules/userPageStreams/actions'
+import {
+    getStreams,
+    updateFilter,
+    deleteStream,
+    getStreamStatus,
+    cancelStreamStatusFetch,
+    clearStreamsList,
+} from '$userpages/modules/userPageStreams/actions'
 import { selectStreams, selectFetching, selectFilter, selectHasMoreSearchResults } from '$userpages/modules/userPageStreams/selectors'
 import { getFilters } from '$userpages/utils/constants'
 import Table from '$shared/components/Table'
@@ -71,6 +78,7 @@ export type StateProps = {
 
 export type DispatchProps = {
     getStreams: (replace?: boolean) => void,
+    clearStreamsList: () => void,
     updateFilter: (filter: Filter) => void,
     showStream: (StreamId) => void,
     deleteStream: (StreamId) => void,
@@ -147,11 +155,12 @@ class StreamList extends Component<Props, State> {
         if (!filter) {
             updateFilter(this.defaultFilter)
         }
-        getStreams()
+        getStreams(true)
     }
 
     componentWillUnmount() {
         this.props.cancelStreamStatusFetch()
+        this.props.clearStreamsList()
     }
 
     onSearchChange = (value: string) => {
@@ -499,6 +508,7 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = (dispatch) => ({
+    clearStreamsList: () => dispatch(clearStreamsList()),
     getStreams: (replace: boolean = false) => dispatch(getStreams(replace)),
     updateFilter: (filter) => dispatch(updateFilter(filter)),
     showStream: (id: StreamId) => dispatch(push(`${links.userpages.streamShow}/${id}`)),

--- a/app/src/userpages/flowtype/states/stream-state.js
+++ b/app/src/userpages/flowtype/states/stream-state.js
@@ -27,6 +27,5 @@ export type UserPageStreamsState = {
     autodetectFetching: boolean,
     permissions: ?Array<Operation>,
     pageSize: number,
-    offset: number,
     hasMoreSearchResults: ?boolean,
 }

--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -256,9 +256,13 @@ const getStreamRangeRequest = () => ({
     type: GET_STREAM_RANGE_REQUEST,
 })
 
-const clearStreamList = () => ({
+const clearStreamsListAction = () => ({
     type: CLEAR_STREAM_LIST,
 })
+
+export const clearStreamsList = () => (dispatch: Function) => (
+    dispatch(clearStreamsListAction())
+)
 
 export const getStream = (id: StreamId) => (dispatch: Function) => {
     dispatch(getStreamRequest())
@@ -341,7 +345,7 @@ export const getStreams = (replace: ?boolean = false) => (dispatch: Function, ge
                 streamStatus: 'inactive',
             })))
             if (replace) {
-                dispatch(clearStreamList())
+                dispatch(clearStreamsListAction())
             }
             dispatch(getStreamsSuccess(ids, hasMoreResults))
             streamStatusCancel = dispatch(updateStreamStatuses(ids))

--- a/app/src/userpages/modules/userPageStreams/reducer.js
+++ b/app/src/userpages/modules/userPageStreams/reducer.js
@@ -65,7 +65,6 @@ const initialState = {
     streamFieldAutodetectError: null,
     permissions: null,
     pageSize: streamListPageSize,
-    offset: 0,
     hasMoreSearchResults: null,
 }
 
@@ -128,6 +127,11 @@ export default function (state: UserPageStreamsState = initialState, action: Str
             }
 
         case GET_STREAM_SUCCESS:
+            return {
+                ...state,
+                fetching: false,
+                error: null,
+            }
         case CREATE_STREAM_SUCCESS:
             return {
                 ...state,
@@ -135,22 +139,28 @@ export default function (state: UserPageStreamsState = initialState, action: Str
                 error: null,
             }
 
-        case GET_STREAMS_SUCCESS:
+        case GET_STREAMS_SUCCESS: {
+            const ids = [
+                ...new Set(( // ensure no duplicates in ids list
+                    state.ids
+                        .concat(action.streams)
+                        .reverse() // reverse before new Set to remove earlier id
+                )),
+            ].reverse() // then re-reverse results to restore original ordering
             return {
                 ...state,
                 fetching: false,
                 error: null,
-                ids: state.ids.concat(action.streams),
-                offset: state.offset + action.streams.length,
+                ids,
                 hasMoreSearchResults: action.hasMoreResults,
             }
+        }
 
         case CLEAR_STREAM_LIST:
             return {
                 ...state,
                 error: null,
                 ids: [],
-                offset: 0,
                 hasMoreSearchResults: null,
             }
 
@@ -163,9 +173,10 @@ export default function (state: UserPageStreamsState = initialState, action: Str
 
         case DELETE_STREAM_SUCCESS: {
             const removedId = action.id // flow complains about using action.id directly ¯\_(ツ)_/¯
+            const ids = state.ids.filter((id) => (id !== removedId))
             return {
                 ...state,
-                ids: state.ids.filter((id) => (id !== removedId)),
+                ids,
                 fetching: false,
                 error: null,
             }

--- a/app/src/userpages/modules/userPageStreams/selectors.js
+++ b/app/src/userpages/modules/userPageStreams/selectors.js
@@ -93,8 +93,8 @@ export const selectPageSize: (StoreState) => number = createSelector(
 )
 
 export const selectOffset: (StoreState) => number = createSelector(
-    selectUserPageStreamsState,
-    (subState: UserPageStreamsState): number => subState.offset,
+    selectStreamIds,
+    (subState: StreamIdList): number => subState.length,
 )
 
 export const selectHasMoreSearchResults: (StoreState) => boolean = createSelector(

--- a/app/src/userpages/tests/modules/userPagesStreams/reducer.test.js
+++ b/app/src/userpages/tests/modules/userPagesStreams/reducer.test.js
@@ -18,7 +18,6 @@ const initialState = {
     streamFieldAutodetectError: null,
     permissions: null,
     pageSize: 20,
-    offset: 0,
     hasMoreSearchResults: null,
 }
 
@@ -79,14 +78,12 @@ describe('Stream reducer', () => {
                     ...initialState,
                     error: null,
                     ids: [1, 2, 3, 4, 5],
-                    offset: 4,
                     hasMoreSearchResults: true,
                 }
 
                 const mockState = {
                     ...initialState,
                     ids: [1, 2, 3],
-                    offset: 2,
                     hasMoreSearchResults: true,
                 }
 
@@ -104,7 +101,6 @@ describe('Stream reducer', () => {
                     ...initialState,
                     error: null,
                     ids: [],
-                    offset: 0,
                     hasMoreSearchResults: null,
                 }
 
@@ -112,7 +108,6 @@ describe('Stream reducer', () => {
                     ...initialState,
                     error: {},
                     ids: [1, 2, 3],
-                    offset: 2,
                     hasMoreSearchResults: true,
                 }
 


### PR DESCRIPTION
Re-requests a new stream list on stream page mount. This ensures we're showing at least the first page of the latest results. By default this will show the most recently created stream first. 
Also removes the list of streams on unmount to prevent any flash of streams which are about to get clobbered when the new stream list update finishes on remounting. Also fixes an issue where duplicate streams would appear in the list.

Note the start/end of "pages" in the client will immediately desync with the start/end of the pages on the server any time the list of streams is mutated by adding, removing or updating something that affects the list item content or ordering. Pagination desync means items may be missing or appear out of order.

To test:

1. Open Streams list.
2. Create & Save new Stream.
3. Note new stream is now in list.
