### PR TITLE
[PLATFORM-955] Clip long module/stream results text with ellipsis.

### DIFF
--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -108,6 +108,7 @@ const ModuleMenuItem = ({ module, addModule }) => (
         onDragStart={(e) => { onDragStart(e, module.id, module.name) }}
         onClick={() => addModule(module.id)}
         className={styles.ModuleItem}
+        title={startCase(module.name)}
     >
         {startCase(module.name)}
     </SearchRow>
@@ -350,6 +351,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                         draggable
                         onDragStart={(e) => { onDragStart(e, m.id, m.name) }}
                         onClick={() => this.addModule(m.id)}
+                        title={startCase(m.name)}
                     >
                         <span className={styles.ModuleName}>{startCase(m.name)}</span>
                         <span className={styles.ModuleCategory}>{m.path}</span>
@@ -366,8 +368,9 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                         draggable
                         onDragStart={(e) => { onDragStart(e, STREAM_MODULE_ID, stream.name, stream.id) }}
                         onClick={() => this.addModule(STREAM_MODULE_ID, null, null, stream.id)}
+                        title={[stream.name, stream.description].filter(Boolean).join('\n\n')}
                     >
-                        {stream.name}
+                        <span className={styles.StreamName}>{stream.name}</span>
                         <div className={styles.Description}>{stream.description || 'No description'}</div>
                     </SearchRow>
                 ))}

--- a/app/src/editor/canvas/components/ModuleSearch.pcss
+++ b/app/src/editor/canvas/components/ModuleSearch.pcss
@@ -2,6 +2,15 @@
 
 }
 
+.SearchCategory > span,
+.ModuleItem > span,
+.StreamItem > span {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 100%;
+}
+
 body .Category {
   display: flex;
   align-items: center;

--- a/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
+++ b/app/src/editor/shared/components/SearchPanel/SearchPanel.pcss
@@ -184,6 +184,9 @@
   letter-spacing: 0;
   border-bottom: 1px solid #EFEFEF;
   transition: background 0.1s, color 0.1s;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 100%;
 }
 
 .SearchRow:first-child {


### PR DESCRIPTION
Clip long module/stream results text with ellipsis.
Show full text in native tooltip.

![image](https://user-images.githubusercontent.com/43438/62443091-89665400-b78c-11e9-9df0-617f33500d4d.png)
