### PR TITLE
Refactor Toolbar for full width

### DIFF
--- a/app/src/marketplace/components/ProductPage/index.jsx
+++ b/app/src/marketplace/components/ProductPage/index.jsx
@@ -69,7 +69,7 @@ class ProductPage extends Component<Props> {
         return !!product && (
             <div className={classNames(styles.productPage, !!showToolbar && styles.withToolbar)}>
                 {showToolbar && (
-                    <Toolbar status={toolbarStatus} actions={toolbarActions} />
+                    <Toolbar left={toolbarStatus} actions={toolbarActions} />
                 )}
                 <Hero
                     product={product}

--- a/app/src/marketplace/components/ProductPageEditor/index.jsx
+++ b/app/src/marketplace/components/ProductPageEditor/index.jsx
@@ -56,7 +56,7 @@ export default class ProductPage extends Component<Props> {
 
         return !!product && (
             <div className={styles.productPage}>
-                <Toolbar actions={toolbarActions} status={<BackButton />} />
+                <Toolbar actions={toolbarActions} left={<BackButton />} />
                 <Hero
                     product={product}
                     leftContent={<ImageUpload

--- a/app/src/marketplace/components/Steps/index.jsx
+++ b/app/src/marketplace/components/Steps/index.jsx
@@ -89,7 +89,7 @@ class Steps extends Component<Props, State> {
             {this.tabs()}
             {this.contents()}
             <Buttons
-                className={classNames({
+                className={classNames(styles.buttons, {
                     [styles.withErrors]: !!this.props.errors,
                 })}
                 actions={{

--- a/app/src/marketplace/components/Steps/steps.pcss
+++ b/app/src/marketplace/components/Steps/steps.pcss
@@ -2,6 +2,10 @@
   width: 100%;
 }
 
+.buttons {
+  padding: 20px 0;
+}
+
 .errors {
   float: left;
   padding: 20px 0;

--- a/app/src/marketplace/containers/EditProductPage2/editProductPage.pcss
+++ b/app/src/marketplace/containers/EditProductPage2/editProductPage.pcss
@@ -13,6 +13,6 @@
 
 .editor {
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: 200px 1fr;
   grid-column-gap: 2.25rem;
 }

--- a/app/src/marketplace/containers/EditProductPage2/index.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/index.jsx
@@ -1,12 +1,13 @@
 // @flow
 
 import React from 'react'
-import { Container } from 'reactstrap'
 import { withRouter } from 'react-router-dom'
 import cx from 'classnames'
 
-import Layout from '$shared/components/Layout'
+import CoreLayout from '$shared/components/Layout/Core'
 import * as UndoContext from '$shared/components/UndoContextProvider'
+import DetailsContainer from '$shared/components/Container/Details'
+import Toolbar from '$shared/components/Toolbar'
 
 import ProductController from '../ProductController'
 import useProduct from '../ProductController/useProduct'
@@ -17,12 +18,11 @@ import CoverImage from './CoverImage'
 import ProductDescription from './ProductDescription'
 import StreamSelector from './StreamSelector'
 import PriceSelector from './PriceSelector'
-
 import styles from './editProductPage.pcss'
 
 const EditProductPage = () => (
     <div className={cx(styles.root, styles.EditProductPage)}>
-        <Container className={styles.container}>
+        <DetailsContainer className={styles.container}>
             <div className={styles.editor}>
                 <div className={styles.nav}>
                     <EditorNav />
@@ -35,7 +35,7 @@ const EditProductPage = () => (
                     <PriceSelector />
                 </div>
             </div>
-        </Container>
+        </DetailsContainer>
     </div>
 )
 
@@ -65,7 +65,34 @@ const ProductContainer = withRouter((props) => (
 ))
 
 export default () => (
-    <Layout className={styles.layout}>
+    <CoreLayout
+        className={styles.layout}
+        hideNavOnDesktop
+        navComponent={(
+            <Toolbar
+                actions={{
+                    saveAndExit: {
+                        title: 'Save & Exit',
+                        color: 'link',
+                        outline: true,
+                        onClick: () => {},
+                    },
+                    preview: {
+                        title: 'Preview',
+                        outline: true,
+                        onClick: () => {},
+                    },
+                    continue: {
+                        title: 'Continue',
+                        color: 'primary',
+                        onClick: () => {},
+                        disabled: true,
+                    },
+                }}
+                altMobileLayout
+            />
+        )}
+    >
         <ProductContainer />
-    </Layout>
+    </CoreLayout>
 )

--- a/app/src/shared/components/Buttons/buttons.pcss
+++ b/app/src/shared/components/Buttons/buttons.pcss
@@ -1,5 +1,4 @@
 .buttons {
-  padding: 20px 0;
   display: flex;
   justify-content: flex-end;
 
@@ -19,12 +18,5 @@
 }
 
 .buttons > :global(.btn) + :global(.btn) {
-  margin-left: 12px;
-}
-
-@media (--xs) {
-  .buttons {
-    padding: 20px 0 !important;
-    justify-content: center;
-  }
+  margin-left: 1rem;
 }

--- a/app/src/shared/components/ConfirmDialog/confirmDialog.pcss
+++ b/app/src/shared/components/ConfirmDialog/confirmDialog.pcss
@@ -3,12 +3,15 @@
 }
 
 .footer {
-  padding: 0 37px;
+  padding: 20px 37px;
+}
+
+.dontShowAgainFooter {
   display: flex;
   align-items: center;
 }
 
-.downShowAgain {
+.dontShowAgain {
   flex: 1;
   text-align: left;
 }

--- a/app/src/shared/components/ConfirmDialog/index.jsx
+++ b/app/src/shared/components/ConfirmDialog/index.jsx
@@ -87,13 +87,13 @@ const ConfirmDialog = (props: Props) => {
                 onClose={actions.cancel.onClick}
                 actions={actions}
                 renderActions={() => (
-                    <div className={cx({
-                        [styles.footer]: !!dontShowAgain,
+                    <div className={cx(styles.footer, {
+                        [styles.dontShowAgainFooter]: !!dontShowAgain,
                     })}
                     >
                         {!!dontShowAgain && (
                             <div className={cx({
-                                [styles.downShowAgain]: !!dontShowAgain,
+                                [styles.dontShowAgain]: !!dontShowAgain,
                             })}
                             >
                                 <FormGroup check className={styles.formGroup}>

--- a/app/src/shared/components/Toolbar/index.jsx
+++ b/app/src/shared/components/Toolbar/index.jsx
@@ -3,33 +3,37 @@
 import React, { type Node } from 'react'
 import cx from 'classnames'
 
-import { Container } from 'reactstrap'
 import Buttons, { type ButtonActions } from '$shared/components/Buttons'
 
 import styles from './toolbar.pcss'
 
 type Props = {
-    status?: Node,
+    left?: Node,
+    middle?: Node,
     actions?: ButtonActions,
     altMobileLayout?: boolean,
 }
 
-const Toolbar = ({ status, actions, altMobileLayout }: Props) => (
+const Toolbar = ({ left, middle, actions, altMobileLayout }: Props) => (
     <div
         className={cx(styles.toolbar, {
             [styles.altMobileLayout]: altMobileLayout,
         })}
     >
-        <Container className={styles.container}>
-            <div className={styles.left}>
-                {status}
-            </div>
-            <div className={styles.right}>
-                {actions && (
-                    <Buttons actions={actions} className={styles.buttons} />
-                )}
-            </div>
-        </Container>
+        <div className={cx(styles.left, {
+            [styles.noMiddle]: !middle,
+        })}
+        >
+            {left}
+        </div>
+        <div className={styles.middle}>
+            {middle}
+        </div>
+        <div className={styles.right}>
+            {actions && (
+                <Buttons actions={actions} className={styles.buttons} />
+            )}
+        </div>
     </div>
 )
 

--- a/app/src/shared/components/Toolbar/toolbar.pcss
+++ b/app/src/shared/components/Toolbar/toolbar.pcss
@@ -1,5 +1,5 @@
 .toolbar {
-  padding: 20px 0;
+  padding: 1.25rem 2rem;
   display: flex;
   position: sticky;
   top: 0;
@@ -22,44 +22,30 @@
   }
 }
 
-.container {
-  display: flex;
-}
-
-@media (--md-down) {
-  .container {
-    max-width: 100%;
-  }
-}
-
-.left,
-.right {
-  button,
-  a {
-    margin: 0 10px;
-  }
-}
+.noMiddle {}
 
 .left {
-  flex: 50%;
+  flex: 1;
   text-align: left;
   display: flex;
   align-items: center;
+
+  &.noMiddle:empty {
+    display: none;
+  }
+}
+
+.middle {
+  &:empty {
+    display: none;
+  }
 }
 
 .right {
-  flex: 50%;
+  flex: 1;
   text-align: right;
-}
 
-.buttons {
-  display: flex;
-  flex-wrap: nowrap;
-  justify-content: flex-end;
-  padding: 0;
-}
-
-.buttons > *:last-child {
-  margin-right: 0;
-  min-width: 168px;
+  &:empty {
+    display: none;
+  }
 }

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -77,7 +77,6 @@ export class ProfilePage extends Component<Props, State> {
         const { saving } = this.state
         return (
             <CoreLayout
-                className={styles.profilePage}
                 hideNavOnDesktop
                 navComponent={(
                     <Toolbar

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/shareDialogContent.pcss
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/shareDialogContent.pcss
@@ -9,7 +9,7 @@
 
 .footer {
   display: flex;
-  padding: 0 37px;
+  padding: 20px 37px;
   align-items: center;
 }
 

--- a/app/src/userpages/components/StreamPage/Show/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/index.jsx
@@ -178,7 +178,6 @@ export class StreamShowView extends Component<Props, State> {
 
         return (
             <CoreLayout
-                className={styles.streamShowView}
                 hideNavOnDesktop
                 navComponent={(
                     <MediaQuery minWidth={lg.min}>

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -41,6 +41,7 @@ import Tooltip from '$shared/components/Tooltip'
 import ContextMenu from '$shared/components/ContextMenu'
 import { NotificationIcon } from '$shared/utils/constants'
 import RadioButtonGroup from '$shared/components/RadioButtonGroup'
+import Toolbar from '$shared/components/Toolbar'
 
 import sharedStyles from './shared.pcss'
 
@@ -689,5 +690,48 @@ story('RadioButtonGroup')
             options={['value 1', 'value 2', 'value 3']}
             selectedOption="value 2"
             onChange={action('selected')}
+        />
+    ))
+
+const toolbarActions = {
+    cancel: {
+        title: 'Cancel',
+        color: 'link',
+        onClick: action('cancel'),
+    },
+    ok: {
+        title: 'Ok',
+        color: 'primary',
+        onClick: action('ok'),
+        disabled: boolean('disabled'),
+        spinner: boolean('spinner'),
+    },
+}
+
+story('Toolbar')
+    .addDecorator(styles({
+        backgroundColor: '#323232',
+        padding: '15px',
+    }))
+    .addWithJSX('basic', () => (
+        <Toolbar actions={toolbarActions} />
+    ))
+    .addWithJSX('left status text', () => (
+        <Toolbar
+            left={text('status text', 'status')}
+            actions={toolbarActions}
+        />
+    ))
+    .addWithJSX('middle icon', () => (
+        <Toolbar
+            left={text('status text', 'status')}
+            middle={<SvgIcon
+                name="user"
+                style={{
+                    width: '40px',
+                    height: '40px',
+                }}
+            />}
+            actions={toolbarActions}
         />
     ))


### PR DESCRIPTION
Make toolbar full width in product, profile and stream edit page. Added also a `middle` prop that can be used for the wallet status icon (can be seen in storybook). I removed the padding from the `Buttons` component which was used in these components (other than the toolbar):

- `Steps`
- `ConfirmDialog`
- `Dialog`
- `KeyFieldEditor`
- `ShareDialogContent`
- `SnippetDialog`

I checked that these should work as before but let know if there are problems.