### PR TITLE
[PLATFORM-982] Fix default values

### DIFF
--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { RunStates } from '../../../state'
+import { RunStates, getPortUserValueOrDefault } from '../../../state'
 import Color from './Color'
 import Map from './Map'
 import Select from './Select'
@@ -43,10 +43,8 @@ const Value = ({ canvas, port, onChange }: Props) => {
     // Enable non-running input whether connected or not if port.canHaveInitialValue
     const disabled = isRunning || (!port.canHaveInitialValue && port.connected)
     const type = getPortType(port)
-    const isParam = 'defaultValue' in port
-
     // TODO: Ignore when editing.
-    const value = (isParam ? (port.value || port.defaultValue) : port.initialValue) || ''
+    const value = getPortUserValueOrDefault(canvas, port.id)
     const commonProps: CommonProps = {
         disabled,
         onChange,

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -701,10 +701,14 @@ export function setPortUserValue(canvas, portId, value) {
 
     const port = getPort(canvas, portId)
 
-    // coerce double to number or undefined if empty or invalid
+    const defaultValue = getPortDefaultValue(canvas, portId)
+    if (isBlank(value)) {
+        value = defaultValue
+    }
+
+    // coerce double to number if invalid
     if (port.type === 'Double') {
-        value = value != null ? String(value).trim() : undefined
-        if (value == null || value === '') {
+        if (isBlank(value)) {
             value = undefined
         } else {
             // swap , for .
@@ -712,9 +716,9 @@ export function setPortUserValue(canvas, portId, value) {
             const num = Number.parseFloat(value)
             // infinite/NaN = undefined
             if (Number.isNaN(num) || !Number.isFinite(num)) {
-                value = undefined
+                value = defaultValue
             } else {
-                value = String(num)
+                value = num
             }
         }
     }
@@ -737,6 +741,23 @@ export function getPortUserValue(canvas, portId) {
     const key = PORT_USER_VALUE_KEYS[getPortType(canvas, portId)]
     const port = getPort(canvas, portId)
     return port[key]
+}
+
+function isBlank(value) {
+    return value == null || String(value).trim() === ''
+}
+
+export function getPortDefaultValue(canvas, portId) {
+    const port = getPort(canvas, portId)
+    const defaultValue = 'defaultValue' in port
+        ? port.defaultValue
+        : port.initialValue
+    return !isBlank(defaultValue) ? defaultValue : undefined
+}
+
+export function getPortUserValueOrDefault(canvas, portId) {
+    const value = getPortUserValue(canvas, portId)
+    return !isBlank(value) ? value : getPortDefaultValue(canvas, portId)
 }
 
 /**

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -257,38 +257,58 @@ describe('Canvas State', () => {
                     canvas = State.addModule(canvas, await loadModuleDefinition('Equals'))
                     const [equalsModule] = canvas.modules
                     // params[0] is 'tolerance', of Double type
-                    // coerce empty string to undefined
+                    // coerce empty string to default
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, ''))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(undefined)
+                    const defaultValue = State.getPortDefaultValue(canvas, equalsModule.params[0].id)
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(defaultValue)
                     // handles commas
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2,3'))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(2.3)
                     // handles zero
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '0'))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('0')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(0)
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '0.0'))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('0')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(0)
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, 0))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('0')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(0)
                     // handles negative numbers
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '-2.3'))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('-2.3')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(-2.3)
                     // ignores whitespace
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2.3 '))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(2.3)
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2,3  '))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2.3')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(2.3)
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '  -2.3  '))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('-2.3')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(-2.3)
                     // tries to parse a number
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, '2dasd'))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe('2')
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(2)
                     // Falls back to undefined if it cannot
                     canvas = State.updateCanvas(State.setPortUserValue(canvas, equalsModule.params[0].id, 'dasd'))
-                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(undefined)
+                    expect(State.getPortUserValue(canvas, equalsModule.params[0].id)).toBe(defaultValue)
 
-                    // test server accepts state with undefined value
+                    // test server accepts state
                     expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
+                })
+            })
+
+            describe('getPortUserValueOrDefault', () => {
+                it('gets value or default if value not set', async () => {
+                    let canvas = State.emptyCanvas()
+                    canvas = State.addModule(canvas, await loadModuleDefinition('MovingAverage'))
+                    const [movingAverage] = canvas.modules
+                    // gets value if set
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, movingAverage.params[0].id, 3))
+                    expect(State.getPortUserValueOrDefault(canvas, movingAverage.params[0].id)).toBe(3)
+                    // gets default if undefined
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, movingAverage.params[0].id, undefined))
+                    expect(State.getPortUserValue(canvas, movingAverage.params[0].id)).toBe(0)
+                    expect(State.getPortUserValueOrDefault(canvas, movingAverage.params[0].id)).toBe(0)
+                    // gets default if empty string
+                    canvas = State.updateCanvas(State.setPortUserValue(canvas, movingAverage.params[0].id, ''))
+                    expect(State.getPortUserValue(canvas, movingAverage.params[0].id)).toBe(0)
+                    expect(State.getPortUserValueOrDefault(canvas, movingAverage.params[0].id)).toBe(0)
                 })
             })
         })

--- a/app/src/shared/components/EditableText/editableText.pcss
+++ b/app/src/shared/components/EditableText/editableText.pcss
@@ -24,10 +24,15 @@
   padding: 0;
   position: absolute;
   width: 100%;
+  overflow: visible;
 }
 
 .inner input::selection {
   background-color: #CCE9FD;
+}
+
+.inner input::placeholder {
+  overflow: visible;
 }
 
 .idle {
@@ -47,8 +52,14 @@
   overflow: hidden;
   visibility: hidden;
   white-space: pre;
+  padding-right: 0.05em; /* also balance extra width added by input when editing */
 }
 
 .blank {
   font-style: italic;
+}
+
+.idle.blank .inner {
+  /* ensures right-hand side of italic spaceholder text is not cut off */
+  padding-right: 0.25em; /* also balance extra width added by input when editing */
 }

--- a/app/src/shared/components/EditableText/editableText.stories.jsx
+++ b/app/src/shared/components/EditableText/editableText.stories.jsx
@@ -49,6 +49,44 @@ stories.add('zero', () => (
     </UseState>
 ))
 
+stories.add('placeholder', () => (
+    <UseState initialValue={false}>
+        {(editing, setEditing) => (
+            <UseState initialValue="">
+                {(text, setText) => (
+                    <EditableText
+                        placeholder="Placeholder Text"
+                        editing={editing}
+                        onChange={setText}
+                        setEditing={setEditing}
+                    >
+                        {text}
+                    </EditableText>
+                )}
+            </UseState>
+        )}
+    </UseState>
+))
+
+stories.add('short placeholder', () => (
+    <UseState initialValue={false}>
+        {(editing, setEditing) => (
+            <UseState initialValue="">
+                {(text, setText) => (
+                    <EditableText
+                        placeholder="M"
+                        editing={editing}
+                        onChange={setText}
+                        setEditing={setEditing}
+                    >
+                        {text}
+                    </EditableText>
+                )}
+            </UseState>
+        )}
+    </UseState>
+))
+
 stories.add('edit on focus', () => (
     <div>
         <button

--- a/app/src/shared/components/EditableText/editableText.stories.jsx
+++ b/app/src/shared/components/EditableText/editableText.stories.jsx
@@ -31,6 +31,24 @@ stories.add('default', () => (
     </UseState>
 ))
 
+stories.add('zero', () => (
+    <UseState initialValue={false}>
+        {(editing, setEditing) => (
+            <UseState initialValue={0}>
+                {(text, setText) => (
+                    <EditableText
+                        editing={editing}
+                        onChange={setText}
+                        setEditing={setEditing}
+                    >
+                        {text}
+                    </EditableText>
+                )}
+            </UseState>
+        )}
+    </UseState>
+))
+
 stories.add('edit on focus', () => (
     <div>
         <button

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -23,6 +23,10 @@ type Props = {
     setEditing: (boolean) => void,
 }
 
+function isBlank(str) {
+    return str == null || str === ''
+}
+
 const EditableText = ({
     autoFocus,
     children: childrenProp,
@@ -81,12 +85,16 @@ const EditableText = ({
         }
     }, [])
 
+    const renderValue = useCallback((val) => (
+        !isBlank(val) ? val : (placeholder || '')
+    ), [placeholder])
+
     return (
         <div
             className={cx(styles.root, className, {
                 [styles.idle]: !editing,
                 [styles.disabled]: disabled,
-                [styles.blank]: (editing && !value) || (!editing && !children),
+                [styles.blank]: isBlank(editing ? value : children),
                 [ModuleStyles.dragCancel]: !!editing,
             })}
             onDoubleClick={startEditing}
@@ -117,10 +125,10 @@ const EditableText = ({
                             value={children}
                         />
                         <span className={styles.spaceholder}>
-                            {value || placeholder || ''}
+                            {renderValue(value)}
                         </span>
                     </Fragment>
-                ) : (children || placeholder)}
+                ) : renderValue(children)}
             </span>
         </div>
     )


### PR DESCRIPTION
Fixes issue where value of `0` was not operating correctly. 

Also fixes clipping right-hand side of placeholder text.

To test:

1. Create a `MovingAverage` module.
2. Note that defaults for `windowLength` & `minSamples` inputs are filled with the default value of zero (fixes original issue).

