### PR TITLE
[PLATFORM-968] Create empty product

### DIFF
--- a/app/src/marketplace/components/ProductTypeChooser/index.jsx
+++ b/app/src/marketplace/components/ProductTypeChooser/index.jsx
@@ -40,7 +40,7 @@ const ProductTypeChooser = ({ onSelect }: Props) => (
                     <button
                         type="button"
                         className={cx('btn', 'btn-special', styles.button)}
-                        onClick={() => onSelect('standard')}
+                        onClick={() => onSelect('NORMAL')}
                     >
                         <Translate value="productTypeChooser.standard.linkTitle" />
                     </button>
@@ -64,7 +64,7 @@ const ProductTypeChooser = ({ onSelect }: Props) => (
                     <button
                         type="button"
                         className={cx('btn', 'btn-special', styles.button)}
-                        onClick={() => onSelect('community')}
+                        onClick={() => onSelect('COMMUNITY')}
                     >
                         <Translate value="productTypeChooser.community.linkTitle" />
                     </button>

--- a/app/src/marketplace/containers/CreateProductPage/index.jsx
+++ b/app/src/marketplace/containers/CreateProductPage/index.jsx
@@ -8,20 +8,27 @@ import { push } from 'connected-react-router'
 import routes from '$routes'
 import type { ProductType } from '$mp/flowtype/product-types'
 import ProductTypeChooser from '$mp/components/ProductTypeChooser'
+import { postEmptyProduct } from '$mp/modules/editProduct/services'
 
 import styles from './createProductPage.pcss'
 
 const CreateProductPage = () => {
     const dispatch = useDispatch()
 
-    const onTypeSelect = useCallback((type: ProductType) => {
-        console.log(type)
-
-        // TODO: here we'd call API first and then do the redirect with new product id
-        dispatch(push(routes.editProduct2({
-            id: '123',
-        })))
+    const createProduct = useCallback(async (type: ProductType) => {
+        try {
+            const product = await postEmptyProduct(type)
+            dispatch(push(routes.editProduct2({
+                id: product.id,
+            })))
+        } catch (err) {
+            console.error('Could not create an empty product', err)
+        }
     }, [dispatch])
+
+    const onTypeSelect = useCallback((type: ProductType) => {
+        createProduct(type)
+    }, [])
 
     return (
         <div className={styles.root}>

--- a/app/src/marketplace/containers/CreateProductPage/index.jsx
+++ b/app/src/marketplace/containers/CreateProductPage/index.jsx
@@ -28,7 +28,7 @@ const CreateProductPage = () => {
 
     const onTypeSelect = useCallback((type: ProductType) => {
         createProduct(type)
-    }, [])
+    }, [createProduct])
 
     return (
         <div className={styles.root}>

--- a/app/src/marketplace/flowtype/product-types.js
+++ b/app/src/marketplace/flowtype/product-types.js
@@ -106,4 +106,4 @@ export type ProductPermissions = {
     permissionsError: ?ErrorInUi,
 }
 
-export type ProductType = 'standard' | 'community'
+export type ProductType = 'NORMAL' | 'COMMUNITY'

--- a/app/src/marketplace/modules/editProduct/services.js
+++ b/app/src/marketplace/modules/editProduct/services.js
@@ -4,7 +4,7 @@ import { put, post } from '$shared/utils/api'
 import { mapProductFromApi, mapProductToApi, isPaidAndNotPublishedProduct } from '../../utils/product'
 import { formatApiUrl } from '$shared/utils/url'
 import type { ApiResult } from '$shared/flowtype/common-types'
-import type { EditProduct, Product, ProductId } from '../../flowtype/product-types'
+import type { EditProduct, Product, ProductId, ProductType } from '../../flowtype/product-types'
 
 export const putProduct = (data: EditProduct, id: ProductId): ApiResult<Product> => {
     const isPaidAndNotPublished = isPaidAndNotPublishedProduct(data)
@@ -12,8 +12,18 @@ export const putProduct = (data: EditProduct, id: ProductId): ApiResult<Product>
     return put(formatApiUrl('products', id), isPaidAndNotPublished ? mapProductToApi(data) : data)
         .then(mapProductFromApi)
 }
+
 export const postProduct = (product: Product): ApiResult<Product> => post(formatApiUrl('products'), mapProductToApi(product))
     .then(mapProductFromApi)
+
+export const postEmptyProduct = (type: ProductType): ApiResult<Product> => {
+    const product = {
+        type,
+    }
+
+    return post(formatApiUrl('products'), product)
+        .then(mapProductFromApi)
+}
 
 export const postImage = (id: ProductId, image: File): ApiResult<EditProduct> => {
     const options = {


### PR DESCRIPTION
Add logic for POSTing an empty product when we have selected type from `ProductTypeChooser`.

Current backend will reject the call but it should start working after https://github.com/streamr-dev/engine-and-editor/pull/628 is merged.