### PR TITLE
[PLATFORM-981] Fix "possible values" dropdown to be visible.

### DIFF
--- a/app/src/editor/canvas/components/Ports/Value/Select/select.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/Select/select.pcss
@@ -20,6 +20,7 @@
   padding: 0 calc(0.5 * var(--um));
   transition: 200ms linear;
   transition-property: background-color, color, box-shadow;
+  width: auto;
 }
 
 .root select:hover,


### PR DESCRIPTION
To test:

1. Create a `MovingAverage` module.
2. Note that the dropdown for `Window Type` is visible.