### PR TITLE
[PLATFORM-979] Wrong key for "Object" type

### DIFF
--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
@@ -109,7 +109,7 @@ export class NewFieldEditor extends Component<Props, State> {
                                     key={t}
                                     value={t}
                                 >
-                                    {t}
+                                    <Translate value={`userpages.streams.fieldTypes.${t}`} />
                                 </Dropdown.Item>
                             ))}
                         </Dropdown>

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
@@ -244,7 +244,7 @@ export class ConfigureView extends Component<Props, State> {
                                                                 key={t}
                                                                 value={t}
                                                             >
-                                                                {t}
+                                                                <Translate value={`userpages.streams.fieldTypes.${t}`} />
                                                             </Dropdown.Item>
                                                         ))}
                                                     </Dropdown>

--- a/app/src/userpages/components/StreamPage/constants.js
+++ b/app/src/userpages/components/StreamPage/constants.js
@@ -13,4 +13,4 @@ export const rightColumn = {
     sm: 12,
 }
 
-export const fieldTypes = ['number', 'boolean', 'object', 'list', 'string', 'timestamp']
+export const fieldTypes = ['number', 'boolean', 'map', 'list', 'string', 'timestamp']

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -425,6 +425,24 @@ msgstr "Custom Java SimpleDateFormat"
 msgid "userpages##streams##edit##history##datePicker##selectDate"
 msgstr "Select date"
 
+msgid "userpages##streams##fieldTypes##number"
+msgstr "Number"
+
+msgid "userpages##streams##fieldTypes##boolean"
+msgstr "Boolean"
+
+msgid "userpages##streams##fieldTypes##map"
+msgstr "Object"
+
+msgid "userpages##streams##fieldTypes##list"
+msgstr "List"
+
+msgid "userpages##streams##fieldTypes##string"
+msgstr "String"
+
+msgid "userpages##streams##fieldTypes##timestamp"
+msgstr "Timestamp"
+
 msgid "userpages##transactions##noTransactions##title"
 msgstr "No transactions."
 


### PR DESCRIPTION
In stream field config, the dropdown label `Object` has the wrong value `object`. The correct value is `map`. Fixed according to issue description - kept user facing label as `Object` but use the value `map`.