### PR TITLE
Update with server state on autosave

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/index.jsx
+++ b/app/src/editor/canvas/components/CanvasController/index.jsx
@@ -18,6 +18,8 @@ import useModuleLoadCallback from './useModuleLoadCallback'
 
 import styles from './CanvasController.pcss'
 
+const CanvasControllerContext = React.createContext()
+
 function useCanvasLoadEffect() {
     const canvas = useCanvas()
     const load = useCanvasLoadCallback()
@@ -72,23 +74,6 @@ export function useChangedModuleLoader() {
     }), [resetChanged, markChanged, loadChanged])
 }
 
-export function useController() {
-    const create = useCanvasCreateCallback()
-    const load = useCanvasLoadCallback()
-    const remove = useCanvasRemoveCallback()
-    const duplicate = useCanvasDuplicateCallback()
-    const loadModule = useModuleLoadCallback()
-    const changedLoader = useChangedModuleLoader()
-    return useMemo(() => ({
-        load,
-        create,
-        remove,
-        duplicate,
-        loadModule,
-        changedLoader,
-    }), [load, create, remove, duplicate, loadModule, changedLoader])
-}
-
 function useCanvasCreateEffect() {
     const { match } = useContext(RouterContext.Context)
     const { isPending } = usePending('canvas.CREATE')
@@ -125,13 +110,44 @@ function CanvasLoadingIndicator() {
     )
 }
 
+export function useController() {
+    return useContext(CanvasControllerContext)
+}
+
+function useCanvasController() {
+    const create = useCanvasCreateCallback()
+    const load = useCanvasLoadCallback()
+    const remove = useCanvasRemoveCallback()
+    const duplicate = useCanvasDuplicateCallback()
+    const loadModule = useModuleLoadCallback()
+    const changedLoader = useChangedModuleLoader()
+    return useMemo(() => ({
+        load,
+        create,
+        remove,
+        duplicate,
+        loadModule,
+        changedLoader,
+    }), [load, create, remove, duplicate, loadModule, changedLoader])
+}
+
+function ControllerProvider({ children }) {
+    return (
+        <CanvasControllerContext.Provider value={useCanvasController()}>
+            {children}
+        </CanvasControllerContext.Provider>
+    )
+}
+
 const CanvasControllerProvider = ({ children }) => (
     <RouterContext.Provider>
         <PendingProvider>
             <PermissionsProvider>
-                <CanvasLoadingIndicator />
-                <CanvasEffects />
-                {children || null}
+                <ControllerProvider>
+                    <CanvasLoadingIndicator />
+                    <CanvasEffects />
+                    {children || null}
+                </ControllerProvider>
             </PermissionsProvider>
         </PendingProvider>
     </RouterContext.Provider>

--- a/app/src/editor/canvas/components/CanvasController/index.jsx
+++ b/app/src/editor/canvas/components/CanvasController/index.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useCallback, useState } from 'react'
+import React, { useContext, useEffect, useMemo } from 'react'
 import { Helmet } from 'react-helmet'
 import LoadingIndicator from '$userpages/components/LoadingIndicator'
 
@@ -37,41 +37,6 @@ function useCanvasLoadEffect() {
             load(canvasId)
         }
     }, [urlId, canvasId, currentCanvasRootId, load, canvas, isPending])
-}
-
-export function useChangedModuleLoader() {
-    const [changed, setChanged] = useState(new Set())
-    const markChanged = useCallback((id) => {
-        setChanged((changed) => {
-            if (changed.has(id)) { return changed }
-            return new Set([...changed, id])
-        })
-    }, [setChanged])
-
-    const loadChanged = useCallback((prevChanged, canvas, updatedCanvas) => {
-        prevChanged.forEach((hash) => {
-            if (changed.has(hash)) {
-                // item changed again, don't update this round
-                return
-            }
-            canvas = CanvasState.updateModule(canvas, hash, () => (
-                CanvasState.getModule(updatedCanvas, hash)
-            ))
-        })
-        return canvas
-    }, [changed])
-
-    const resetChanged = useCallback(() => {
-        const prev = changed
-        setChanged(new Set())
-        return prev
-    }, [changed])
-
-    return useMemo(() => ({
-        resetChanged,
-        markChanged,
-        loadChanged,
-    }), [resetChanged, markChanged, loadChanged])
 }
 
 function useCanvasCreateEffect() {
@@ -120,15 +85,13 @@ function useCanvasController() {
     const remove = useCanvasRemoveCallback()
     const duplicate = useCanvasDuplicateCallback()
     const loadModule = useModuleLoadCallback()
-    const changedLoader = useChangedModuleLoader()
     return useMemo(() => ({
         load,
         create,
         remove,
         duplicate,
         loadModule,
-        changedLoader,
-    }), [load, create, remove, duplicate, loadModule, changedLoader])
+    }), [load, create, remove, duplicate, loadModule])
 }
 
 function ControllerProvider({ children }) {

--- a/app/src/editor/canvas/components/CanvasController/useAutosaveEffect.js
+++ b/app/src/editor/canvas/components/CanvasController/useAutosaveEffect.js
@@ -4,7 +4,7 @@ import usePending from '$shared/hooks/usePending'
 
 import * as services from '../../services'
 import * as CanvasState from '../../state'
-import { changedModules, isEqualCanvas } from '../../state/diff'
+import { isEqualCanvas } from '../../state/diff'
 import useCanvas from './useCanvas'
 import useCanvasUpdater from './useCanvasUpdater'
 import * as RunController from './Run'
@@ -26,24 +26,12 @@ export default function useAutosaveEffect() {
         const currentCanvas = currCanvasRef.current
         const savingCanvas = savingCanvasRef.current
         lastServerStateRef.current = serverCanvas
-
-        if (isEqualCanvas(currentCanvas, savingCanvas)) {
-            // if no changes replace with state from server
-            canvasUpdater.replaceCanvas(() => serverCanvas)
-            return
-        }
-
-        const changed = new Set(changedModules(savingCanvas, currentCanvas))
-        let nextCanvas = currentCanvas
-        serverCanvas.modules.forEach((m) => {
-            // item changed again, don't update this round
-            if (changed.has(m.hash)) { return }
-            // ignore changes to modules not in serverCanvas
-            if (!CanvasState.getModuleIfExists(serverCanvas, m.hash)) { return }
-            nextCanvas = CanvasState.updateModule(nextCanvas, m.hash, () => (
-                CanvasState.getModule(serverCanvas, m.hash)
-            ))
+        const nextCanvas = CanvasState.applyChanges({
+            sent: savingCanvas,
+            received: serverCanvas,
+            current: currentCanvas,
         })
+
         // do nothing if no changes
         if (nextCanvas === currentCanvas) { return }
         // TODO set updated time

--- a/app/src/editor/canvas/components/CanvasController/useAutosaveEffect.js
+++ b/app/src/editor/canvas/components/CanvasController/useAutosaveEffect.js
@@ -1,0 +1,72 @@
+import { useContext, useEffect, useRef, useCallback, useMemo } from 'react'
+import useIsMounted from '$shared/hooks/useIsMounted'
+import usePending from '$shared/hooks/usePending'
+
+import * as services from '../../services'
+import * as CanvasState from '../../state'
+import { changedModules, isEqualCanvas } from '../../state/diff'
+import useCanvas from './useCanvas'
+import useCanvasUpdater from './useCanvasUpdater'
+import * as RunController from './Run'
+
+export default function useAutosaveEffect() {
+    const runController = useContext(RunController.Context)
+    const isMounted = useIsMounted()
+    const canvasUpdater = useCanvasUpdater()
+
+    const canvas = useCanvas()
+    const currCanvasRef = useRef(canvas)
+    const prevCanvas = currCanvasRef.current
+    currCanvasRef.current = canvas
+
+    const savingCanvasRef = useRef()
+
+    const onAutosaveComplete = useCallback((serverCanvas) => {
+        const currentCanvas = currCanvasRef.current
+        const savingCanvas = savingCanvasRef.current
+        if (isEqualCanvas(currentCanvas, savingCanvas)) {
+            // if no changes replace with state from server
+            canvasUpdater.replaceCanvas(() => serverCanvas)
+            return
+        }
+
+        const changed = new Set(changedModules(savingCanvas, currentCanvas))
+        let nextCanvas = currentCanvas
+        serverCanvas.modules.forEach((m) => {
+            // item changed again, don't update this round
+            if (changed.has(m.hash)) { return }
+            // ignore changes to modules not in serverCanvas
+            if (!CanvasState.getModuleIfExists(serverCanvas, m.hash)) { return }
+            nextCanvas = CanvasState.updateModule(nextCanvas, m.hash, () => (
+                CanvasState.getModule(serverCanvas, m.hash)
+            ))
+        })
+        // do nothing if no changes
+        if (nextCanvas === currentCanvas) { return }
+        // TODO set updated time
+        // TODO do not save deleted canvases
+        canvasUpdater.replaceCanvas(() => nextCanvas)
+    }, [savingCanvasRef, currCanvasRef, canvasUpdater])
+
+    const { isEditable } = runController
+    const { wrap: autosavePendingWrap } = usePending('canvas.AUTOSAVE')
+
+    const canvasChanged = useMemo(() => (
+        !isEqualCanvas(prevCanvas, canvas)
+    ), [prevCanvas, canvas])
+
+    useEffect(() => {
+        if (!isEditable || !canvasChanged) { return }
+        const currentCanvas = currCanvasRef.current
+        if (savingCanvasRef.current === currentCanvas) { return }
+        if (isEqualCanvas(savingCanvasRef.current, currentCanvas)) { return }
+        savingCanvasRef.current = currentCanvas
+        autosavePendingWrap(() => services.autosave(currentCanvas))
+            .then((...args) => {
+                if (!isMounted()) { return }
+                if (savingCanvasRef.current !== currentCanvas) { return } // ignore if canvas to be saved changed
+                onAutosaveComplete(...args)
+                savingCanvasRef.current = undefined
+            })
+    }, [canvasChanged, autosavePendingWrap, savingCanvasRef, isEditable, isMounted, onAutosaveComplete])
+}

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -8,7 +8,7 @@ import withErrorBoundary from '$shared/utils/withErrorBoundary'
 import ModuleUI from '$editor/shared/components/ModuleUI'
 import { UiEmitter } from '$editor/shared/components/RunStateLoader'
 
-import { RunStates, getPort, getModuleForPort } from '../state'
+import { RunStates } from '../state'
 
 import Ports from './Ports'
 import ModuleDragger from './ModuleDragger'
@@ -114,20 +114,10 @@ class CanvasModule extends React.PureComponent {
     )
 
     onPortValueChange = (portId, value, oldValue) => {
+        if (value === oldValue) { return }
         // Check if reload is needed after the change
-        const { canvas, api } = this.props
-        const port = getPort(canvas, portId)
-        const portModule = getModuleForPort(canvas, portId)
-
-        api.port.onChange(portId, value, () => {
-            if (!this.unmounted &&
-                port &&
-                (port.updateOnChange || port.type === 'EthereumContract') &&
-                oldValue !== value
-            ) {
-                api.loadNewDefinition(portModule.hash)
-            }
-        })
+        const { api } = this.props
+        api.port.onChange(portId, value)
     }
 
     onHamburgerButtonFocus = (e) => {

--- a/app/src/editor/canvas/components/ModuleDragger.jsx
+++ b/app/src/editor/canvas/components/ModuleDragger.jsx
@@ -1,22 +1,11 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import { updateModulePosition } from '../state'
 import { Draggable } from './DragDropContext'
 import ModuleStyles from '$editor/shared/components/Module.pcss'
-import { useController } from './CanvasController'
 import styles from './Module.pcss'
 
-export default function (props) {
-    const canvasController = useController()
-    const onStartDragModule = useCallback((hash) => {
-        canvasController.changedLoader.markChanged(hash)
-    }, [canvasController])
-    return (
-        <ModuleDragger {...props} onStartDragModule={onStartDragModule} />
-    )
-}
-
-class ModuleDragger extends React.Component {
+export default class ModuleDragger extends React.Component {
     onDropModule = (event, data) => {
         if (this.context.isCancelled) { return }
         if (data.diff.x === 0 && data.diff.y === 0) {

--- a/app/src/editor/canvas/components/PortDragger.jsx
+++ b/app/src/editor/canvas/components/PortDragger.jsx
@@ -32,7 +32,6 @@ class DraggablePort extends React.Component {
     canConnectPorts(canvas) {
         const { data } = this.context
         const { sourceId, portId, overId } = data
-        if (portId === overId) { return false } // cannot re-connect to self
         const fromId = sourceId || portId // treat as if dragging sourceId
         return CanvasState.canConnectPorts(canvas, fromId, overId)
     }

--- a/app/src/editor/canvas/components/Ports/Plug/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Plug/index.jsx
@@ -5,11 +5,7 @@ import cx from 'classnames'
 import { type Ref } from '$shared/flowtype/common-types'
 import { DropTarget, DragSource } from '../../PortDragger'
 import { DragDropContext } from '../../DragDropContext'
-import {
-    arePortsOfSameModule,
-    canConnectPorts,
-    hasPort,
-} from '../../../state'
+import { canConnectPorts, hasPort } from '../../../state'
 
 import styles from './plug.pcss'
 
@@ -49,18 +45,17 @@ const Plug = ({
     const { sourceId, portId } = data || {}
     const fromId = sourceId || portId || null
     const dragInProgress = !!isDragging && portId != null
-    const sourcePortId = dragInProgress ? fromId : null
-    const draggingFromSameModule = dragInProgress && hasPort(canvas, sourcePortId) && arePortsOfSameModule(canvas, sourcePortId, port.id)
+    const draggingFromSamePort = dragInProgress && hasPort(canvas, fromId) && port.id === fromId
     const canDrop = dragInProgress && canConnectPorts(canvas, fromId, port.id)
 
     return (
         <div
             {...props}
             className={cx(styles.root, className, {
-                [styles.allowDrop]: !draggingFromSameModule && canDrop,
+                [styles.allowDrop]: !draggingFromSamePort && canDrop,
                 [styles.idle]: !dragInProgress,
-                [styles.ignoreDrop]: draggingFromSameModule,
-                [styles.rejectDrop]: dragInProgress && !draggingFromSameModule && !canDrop,
+                [styles.ignoreDrop]: draggingFromSamePort,
+                [styles.rejectDrop]: dragInProgress && !draggingFromSamePort && !canDrop,
             })}
         >
             <div

--- a/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
@@ -22,11 +22,14 @@ const Select = ({
         onChangeProp(e.target.value)
     }, [onChangeProp])
 
+    if (value == null) { value = undefined } // select doesn't want null value
+
     const optionMap = useMemo(() => (
-        options.reduce((memo, { name, value }) => ({
-            ...memo,
-            [value || '']: name,
-        }), {})
+        options.reduce((memo, { name, value }) => {
+            if (value == null) { value = undefined }
+            memo.set(value, name)
+            return memo
+        }, new Map())
     ), [options])
 
     return (
@@ -46,7 +49,7 @@ const Select = ({
                 {/* `select` holding a currently selected value. This hidden (`visibility: hidden`) control
                     dictates the width of the actual (visible) control above. */}
                 <select className={styles.spaceholder}>
-                    <option>{optionMap[value]}</option>
+                    <option>{optionMap.get(value)}</option>
                 </select>
             </div>
         </div>

--- a/app/src/editor/canvas/components/Ports/Value/Select/select.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/Select/select.pcss
@@ -19,8 +19,8 @@
   outline: 0;
   padding: 0 calc(0.5 * var(--um));
   transition: 200ms linear;
-  transition-property: background-color, color, box-shadow;
-  width: auto;
+  transition-property: background-color, color, width, box-shadow;
+  width: 100%;
 }
 
 .root select:hover,

--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react'
+import cx from 'classnames'
 import * as State from '../../../state'
 import Color from './Color'
 import Map from './Map'
@@ -53,7 +54,11 @@ const Value = ({ canvas, port, onChange }: Props) => {
     }
 
     return (
-        <div className={styles.root}>
+        <div
+            className={cx(styles.root, {
+                [styles.disabled]: disabled,
+            })}
+        >
             {type === 'map' && (
                 <Map
                     {...commonProps}

--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { RunStates, getPortUserValueOrDefault } from '../../../state'
+import * as State from '../../../state'
 import Color from './Color'
 import Map from './Map'
 import Select from './Select'
@@ -39,12 +39,10 @@ export type CommonProps = {
 }
 
 const Value = ({ canvas, port, onChange }: Props) => {
-    const isRunning = canvas.state === RunStates.Running
     // Enable non-running input whether connected or not if port.canHaveInitialValue
-    const disabled = isRunning || (!port.canHaveInitialValue && port.connected)
+    const disabled = State.isPortValueEditDisabled(canvas, port.id)
     const type = getPortType(port)
-    // TODO: Ignore when editing.
-    const value = getPortUserValueOrDefault(canvas, port.id)
+    const value = State.getPortValue(canvas, port.id)
     const commonProps: CommonProps = {
         disabled,
         onChange,

--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -36,6 +36,7 @@ export type CommonProps = {
     disabled: boolean,
     onChange: (any) => void,
     value: any,
+    placeholder: any,
 }
 
 const Value = ({ canvas, port, onChange }: Props) => {
@@ -43,10 +44,12 @@ const Value = ({ canvas, port, onChange }: Props) => {
     const disabled = State.isPortValueEditDisabled(canvas, port.id)
     const type = getPortType(port)
     const value = State.getPortValue(canvas, port.id)
+    const placeholder = State.getPortPlaceholder(canvas, port.id)
     const commonProps: CommonProps = {
         disabled,
         onChange,
         value,
+        placeholder,
     }
 
     return (
@@ -71,7 +74,6 @@ const Value = ({ canvas, port, onChange }: Props) => {
             {type === 'text' && (
                 <Text
                     {...commonProps}
-                    placeholder={port.displayName || port.name}
                 />
             )}
             {type === 'stream' && (

--- a/app/src/editor/canvas/components/Ports/Value/value.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/value.pcss
@@ -2,3 +2,7 @@
   margin-left: calc(0.5 * var(--um));
   min-width: 0.5em;
 }
+
+.disabled {
+  opacity: 0.5;
+}

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -230,8 +230,6 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         this.setCanvas({ type: 'Set Module Options' }, (canvas) => (
             CanvasState.setModuleOptions(canvas, hash, options)
         ))
-
-        this.props.canvasController.changedLoader.markChanged(hash)
     }
 
     setRunTab = (runTab) => {

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -129,6 +129,8 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
     async autosave() {
         const { canvas, runController, canvasController } = this.props
+        this.autosaveId = this.autosaveId + 1 || 0
+        const { autosaveId } = this
         if (this.isDeleted) { return } // do not autosave deleted canvases
         if (!runController.isEditable) {
             // do not autosave running/adhoc canvases or if we have no write permission
@@ -139,6 +141,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
 
         const newCanvas = await services.autosave(canvas)
         if (this.unmounted) { return }
+        if (this.autosaveId !== autosaveId) { return } // do nothing if autosave called again
         // ignore new canvas, just extract updated time from it
         this.props.setUpdated(newCanvas.updated)
         this.props.replace((canvas) => this.props.canvasController.changedLoader.loadChanged(changed, canvas, newCanvas))

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -185,19 +185,6 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         ))
     }
 
-    loadNewDefinition = async (hash) => {
-        const { canvas, canvasController, replace } = this.props
-        try {
-            const moduleData = await canvasController.loadModule(canvas, { hash })
-            if (this.unmounted) { return }
-            replace((canvas) => CanvasState.replaceModule(canvas, moduleData))
-        } catch (error) {
-            console.error(error.message)
-            // undo value change
-            this.props.undo()
-        }
-    }
-
     pushNewDefinition = async (hash, value) => {
         const module = CanvasState.getModule(this.props.canvas, hash)
 
@@ -347,7 +334,6 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     moduleSidebarOpen={this.moduleSidebarOpen}
                     moduleSidebarIsOpen={moduleSidebarIsOpen && !keyboardShortcutIsOpen}
                     setCanvas={this.setCanvas}
-                    loadNewDefinition={this.loadNewDefinition}
                     pushNewDefinition={this.pushNewDefinition}
                 >
                     {runController.hasWritePermission ? (

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -6,7 +6,7 @@ import analytics from '$shared/../analytics'
 import api from '$editor/shared/utils/api'
 import Autosave from '$editor/shared/utils/autosave'
 import { nextUniqueName, nextUniqueCopyName } from '$editor/shared/utils/uniqueName'
-import { emptyCanvas, isRunning, RunStates, isHistoricalModeSelected, clearValuesOnUsedPorts } from './state'
+import { emptyCanvas, isRunning, RunStates, isHistoricalModeSelected } from './state'
 import { link, unlink, getLink } from './state/linking'
 
 const getData = ({ data }) => data
@@ -18,7 +18,6 @@ const streamsUrl = `${process.env.STREAMR_API_URL}/streams`
 const AUTOSAVE_DELAY = 3000
 
 async function save(canvas) {
-    canvas = clearValuesOnUsedPorts(canvas)
     return api().put(`${canvasesUrl}/${canvas.id}`, canvas).then(getData)
 }
 

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -6,7 +6,7 @@ import analytics from '$shared/../analytics'
 import api from '$editor/shared/utils/api'
 import Autosave from '$editor/shared/utils/autosave'
 import { nextUniqueName, nextUniqueCopyName } from '$editor/shared/utils/uniqueName'
-import { emptyCanvas, isRunning, RunStates, isHistoricalModeSelected } from './state'
+import { emptyCanvas, isRunning, RunStates, isHistoricalModeSelected, clearValuesOnUsedPorts } from './state'
 import { link, unlink, getLink } from './state/linking'
 
 const getData = ({ data }) => data
@@ -18,6 +18,7 @@ const streamsUrl = `${process.env.STREAMR_API_URL}/streams`
 const AUTOSAVE_DELAY = 3000
 
 async function save(canvas) {
+    canvas = clearValuesOnUsedPorts(canvas)
     return api().put(`${canvasesUrl}/${canvas.id}`, canvas).then(getData)
 }
 

--- a/app/src/editor/canvas/state/diff.js
+++ b/app/src/editor/canvas/state/diff.js
@@ -1,0 +1,28 @@
+import isEqual from 'lodash/isEqual'
+import differenceWith from 'lodash/differenceWith'
+import orderBy from 'lodash/orderBy'
+
+const EMPTY = []
+
+export function changedModules(canvasA, canvasB) {
+    if (canvasA === canvasB || canvasA.modules === canvasB.modules) { return EMPTY }
+    const modulesA = orderBy(canvasA.modules || [], 'hash')
+    const modulesB = orderBy(canvasB.modules || [], 'hash')
+    const AtoB = differenceWith(modulesA, modulesB, isEqual).map(({ hash }) => hash)
+    const BtoA = differenceWith(modulesB, modulesA, isEqual).map(({ hash }) => hash)
+    return Array.from(new Set([...AtoB, ...BtoA]))
+}
+
+export function isEqualCanvas(canvasA, canvasB) {
+    if (canvasA === canvasB) { return true }
+    const hasChangedModules = changedModules(canvasA, canvasB)
+    if (hasChangedModules) { return false }
+    // don't re-check modules
+    return isEqual({
+        ...canvasA,
+        modules: [],
+    }, {
+        ...canvasB,
+        modules: [],
+    })
+}

--- a/app/src/editor/canvas/state/diff.js
+++ b/app/src/editor/canvas/state/diff.js
@@ -15,14 +15,19 @@ export function changedModules(canvasA, canvasB) {
 
 export function isEqualCanvas(canvasA, canvasB) {
     if (canvasA === canvasB) { return true }
+    if (!canvasA || !canvasB) { return false }
     const hasChangedModules = changedModules(canvasA, canvasB)
-    if (hasChangedModules) { return false }
-    // don't re-check modules
+    if (hasChangedModules.length) { return false }
+    // don't re-check modules, ignore updated time
     return isEqual({
         ...canvasA,
+        updated: '',
+        created: '',
         modules: [],
     }, {
         ...canvasB,
+        updated: '',
+        created: '',
         modules: [],
     })
 }

--- a/app/src/editor/canvas/state/diff.js
+++ b/app/src/editor/canvas/state/diff.js
@@ -4,13 +4,30 @@ import orderBy from 'lodash/orderBy'
 
 const EMPTY = []
 
+function isEqualModule(moduleA, moduleB) {
+    if (!moduleA.modules && !moduleB.modules) {
+        return isEqual(moduleA, moduleB)
+    }
+
+    // ignore module internals e.g. subcanvas module
+    return isEqual({
+        ...moduleA,
+        modules: [],
+    }, {
+        ...moduleB,
+        modules: [],
+    })
+}
+
 export function changedModules(canvasA, canvasB) {
     if (canvasA === canvasB || canvasA.modules === canvasB.modules) { return EMPTY }
     const modulesA = orderBy(canvasA.modules || [], 'hash')
     const modulesB = orderBy(canvasB.modules || [], 'hash')
-    const AtoB = differenceWith(modulesA, modulesB, isEqual).map(({ hash }) => hash)
-    const BtoA = differenceWith(modulesB, modulesA, isEqual).map(({ hash }) => hash)
-    return Array.from(new Set([...AtoB, ...BtoA]))
+    const AtoB = differenceWith(modulesA, modulesB, isEqualModule).map(({ hash }) => hash)
+    const BtoA = differenceWith(modulesB, modulesA, isEqualModule).map(({ hash }) => hash)
+    const result = Array.from(new Set([...AtoB, ...BtoA]))
+    if (!result.length) { return EMPTY }
+    return result
 }
 
 export function isEqualCanvas(canvasA, canvasB) {

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -769,6 +769,17 @@ export function isPortValueEditDisabled(canvas, portId) {
     return false
 }
 
+export function getPortPlaceholder(canvas, portId) {
+    if (isPortConnected(canvas, portId)) {
+        const [connectedId] = getConnectedPortIds(canvas, portId)
+        const connectedPort = getPort(canvas, connectedId)
+        return connectedPort.longName || connectedPort.displayName || connectedPort.name
+    }
+
+    const port = getPort(canvas, portId)
+    return getDisplayNameFromPort(port)
+}
+
 export function getPortValue(canvas, portId) {
     const port = getPort(canvas, portId)
     const portType = getPortType(canvas, portId)

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -791,7 +791,7 @@ export function getPortValue(canvas, portId) {
         return port.value
     }
 
-    if (portType === 'param' && portType.canHaveInitialValue) {
+    if (portType === 'input' && port.canHaveInitialValue) {
         return port.initialValue
     }
 

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -354,23 +354,6 @@ export function updateModuleSize(canvas, moduleHash, size) {
     }), canvas)
 }
 
-function clearValuesOnUsedModulePorts(canvas, hash) {
-    const ports = getAllPorts(canvas, hash)
-    const usedPortIds = ports.map(({ id }) => id).filter((id) => isPortUsed(canvas, id))
-    return usedPortIds.reduce((nextCanvas, id) => (
-        updatePort(nextCanvas, id, (p) => ({
-            ...p,
-            value: undefined,
-        }))
-    ), canvas)
-}
-
-export function clearValuesOnUsedPorts(canvas) {
-    return canvas.modules.reduce((nextCanvas, { hash }) => (
-        clearValuesOnUsedModulePorts(nextCanvas, hash)
-    ), canvas)
-}
-
 function getOutputInputPorts(canvas, portIdA, portIdB) {
     const ports = [getPortIfExists(canvas, portIdA), getPortIfExists(canvas, portIdB)]
     if (getIsOutput(canvas, portIdB) || !getIsOutput(canvas, portIdA)) {

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -502,6 +502,10 @@ function disconnectInput(canvas, portId) {
             newPort.defaultValue = undefined
         }
 
+        if (newPort.type === 'EthereumContract' && newPort.value) {
+            delete newPort.value
+        }
+
         return newPort
     })
 }

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -783,15 +783,19 @@ export function getPortPlaceholder(canvas, portId) {
 export function getPortValue(canvas, portId) {
     const port = getPort(canvas, portId)
     const portType = getPortType(canvas, portId)
-    if (isRunning(canvas) || portType === 'output') {
+    if (portType === 'output') {
         return port.value
     }
+
+    if (portType === 'param' && portType.canHaveInitialValue) {
+        return port.initialValue
+    }
+
     if (isPortConnected(canvas, portId)) {
         const [connectedId] = getConnectedPortIds(canvas, portId)
         return getPortValue(canvas, connectedId)
     }
-
-    if (portType === 'param' && isPortExported(canvas, portId)) {
+    if (isPortExported(canvas, portId)) {
         return port.value
     }
 

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -189,9 +189,21 @@ function getIsOutput(canvas, portId) {
     return type === PortTypes.output
 }
 
-export function getModuleIfExists(canvas, moduleHash) {
+function getModulePath(canvas, moduleHash) {
     const { modules } = getIndex(canvas)
-    return get(canvas, modules[moduleHash])
+    return modules[moduleHash]
+}
+
+function validateModuleExists(canvas, moduleHash) {
+    const m = getModuleIfExists(canvas, moduleHash)
+    return validateModule(m, {
+        canvas,
+        moduleHash,
+    })
+}
+
+export function getModuleIfExists(canvas, moduleHash) {
+    return get(canvas, getModulePath(canvas, moduleHash))
 }
 
 export function getModule(canvas, moduleHash) {
@@ -330,13 +342,14 @@ export function updatePort(canvas, portId, fn) {
 }
 
 export function updateModule(canvas, moduleHash, fn) {
-    const { modules } = getIndex(canvas)
-    return update(modules[moduleHash], fn, canvas)
+    validateModuleExists(canvas, moduleHash)
+    const modulePath = getModulePath(canvas, moduleHash)
+    return update(modulePath, fn, canvas)
 }
 
 export function updateModulePosition(canvas, moduleHash, newPosition) {
-    const { modules } = getIndex(canvas)
-    const modulePath = modules[moduleHash]
+    validateModuleExists(canvas, moduleHash)
+    const modulePath = getModulePath(canvas, moduleHash)
     return update(modulePath.concat('layout', 'position'), (position) => ({
         ...position,
         top: `${Number.parseInt(newPosition.top, 10)}px`,
@@ -345,8 +358,8 @@ export function updateModulePosition(canvas, moduleHash, newPosition) {
 }
 
 export function updateModuleSize(canvas, moduleHash, size) {
-    const { modules } = getIndex(canvas)
-    const modulePath = modules[moduleHash]
+    validateModuleExists(canvas, moduleHash)
+    const modulePath = getModulePath(canvas, moduleHash)
     return update(modulePath.concat('layout'), (layout) => ({
         ...layout,
         height: `${size.height}px`,
@@ -815,8 +828,8 @@ export function setPortOptions(canvas, portId, options = {}) {
  */
 
 export function setModuleOptions(canvas, moduleHash, newOptions = {}) {
-    const { modules } = getIndex(canvas)
-    const modulePath = modules[moduleHash]
+    validateModuleExists(canvas, moduleHash)
+    const modulePath = getModulePath(canvas, moduleHash)
     return update(modulePath.concat('options'), (options = {}) => (
         Object.keys(newOptions).reduce((options, key) => {
             if (get(options, [key].concat('value')) === newOptions[key]) {

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -354,6 +354,23 @@ export function updateModuleSize(canvas, moduleHash, size) {
     }), canvas)
 }
 
+function clearValuesOnUsedModulePorts(canvas, hash) {
+    const ports = getAllPorts(canvas, hash)
+    const usedPortIds = ports.map(({ id }) => id).filter((id) => isPortUsed(canvas, id))
+    return usedPortIds.reduce((nextCanvas, id) => (
+        updatePort(nextCanvas, id, (p) => ({
+            ...p,
+            value: undefined,
+        }))
+    ), canvas)
+}
+
+export function clearValuesOnUsedPorts(canvas) {
+    return canvas.modules.reduce((nextCanvas, { hash }) => (
+        clearValuesOnUsedModulePorts(nextCanvas, hash)
+    ), canvas)
+}
+
 function getOutputInputPorts(canvas, portIdA, portIdB) {
     const ports = [getPortIfExists(canvas, portIdA), getPortIfExists(canvas, portIdB)]
     if (getIsOutput(canvas, portIdB) || !getIsOutput(canvas, portIdA)) {

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -722,7 +722,7 @@ export function setPortUserValue(canvas, portId, value) {
     const port = getPort(canvas, portId)
 
     const defaultValue = getPortDefaultValue(canvas, portId)
-    if (isBlank(value)) {
+    if (isBlank(value) && defaultValue != null) {
         value = defaultValue
     }
 
@@ -796,8 +796,7 @@ export function getPortValue(canvas, portId) {
     }
 
     if (isPortConnected(canvas, portId)) {
-        const [connectedId] = getConnectedPortIds(canvas, portId)
-        return getPortValue(canvas, connectedId)
+        return undefined
     }
     if (isPortExported(canvas, portId)) {
         return port.value
@@ -818,9 +817,7 @@ function isBlank(value) {
 
 export function getPortDefaultValue(canvas, portId) {
     const port = getPort(canvas, portId)
-    return 'defaultValue' in port
-        ? port.defaultValue
-        : port.initialValue
+    return port.defaultValue
 }
 
 export function getPortUserValueOrDefault(canvas, portId) {

--- a/app/src/editor/canvas/tests/changes.test.js
+++ b/app/src/editor/canvas/tests/changes.test.js
@@ -1,0 +1,74 @@
+import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/tests/utils'
+
+import * as State from '../state'
+import * as Services from '../services'
+
+import './utils'
+
+describe('Canvas applyChanges', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setupAuthorizationHeader()
+    }, 60000)
+
+    afterAll(async () => {
+        await Services.deleteAllCanvases()
+        await teardown()
+    })
+
+    it('can apply changes', async () => {
+        let canvas = await Services.create()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        const [constant1] = canvas.modules
+        // pretend server changed value
+        const serverCanvas = State.updateCanvas(State.setPortUserValue(canvas, constant1.params[0].id, 3))
+        canvas = State.applyChanges({
+            sent: canvas,
+            received: serverCanvas,
+            current: canvas,
+        })
+        // changes from "server" were applied
+        expect(canvas).toMatchCanvas(serverCanvas)
+    })
+
+    it('does not apply changes if current changed', async () => {
+        let canvas = await Services.create()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        const [constant1] = canvas.modules
+
+        const currentCanvas = State.updateCanvas(State.setPortUserValue(canvas, constant1.params[0].id, 3))
+        const serverCanvas = State.updateCanvas(State.setPortUserValue(canvas, constant1.params[0].id, 4))
+        canvas = State.applyChanges({
+            sent: canvas,
+            received: serverCanvas,
+            current: currentCanvas,
+        })
+        // changes from server were not applied
+        expect(canvas).toMatchCanvas(currentCanvas)
+    })
+
+    it('will apply changes only to unchanged modules', async () => {
+        let canvas = await Services.create()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        const [constant1, constant2] = canvas.modules
+        // change first constant locally
+        const currentCanvas = State.updateCanvas(State.setPortUserValue(canvas, constant1.params[0].id, 3))
+
+        // change both constants on "server"
+        let serverCanvas = State.updateCanvas(State.setPortUserValue(canvas, constant1.params[0].id, 4))
+        serverCanvas = State.updateCanvas(State.setPortUserValue(canvas, constant2.params[0].id, 5))
+
+        canvas = State.applyChanges({
+            sent: canvas,
+            received: serverCanvas,
+            current: currentCanvas,
+        })
+
+        // local changes to first constant were not clobbered
+        expect(State.getPortUserValue(canvas, constant1.params[0].id)).toBe(3)
+        // second constant changes were applied
+        expect(State.getPortUserValue(canvas, constant2.params[0].id)).toBe(5)
+    })
+})

--- a/app/src/editor/canvas/tests/connection.test.js
+++ b/app/src/editor/canvas/tests/connection.test.js
@@ -205,4 +205,84 @@ describe('Connecting Modules', () => {
         // test server accepts state
         expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
     })
+
+    it('resets param value to default on connect/disconnect', async () => {
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        let [constant1, constant2] = canvas.modules
+
+        const val1 = 5
+        const val2 = 6
+        const originalDefault = State.getPortDefaultValue(canvas, constant2.params[0].id)
+        canvas = State.updateCanvas(State.setPortUserValue(canvas, constant1.params[0].id, val1))
+        canvas = State.updateCanvas(State.setPortUserValue(canvas, constant2.params[0].id, val2))
+        canvas = State.updateCanvas(await Services.create(canvas))
+        expect(State.getPortValue(canvas, constant2.params[0].id)).toBe(val2)
+        canvas = State.updateCanvas(State.connectPorts(canvas, constant1.outputs[0].id, constant2.params[0].id))
+        canvas = State.updateCanvas(await Services.saveNow(canvas))
+        ;[constant1, constant2] = canvas.modules // eslint-disable-line semi-style
+        // server set default to prev value (?!)
+        expect(State.getPortDefaultValue(canvas, constant2.params[0].id)).toBe(val2)
+        // server updated output and connected param value to input value (Constant module behaviour)
+        expect(State.getPortValue(canvas, constant1.params[0].id)).toBe(val1)
+        expect(State.getPortValue(canvas, constant1.outputs[0].id)).toBe(val1)
+        expect(State.getPortValue(canvas, constant2.params[0].id)).toBe(val1)
+        canvas = State.updateCanvas(State.disconnectPorts(canvas, constant1.outputs[0].id, constant2.params[0].id))
+        ;[constant1, constant2] = canvas.modules // eslint-disable-line semi-style
+        // value should be same as default
+        expect(State.getPortValue(canvas, constant2.params[0].id)).toBe(State.getPortDefaultValue(canvas, constant2.params[0].id))
+        canvas = State.updateCanvas(await Services.saveNow(canvas))
+        // server reset defaultValue to original default (?!)
+        expect(State.getPortDefaultValue(canvas, constant2.params[0].id)).toBe(originalDefault)
+        // output unchanged
+        expect(State.getPortValue(canvas, constant1.params[0].id)).toBe(val1)
+    })
+
+    it('resets input value to default on connect/disconnect', async () => {
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('MovingAverage'))
+        let [constant1, movingAverage] = canvas.modules
+
+        const val1 = 5
+        const val2 = 6
+        canvas = State.updateCanvas(State.setPortUserValue(canvas, constant1.params[0].id, val1))
+        canvas = State.updateCanvas(State.setPortUserValue(canvas, movingAverage.inputs[0].id, val2))
+        canvas = State.updateCanvas(await Services.create(canvas))
+        expect(State.getPortUserValue(canvas, movingAverage.inputs[0].id)).toBe(val2)
+        canvas = State.updateCanvas(State.connectPorts(canvas, constant1.outputs[0].id, movingAverage.inputs[0].id))
+        canvas = State.updateCanvas(await Services.saveNow(canvas))
+        ;[constant1, movingAverage] = canvas.modules // eslint-disable-line semi-style
+        // server updated output and connected param value to input value (Constant module behaviour)
+        expect(State.getPortValue(canvas, constant1.params[0].id)).toBe(val1)
+        expect(State.getPortValue(canvas, constant1.outputs[0].id)).toBe(val1)
+
+        // for inputs initial value continues to show
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(val2)
+
+        // starting canvas uses port.value
+        canvas = State.updateCanvas(await Services.start(canvas))
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(val1)
+
+        canvas = State.updateCanvas(await Services.stop(canvas))
+        // shows initialValue after stop
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(val2)
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(State.getPortDefaultValue(canvas, movingAverage.inputs[0].id))
+
+        canvas = State.updateCanvas(State.disconnectPorts(canvas, constant1.outputs[0].id, movingAverage.inputs[0].id))
+        ;[constant1, movingAverage] = canvas.modules // eslint-disable-line semi-style
+        // disconnect doesn't change value
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(val2)
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(State.getPortDefaultValue(canvas, movingAverage.inputs[0].id))
+        canvas = State.updateCanvas(await Services.saveNow(canvas))
+        // server value should be same
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(val2)
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(State.getPortDefaultValue(canvas, movingAverage.inputs[0].id))
+        // value should be same as default
+        expect(State.getPortValue(canvas, movingAverage.inputs[0].id)).toBe(val2)
+        expect(State.getPortDefaultValue(canvas, movingAverage.inputs[0].id)).toBe(val2)
+        // output unchanged
+        expect(State.getPortValue(canvas, constant1.params[0].id)).toBe(val1)
+    })
 })

--- a/app/src/editor/canvas/tests/diff.test.js
+++ b/app/src/editor/canvas/tests/diff.test.js
@@ -132,6 +132,6 @@ describe('Canvas Diff', () => {
         canvas = State.updateCanvas(await Services.saveNow(canvas))
         // canvas module should have changed
         expect(changedModules(canvas, canvasBefore)).toEqual([canvasModule.hash])
-        expect(isEqualCanvas(canvas, canvasBefore)).toBe(true)
+        expect(isEqualCanvas(canvas, canvasBefore)).toBe(false)
     })
 })

--- a/app/src/editor/canvas/tests/diff.test.js
+++ b/app/src/editor/canvas/tests/diff.test.js
@@ -1,0 +1,55 @@
+import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/tests/utils'
+
+import * as State from '../state'
+import { changedModules } from '../state/diff'
+import * as Services from '../services'
+
+import './utils'
+
+describe('Canvas Diff', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setupAuthorizationHeader()
+    }, 60000)
+
+    afterAll(async () => {
+        await Services.deleteAllCanvases()
+        await teardown()
+    })
+    describe('changedModules', () => {
+        it('reports no change for identical canvases', async () => {
+            const canvas = State.emptyCanvas()
+            expect(changedModules(canvas, canvas)).toEqual([])
+            expect(changedModules(State.emptyCanvas(), State.emptyCanvas())).toEqual([])
+        })
+
+        it('reports change for canvas with different modules', async () => {
+            let canvas = State.emptyCanvas()
+            canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+            const [constantText] = canvas.modules
+            expect(changedModules(canvas, State.emptyCanvas())).toEqual([constantText.hash])
+            expect(changedModules(State.emptyCanvas(), canvas)).toEqual([constantText.hash])
+        })
+
+        it('reports change for canvas with different modules', async () => {
+            let canvas = State.emptyCanvas()
+            canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+            const [constantText] = canvas.modules
+            expect(changedModules(canvas, State.emptyCanvas())).toEqual([constantText.hash])
+            expect(changedModules(State.emptyCanvas(), canvas)).toEqual([constantText.hash])
+        })
+
+        it('ignores change if modules just reordered', async () => {
+            let canvas = State.emptyCanvas()
+            canvas = State.addModule(canvas, await loadModuleDefinition('ConstantText'))
+            canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+            const canvas2 = {
+                ...canvas,
+                modules: canvas.modules.slice().reverse().map((m) => ({ ...m })),
+            }
+            expect(changedModules(canvas, canvas2)).toEqual([])
+            expect(changedModules(canvas2, canvas)).toEqual([])
+        })
+    })
+})

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -251,6 +251,60 @@ describe('Canvas State', () => {
                 })
             })
 
+            describe('updateModulePosition', () => {
+                it('updates position', async () => {
+                    let canvas = State.emptyCanvas()
+                    canvas = State.addModule(canvas, await loadModuleDefinition('Equals'))
+                    const [equals] = canvas.modules
+                    const newPosition = {
+                        top: Number.parseInt(equals.layout.position.top, 10) + 333,
+                        left: Number.parseInt(equals.layout.position.left, 10) + 333,
+                    }
+                    canvas = State.updateModulePosition(canvas, equals.hash, newPosition)
+                    const [equalsUpdated] = canvas.modules
+                    expect(equalsUpdated.layout.position).toMatchObject({
+                        top: `${newPosition.top}px`,
+                        left: `${newPosition.left}px`,
+                    })
+                })
+                it('throws on bad module hash', () => {
+                    let canvas = State.emptyCanvas()
+                    expect(() => {
+                        canvas = State.updateModulePosition(canvas, 'not found', {
+                            top: 0,
+                            left: 0,
+                        })
+                    }).toThrow(State.MissingEntityError)
+                })
+            })
+
+            describe('updateModuleSize', () => {
+                it('updates size', async () => {
+                    let canvas = State.emptyCanvas()
+                    canvas = State.addModule(canvas, await loadModuleDefinition('Equals'))
+                    const [equals] = canvas.modules
+                    const newSize = {
+                        width: Number.parseInt(equals.layout.width, 10) + 333,
+                        height: Number.parseInt(equals.layout.height, 10) + 333,
+                    }
+                    canvas = State.updateModuleSize(canvas, equals.hash, newSize)
+                    const [equalsUpdated] = canvas.modules
+                    expect(equalsUpdated.layout).toMatchObject({
+                        width: `${newSize.width}px`,
+                        height: `${newSize.height}px`,
+                    })
+                })
+                it('throws on bad module hash', () => {
+                    let canvas = State.emptyCanvas()
+                    expect(() => {
+                        canvas = State.updateModuleSize(canvas, 'not found', {
+                            width: 100,
+                            height: 100,
+                        })
+                    }).toThrow(State.MissingEntityError)
+                })
+            })
+
             describe('{set,get}PortUserValue', () => {
                 it('should coerce numberish values to numbers for Double type', async () => {
                     let canvas = State.emptyCanvas()

--- a/app/src/editor/canvas/tests/variadic.test.js
+++ b/app/src/editor/canvas/tests/variadic.test.js
@@ -486,13 +486,12 @@ describe('Variadic Port Handling', () => {
             // change passthrough.in1/out1 type to number by connecting constantNumber.out to passthrough.in1
             expect(State.canConnectPorts(canvas, constantNumber.outputs[0].id, passThrough.inputs[0].id)).toBeTruthy()
             canvas = State.updateCanvas(State.connectPorts(canvas, constantNumber.outputs[0].id, passThrough.inputs[0].id))
+            // test server accepts state
+            canvas = State.updateCanvas(await Services.create(canvas))
             expect(State.arePortsConnected(canvas, constantNumber.outputs[0].id, passThrough.inputs[0].id)).toBeTruthy()
             // verify previous (incompatible) connections were dropped
             expect(State.arePortsConnected(canvas, constantText1.outputs[0].id, passThrough.inputs[0].id)).not.toBeTruthy()
             expect(State.arePortsConnected(canvas, passThrough.outputs[0].id, constantText2.params[0].id)).not.toBeTruthy()
-
-            // test server accepts state
-            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
 
         it('can connect linked output when input exported', async () => {
@@ -514,22 +513,21 @@ describe('Variadic Port Handling', () => {
 
             // connect passthrough out to label in
             canvas = State.updateCanvas(State.connectPorts(canvas, passthrough.outputs[0].id, label.inputs[0].id))
+            canvas = State.updateCanvas(await Services.create(canvas))
 
             // linked output is connected even though exported input is not connected
             expect(State.arePortsConnected(canvas, passthrough.outputs[0].id, label.inputs[0].id)).toBeTruthy()
-
             // de-export input
             canvas = State.updateCanvas(State.setPortOptions(canvas, passthrough.inputs[0].id, {
                 export: false,
             }))
 
+            // test server accepts state
+            canvas = State.updateCanvas(await Services.saveNow(canvas))
             // can no longer connect
             expect(State.canConnectPorts(canvas, passthrough.outputs[0].id, label.inputs[0].id)).not.toBeTruthy()
             // connection was automatically removed
             expect(State.arePortsConnected(canvas, passthrough.outputs[0].id, label.inputs[0].id)).not.toBeTruthy()
-
-            // test server accepts state
-            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
 
         it('handles nested connection changes', async () => {
@@ -570,6 +568,8 @@ describe('Variadic Port Handling', () => {
 
             // change passthrough1.in1/out1 type to number by connecting constantNumber.out to passthrough1.in1
             canvas = State.updateCanvas(State.connectPorts(canvas, constantNumber.outputs[0].id, passThrough1.inputs[0].id))
+            // test server accepts state
+            canvas = State.updateCanvas(await Services.create(canvas))
 
             // check valid connections maintained
             expect(State.arePortsConnected(canvas, constantNumber.outputs[0].id, passThrough1.inputs[0].id)).toBeTruthy()
@@ -577,9 +577,6 @@ describe('Variadic Port Handling', () => {
             expect(State.arePortsConnected(canvas, passThrough2.outputs[0].id, passThrough1.inputs[1].id)).toBeTruthy()
             // verify previous (incompatible) connections were dropped
             expect(State.arePortsConnected(canvas, constantNumber.outputs[0].id, constantText2.params[0].id)).not.toBeTruthy()
-
-            // test server accepts state
-            expect(State.updateCanvas(await Services.create(canvas))).toMatchCanvas(canvas)
         })
 
         it('permits renaming outputs', async () => {

--- a/app/src/editor/shared/utils/autosave.js
+++ b/app/src/editor/shared/utils/autosave.js
@@ -41,6 +41,7 @@ export function CancellableDebounce(fn, waitTime) {
                 // capture debounced function
                 function run(...args) {
                     if (!canRun) { return } // noop if cancelled
+                    emitter.emit('run', ...args)
 
                     reset()
                     fn(...args).then((result) => {
@@ -96,6 +97,9 @@ export default function Autosave(saveFn, waitTime) {
         })
         .on('fail', (err, canvas = {}) => {
             console.warn('Autosave failed', canvas.id, err) // eslint-disable-line no-console
+        })
+        .on('run', (_, canvas = {}) => {
+            console.info('Autosaving...', canvas.id) // eslint-disable-line no-console
         })
         .on('start', () => {
             window.addEventListener('beforeunload', unsavedUnloadWarning)

--- a/app/src/shared/components/TextControl/index.jsx
+++ b/app/src/shared/components/TextControl/index.jsx
@@ -59,7 +59,7 @@ const TextControl = ({
         if (flushHistoryOnBlur) {
             // `blurCount` is used as `key` of the actual control. Changing it replaces the control
             // with a new instance thus the old instance along with its change history gets forgotten.
-            setBlurCount(blurCount + 1)
+            setBlurCount((count) => count + 1)
         }
 
         if (!immediateCommit) {
@@ -73,7 +73,7 @@ const TextControl = ({
         if (onBlurProp) {
             onBlurProp(e)
         }
-    }, [onBlurProp, flushHistoryOnBlur, commit, sanitizedValue, commitEmpty, normalizedValue, blurCount, immediateCommit])
+    }, [onBlurProp, flushHistoryOnBlur, commit, sanitizedValue, commitEmpty, normalizedValue, immediateCommit])
 
     const onFocus = useCallback((e: SyntheticInputEvent<EventTarget>) => {
         if (selectAllOnFocus) {

--- a/app/src/shared/hooks/usePending.jsx
+++ b/app/src/shared/hooks/usePending.jsx
@@ -28,8 +28,10 @@ export function usePending(name: string) {
 
     return useMemo(() => ({
         isPending: isCurrentPending,
+        start,
+        end,
         wrap,
-    }), [isCurrentPending, wrap])
+    }), [isCurrentPending, start, end, wrap])
 }
 
 export function useAnyPending() {


### PR DESCRIPTION
Set up to read in values in from server on autosave. Won't clobber modules that have changed since the autosave was triggered.


* Values should update appropriately when connections are made https://github.com/streamr-dev/streamr-platform/pull/598#pullrequestreview-266618452
* Options changes should trigger module content updates e.g. chart module input counts.
* Disconnecting should restore previously set value.

A few things to improve still before this is ready:
* Loading indicator is a bit much
* Handling stuff which is not changed but is currently being edited/dragged when server response comes back.
* Verifying undo/redo works as expected.

@juhah can you do me a favour and test that the logic you added for the Java/Ethereum contract modules still works as expected? I believe the new autosave functionality should handle updating the modules appropriately simply by using the response from the server. 

Also please do your best to find other ways to break it.