### PR TITLE
Shared Content containers

### DIFF
--- a/app/src/docs/components/DocsLayout/docsLayout.pcss
+++ b/app/src/docs/components/DocsLayout/docsLayout.pcss
@@ -185,22 +185,17 @@
   }
 }
 
-@media (--lg-up) {
-  .docsLayout {
-    :global(.container) {
-      max-width: 1080px;
-    }
-  }
+.grid {
+  display: grid;
+}
+
+.content {
+  overflow: auto;
 }
 
 @media (--md-down) {
   .docsLayout {
     padding: 0 0 2.5em;
-
-    :global(.container) {
-      padding-left: 30px;
-      padding-right: 30px;
-    }
 
     .mdH1 {
       font-size: 32px;
@@ -227,5 +222,12 @@
       font-size: 16px;
       line-height: 28px;
     }
+  }
+}
+
+@media (--lg-up) {
+  .grid {
+    grid-template-columns: 250px 1fr;
+    grid-column-gap: 2rem;
   }
 }

--- a/app/src/docs/components/DocsLayout/index.jsx
+++ b/app/src/docs/components/DocsLayout/index.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React from 'react'
-import { Container, Row, Col } from 'reactstrap'
 import { MDXProvider } from '@mdx-js/react'
 
 import type { NavigationLink } from '$docs/flowtype/navigation-types'
@@ -10,6 +9,7 @@ import Navigation from './Navigation'
 import mainNav from './Navigation/navLinks'
 import Components from '$docs/mdxConfig'
 import PageTurner from '$docs/components/PageTurner'
+import DocsContainer from '$shared/components/Container/Docs'
 
 import styles from './docsLayout.pcss'
 
@@ -23,22 +23,22 @@ const DocsLayout = ({ subNav, ...props }: Props = {}) => (
             responsive
             navigationItems={mainNav}
         />
-        <Container>
-            <Row>
-                <Col md={12} lg={3}>
+        <DocsContainer>
+            <div className={styles.grid}>
+                <div>
                     <Navigation
                         navigationItems={mainNav}
                         subNavigationItems={subNav}
                     />
-                </Col>
-                <Col md={12} lg={9}>
+                </div>
+                <div className={styles.content}>
                     <MDXProvider components={Components}>
                         <div {...props} />
                     </MDXProvider>
                     <PageTurner navigationItems={mainNav} />
-                </Col>
-            </Row>
-        </Container>
+                </div>
+            </div>
+        </DocsContainer>
     </Layout>
 )
 

--- a/app/src/marketplace/components/Hero/hero.pcss
+++ b/app/src/marketplace/components/Hero/hero.pcss
@@ -3,11 +3,21 @@
   padding: 2.5em 0;
 }
 
-@media (--md-down) {
-  .heroContainer {
-    width: 100%;
-  }
+.container {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-row-gap: 1.75rem;
+}
 
+@media (--md-up) {
+  .container {
+    grid-template-columns: 380px 1fr;
+    grid-row-gap: 0;
+    grid-column-gap: 3rem;
+  }
+}
+
+@media (--md-down) {
   .heroRow {
     margin-right: 0;
     margin-left: 0;
@@ -22,5 +32,11 @@
 @media (--lg-up) {
   .hero {
     padding: 4em 0;
+  }
+}
+
+@media (--xl) {
+  .container {
+    grid-template-columns: 480px 1fr;
   }
 }

--- a/app/src/marketplace/components/Hero/index.jsx
+++ b/app/src/marketplace/components/Hero/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import { Container, Row, Col } from 'reactstrap'
+import ProductContainer from '$shared/components/Container/Product'
 
 import styles from './hero.pcss'
 
@@ -12,16 +12,14 @@ type Props = {
 
 const Hero = ({ leftContent, rightContent }: Props) => (
     <div className={styles.hero}>
-        <Container className={styles.heroContainer}>
-            <Row className={styles.heroRow}>
-                <Col xs={12} md={5} className={styles.heroColumn}>
-                    {leftContent}
-                </Col>
-                <Col xs={12} md={7} className={styles.heroColumn}>
-                    {rightContent}
-                </Col>
-            </Row>
-        </Container>
+        <ProductContainer className={styles.container}>
+            <div className={styles.leftColumn}>
+                {leftContent}
+            </div>
+            <div className={styles.rightColumn}>
+                {rightContent}
+            </div>
+        </ProductContainer>
     </div>
 )
 

--- a/app/src/marketplace/components/ProductPage/ProductDetails/productDetails.pcss
+++ b/app/src/marketplace/components/ProductPage/ProductDetails/productDetails.pcss
@@ -13,7 +13,7 @@
 }
 
 .basics {
-  margin-top: 1.75em;
+  margin-top: 0;
 }
 
 .buttonWrapper {
@@ -89,14 +89,6 @@
 }
 
 @media (--md-up) {
-  .root {
-    padding-left: 2em;
-  }
-
-  .basics {
-    margin-top: 0;
-  }
-
   .buttonWrapper {
     margin: 2em 0;
   }
@@ -109,10 +101,6 @@
 }
 
 @media (--lg-up) {
-  .root {
-    padding-left: 2.5em;
-  }
-
   .basics {
     margin-bottom: 2.5em;
   }
@@ -133,11 +121,5 @@
 
   .offer {
     font-size: 1em;
-  }
-}
-
-@media (--xl) {
-  .root {
-    padding-left: 3em;
   }
 }

--- a/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
+++ b/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
@@ -1,10 +1,11 @@
 // @flow
 
 import React from 'react'
-import { Container, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import classNames from 'classnames'
 import MediaQuery from 'react-responsive'
 import { Translate } from 'react-redux-i18n'
+import ProductContainer from '$shared/components/Container/Product'
 
 import routes from '$routes'
 import type { Stream, StreamList, StreamId } from '$shared/flowtype/stream-types'
@@ -121,7 +122,7 @@ const StreamListing = ({
     isProductSubscriptionValid,
     className,
 }: Props) => (
-    <Container id={styles.details} className={classNames(styles.details, className)}>
+    <ProductContainer id={styles.details} className={classNames(styles.details, className)}>
         <div className={classNames(styles.streams)}>
             <HeaderRow title={<TitleStreamCount count={streams.length || 0} />} className={styles.headerRow}>
                 <MediaQuery minWidth={767}>
@@ -180,7 +181,7 @@ const StreamListing = ({
                 </Row>
             )}
         </div>
-    </Container>
+    </ProductContainer>
 )
 
 export default StreamListing

--- a/app/src/newdocs/components/DocsLayout/docsLayout.pcss
+++ b/app/src/newdocs/components/DocsLayout/docsLayout.pcss
@@ -185,22 +185,17 @@
   }
 }
 
-@media (--lg-up) {
-  .docsLayout {
-    :global(.container) {
-      max-width: 1080px;
-    }
-  }
+.grid {
+  display: grid;
+}
+
+.content {
+  overflow: auto;
 }
 
 @media (--md-down) {
   .docsLayout {
     padding: 0 0 2.5em;
-
-    :global(.container) {
-      padding-left: 30px;
-      padding-right: 30px;
-    }
 
     .mdH1 {
       font-size: 32px;
@@ -227,5 +222,12 @@
       font-size: 16px;
       line-height: 28px;
     }
+  }
+}
+
+@media (--lg-up) {
+  .grid {
+    grid-template-columns: 250px 1fr;
+    grid-column-gap: 2rem;
   }
 }

--- a/app/src/newdocs/components/DocsLayout/index.jsx
+++ b/app/src/newdocs/components/DocsLayout/index.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React from 'react'
-import { Container, Row, Col } from 'reactstrap'
 import { MDXProvider } from '@mdx-js/react'
 
 import type { NavigationLink } from '$newdocs/flowtype/navigation-types'
@@ -10,6 +9,7 @@ import Navigation from './Navigation'
 import mainNav from './Navigation/navLinks'
 import Components from '$newdocs/mdxConfig'
 import PageTurner from '$newdocs/components/PageTurner'
+import DocsContainer from '$shared/components/Container/Docs'
 
 import styles from './docsLayout.pcss'
 
@@ -23,22 +23,22 @@ const DocsLayout = ({ subNav, ...props }: Props = {}) => (
             responsive
             navigationItems={mainNav}
         />
-        <Container>
-            <Row>
-                <Col md={12} lg={3}>
+        <DocsContainer>
+            <div className={styles.grid}>
+                <div>
                     <Navigation
                         navigationItems={mainNav}
                         subNavigationItems={subNav}
                     />
-                </Col>
-                <Col md={12} lg={9}>
+                </div>
+                <div className={styles.content}>
                     <MDXProvider components={Components}>
                         <div {...props} />
                     </MDXProvider>
                     <PageTurner navigationItems={mainNav} />
-                </Col>
-            </Row>
-        </Container>
+                </div>
+            </div>
+        </DocsContainer>
     </Layout>
 )
 

--- a/app/src/shared/components/Container/Details.jsx
+++ b/app/src/shared/components/Container/Details.jsx
@@ -1,0 +1,19 @@
+// @flow
+
+import React, { type Node } from 'react'
+import cx from 'classnames'
+
+import styles from './details.pcss'
+
+type Props = {
+    className?: string,
+    children: Node,
+}
+
+const Details = ({ className, children }: Props) => (
+    <div className={cx(styles.root, className)}>
+        {children}
+    </div>
+)
+
+export default Details

--- a/app/src/shared/components/Container/Details.jsx
+++ b/app/src/shared/components/Container/Details.jsx
@@ -10,8 +10,8 @@ type Props = {
     children?: Node,
 }
 
-const Details = ({ className, children }: Props) => (
-    <div className={cx(styles.root, className)}>
+const Details = ({ className, children, ...props }: Props) => (
+    <div className={cx(styles.root, styles.DetailsContainer, className)} {...props}>
         {children}
     </div>
 )

--- a/app/src/shared/components/Container/Docs.jsx
+++ b/app/src/shared/components/Container/Docs.jsx
@@ -1,0 +1,19 @@
+// @flow
+
+import React, { type Node } from 'react'
+import cx from 'classnames'
+
+import styles from './docs.pcss'
+
+type Props = {
+    className?: string,
+    children?: Node,
+}
+
+const Docs = ({ className, children, ...props }: Props) => (
+    <div className={cx(styles.root, styles.DocsContainer, className)} {...props}>
+        {children}
+    </div>
+)
+
+export default Docs

--- a/app/src/shared/components/Container/List.jsx
+++ b/app/src/shared/components/Container/List.jsx
@@ -3,17 +3,17 @@
 import React, { type Node } from 'react'
 import cx from 'classnames'
 
-import styles from './details.pcss'
+import styles from './list.pcss'
 
 type Props = {
     className?: string,
     children?: Node,
 }
 
-const Details = ({ className, children }: Props) => (
+const List = ({ className, children }: Props) => (
     <div className={cx(styles.root, className)}>
         {children}
     </div>
 )
 
-export default Details
+export default List

--- a/app/src/shared/components/Container/List.jsx
+++ b/app/src/shared/components/Container/List.jsx
@@ -10,8 +10,8 @@ type Props = {
     children?: Node,
 }
 
-const List = ({ className, children }: Props) => (
-    <div className={cx(styles.root, className)}>
+const List = ({ className, children, ...props }: Props) => (
+    <div className={cx(styles.root, styles.ListContainer, className)} {...props}>
         {children}
     </div>
 )

--- a/app/src/shared/components/Container/Product.jsx
+++ b/app/src/shared/components/Container/Product.jsx
@@ -1,0 +1,19 @@
+// @flow
+
+import React, { type Node } from 'react'
+import cx from 'classnames'
+
+import styles from './product.pcss'
+
+type Props = {
+    className?: string,
+    children?: Node,
+}
+
+const Product = ({ className, children, ...props }: Props) => (
+    <div className={cx(styles.root, styles.ProductContainer, className)} {...props}>
+        {children}
+    </div>
+)
+
+export default Product

--- a/app/src/shared/components/Container/details.pcss
+++ b/app/src/shared/components/Container/details.pcss
@@ -13,6 +13,10 @@
   }
 
   @media (--lg-up) {
+    max-width: 800px;
+  }
+
+  @media (--xl) {
     max-width: 900px;
   }
 }

--- a/app/src/shared/components/Container/details.pcss
+++ b/app/src/shared/components/Container/details.pcss
@@ -1,0 +1,18 @@
+.root {
+  margin: 0 auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  width: 100%;
+
+  @media (--sm-up) {
+    max-width: 540px;
+  }
+
+  @media (--md-up) {
+    max-width: 720px;
+  }
+
+  @media (--lg-up) {
+    max-width: 900px;
+  }
+}

--- a/app/src/shared/components/Container/details.pcss
+++ b/app/src/shared/components/Container/details.pcss
@@ -20,3 +20,5 @@
     max-width: 900px;
   }
 }
+
+.DetailsContainer {}

--- a/app/src/shared/components/Container/docs.pcss
+++ b/app/src/shared/components/Container/docs.pcss
@@ -1,0 +1,20 @@
+.root {
+  margin: 0 auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  width: 100%;
+
+  @media (--sm-up) {
+    max-width: 540px;
+  }
+
+  @media (--md-up) {
+    max-width: 720px;
+  }
+
+  @media (--lg-up) {
+    max-width: 1080px;
+  }
+}
+
+.DocsContainer {}

--- a/app/src/shared/components/Container/list.pcss
+++ b/app/src/shared/components/Container/list.pcss
@@ -1,0 +1,14 @@
+.root {
+  margin: 0 auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  width: 100%;
+
+  @media (--lg-up) {
+    max-width: 960px;
+  }
+
+  @media (--xl) {
+    max-width: 1336px;
+  }
+}

--- a/app/src/shared/components/Container/product.pcss
+++ b/app/src/shared/components/Container/product.pcss
@@ -4,13 +4,9 @@
   padding-right: 1.5rem;
   width: 100%;
 
-  @media (--lg-up) {
-    max-width: 960px;
-  }
-
   @media (--xl) {
-    max-width: 1336px;
+    max-width: 1100px;
   }
 }
 
-.ListContainer {}
+.ProductContainer {}

--- a/app/src/shared/components/Layout/Core.jsx
+++ b/app/src/shared/components/Layout/Core.jsx
@@ -13,10 +13,21 @@ type Props = {
     loading?: boolean,
     className?: string,
     navComponent?: Node,
+    hideNavOnDesktop?: boolean,
 }
 
-const CoreLayout = ({ loading, children, className, navComponent }: Props) => (
-    <Layout footer={false} className={cx(styles.container, className)}>
+const CoreLayout = ({
+    loading,
+    children,
+    className,
+    navComponent,
+    hideNavOnDesktop,
+}: Props) => (
+    <Layout
+        footer={false}
+        className={cx(styles.container, className)}
+        hideNavOnDesktop={hideNavOnDesktop}
+    >
         {navComponent || null}
         <LoadingIndicator loading={!!loading} className={styles.loadingIndicator} />
         <div className={styles.content}>

--- a/app/src/shared/components/Layout/core.pcss
+++ b/app/src/shared/components/Layout/core.pcss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  color: var(--greyDark);
 }
 
 .loadingIndicator {

--- a/app/src/shared/components/Layout/index.jsx
+++ b/app/src/shared/components/Layout/index.jsx
@@ -3,6 +3,7 @@
 import '$shared/styles/pcss'
 
 import React from 'react'
+import cx from 'classnames'
 
 import MobileNav from '$shared/components/MobileNav'
 import Nav from '$shared/components/Nav'
@@ -11,12 +12,16 @@ import styles from './layout.pcss'
 
 type Props = {
     footer?: boolean,
+    hideNavOnDesktop?: boolean,
 }
 
-const Layout = ({ footer = true, ...props }: Props = {}) => (
+const Layout = ({ footer = true, hideNavOnDesktop = false, ...props }: Props = {}) => (
     <div className={styles.framed}>
         <div className={styles.inner}>
-            <Nav className={styles.desktopNav} />
+            <Nav className={cx(styles.desktopNav, {
+                [styles.hideNavOnDesktop]: !!hideNavOnDesktop,
+            })}
+            />
             <MobileNav className={styles.mobileNav} />
             <div {...props} />
         </div>

--- a/app/src/shared/components/Layout/layout.pcss
+++ b/app/src/shared/components/Layout/layout.pcss
@@ -31,3 +31,9 @@
     display: none;
   }
 }
+
+@media (--lg-up) {
+  .hideNavOnDesktop {
+    display: none;
+  }
+}

--- a/app/src/shared/components/Tile/tile.pcss
+++ b/app/src/shared/components/Tile/tile.pcss
@@ -1,7 +1,6 @@
 .tile {
   position: relative;
   display: block;
-  margin: 1em auto 0;
   border-radius: 2px;
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 16px;

--- a/app/src/shared/components/TileGrid/index.jsx
+++ b/app/src/shared/components/TileGrid/index.jsx
@@ -1,0 +1,19 @@
+// @flow
+
+import React, { type Node } from 'react'
+import cx from 'classnames'
+
+import styles from './tileGrid.pcss'
+
+type Props = {
+    className?: string,
+    children?: Node,
+}
+
+const TileGrid = ({ className, children }: Props) => (
+    <div className={cx(styles.root, className)}>
+        {children}
+    </div>
+)
+
+export default TileGrid

--- a/app/src/shared/components/TileGrid/tileGrid.pcss
+++ b/app/src/shared/components/TileGrid/tileGrid.pcss
@@ -1,0 +1,15 @@
+.root {
+  display: grid;
+  grid-row-gap: 1.5rem;
+  grid-column-gap: 1.5rem;
+
+  @media (--sm-up) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (--lg-up) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-row-gap: 1rem;
+    grid-column-gap: 1rem;
+  }
+}

--- a/app/src/userpages/components/CanvasPage/List/canvasList.pcss
+++ b/app/src/userpages/components/CanvasPage/List/canvasList.pcss
@@ -19,10 +19,6 @@
 
 @media (--md-down) {
   :global(html) .corepageContentContainer {
-    width: 100%;
-    max-width: none;
-    padding-right: 24px;
-    padding-left: 24px;
     margin-top: 34px;
   }
 }

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Row, Col, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import { capital } from 'case'
 import Link from '$shared/components/Link'
 import { push } from 'connected-react-router'
@@ -19,7 +19,7 @@ import Layout from '$userpages/components/Layout'
 import links from '$app/src/links'
 import { getCanvases, deleteCanvas, updateFilter } from '$userpages/modules/canvas/actions'
 import { selectCanvases, selectFilter, selectFetching } from '$userpages/modules/canvas/selectors'
-import { defaultColumns, getFilters } from '$userpages/utils/constants'
+import { getFilters } from '$userpages/utils/constants'
 import Tile from '$shared/components/Tile'
 import DropdownActions from '$shared/components/DropdownActions'
 import { formatExternalUrl } from '$shared/utils/url'
@@ -36,6 +36,7 @@ import CanvasPreview from '$editor/canvas/components/Preview'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
 import ListContainer from '$shared/components/Container/List'
+import TileGrid from '$shared/components/TileGrid'
 
 import styles from './canvasList.pcss'
 
@@ -249,32 +250,31 @@ class CanvasList extends Component<Props, State> {
                             onResetFilter={this.resetFilter}
                         />
                     )}
-                    <Row>
+                    <TileGrid>
                         {canvases.map((canvas) => (
-                            <Col {...defaultColumns} key={canvas.id}>
-                                <Tile
-                                    link={`${links.editor.canvasEditor}/${canvas.id}`}
-                                    dropdownActions={this.getActions(canvas)}
-                                    image={<CanvasPreview className={styles.PreviewImage} canvas={canvas} />}
+                            <Tile
+                                key={canvas.id}
+                                link={`${links.editor.canvasEditor}/${canvas.id}`}
+                                dropdownActions={this.getActions(canvas)}
+                                image={<CanvasPreview className={styles.PreviewImage} canvas={canvas} />}
+                            >
+                                <Tile.Title>{canvas.name}</Tile.Title>
+                                <Tile.Description>
+                                    {canvas.updated === canvas.created ? 'Created ' : 'Updated '}
+                                    {this.generateTimeAgoDescription(new Date(canvas.updated))}
+                                </Tile.Description>
+                                <Tile.Status
+                                    className={
+                                        cx({
+                                            [styles.running]: canvas.state === RunStates.Running,
+                                            [styles.stopped]: canvas.state === RunStates.Stopped,
+                                        })}
                                 >
-                                    <Tile.Title>{canvas.name}</Tile.Title>
-                                    <Tile.Description>
-                                        {canvas.updated === canvas.created ? 'Created ' : 'Updated '}
-                                        {this.generateTimeAgoDescription(new Date(canvas.updated))}
-                                    </Tile.Description>
-                                    <Tile.Status
-                                        className={
-                                            cx({
-                                                [styles.running]: canvas.state === RunStates.Running,
-                                                [styles.stopped]: canvas.state === RunStates.Stopped,
-                                            })}
-                                    >
-                                        {capital(canvas.state)}
-                                    </Tile.Status>
-                                </Tile>
-                            </Col>
+                                    {capital(canvas.state)}
+                                </Tile.Status>
+                            </Tile>
                         ))}
-                    </Row>
+                    </TileGrid>
                 </ListContainer>
                 <DocsShortcuts />
             </Layout>

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Container, Row, Col, Button } from 'reactstrap'
+import { Row, Col, Button } from 'reactstrap'
 import { capital } from 'case'
 import Link from '$shared/components/Link'
 import { push } from 'connected-react-router'
@@ -35,6 +35,7 @@ import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import CanvasPreview from '$editor/canvas/components/Preview'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
+import ListContainer from '$shared/components/Container/List'
 
 import styles from './canvasList.pcss'
 
@@ -239,7 +240,7 @@ class CanvasList extends Component<Props, State> {
                         allowEmbed={!!process.env.CANVAS_EMBED} // TODO: remove when embed is ready
                     />
                 )}
-                <Container className={styles.corepageContentContainer}>
+                <ListContainer className={styles.corepageContentContainer}>
                     <Helmet title={`Streamr Core | ${I18n.t('userpages.canvases.title')}`} />
                     {!fetching && canvases && !canvases.length && (
                         <NoCanvasesView
@@ -274,7 +275,7 @@ class CanvasList extends Component<Props, State> {
                             </Col>
                         ))}
                     </Row>
-                </Container>
+                </ListContainer>
                 <DocsShortcuts />
             </Layout>
         )

--- a/app/src/userpages/components/DashboardPage/List/dashboardList.pcss
+++ b/app/src/userpages/components/DashboardPage/List/dashboardList.pcss
@@ -17,10 +17,6 @@
   }
 
   :global(html) .corepageContentContainer {
-    width: 100%;
-    max-width: none;
-    padding-right: 24px;
-    padding-left: 24px;
     margin-top: 34px;
   }
 }

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Container, Row, Col, Button } from 'reactstrap'
+import { Row, Col, Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import Helmet from 'react-helmet'
 import { Link } from 'react-router-dom'
@@ -21,6 +21,7 @@ import Dropdown from '$shared/components/Dropdown'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import DashboardPreview from '$editor/dashboard/components/Preview'
 import styles from './dashboardList.pcss'
+import ListContainer from '$shared/components/Container/List'
 
 import NoDashboardsView from './NoDashboards'
 
@@ -131,7 +132,7 @@ class DashboardList extends Component<Props> {
                 loading={fetching}
             >
                 <Helmet title={`Streamr Core | ${I18n.t('userpages.title.dashboards')}`} />
-                <Container className={styles.corepageContentContainer} >
+                <ListContainer className={styles.corepageContentContainer} >
                     {!fetching && dashboards && dashboards.length <= 0 && (
                         <NoDashboardsView
                             hasFilter={!!filter && (!!filter.search || !!filter.key)}
@@ -153,7 +154,7 @@ class DashboardList extends Component<Props> {
                             ))}
                         </Row>
                     )}
-                </Container>
+                </ListContainer>
                 <DocsShortcuts />
             </Layout>
         )

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Row, Col, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import Helmet from 'react-helmet'
 import { Link } from 'react-router-dom'
@@ -14,7 +14,7 @@ import type { StoreState } from '$userpages/flowtype/states/store-state'
 import type { DashboardList as DashboardListType } from '$userpages/flowtype/dashboard-types'
 import type { Filter, SortOption } from '$userpages/flowtype/common-types'
 import Layout from '$userpages/components/Layout'
-import { defaultColumns, getFilters } from '$userpages/utils/constants'
+import { getFilters } from '$userpages/utils/constants'
 import Tile from '$shared/components/Tile'
 import Search from '../../Header/Search'
 import Dropdown from '$shared/components/Dropdown'
@@ -22,6 +22,7 @@ import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import DashboardPreview from '$editor/dashboard/components/Preview'
 import styles from './dashboardList.pcss'
 import ListContainer from '$shared/components/Container/List'
+import TileGrid from '$shared/components/TileGrid'
 
 import NoDashboardsView from './NoDashboards'
 
@@ -141,18 +142,17 @@ class DashboardList extends Component<Props> {
                         />
                     )}
                     {dashboards && dashboards.length > 0 && (
-                        <Row>
+                        <TileGrid>
                             {dashboards.map((dashboard) => (
-                                <Col {...defaultColumns} key={dashboard.id}>
-                                    <Tile
-                                        link={`${links.editor.dashboardEditor}/${dashboard.id}`}
-                                        image={<DashboardPreview className={styles.PreviewImage} dashboard={dashboard} />}
-                                    >
-                                        <Tile.Title>{dashboard.name}</Tile.Title>
-                                    </Tile>
-                                </Col>
+                                <Tile
+                                    key={dashboard.id}
+                                    link={`${links.editor.dashboardEditor}/${dashboard.id}`}
+                                    image={<DashboardPreview className={styles.PreviewImage} dashboard={dashboard} />}
+                                >
+                                    <Tile.Title>{dashboard.name}</Tile.Title>
+                                </Tile>
                             ))}
-                        </Row>
+                        </TileGrid>
                     )}
                 </ListContainer>
                 <DocsShortcuts />

--- a/app/src/userpages/components/Header/index.jsx
+++ b/app/src/userpages/components/Header/index.jsx
@@ -37,54 +37,52 @@ const Header = ({
     user,
     noHeader,
 }: Props) => (
-    <React.Fragment>
-        <ListContainer className={cx(styles.listTemp, className)}>
-            {!noHeader && user &&
-                <div className={styles.profile}>
-                    <Avatar
-                        className={styles.avatar}
-                        user={user}
-                        linkToProfile
-                    />
-                    <div className={styles.additionalComponent}>
-                        {additionalComponent}
+    <ListContainer className={cx(styles.listTemp, className)}>
+        {!noHeader && user &&
+            <div className={styles.profile}>
+                <Avatar
+                    className={styles.avatar}
+                    user={user}
+                    linkToProfile
+                />
+                <div className={styles.additionalComponent}>
+                    {additionalComponent}
+                </div>
+            </div>
+        }
+        {!noHeader && (
+            <div className={styles.tabContainer} >
+                <div className={styles.tabBar}>
+                    <div className={styles.searchBar}>
+                        {searchComponent}
+                    </div>
+                    <div className={styles.tabs}>
+                        <Tab to={formatPath(userpages.streams)}>
+                            <Translate value="userpages.header.streams" />
+                        </Tab>
+                        <Tab to={formatPath(userpages.canvases)}>
+                            <Translate value="userpages.header.canvases" />
+                        </Tab>
+                        <Tab to={formatPath(userpages.dashboards)}>
+                            <Translate value="userpages.header.dashboards" />
+                        </Tab>
+                        <Tab to={formatPath(userpages.products)}>
+                            <Translate value="userpages.header.products" />
+                        </Tab>
+                        <Tab to={formatPath(userpages.purchases)}>
+                            <Translate value="userpages.header.purchases" />
+                        </Tab>
+                        <Tab to={formatPath(userpages.transactions)}>
+                            <Translate value="userpages.header.transactions" />
+                        </Tab>
                     </div>
                 </div>
-            }
-            {!noHeader && (
-                <div className={styles.tabContainer} >
-                    <div className={styles.tabBar}>
-                        <div className={styles.searchBar}>
-                            {searchComponent}
-                        </div>
-                        <div className={styles.tabs}>
-                            <Tab to={formatPath(userpages.streams)}>
-                                <Translate value="userpages.header.streams" />
-                            </Tab>
-                            <Tab to={formatPath(userpages.canvases)}>
-                                <Translate value="userpages.header.canvases" />
-                            </Tab>
-                            <Tab to={formatPath(userpages.dashboards)}>
-                                <Translate value="userpages.header.dashboards" />
-                            </Tab>
-                            <Tab to={formatPath(userpages.products)}>
-                                <Translate value="userpages.header.products" />
-                            </Tab>
-                            <Tab to={formatPath(userpages.purchases)}>
-                                <Translate value="userpages.header.purchases" />
-                            </Tab>
-                            <Tab to={formatPath(userpages.transactions)}>
-                                <Translate value="userpages.header.transactions" />
-                            </Tab>
-                        </div>
-                    </div>
-                    <div className={styles.filterBar}>
-                        {filterComponent}
-                    </div>
+                <div className={styles.filterBar}>
+                    {filterComponent}
                 </div>
-            )}
-        </ListContainer>
-    </React.Fragment>
+            </div>
+        )}
+    </ListContainer>
 )
 
 Header.defaultProps = {

--- a/app/src/userpages/components/Header/index.jsx
+++ b/app/src/userpages/components/Header/index.jsx
@@ -3,7 +3,6 @@
 import React, { type Node } from 'react'
 import { connect } from 'react-redux'
 import cx from 'classnames'
-import { Container } from 'reactstrap'
 import { Translate } from 'react-redux-i18n'
 
 import type { User } from '$shared/flowtype/user-types'
@@ -13,7 +12,7 @@ import { userpages } from '../../../links'
 import Tab from './Tab'
 import { formatPath } from '$shared/utils/url'
 import Avatar from '$userpages/components/Avatar'
-
+import ListContainer from '$shared/components/Container/List'
 import styles from './header.pcss'
 
 type OwnProps = {
@@ -38,52 +37,54 @@ const Header = ({
     user,
     noHeader,
 }: Props) => (
-    <Container className={cx(className, styles.containerOverrides)}>
-        {!noHeader && user &&
-            <div className={styles.profile}>
-                <Avatar
-                    className={styles.avatar}
-                    user={user}
-                    linkToProfile
-                />
-                <div className={styles.additionalComponent}>
-                    {additionalComponent}
-                </div>
-            </div>
-        }
-        {!noHeader && (
-            <div className={styles.tabContainer} >
-                <div className={styles.tabBar}>
-                    <div className={styles.searchBar}>
-                        {searchComponent}
-                    </div>
-                    <div className={styles.tabs}>
-                        <Tab to={formatPath(userpages.streams)}>
-                            <Translate value="userpages.header.streams" />
-                        </Tab>
-                        <Tab to={formatPath(userpages.canvases)}>
-                            <Translate value="userpages.header.canvases" />
-                        </Tab>
-                        <Tab to={formatPath(userpages.dashboards)}>
-                            <Translate value="userpages.header.dashboards" />
-                        </Tab>
-                        <Tab to={formatPath(userpages.products)}>
-                            <Translate value="userpages.header.products" />
-                        </Tab>
-                        <Tab to={formatPath(userpages.purchases)}>
-                            <Translate value="userpages.header.purchases" />
-                        </Tab>
-                        <Tab to={formatPath(userpages.transactions)}>
-                            <Translate value="userpages.header.transactions" />
-                        </Tab>
+    <React.Fragment>
+        <ListContainer className={cx(styles.listTemp, className)}>
+            {!noHeader && user &&
+                <div className={styles.profile}>
+                    <Avatar
+                        className={styles.avatar}
+                        user={user}
+                        linkToProfile
+                    />
+                    <div className={styles.additionalComponent}>
+                        {additionalComponent}
                     </div>
                 </div>
-                <div className={styles.filterBar}>
-                    {filterComponent}
+            }
+            {!noHeader && (
+                <div className={styles.tabContainer} >
+                    <div className={styles.tabBar}>
+                        <div className={styles.searchBar}>
+                            {searchComponent}
+                        </div>
+                        <div className={styles.tabs}>
+                            <Tab to={formatPath(userpages.streams)}>
+                                <Translate value="userpages.header.streams" />
+                            </Tab>
+                            <Tab to={formatPath(userpages.canvases)}>
+                                <Translate value="userpages.header.canvases" />
+                            </Tab>
+                            <Tab to={formatPath(userpages.dashboards)}>
+                                <Translate value="userpages.header.dashboards" />
+                            </Tab>
+                            <Tab to={formatPath(userpages.products)}>
+                                <Translate value="userpages.header.products" />
+                            </Tab>
+                            <Tab to={formatPath(userpages.purchases)}>
+                                <Translate value="userpages.header.purchases" />
+                            </Tab>
+                            <Tab to={formatPath(userpages.transactions)}>
+                                <Translate value="userpages.header.transactions" />
+                            </Tab>
+                        </div>
+                    </div>
+                    <div className={styles.filterBar}>
+                        {filterComponent}
+                    </div>
                 </div>
-            </div>
-        )}
-    </Container>
+            )}
+        </ListContainer>
+    </React.Fragment>
 )
 
 Header.defaultProps = {

--- a/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
+++ b/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
@@ -2,14 +2,13 @@
 
 import React from 'react'
 import { I18n } from 'react-redux-i18n'
-import { Row, Col } from 'reactstrap'
 import cx from 'classnames'
 
 import type { ResourcePermission } from '$shared/flowtype/resource-key-types'
 import TextInput from '$shared/components/TextInput'
 import Buttons from '$shared/components/Buttons'
 import Dropdown from '$shared/components/Dropdown'
-import { leftColumn, rightColumn } from '$userpages/components/StreamPage/constants'
+import SplitControl from '$userpages/components/SplitControl'
 
 import styles from './keyFieldEditor.pcss'
 
@@ -79,15 +78,14 @@ class KeyFieldEditor extends React.Component<Props, State> {
             showPermissionType,
         } = this.props
         const filled = !!keyName && (createNew || !!keyId)
-        const leftCol = showPermissionType ? leftColumn : { xs: 12 }
 
         return (
             <div className={cx(styles.editor, {
                 [styles.editorWithPermissions]: showPermissionType,
             })}
             >
-                <Row>
-                    <Col {...leftCol}>
+                {showPermissionType && (
+                    <SplitControl>
                         <div className={styles.keyName}>
                             <TextInput
                                 label={I18n.t('userpages.keyFieldEditor.keyName')}
@@ -97,59 +95,64 @@ class KeyFieldEditor extends React.Component<Props, State> {
                                 error={(createNew && !editValue && error) || undefined}
                             />
                         </div>
-                        {(!createNew || editValue) && (
-                            <div className={styles.keyValue}>
-                                <TextInput
-                                    label={I18n.t('userpages.keyFieldEditor.apiKey')}
-                                    value={keyId}
-                                    onChange={this.onValueChange}
-                                    preserveLabelSpace
-                                    readOnly={!editValue}
-                                    error={error || undefined}
-                                />
-                            </div>
-                        )}
-                    </Col>
-                    {showPermissionType && (
-                        <Col {...rightColumn}>
-                            <Dropdown
-                                title=""
-                                onChange={this.onPermissionChange}
-                                selectedItem={permission}
-                                className={styles.permissionDropdown}
-                            >
-                                <Dropdown.Item key="read" value="read">
-                                    Read
-                                </Dropdown.Item>
-                                <Dropdown.Item key="write" value="write">
-                                    Write
-                                </Dropdown.Item>
-                            </Dropdown>
-                        </Col>
-                    )}
-                    <Col>
-                        <Buttons
-                            className={styles.buttons}
-                            actions={{
-                                save: {
-                                    title: I18n.t(`userpages.keyFieldEditor.${createNew ? 'add' : 'save'}`),
-                                    color: 'primary',
-                                    outline: true,
-                                    onClick: this.onSave,
-                                    disabled: !filled || waiting,
-                                    spinner: waiting,
-                                },
-                                cancel: {
-                                    color: 'link',
-                                    className: 'grey-container',
-                                    title: I18n.t('userpages.keyFieldEditor.cancel'),
-                                    outline: true,
-                                    onClick: onCancel,
-                                },
-                            }}
+                        <Dropdown
+                            title=""
+                            onChange={this.onPermissionChange}
+                            selectedItem={permission}
+                            className={styles.permissionDropdown}
+                        >
+                            <Dropdown.Item key="read" value="read">
+                                Read
+                            </Dropdown.Item>
+                            <Dropdown.Item key="write" value="write">
+                                Write
+                            </Dropdown.Item>
+                        </Dropdown>
+                    </SplitControl>
+                )}
+                {!showPermissionType && (
+                    <div className={styles.keyName}>
+                        <TextInput
+                            label={I18n.t('userpages.keyFieldEditor.keyName')}
+                            value={keyName}
+                            onChange={this.onKeyNameChange}
+                            preserveLabelSpace
+                            error={(createNew && !editValue && error) || undefined}
                         />
-                    </Col>
-                </Row>
+                    </div>
+                )}
+                {(!createNew || editValue) && (
+                    <div className={styles.keyValue}>
+                        <TextInput
+                            label={I18n.t('userpages.keyFieldEditor.apiKey')}
+                            value={keyId}
+                            onChange={this.onValueChange}
+                            preserveLabelSpace
+                            readOnly={!editValue}
+                            error={error || undefined}
+                        />
+                    </div>
+                )}
+                <Buttons
+                    className={styles.buttons}
+                    actions={{
+                        save: {
+                            title: I18n.t(`userpages.keyFieldEditor.${createNew ? 'add' : 'save'}`),
+                            color: 'primary',
+                            outline: true,
+                            onClick: this.onSave,
+                            disabled: !filled || waiting,
+                            spinner: waiting,
+                        },
+                        cancel: {
+                            color: 'link',
+                            className: 'grey-container',
+                            title: I18n.t('userpages.keyFieldEditor.cancel'),
+                            outline: true,
+                            onClick: onCancel,
+                        },
+                    }}
+                />
             </div>
         )
     }

--- a/app/src/userpages/components/KeyField/KeyFieldEditor/keyFieldEditor.pcss
+++ b/app/src/userpages/components/KeyField/KeyFieldEditor/keyFieldEditor.pcss
@@ -40,7 +40,6 @@
   display: flex;
   justify-content: flex-end;
   border-radius: 4px;
-  right: 22px;
 
   :global(.dropdown-menu) {
     margin-top: 8px;

--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -4,14 +4,13 @@ import React from 'react'
 import copy from 'copy-to-clipboard'
 import cx from 'classnames'
 import { I18n, Translate } from 'react-redux-i18n'
-import { Row, Col } from 'reactstrap'
 
 import type { ResourcePermission } from '$shared/flowtype/resource-key-types'
 import TextInput from '$shared/components/TextInput'
 import Meatball from '$shared/components/Meatball'
 import DropdownActions from '$shared/components/DropdownActions'
 import Dropdown from '$shared/components/Dropdown'
-
+import SplitControl from '$userpages/components/SplitControl'
 import KeyFieldEditor from './KeyFieldEditor'
 import styles from './keyField.pcss'
 
@@ -167,61 +166,58 @@ class KeyField extends React.Component<Props, State> {
         } = this.state
 
         return !editing ? (
-            <Row>
-                <Col md={12} lg={11}>
-                    <div
-                        className={cx(styles.container, className, {
-                            [styles.withMenu]: menuOpen,
-                        })}
-                    >
-                        <TextInput label={keyName} value={value} readOnly type={hidden ? 'password' : 'text'} />
-                        <div className={styles.actions}>
-                            <DropdownActions
-                                onMenuToggle={this.onMenuToggle}
-                                title={<Meatball alt={I18n.t('userpages.keyField.options')} blue />}
-                                noCaret
-                            >
-                                {!!hideValue && (
-                                    <DropdownActions.Item onClick={this.toggleHidden}>
-                                        <Translate value={`userpages.keyField.${hidden ? 'reveal' : 'conceal'}`} />
-                                    </DropdownActions.Item>
-                                )}
-                                <DropdownActions.Item onClick={this.onCopy}>
-                                    <Translate value="userpages.keyField.copy" />
+            <SplitControl>
+                <div
+                    className={cx(styles.container, className, {
+                        [styles.withMenu]: menuOpen,
+                    })}
+                >
+                    <TextInput label={keyName} value={value} readOnly type={hidden ? 'password' : 'text'} />
+                    <div className={styles.actions}>
+                        <DropdownActions
+                            onMenuToggle={this.onMenuToggle}
+                            title={<Meatball alt={I18n.t('userpages.keyField.options')} blue />}
+                            noCaret
+                        >
+                            {!!hideValue && (
+                                <DropdownActions.Item onClick={this.toggleHidden}>
+                                    <Translate value={`userpages.keyField.${hidden ? 'reveal' : 'conceal'}`} />
                                 </DropdownActions.Item>
-                                {!!allowEdit && (
-                                    <DropdownActions.Item onClick={this.onEdit}>
-                                        <Translate value="userpages.keyField.edit" />
-                                    </DropdownActions.Item>
-                                )}
-                                {!!allowDelete && (
-                                    <DropdownActions.Item onClick={this.onDelete} disabled={disableDelete}>
-                                        <Translate value="userpages.keyField.delete" />
-                                    </DropdownActions.Item>
-                                )}
-                            </DropdownActions>
-                        </div>
+                            )}
+                            <DropdownActions.Item onClick={this.onCopy}>
+                                <Translate value="userpages.keyField.copy" />
+                            </DropdownActions.Item>
+                            {!!allowEdit && (
+                                <DropdownActions.Item onClick={this.onEdit}>
+                                    <Translate value="userpages.keyField.edit" />
+                                </DropdownActions.Item>
+                            )}
+                            {!!allowDelete && (
+                                <DropdownActions.Item onClick={this.onDelete} disabled={disableDelete}>
+                                    <Translate value="userpages.keyField.delete" />
+                                </DropdownActions.Item>
+                            )}
+                        </DropdownActions>
                     </div>
-                    {showPermissionType && (
-                        <div className={styles.permissionDropdownContainer}>
-                            <Dropdown
-                                title=""
-                                onChange={this.onPermissionChange}
-                                className={styles.permissionDropdown}
-                                selectedItem={permission}
-                            >
-                                <Dropdown.Item key="read" value="read" onClick={(val) => this.onPermissionChange(val.toString())}>
-                                    Read
-                                </Dropdown.Item>
-                                <Dropdown.Item key="write" value="write" onClick={(val) => this.onPermissionChange(val.toString())}>
-                                    Write
-                                </Dropdown.Item>
-                            </Dropdown>
-                        </div>
-                    )}
-                </Col>
-                <Col md={12} lg={1} className={styles.offsetColOverride} />
-            </Row>
+                </div>
+                {showPermissionType && (
+                    <div className={styles.permissionDropdownContainer}>
+                        <Dropdown
+                            title=""
+                            onChange={this.onPermissionChange}
+                            className={styles.permissionDropdown}
+                            selectedItem={permission}
+                        >
+                            <Dropdown.Item key="read" value="read" onClick={(val) => this.onPermissionChange(val.toString())}>
+                                Read
+                            </Dropdown.Item>
+                            <Dropdown.Item key="write" value="write" onClick={(val) => this.onPermissionChange(val.toString())}>
+                                Write
+                            </Dropdown.Item>
+                        </Dropdown>
+                    </div>
+                )}
+            </SplitControl>
         ) : (
             <KeyFieldEditor
                 keyName={keyName}

--- a/app/src/userpages/components/KeyField/keyField.pcss
+++ b/app/src/userpages/components/KeyField/keyField.pcss
@@ -36,7 +36,6 @@
   display: flex;
   justify-content: flex-end;
   border-radius: 4px;
-  margin-right: -26px;
 
   :global(.dropdown-menu) {
     margin-top: 8px;

--- a/app/src/userpages/components/KeyField/keyField.pcss
+++ b/app/src/userpages/components/KeyField/keyField.pcss
@@ -26,12 +26,6 @@
   right: 0;
 }
 
-@media (--lg-down) {
-  .permissionDropdownContainer {
-    right: -110px;
-  }
-}
-
 .permissionDropdown {
   display: flex;
   justify-content: flex-end;

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Container, Row, Col, Button } from 'reactstrap'
+import { Row, Col, Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
 import { push } from 'connected-react-router'
@@ -23,6 +23,7 @@ import { formatPath, formatExternalUrl } from '$shared/utils/url'
 import DropdownActions from '$shared/components/DropdownActions'
 import NoProductsView from './NoProducts'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
+import ListContainer from '$shared/components/Container/List'
 
 import type { ProductList, ProductId, Product } from '$mp/flowtype/product-types'
 import type { Filter, SortOption } from '$userpages/flowtype/common-types'
@@ -175,7 +176,7 @@ class ProductsPage extends Component<Props> {
                 loading={fetching}
             >
                 <Helmet title={`Streamr Core | ${I18n.t('userpages.title.products')}`} />
-                <Container className={styles.corepageContentContainer}>
+                <ListContainer className={styles.corepageContentContainer}>
                     {!fetching && products && !products.length && (
                         <NoProductsView
                             hasFilter={!!filter && (!!filter.search || !!filter.key)}
@@ -209,7 +210,7 @@ class ProductsPage extends Component<Props> {
                             </Col>
                         ))}
                     </Row>
-                </Container>
+                </ListContainer>
                 <DocsShortcuts />
             </Layout>
         )

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Row, Col, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
 import { push } from 'connected-react-router'
@@ -12,7 +12,7 @@ import moment from 'moment'
 
 import Layout from '../Layout'
 import links from '../../../links'
-import { defaultColumns, getFilters } from '../../utils/constants'
+import { getFilters } from '../../utils/constants'
 import { getMyProducts, updateFilter } from '$mp/modules/myProductList/actions'
 import { selectMyProductList, selectFilter, selectFetching } from '$mp/modules/myProductList/selectors'
 import { productStates } from '$shared/utils/constants'
@@ -24,6 +24,7 @@ import DropdownActions from '$shared/components/DropdownActions'
 import NoProductsView from './NoProducts'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import ListContainer from '$shared/components/Container/List'
+import TileGrid from '$shared/components/TileGrid'
 
 import type { ProductList, ProductId, Product } from '$mp/flowtype/product-types'
 import type { Filter, SortOption } from '$userpages/flowtype/common-types'
@@ -184,32 +185,31 @@ class ProductsPage extends Component<Props> {
                             onResetFilter={this.resetFilter}
                         />
                     )}
-                    <Row>
+                    <TileGrid>
                         {products.map((product) => (
-                            <Col {...defaultColumns} key={product.id}>
-                                <Tile
-                                    imageUrl={product.imageUrl}
-                                    link={product.id && `${links.marketplace.products}/${product.id}`}
-                                    dropdownActions={this.getActions(product)}
+                            <Tile
+                                key={product.id}
+                                imageUrl={product.imageUrl}
+                                link={product.id && `${links.marketplace.products}/${product.id}`}
+                                dropdownActions={this.getActions(product)}
+                            >
+                                <Tile.Title>{product.name}</Tile.Title>
+                                <Tile.Tag >
+                                    {product.updated === product.created ? 'Created ' : 'Updated '}
+                                    {product.updated && this.generateTimeAgoDescription(new Date(product.updated))}
+                                </Tile.Tag>
+                                <Tile.Tag
+                                    className={product.state === productStates.DEPLOYED ? styles.green : styles.grey}
                                 >
-                                    <Tile.Title>{product.name}</Tile.Title>
-                                    <Tile.Tag >
-                                        {product.updated === product.created ? 'Created ' : 'Updated '}
-                                        {product.updated && this.generateTimeAgoDescription(new Date(product.updated))}
-                                    </Tile.Tag>
-                                    <Tile.Tag
-                                        className={product.state === productStates.DEPLOYED ? styles.green : styles.grey}
-                                    >
-                                        {
-                                            product.state === productStates.DEPLOYED ?
-                                                <Translate value="userpages.products.published" /> :
-                                                <Translate value="userpages.products.draft" />
-                                        }
-                                    </Tile.Tag>
-                                </Tile>
-                            </Col>
+                                    {
+                                        product.state === productStates.DEPLOYED ?
+                                            <Translate value="userpages.products.published" /> :
+                                            <Translate value="userpages.products.draft" />
+                                    }
+                                </Tile.Tag>
+                            </Tile>
                         ))}
-                    </Row>
+                    </TileGrid>
                 </ListContainer>
                 <DocsShortcuts />
             </Layout>

--- a/app/src/userpages/components/ProductsPage/products.pcss
+++ b/app/src/userpages/components/ProductsPage/products.pcss
@@ -14,10 +14,6 @@
   }
 
   :global(html) .corepageContentContainer {
-    width: 100%;
-    max-width: none;
-    padding-right: 24px;
-    padding-left: 24px;
     margin-top: 34px;
   }
 }

--- a/app/src/userpages/components/ProfilePage/APICredentials/CredentialsControl/credentialsControl.pcss
+++ b/app/src/userpages/components/ProfilePage/APICredentials/CredentialsControl/credentialsControl.pcss
@@ -26,11 +26,4 @@
   font-family: 'IBM Plex Sans', sans-serif;
   letter-spacing: 0;
   line-height: 20px;
-  margin-left: -110px;
-}
-
-@media (--lg-down) {
-  .permissionColHeading {
-    margin-left: 0;
-  }
 }

--- a/app/src/userpages/components/ProfilePage/APICredentials/CredentialsControl/index.jsx
+++ b/app/src/userpages/components/ProfilePage/APICredentials/CredentialsControl/index.jsx
@@ -2,12 +2,11 @@
 
 import React, { Component, Fragment } from 'react'
 import { I18n, Translate } from 'react-redux-i18n'
-import { Row, Col } from 'reactstrap'
 import cx from 'classnames'
 
 import KeyField from '$userpages/components/KeyField'
 import AddKeyField from '$userpages/components/KeyField/AddKeyField'
-
+import SplitControl from '$userpages/components/SplitControl'
 import type { ResourceKeyId, ResourceKey, ResourcePermission } from '$shared/flowtype/resource-key-types'
 import type { StreamId } from '$shared/flowtype/stream-types'
 
@@ -52,17 +51,15 @@ export default class CredentialsControl extends Component<Props> {
                     {this.props.keys.map((key: ResourceKey, index: number) => (
                         <Fragment key={key.id}>
                             {!index && (
-                                <Row>
-                                    <Col md={12} lg={11} />
-                                    <Col md={12} lg={1}>
-                                        {showPermissionType && (
-                                            <Translate
-                                                value="userpages.streams.edit.configure.permission"
-                                                className={styles.permissionColHeading}
-                                            />
-                                        )}
-                                    </Col>
-                                </Row>
+                                <SplitControl>
+                                    <div />
+                                    {showPermissionType && (
+                                        <Translate
+                                            value="userpages.streams.edit.configure.permission"
+                                            className={styles.permissionColHeading}
+                                        />
+                                    )}
+                                </SplitControl>
                             )}
                             <KeyField
                                 className={cx(styles.singleKey, {

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -4,13 +4,13 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { I18n } from 'react-redux-i18n'
 import { push } from 'connected-react-router'
-import cx from 'classnames'
 import Helmet from 'react-helmet'
 import MediaQuery from 'react-responsive'
 
 import { saveCurrentUser } from '$shared/modules/user/actions'
 import Toolbar from '$shared/components/Toolbar'
 import TOCPage from '$userpages/components/TOCPage'
+import DetailsContainer from '$shared/components/Container/Details'
 import ConfigureAnchorOffset from '$shared/components/ConfigureAnchorOffset'
 import { lg } from '$app/scripts/breakpoints'
 import links from '$shared/../links'
@@ -78,6 +78,7 @@ export class ProfilePage extends Component<Props, State> {
         return (
             <CoreLayout
                 className={styles.profilePage}
+                hideNavOnDesktop
                 navComponent={(
                     <Toolbar
                         altMobileLayout
@@ -102,7 +103,7 @@ export class ProfilePage extends Component<Props, State> {
                 <MediaQuery minWidth={lg.min}>
                     <ConfigureAnchorOffset value={-80} />
                 </MediaQuery>
-                <div className={cx('container', styles.containerOverrides)}>
+                <DetailsContainer className={styles.profilePage}>
                     <TOCPage title={I18n.t('userpages.profilePage.pageTitle')}>
                         <TOCPage.Section id="profile" title={I18n.t('userpages.profilePage.profile.title')}>
                             <ProfileSettings />
@@ -136,7 +137,7 @@ export class ProfilePage extends Component<Props, State> {
                             <DeleteAccount />
                         </TOCPage.Section>
                     </TOCPage>
-                </div>
+                </DetailsContainer>
             </CoreLayout>
         )
     }

--- a/app/src/userpages/components/ProfilePage/profilePage.pcss
+++ b/app/src/userpages/components/ProfilePage/profilePage.pcss
@@ -1,35 +1,8 @@
 .profilePage {
-  position: relative;
-  color: var(--greyDark);
-  font-size: 14px;
-  padding-bottom: 3em;
-
-  @media (--lg-up) {
-    top: -7.4em;
-
-    /* 80px of navbar + 2.5 of top padding at the layout level. */
-    top: calc(-2.5rem - 80px);
-    z-index: 11;
-  }
-
-  @media (--xs) {
-    top: auto;
-  }
+  padding-bottom: 3rem;
 }
 
 .longText {
   line-height: 20px;
   max-width: 488px;
-}
-
-@media (--md-down) {
-  .containerOverrides {
-    max-width: 900px;
-  }
-}
-
-@media (--sm-down) {
-  .containerOverrides {
-    max-width: 540px;
-  }
 }

--- a/app/src/userpages/components/ProfilePage/profilePage.pcss
+++ b/app/src/userpages/components/ProfilePage/profilePage.pcss
@@ -3,6 +3,6 @@
 }
 
 .longText {
-  line-height: 20px;
+  line-height: 24px;
   max-width: 488px;
 }

--- a/app/src/userpages/components/PurchasesPage/index.jsx
+++ b/app/src/userpages/components/PurchasesPage/index.jsx
@@ -2,14 +2,13 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Row, Col } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import cx from 'classnames'
 import Helmet from 'react-helmet'
 
 import Layout from '../Layout'
 import links from '../../../links'
-import { defaultColumns, getFilters } from '../../utils/constants'
+import { getFilters } from '../../utils/constants'
 import { getMyPurchases, updateFilter, applyFilter } from '$mp/modules/myPurchaseList/actions'
 import { selectMyPurchaseList, selectSubscriptions, selectFilter, selectFetchingMyPurchaseList } from '$mp/modules/myPurchaseList/selectors'
 import Tile from '$shared/components/Tile'
@@ -19,6 +18,7 @@ import Dropdown from '$shared/components/Dropdown'
 import NoPurchasesView from './NoPurchases'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import ListContainer from '$shared/components/Container/List'
+import TileGrid from '$shared/components/TileGrid'
 
 import type { ProductList, ProductSubscription } from '$mp/flowtype/product-types'
 import type { Filter, SortOption } from '$userpages/flowtype/common-types'
@@ -135,36 +135,35 @@ class PurchasesPage extends Component<Props> {
                             onResetFilter={this.resetFilter}
                         />
                     )}
-                    <Row>
+                    <TileGrid>
                         {purchases.map((product) => {
                             const isActive = subscriptions && isSubscriptionActive(subscriptions.find((s) => s.product.id === product.id))
 
                             return (
-                                <Col {...defaultColumns} key={product.id}>
-                                    <Tile
-                                        imageUrl={product.imageUrl}
-                                        link={product.id && `${links.marketplace.products}/${product.id}`}
+                                <Tile
+                                    key={product.id}
+                                    imageUrl={product.imageUrl}
+                                    link={product.id && `${links.marketplace.products}/${product.id}`}
+                                >
+                                    <Tile.Title>{product.name}</Tile.Title>
+                                    <Tile.Description>{product.owner}</Tile.Description>
+                                    <Tile.Status
+                                        className={
+                                            cx({
+                                                [styles.active]: isActive,
+                                                [styles.expired]: !isActive,
+                                            })}
                                     >
-                                        <Tile.Title>{product.name}</Tile.Title>
-                                        <Tile.Description>{product.owner}</Tile.Description>
-                                        <Tile.Status
-                                            className={
-                                                cx({
-                                                    [styles.active]: isActive,
-                                                    [styles.expired]: !isActive,
-                                                })}
-                                        >
-                                            {
-                                                isActive ?
-                                                    <Translate value="userpages.purchases.active" /> :
-                                                    <Translate value="userpages.purchases.expired" />
-                                            }
-                                        </Tile.Status>
-                                    </Tile>
-                                </Col>
+                                        {
+                                            isActive ?
+                                                <Translate value="userpages.purchases.active" /> :
+                                                <Translate value="userpages.purchases.expired" />
+                                        }
+                                    </Tile.Status>
+                                </Tile>
                             )
                         })}
-                    </Row>
+                    </TileGrid>
                 </ListContainer>
                 <DocsShortcuts />
             </Layout>

--- a/app/src/userpages/components/PurchasesPage/index.jsx
+++ b/app/src/userpages/components/PurchasesPage/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Container, Row, Col } from 'reactstrap'
+import { Row, Col } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import cx from 'classnames'
 import Helmet from 'react-helmet'
@@ -18,6 +18,7 @@ import Search from '../Header/Search'
 import Dropdown from '$shared/components/Dropdown'
 import NoPurchasesView from './NoPurchases'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
+import ListContainer from '$shared/components/Container/List'
 
 import type { ProductList, ProductSubscription } from '$mp/flowtype/product-types'
 import type { Filter, SortOption } from '$userpages/flowtype/common-types'
@@ -126,7 +127,7 @@ class PurchasesPage extends Component<Props> {
                 loading={fetching}
             >
                 <Helmet title={`Streamr Core | ${I18n.t('userpages.title.purchases')}`} />
-                <Container className={styles.corepageContentContainer} >
+                <ListContainer className={styles.corepageContentContainer} >
                     {!fetching && purchases && !purchases.length && (
                         <NoPurchasesView
                             hasFilter={!!filter && (!!filter.search || !!filter.key)}
@@ -164,7 +165,7 @@ class PurchasesPage extends Component<Props> {
                             )
                         })}
                     </Row>
-                </Container>
+                </ListContainer>
                 <DocsShortcuts />
             </Layout>
         )

--- a/app/src/userpages/components/PurchasesPage/purchases.pcss
+++ b/app/src/userpages/components/PurchasesPage/purchases.pcss
@@ -33,10 +33,6 @@
 
 @media (--md-down) {
   :global(html) .corepageContentContainer {
-    width: 100%;
-    max-width: none;
-    padding-right: 24px;
-    padding-left: 24px;
     margin-top: 34px;
   }
 }

--- a/app/src/userpages/components/SplitControl/index.jsx
+++ b/app/src/userpages/components/SplitControl/index.jsx
@@ -1,0 +1,19 @@
+// @flow
+
+import React, { type Node } from 'react'
+import cx from 'classnames'
+
+import styles from './splitControl.pcss'
+
+type Props = {
+    className?: string,
+    children?: Node,
+}
+
+const SplitControl = ({ className, children }: Props) => (
+    <div className={cx(styles.root, className)}>
+        {children}
+    </div>
+)
+
+export default SplitControl

--- a/app/src/userpages/components/SplitControl/splitControl.pcss
+++ b/app/src/userpages/components/SplitControl/splitControl.pcss
@@ -1,0 +1,6 @@
+.root {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 130px;
+  grid-column-gap: 1rem;
+}

--- a/app/src/userpages/components/SplitControl/splitControl.pcss
+++ b/app/src/userpages/components/SplitControl/splitControl.pcss
@@ -2,5 +2,5 @@
   position: relative;
   display: grid;
   grid-template-columns: 1fr 130px;
-  grid-column-gap: 1rem;
+  grid-column-gap: 3rem;
 }

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -48,6 +48,7 @@ import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import breakpoints from '$app/scripts/breakpoints'
 import Notification from '$shared/utils/Notification'
 import LoadMore from '$mp/components/LoadMore'
+import ListContainer from '$shared/components/Container/List'
 
 import styles from './streamsList.pcss'
 
@@ -326,7 +327,7 @@ class StreamList extends Component<Props, State> {
                         onClose={this.onCloseDialog}
                     />
                 )}
-                <div className={cx('container', styles.streamListTabletContainer)}>
+                <ListContainer className={styles.streamListTabletContainer}>
                     {!fetching && streams && streams.length <= 0 && (
                         <NoStreamsView
                             hasFilter={!!filter && (!!filter.search || !!filter.key)}
@@ -490,7 +491,7 @@ class StreamList extends Component<Props, State> {
                             </MediaQuery>
                         </Fragment>
                     )}
-                </div>
+                </ListContainer>
                 <DocsShortcuts />
             </Layout>
         )

--- a/app/src/userpages/components/StreamPage/List/streamsList.pcss
+++ b/app/src/userpages/components/StreamPage/List/streamsList.pcss
@@ -71,15 +71,6 @@
     display: none;
   }
 
-  :global(html) .streamListTabletContainer {
-    width: 100%;
-    max-width: none;
-    padding-right: 16px;
-    padding-left: 16px;
-    margin-right: auto;
-    margin-left: auto;
-  }
-
   .streamsTable {
     margin-top: 50px;
     margin-bottom: 4em;

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
@@ -1,14 +1,15 @@
 // @flow
 
 import React, { Component } from 'react'
-import { Col, Row, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import { I18n, Translate } from 'react-redux-i18n'
 
 import Dropdown from '$shared/components/Dropdown'
 import TextInput from '$shared/components/TextInput'
 import type { StreamField } from '$shared/flowtype/stream-types'
+import SplitControl from '$userpages/components/SplitControl'
 
-import { leftColumn, rightColumn, fieldTypes } from '../../../constants'
+import { fieldTypes } from '../../../constants'
 import styles from './newFieldEditor.pcss'
 
 type Props = {
@@ -86,35 +87,31 @@ export class NewFieldEditor extends Component<Props, State> {
 
         return (
             <div className={styles.container}>
-                <Row>
-                    <Col {...leftColumn}>
-                        <TextInput
-                            value={name}
-                            label={I18n.t('userpages.streams.edit.configure.newFieldEditor.namePlaceholder')}
-                            onChange={(e) => this.onNameChange(e.target.value)}
-                            error={nameError || ''}
-                            autoFocus
-                            onKeyPress={(e) => this.handleKeyPress(e.key)}
-                        />
-                    </Col>
-                    <Col {...rightColumn}>
-                        <Dropdown
-                            title=""
-                            selectedItem={type}
-                            onChange={this.onTypeChange}
-                            className={styles.dropdownToggle}
-                        >
-                            {fieldTypes.map((t) => (
-                                <Dropdown.Item
-                                    key={t}
-                                    value={t}
-                                >
-                                    <Translate value={`userpages.streams.fieldTypes.${t}`} />
-                                </Dropdown.Item>
-                            ))}
-                        </Dropdown>
-                    </Col>
-                </Row>
+                <SplitControl>
+                    <TextInput
+                        value={name}
+                        label={I18n.t('userpages.streams.edit.configure.newFieldEditor.namePlaceholder')}
+                        onChange={(e) => this.onNameChange(e.target.value)}
+                        error={nameError || ''}
+                        autoFocus
+                        onKeyPress={(e) => this.handleKeyPress(e.key)}
+                    />
+                    <Dropdown
+                        title=""
+                        selectedItem={type}
+                        onChange={this.onTypeChange}
+                        className={styles.dropdownToggle}
+                    >
+                        {fieldTypes.map((t) => (
+                            <Dropdown.Item
+                                key={t}
+                                value={t}
+                            >
+                                <Translate value={`userpages.streams.fieldTypes.${t}`} />
+                            </Dropdown.Item>
+                        ))}
+                    </Dropdown>
+                </SplitControl>
                 <Button
                     disabled={nameError !== null}
                     className={styles.addButton}

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
@@ -4,13 +4,12 @@
 
 .fieldHeaderRow,
 .fieldItem {
-  max-width: 682px;
+  max-width: 610px;
 }
 
 .helpText {
   font-size: 14px;
   margin-bottom: 2em;
-  max-width: 682px;
 }
 
 .spinner {
@@ -45,10 +44,15 @@
   .autodetect {
     margin-left: 0;
   }
+
+  .fieldHeaderRow,
+  .fieldItem {
+    max-width: 540px;
+  }
 }
 
 .hoverContainer {
-  width: 100%;
+  margin-right: -120px;
 
   &:hover,
   &:focus {
@@ -69,7 +73,6 @@
 }
 
 .settings {
-  max-width: 682px;
   margin-top: 3em;
 
   label span {

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
@@ -37,7 +37,6 @@
 }
 
 .autodetect {
-  margin-left: 42px;
   height: 32px;
   width: 128px;
 }
@@ -79,15 +78,14 @@
 }
 
 .toggle {
-  label {
-    margin-left: 30px;
-  }
+  text-align: right;
+  margin-top: 0.5rem;
+  margin-bottom: 0;
 }
 
 .fieldHeaderRow {
   .dataTypeHeader {
     font-size: 12px;
-    margin-left: -28px;
   }
 }
 

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Col, Row, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import copy from 'copy-to-clipboard'
 import { arrayMove } from 'react-sortable-hoc'
 import { Translate } from 'react-redux-i18n'
@@ -18,8 +18,9 @@ import { updateEditStreamField, updateEditStream, streamFieldsAutodetect } from 
 import { selectEditedStream, selectFieldsAutodetectFetching } from '$userpages/modules/userPageStreams/selectors'
 import TextInput from '$shared/components/TextInput'
 import Toggle from '$shared/components/Toggle'
+import SplitControl from '$userpages/components/SplitControl'
 
-import { leftColumn, rightColumn, fieldTypes } from '../../constants'
+import { fieldTypes } from '../../constants'
 
 import styles from './configureView.pcss'
 import NewFieldEditor from './NewFieldEditor'
@@ -171,94 +172,70 @@ export class ConfigureView extends Component<Props, State> {
 
         return (
             <div>
-                <Row className={styles.helpText}>
-                    <Col sm={12} md={9}>
-                        <Translate value="userpages.streams.edit.configure.help" tag="p" className={styles.longText} />
-                    </Col>
-                    <Col sm={12} md={3}>
-                        <Button
-                            color="userpages"
-                            className={styles.autodetect}
-                            outline
-                            onClick={this.autodetectFields}
-                            disabled={this.props.fieldsAutodetectFetching || disabled}
-                        >
-                            {!this.props.fieldsAutodetectFetching && (
-                                <Translate value="userpages.streams.edit.configure.autodetect" />
-                            )}
-                            {this.props.fieldsAutodetectFetching && (
-                                <Fragment>
-                                    <Translate value="userpages.streams.edit.configure.waiting" />
-                                    <Spinner size="small" className={styles.spinner} color="white" />
-                                </Fragment>
-                            )}
-                        </Button>
-                    </Col>
-                </Row>
+                <SplitControl className={styles.helpText}>
+                    <Translate value="userpages.streams.edit.configure.help" tag="p" className={styles.longText} />
+                    <Button
+                        color="userpages"
+                        className={styles.autodetect}
+                        outline
+                        onClick={this.autodetectFields}
+                        disabled={this.props.fieldsAutodetectFetching || disabled}
+                    >
+                        {!this.props.fieldsAutodetectFetching && (
+                            <Translate value="userpages.streams.edit.configure.autodetect" />
+                        )}
+                        {this.props.fieldsAutodetectFetching && (
+                            <Fragment>
+                                <Translate value="userpages.streams.edit.configure.waiting" />
+                                <Spinner size="small" className={styles.spinner} color="white" />
+                            </Fragment>
+                        )}
+                    </Button>
+                </SplitControl>
                 {stream && stream.config && stream.config.fields && !!stream.config.fields.length &&
                     <Fragment>
-                        <div className={styles.fieldHeaderRow}>
-                            <Row>
-                                <Col {...leftColumn}>
-                                    <Translate value="userpages.streams.edit.configure.fieldName" />
-                                </Col>
-                                <Col {...rightColumn}>
-                                    <Translate value="userpages.streams.edit.configure.dataType" className={styles.dataTypeHeader} />
-                                </Col>
-                            </Row>
-                        </div>
+                        <SplitControl className={styles.fieldHeaderRow}>
+                            <Translate value="userpages.streams.edit.configure.fieldName" />
+                            <Translate value="userpages.streams.edit.configure.dataType" className={styles.dataTypeHeader} />
+                        </SplitControl>
                         <FieldList onSortEnd={this.onSortEnd}>
                             {stream.config.fields.map((field, index) => (
                                 <div className={styles.hoverContainer} key={field.id || index} >
                                     <div className={styles.fieldItem} >
                                         <FieldItem name={field.name}>
-                                            <Row>
-                                                <Col {...leftColumn}>
-                                                    <Translate
-                                                        value="userpages.streams.edit.configure.fieldName"
-                                                        className={styles.tabletHeading}
-                                                        tag="span"
-                                                    />
-                                                    <TextInput
-                                                        label=""
-                                                        value={field.name}
-                                                        onChange={(e) => this.onFieldNameChange(field.name, e.target.value)}
-                                                        disabled={disabled}
-                                                    />
-                                                </Col>
-                                                <Col {...rightColumn}>
-                                                    <Translate
-                                                        value="userpages.streams.edit.configure.dataType"
-                                                        className={styles.tabletHeading}
-                                                        tag="span"
-                                                    />
-                                                    <Dropdown
-                                                        title=""
-                                                        selectedItem={field.type}
-                                                        onChange={(val) => this.onFieldTypeChange(field.name, val)}
-                                                        className={styles.permissionsDropdown}
-                                                        disabled={disabled}
-                                                    >
-                                                        {fieldTypes.map((t) => (
-                                                            <Dropdown.Item
-                                                                key={t}
-                                                                value={t}
-                                                            >
-                                                                <Translate value={`userpages.streams.fieldTypes.${t}`} />
-                                                            </Dropdown.Item>
-                                                        ))}
-                                                    </Dropdown>
-                                                    <Button
-                                                        outline
-                                                        color="userpages"
-                                                        className={styles.deleteFieldButton}
-                                                        onClick={() => this.deleteField(field.name)}
-                                                        disabled={disabled}
-                                                    >
-                                                        <Translate value="userpages.streams.edit.configure.delete" />
-                                                    </Button>
-                                                </Col>
-                                            </Row>
+                                            <SplitControl>
+                                                <TextInput
+                                                    label=""
+                                                    value={field.name}
+                                                    onChange={(e) => this.onFieldNameChange(field.name, e.target.value)}
+                                                    disabled={disabled}
+                                                />
+                                                <Dropdown
+                                                    title=""
+                                                    selectedItem={field.type}
+                                                    onChange={(val) => this.onFieldTypeChange(field.name, val)}
+                                                    className={styles.permissionsDropdown}
+                                                    disabled={disabled}
+                                                >
+                                                    {fieldTypes.map((t) => (
+                                                        <Dropdown.Item
+                                                            key={t}
+                                                            value={t}
+                                                        >
+                                                            <Translate value={`userpages.streams.fieldTypes.${t}`} />
+                                                        </Dropdown.Item>
+                                                    ))}
+                                                </Dropdown>
+                                                <Button
+                                                    outline
+                                                    color="userpages"
+                                                    className={styles.deleteFieldButton}
+                                                    onClick={() => this.deleteField(field.name)}
+                                                    disabled={disabled}
+                                                >
+                                                    <Translate value="userpages.streams.edit.configure.delete" />
+                                                </Button>
+                                            </SplitControl>
                                         </FieldItem>
                                     </div>
                                 </div>
@@ -285,42 +262,34 @@ export class ConfigureView extends Component<Props, State> {
                 }
                 <div className={styles.settings}>
                     {/* eslint-disable jsx-a11y/label-has-associated-control */}
-                    {stream && stream.autoConfigure !== undefined &&
-                        <Fragment>
-                            <Row>
-                                <Col {...leftColumn}>
-                                    <label htmlFor="auto-configure">
-                                        <Translate value="userpages.streams.edit.configure.autoConfigure" />
-                                    </label>
-                                </Col>
-                                <Col sm={12} md={3} className={styles.toggle}>
-                                    <Toggle
-                                        id="auto-configure"
-                                        value={stream.autoConfigure}
-                                        onChange={this.onAutoConfigureChange}
-                                        disabled={disabled}
-                                    />
-                                </Col>
-                            </Row>
-                        </Fragment>}
-                    <Row>
-                        {stream && stream.requireSignedData !== undefined &&
-                            <Fragment>
-                                <Col {...leftColumn}>
-                                    <label htmlFor="require-signed">
-                                        <Translate value="userpages.streams.edit.configure.requireSignedData" />
-                                    </label>
-                                </Col>
-                                <Col sm={12} md={3} className={styles.toggle}>
-                                    <Toggle
-                                        id="require-signed"
-                                        value={stream.requireSignedData}
-                                        onChange={this.onRequireSignedChange}
-                                        disabled={disabled}
-                                    />
-                                </Col>
-                            </Fragment>}
-                    </Row>
+                    {stream && stream.autoConfigure !== undefined && (
+                        <SplitControl>
+                            <label htmlFor="auto-configure">
+                                <Translate value="userpages.streams.edit.configure.autoConfigure" />
+                            </label>
+                            <Toggle
+                                id="auto-configure"
+                                value={stream.autoConfigure}
+                                onChange={this.onAutoConfigureChange}
+                                disabled={disabled}
+                                className={styles.toggle}
+                            />
+                        </SplitControl>
+                    )}
+                    {stream && stream.requireSignedData !== undefined && (
+                        <SplitControl>
+                            <label htmlFor="require-signed">
+                                <Translate value="userpages.streams.edit.configure.requireSignedData" />
+                            </label>
+                            <Toggle
+                                id="require-signed"
+                                value={stream.requireSignedData}
+                                onChange={this.onRequireSignedChange}
+                                disabled={disabled}
+                                className={styles.toggle}
+                            />
+                        </SplitControl>
+                    )}
                 </div>
             </div>
         )

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/historyView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/historyView.pcss
@@ -22,17 +22,16 @@
 
 .deleteButton,
 .browseFiles {
-  margin-left: -86px;
-  margin-top: 22px;
   height: 32px;
   min-width: 128px;
+  margin-left: 0;
+  margin-top: 18px;
 }
 
-@media (max-width: 1199px) {
+@media (--xl) {
   .deleteButton,
   .browseFiles {
-    margin-left: 0;
-    margin-top: 18px;
+    margin-top: 24px;
   }
 }
 

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Row, Col, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import cx from 'classnames'
 
@@ -19,6 +19,7 @@ import SvgIcon from '$shared/components/SvgIcon'
 import ConfirmCsvImportDialog from '$userpages/components/StreamPage/ConfirmCsvImportDialog'
 import Spinner from '$shared/components/Spinner'
 import CsvSchemaError from '$shared/errors/CsvSchemaError'
+import SplitControl from '$userpages/components/SplitControl'
 
 import styles from './historyView.pcss'
 
@@ -242,91 +243,82 @@ class HistoryView extends Component<Props, State> {
 
         return (
             <div className={styles.historyView}>
-                <Row>
-                    {streamId && (
-                        <Fragment>
-                            <Col md={12}>
-                                <Translate value="userpages.streams.edit.history.upload.description" tag="p" className={styles.longText} />
-                            </Col>
-                            <Col md={12} lg={11}>
-                                <FileUpload
-                                    ref={this.fileUploadRef}
-                                    className={styles.fileUpload}
-                                    component={
-                                        <TextInput
-                                            label={I18n.t('userpages.streams.edit.history.storedEvents')}
-                                            value={storedEventsText}
-                                            readOnly
-                                            preserveLabelSpace
-                                        />
-                                    }
-                                    dropTargetComponent={<DropTarget mouseOver={false} />}
-                                    dragOverComponent={<DropTarget mouseOver />}
-                                    onFilesAccepted={this.onDropAccepted}
-                                    onError={(error) => console.error(error)}
-                                    acceptMime={['text/csv']}
-                                    maxFileSizeInMB={5}
-                                    multiple={false}
-                                    disablePreview
-                                    disabled={disabled}
-                                />
-                            </Col>
-                            <Col md={12} lg={1}>
-                                <Button
-                                    className={styles.browseFiles}
-                                    color="userpages"
-                                    onClick={() => this.handleBrowseFilesClick()}
-                                    disabled={disabled}
-                                >
-                                    <Translate value="userpages.streams.edit.history.uploadCsvButton" />
-                                </Button>
-                            </Col>
-                        </Fragment>
-                    )}
-                    {!streamId && (
-                        <Col md={12}>
-                            <Translate value="userpages.streams.edit.history.saveFirst" tag="p" className={styles.longText} />
-                        </Col>
-                    )}
-                </Row>
-                {streamId && range && (
-                    <Row>
-                        <Col md={12} lg={11}>
-                            <div className={styles.storedEventsContainer}>
-                                <DatePicker
-                                    label={I18n.t('userpages.streams.edit.history.deleteEvents')}
-                                    openOnFocus
-                                    onChange={this.onDeleteDateChanged}
-                                    error={(deleteDataError && deleteDataError.message) || ''}
-                                    value={deleteDate || 'Select date'}
-                                    preserveLabelSpace
-                                    preserveErrorSpace
-                                    className={styles.storedEvents}
-                                    disabled={disabled}
-                                />
-                            </div>
-                        </Col>
-                        <Col md={12} lg={1}>
-                            <Button
-                                className={styles.deleteButton}
-                                color="userpages"
-                                onClick={() => this.deleteDataUpTo(streamId, deleteDate)}
-                                disabled={deleteDate == null || disabled}
-                            >
-                                <Translate value="userpages.streams.edit.history.deleteRange" />
-                                {deleteInProgress &&
-                                    <Fragment>
-                                        <span>&nbsp;</span>
-                                        <Spinner size="small" color="white" />
-                                    </Fragment>
+                {streamId && (
+                    <Fragment>
+                        <SplitControl>
+                            <Translate value="userpages.streams.edit.history.upload.description" tag="p" className={styles.longText} />
+                        </SplitControl>
+                        <SplitControl>
+                            <FileUpload
+                                ref={this.fileUploadRef}
+                                className={styles.fileUpload}
+                                component={
+                                    <TextInput
+                                        label={I18n.t('userpages.streams.edit.history.storedEvents')}
+                                        value={storedEventsText}
+                                        readOnly
+                                        preserveLabelSpace
+                                    />
                                 }
+                                dropTargetComponent={<DropTarget mouseOver={false} />}
+                                dragOverComponent={<DropTarget mouseOver />}
+                                onFilesAccepted={this.onDropAccepted}
+                                onError={(error) => console.error(error)}
+                                acceptMime={['text/csv']}
+                                maxFileSizeInMB={5}
+                                multiple={false}
+                                disablePreview
+                                disabled={disabled}
+                            />
+                            <Button
+                                className={styles.browseFiles}
+                                color="userpages"
+                                onClick={() => this.handleBrowseFilesClick()}
+                                disabled={disabled}
+                            >
+                                <Translate value="userpages.streams.edit.history.uploadCsvButton" />
                             </Button>
-                        </Col>
-                    </Row>
+                        </SplitControl>
+                    </Fragment>
+                )}
+                {!streamId && (
+                    <SplitControl>
+                        <Translate value="userpages.streams.edit.history.saveFirst" tag="p" className={styles.longText} />
+                    </SplitControl>
+                )}
+                {streamId && range && (
+                    <SplitControl>
+                        <div className={styles.storedEventsContainer}>
+                            <DatePicker
+                                label={I18n.t('userpages.streams.edit.history.deleteEvents')}
+                                openOnFocus
+                                onChange={this.onDeleteDateChanged}
+                                error={(deleteDataError && deleteDataError.message) || ''}
+                                value={deleteDate || 'Select date'}
+                                preserveLabelSpace
+                                preserveErrorSpace
+                                className={styles.storedEvents}
+                                disabled={disabled}
+                            />
+                        </div>
+                        <Button
+                            className={styles.deleteButton}
+                            color="userpages"
+                            onClick={() => this.deleteDataUpTo(streamId, deleteDate)}
+                            disabled={deleteDate == null || disabled}
+                        >
+                            <Translate value="userpages.streams.edit.history.deleteRange" />
+                            {deleteInProgress &&
+                                <Fragment>
+                                    <span>&nbsp;</span>
+                                    <Spinner size="small" color="white" />
+                                </Fragment>
+                            }
+                        </Button>
+                    </SplitControl>
                 )}
                 {stream && stream.storageDays !== undefined &&
-                <Row className={styles.storagePeriod}>
-                    <Col xs={12}>
+                    <Fragment>
                         <label htmlFor="storage-period">
                             <Translate
                                 value="userpages.streams.edit.configure.historicalStoragePeriod.description"
@@ -343,8 +335,7 @@ class HistoryView extends Component<Props, State> {
                             preserveLabelSpace
                             disabled={disabled}
                         />
-                    </Col>
-                </Row>}
+                    </Fragment>}
                 {isModalOpen && (
                     <ConfirmCsvImportDialog
                         streamId={streamId}

--- a/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Col, Row, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import copy from 'copy-to-clipboard'
 import { I18n, Translate } from 'react-redux-i18n'
 
@@ -13,6 +13,7 @@ import TextInput from '$shared/components/TextInput'
 import { updateEditStreamField } from '$userpages/modules/userPageStreams/actions'
 import { selectEditedStream } from '$userpages/modules/userPageStreams/selectors'
 import { NotificationIcon } from '$shared/utils/constants'
+import SplitControl from '$userpages/components/SplitControl'
 
 import styles from './infoView.pcss'
 
@@ -100,67 +101,52 @@ export class InfoView extends Component<Props, State> {
 
         return (
             <div className={styles.infoView}>
-                <Row>
-                    <Col md={12}>
-                        <div className={styles.textInput}>
-                            <TextInput
-                                label={I18n.t('userpages.streams.edit.details.name')}
-                                type="text"
-                                name="name"
-                                value={(stream && stream.name) || ''}
-                                onChange={this.onNameChange}
-                                preserveLabelSpace
-                                disabled={disabled}
-                            />
-                        </div>
-                    </Col>
-                </Row>
-                <Row>
-                    <Col md={12}>
-                        <div className={styles.textInput}>
-                            <TextInput
-                                label={I18n.t('userpages.streams.edit.details.description')}
-                                type="text"
-                                name="description"
-                                value={(stream && stream.description) || ''}
-                                onChange={this.onDescriptionChange}
-                                preserveLabelSpace
-                                disabled={disabled}
-                            />
-                        </div>
-                    </Col>
-                </Row>
+                <div className={styles.textInput}>
+                    <TextInput
+                        label={I18n.t('userpages.streams.edit.details.name')}
+                        type="text"
+                        name="name"
+                        value={(stream && stream.name) || ''}
+                        onChange={this.onNameChange}
+                        preserveLabelSpace
+                        disabled={disabled}
+                    />
+                </div>
+                <div className={styles.textInput}>
+                    <TextInput
+                        label={I18n.t('userpages.streams.edit.details.description')}
+                        type="text"
+                        name="description"
+                        value={(stream && stream.description) || ''}
+                        onChange={this.onDescriptionChange}
+                        preserveLabelSpace
+                        disabled={disabled}
+                    />
+                </div>
                 {stream && stream.id &&
-                    <Row>
-                        <Col md={12} lg={11}>
-                            <div className={styles.textInput}>
-                                <TextInput
-                                    label={I18n.t('userpages.streams.edit.details.streamId')}
-                                    type="text"
-                                    name="id"
-                                    value={(stream && stream.id) || ''}
-                                    preserveLabelSpace
-                                    readOnly
-                                    disabled={disabled}
-                                />
-                            </div>
-                        </Col>
-                        <Col
-                            md={12}
-                            lg={1}
+                    <SplitControl>
+                        <div className={styles.textInput}>
+                            <TextInput
+                                label={I18n.t('userpages.streams.edit.details.streamId')}
+                                type="text"
+                                name="id"
+                                value={(stream && stream.id) || ''}
+                                preserveLabelSpace
+                                readOnly
+                                disabled={disabled}
+                            />
+                        </div>
+                        <Button
+                            color="userpages"
+                            className={styles.copyStreamIdButton}
+                            onClick={() => this.copyStreamTap(stream.id)}
                         >
-                            <Button
-                                color="userpages"
-                                className={styles.copyStreamIdButton}
-                                onClick={() => this.copyStreamTap(stream.id)}
-                            >
-                                {idCopied ?
-                                    <Translate value="userpages.streams.edit.details.copied" /> :
-                                    <Translate value="userpages.streams.edit.details.copyStreamId" />
-                                }
-                            </Button>
-                        </Col>
-                    </Row>
+                            {idCopied ?
+                                <Translate value="userpages.streams.edit.details.copied" /> :
+                                <Translate value="userpages.streams.edit.details.copyStreamId" />
+                            }
+                        </Button>
+                    </SplitControl>
                 }
             </div>
         )

--- a/app/src/userpages/components/StreamPage/Show/InfoView/infoView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/infoView.pcss
@@ -3,31 +3,29 @@
 }
 
 .textInput {
-  margin-bottom: 2rem;
+  margin-bottom: 3rem;
 }
 
 .copyStreamIdButton {
-  margin-left: -86px;
-  margin-top: 22px;
   width: 128px;
   height: 32px;
+  margin-top: 24px;
 }
 
-@media (max-width: 1199px) {
+@media (--md-up) {
   .copyStreamIdButton {
-    margin-top: 18px;
+    margin-top: 10px;
   }
 }
 
-@media (--lg-down) {
+@media (--lg-up) {
   .copyStreamIdButton {
-    margin-left: initial;
+    margin-top: 16px;
   }
 }
 
-@media (--md-down) {
+@media (--xl) {
   .copyStreamIdButton {
-    margin-left: initial;
-    margin-top: 0;
+    margin-top: 24px;
   }
 }

--- a/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
@@ -3,7 +3,6 @@
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
 import { Translate } from 'react-redux-i18n'
-import { Row, Col } from 'reactstrap'
 import { formatPath } from '$shared/utils/url'
 import { Link } from 'react-router-dom'
 
@@ -69,26 +68,20 @@ export class KeyView extends Component<Props> {
         const keys = this.props.keys || []
         return (
             <Fragment>
-                <Row>
-                    <Col xs={12}>
-                        <p className={styles.longText}>
-                            <Translate value="userpages.streams.edit.apiCredentials.description" />
-                            <Link to={formatPath(links.userpages.profile)}>Settings</Link>.
-                        </p>
-                    </Col>
-                    <Col xs={12}>
-                        <CredentialsControl
-                            keys={keys}
-                            addKey={this.addKey}
-                            editStreamResourceKey={this.editStreamResourceKey}
-                            removeKey={this.removeKey}
-                            showPermissionType
-                            newStream={!this.props.streamId}
-                            streamId={this.props.streamId}
-                            disabled={disabled}
-                        />
-                    </Col>
-                </Row>
+                <p className={styles.longText}>
+                    <Translate value="userpages.streams.edit.apiCredentials.description" />
+                    <Link to={formatPath(links.userpages.profile)}>Settings</Link>.
+                </p>
+                <CredentialsControl
+                    keys={keys}
+                    addKey={this.addKey}
+                    editStreamResourceKey={this.editStreamResourceKey}
+                    removeKey={this.removeKey}
+                    showPermissionType
+                    newStream={!this.props.streamId}
+                    streamId={this.props.streamId}
+                    disabled={disabled}
+                />
             </Fragment>
         )
     }

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { Component, Fragment } from 'react'
-import { Col, Row, Button } from 'reactstrap'
+import { Button } from 'reactstrap'
 import { Link } from 'react-router-dom'
 import { Translate } from 'react-redux-i18n'
 import cx from 'classnames'
@@ -51,56 +51,48 @@ export class PreviewView extends Component<Props, State> {
         if (stream) {
             return (
                 <Fragment>
-                    <Row>
-                        <Col xs={12}>
-                            <Translate value="userpages.streams.edit.preview.description" className={styles.longText} tag="p" />
-                        </Col>
-                    </Row>
-                    <Row>
-                        <Col xs={12}>
-                            <p className={!hasData && styles.hasData}>
-                                This Stream has no data yet.
-                                Check out the <Link to={routes.docsGettingStarted()}>Docs</Link> for a guide to push data to your stream.
-                            </p>
-                            <div
-                                className={cx(styles.previewContainer, {
-                                    [styles.hasData]: hasData,
-                                })}
-                            >
-                                <div className={styles.previewControls}>
-                                    <Button color="userpages" className={styles.playPauseButton} onClick={this.onToggleRun}>
-                                        {!isRunning ?
-                                            <SvgIcon name="play" className={styles.icon} /> :
-                                            <SvgIcon name="pause" className={styles.icon} />
-                                        }
-                                    </Button>
-                                    {stream && stream.id && (
-                                        <Button
-                                            className={styles.inspectButton}
-                                            color="userpages"
-                                            tag={Link}
-                                            to={routes.userPageStreamPreview({
-                                                streamId: stream.id,
-                                            })}
-                                        >
-                                            <Translate value="userpages.streams.edit.preview.inspect" />
-                                        </Button>
-                                    )}
-                                </div>
-                                <StreamLivePreview
-                                    key={stream.id}
-                                    streamId={stream.id}
-                                    currentUser={currentUser}
-                                    authApiKeyId={authApiKeyId}
-                                    onSelectDataPoint={() => {}}
-                                    selectedDataPoint={null}
-                                    run={isRunning}
-                                    userpagesPreview
-                                    hasData={this.setHasData}
-                                />
-                            </div>
-                        </Col>
-                    </Row>
+                    <Translate value="userpages.streams.edit.preview.description" className={styles.longText} tag="p" />
+                    <p className={!hasData && styles.hasData}>
+                        This Stream has no data yet.
+                        Check out the <Link to={routes.docsGettingStarted()}>Docs</Link> for a guide to push data to your stream.
+                    </p>
+                    <div
+                        className={cx(styles.previewContainer, {
+                            [styles.hasData]: hasData,
+                        })}
+                    >
+                        <div className={styles.previewControls}>
+                            <Button color="userpages" className={styles.playPauseButton} onClick={this.onToggleRun}>
+                                {!isRunning ?
+                                    <SvgIcon name="play" className={styles.icon} /> :
+                                    <SvgIcon name="pause" className={styles.icon} />
+                                }
+                            </Button>
+                            {stream && stream.id && (
+                                <Button
+                                    className={styles.inspectButton}
+                                    color="userpages"
+                                    tag={Link}
+                                    to={routes.userPageStreamPreview({
+                                        streamId: stream.id,
+                                    })}
+                                >
+                                    <Translate value="userpages.streams.edit.preview.inspect" />
+                                </Button>
+                            )}
+                        </div>
+                        <StreamLivePreview
+                            key={stream.id}
+                            streamId={stream.id}
+                            currentUser={currentUser}
+                            authApiKeyId={authApiKeyId}
+                            onSelectDataPoint={() => {}}
+                            selectedDataPoint={null}
+                            run={isRunning}
+                            userpagesPreview
+                            hasData={this.setHasData}
+                        />
+                    </div>
                 </Fragment>
             )
         }

--- a/app/src/userpages/components/StreamPage/Show/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/index.jsx
@@ -4,7 +4,6 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { I18n } from 'react-redux-i18n'
 import { push } from 'connected-react-router'
-import cx from 'classnames'
 import { withRouter } from 'react-router-dom'
 import MediaQuery from 'react-responsive'
 
@@ -28,6 +27,7 @@ import { getMyResourceKeys } from '$shared/modules/resourceKey/actions'
 import { selectEditedStream, selectPermissions } from '$userpages/modules/userPageStreams/selectors'
 import { selectUserData } from '$shared/modules/user/selectors'
 import { selectAuthApiKeyId } from '$shared/modules/resourceKey/selectors'
+import DetailsContainer from '$shared/components/Container/Details'
 import TOCPage from '$userpages/components/TOCPage'
 import Toolbar from '$shared/components/Toolbar'
 import routes from '$routes'
@@ -179,6 +179,7 @@ export class StreamShowView extends Component<Props, State> {
         return (
             <CoreLayout
                 className={styles.streamShowView}
+                hideNavOnDesktop
                 navComponent={(
                     <MediaQuery minWidth={lg.min}>
                         {(isDesktop) => (
@@ -215,7 +216,7 @@ export class StreamShowView extends Component<Props, State> {
                 <MediaQuery minWidth={lg.min}>
                     <ConfigureAnchorOffset value={-80} />
                 </MediaQuery>
-                <div className={cx('container', styles.containerOverrides)}>
+                <DetailsContainer className={styles.streamShowView}>
                     <TOCPage title="Set up your Stream">
                         <TOCPage.Section
                             id="details"
@@ -258,7 +259,7 @@ export class StreamShowView extends Component<Props, State> {
                             />
                         </TOCPage.Section>
                     </TOCPage>
-                </div>
+                </DetailsContainer>
             </CoreLayout>
         )
     }

--- a/app/src/userpages/components/StreamPage/Show/streamShowView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/streamShowView.pcss
@@ -1,47 +1,5 @@
 .streamShowView {
-  position: relative;
-  color: var(--greyDark);
-  font-size: 14px;
   padding-bottom: 3em;
-  min-height: calc(100vh - 152px);
-
-  @media (--lg-up) {
-    top: -7.4em;
-
-    /* 80px of navbar + 2.5 of top padding at the layout level. */
-    top: calc(-2.5rem - 80px);
-    z-index: 11;
-  }
-
-  @media (--xs) {
-    top: auto;
-  }
-}
-
-/* Some extra media queries due to the 'delete' btn hover state of the field editor */
-
-@media (max-width: 1100px) {
-  .containerOverrides {
-    max-width: 900px;
-  }
-}
-
-@media (--lg-down) {
-  .containerOverrides {
-    max-width: 790px;
-  }
-}
-
-@media (--md-down) {
-  .containerOverrides {
-    max-width: 900px;
-  }
-}
-
-@media (--sm-down) {
-  .containerOverrides {
-    max-width: 540px;
-  }
 }
 
 .longText {

--- a/app/src/userpages/components/StreamPage/Show/streamShowView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/streamShowView.pcss
@@ -1,5 +1,6 @@
 .streamShowView {
   padding-bottom: 3em;
+  font-size: 14px;
 }
 
 .longText {

--- a/app/src/userpages/components/TOCPage/TOCSection/index.jsx
+++ b/app/src/userpages/components/TOCPage/TOCSection/index.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { type Node } from 'react'
-import { Col, Row } from 'reactstrap'
 import ScrollableAnchor from 'react-scrollable-anchor'
 import cx from 'classnames'
 
@@ -22,16 +21,8 @@ export const TOCSection = ({ id, title, children, customStyled }: Props) => (
                 [styles.hideTablet]: customStyled,
             })}
         >
-            <Row>
-                <Col xs={12}>
-                    <h3 className={styles.title}>{title}</h3>
-                </Col>
-            </Row>
-            <Row>
-                <Col xs={12}>
-                    {children}
-                </Col>
-            </Row>
+            <h3 className={styles.title}>{title}</h3>
+            {children}
         </div>
     </ScrollableAnchor>
 )

--- a/app/src/userpages/components/TOCPage/index.jsx
+++ b/app/src/userpages/components/TOCPage/index.jsx
@@ -24,29 +24,31 @@ const TOCPage = withRouter(({ children, location: { hash }, title, className }: 
                 <h1 className={styles.pageTitle}>{title}</h1>
             </React.Fragment>
         )}
-        <ul className={styles.tocList}>
-            {React.Children.map(children, (child) => {
-                if (child.type === TOCSection) {
-                    return (
-                        <li
-                            key={child.props.id}
-                            className={cx(styles.tocListItem, {
-                                [styles.hideTablet]: child.props.customStyled,
-                            })}
-                        >
-                            <a
-                                href={`#${child.props.id}`}
-                                className={cx({
-                                    [styles.active]: hash.substr(1) === child.props.id,
+        <div>
+            <ul className={styles.tocList}>
+                {React.Children.map(children, (child) => {
+                    if (child.type === TOCSection) {
+                        return (
+                            <li
+                                key={child.props.id}
+                                className={cx(styles.tocListItem, {
+                                    [styles.hideTablet]: child.props.customStyled,
                                 })}
                             >
-                                {child.props.linkTitle || child.props.title}
-                            </a>
-                        </li>
-                    )
-                }
-            })}
-        </ul>
+                                <a
+                                    href={`#${child.props.id}`}
+                                    className={cx({
+                                        [styles.active]: hash.substr(1) === child.props.id,
+                                    })}
+                                >
+                                    {child.props.linkTitle || child.props.title}
+                                </a>
+                            </li>
+                        )
+                    }
+                })}
+            </ul>
+        </div>
         <div>
             {children}
         </div>

--- a/app/src/userpages/components/TOCPage/index.jsx
+++ b/app/src/userpages/components/TOCPage/index.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { type Node } from 'react'
-import { Col, Row } from 'reactstrap'
 import { withRouter } from 'react-router-dom'
 import cx from 'classnames'
 
@@ -14,40 +13,44 @@ type Props = {
     location: {
         hash: string,
     },
+    className?: string,
 }
 
-const TOCPage = withRouter(({ children, location: { hash }, title }: Props) => (
-    <Row>
-        <Col xs={12} sm={12} md={3}>
-            <ul className={styles.tocList}>
-                {React.Children.map(children, (child) => {
-                    if (child.type === TOCSection) {
-                        return (
-                            <li
-                                key={child.props.id}
-                                className={cx(styles.tocListItem, {
-                                    [styles.hideTablet]: child.props.customStyled,
+const TOCPage = withRouter(({ children, location: { hash }, title, className }: Props) => (
+    <div className={cx(styles.root, className)}>
+        {!!title && (
+            <React.Fragment>
+                <div className={styles.pageTitle} />
+                <h1 className={styles.pageTitle}>{title}</h1>
+            </React.Fragment>
+        )}
+        <ul className={styles.tocList}>
+            {React.Children.map(children, (child) => {
+                if (child.type === TOCSection) {
+                    return (
+                        <li
+                            key={child.props.id}
+                            className={cx(styles.tocListItem, {
+                                [styles.hideTablet]: child.props.customStyled,
+                            })}
+                        >
+                            <a
+                                href={`#${child.props.id}`}
+                                className={cx({
+                                    [styles.active]: hash.substr(1) === child.props.id,
                                 })}
                             >
-                                <a
-                                    href={`#${child.props.id}`}
-                                    className={cx({
-                                        [styles.active]: hash.substr(1) === child.props.id,
-                                    })}
-                                >
-                                    {child.props.linkTitle || child.props.title}
-                                </a>
-                            </li>
-                        )
-                    }
-                })}
-            </ul>
-        </Col>
-        <Col xs={12} sm={12} md={9} >
-            {!!title && (<h1 className={styles.pageTitle}>{title}</h1>)}
+                                {child.props.linkTitle || child.props.title}
+                            </a>
+                        </li>
+                    )
+                }
+            })}
+        </ul>
+        <div>
             {children}
-        </Col>
-    </Row>
+        </div>
+    </div>
 ))
 
 TOCPage.Section = TOCSection

--- a/app/src/userpages/components/TOCPage/tocPage.pcss
+++ b/app/src/userpages/components/TOCPage/tocPage.pcss
@@ -1,3 +1,9 @@
+.root {
+  display: grid;
+  grid-template-columns: 11.25rem 1fr;
+  grid-column-gap: 4rem;
+}
+
 .pageTitle {
   color: var(--greyDark);
   font-size: 2.2rem;
@@ -9,11 +15,12 @@
 
 .tocList {
   list-style-type: none;
-  margin: 182px 4em 1em 0;
+  margin: 1rem 4rem 1rem 0;
   padding: 0;
   text-align: right;
   position: sticky;
   top: 7em;
+  width: 100%;
 }
 
 .tocListItem {
@@ -50,6 +57,10 @@
 }
 
 @media (--sm-down) {
+  .root {
+    display: block;
+  }
+
   .tocList {
     display: none;
   }

--- a/app/src/userpages/components/TransactionPage/List/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/index.jsx
@@ -26,6 +26,7 @@ import DropdownActions from '$shared/components/DropdownActions'
 import Meatball from '$shared/components/Meatball'
 import LoadMore from '$mp/components/LoadMore'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
+import ListContainer from '$shared/components/Container/List'
 import { selectAccountId } from '$mp/modules/web3/selectors'
 import { areAddressesEqual } from '$mp/utils/smartContract'
 
@@ -93,7 +94,7 @@ class TransactionList extends Component<Props> {
                 }
             >
                 <Helmet title={`Streamr Core | ${I18n.t('userpages.title.transactions')}`} />
-                <div className={cx('container', styles.transactionList)}>
+                <ListContainer className={styles.transactionList}>
                     {!fetching && transactions && transactions.length <= 0 && (
                         <NoTransactionsView
                             accountsExist={accountsExist}
@@ -176,7 +177,7 @@ class TransactionList extends Component<Props> {
                             onClick={this.props.showEvents}
                         />
                     )}
-                </div>
+                </ListContainer>
                 <DocsShortcuts />
             </Layout>
         )


### PR DESCRIPTION
On top of #610, this adds shared container components with the idea of replacing the `Container` and `Row`/`Column` from `react-strap`.

Summary of changes:

* There is a separate container for list views and edit pages (`shared/components/Container/List` and `../Details`)
* Added option to `CoreLayout` to hide the menu under the toolbar in settings pages (so it's not lifted up anymore and there isn't a white bar visible in the bottom)
* Added `TileGrid` to display thumbnails pages (doesn't include the marketplace yet)
* Added `SplitControl` to handle permission dropdowns and buttons