### PR TITLE
[PLATFORM-992] Block edits while canvas is not editable

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/Run.jsx
+++ b/app/src/editor/canvas/components/CanvasController/Run.jsx
@@ -38,6 +38,7 @@ function useRunController(canvas = EMPTY) {
     const stopPending = usePending('canvas.STOP')
     const exitPending = usePending('canvas.EXIT')
     const unlinkPending = usePending('canvas.UNLINK')
+    const loadPending = usePending('canvas.LOAD')
 
     const [isStarting, setIsStarting] = useState(false) // true immediately before starting a canvas
     const [isStopping, setIsStopping] = useState(false) // true immediately before stopping a canvas
@@ -131,6 +132,7 @@ function useRunController(canvas = EMPTY) {
     useCanvasStateChangeEffect(canvas, useCallback(() => setIsStopping(false), [setIsStopping]))
 
     const isAnyPending = [
+        loadPending,
         createAdhocPending,
         startPending,
         stopPending,

--- a/app/src/editor/canvas/components/CanvasController/Run.jsx
+++ b/app/src/editor/canvas/components/CanvasController/Run.jsx
@@ -53,10 +53,6 @@ function useRunController(canvas = EMPTY) {
     const hasWritePermission = permissions &&
         permissions.some((p) => p.operation === 'write')
 
-    const isEditable = !isActive &&
-        !canvas.adhoc &&
-        hasWritePermission
-
     const start = useCallback(async (canvas, options) => {
         if (isHistorical && !canvas.adhoc) {
             const newCanvas = await createAdhocPending.wrap(() => services.createAdhocCanvas(canvas))
@@ -144,6 +140,17 @@ function useRunController(canvas = EMPTY) {
 
     const isPending = !!(isStopping || isStarting || isAnyPending)
 
+    // e.g. move/resize but not commit
+    const isAdjustable = !isPending
+
+    // write commits
+    const isEditable = (
+        !isActive &&
+        isAdjustable &&
+        !canvas.adhoc &&
+        hasWritePermission
+    )
+
     // controls whether user can currently start/stop canvas
     const canChangeRunState = (
         !isPending && // no pending
@@ -165,13 +172,14 @@ function useRunController(canvas = EMPTY) {
         isActive,
         isRunning,
         isHistorical,
+        isAdjustable,
         isEditable,
         hasSharePermission,
         hasWritePermission,
         start,
         stop,
         exit,
-    }), [canvas, isPending, isStarting, isActive, isRunning, isHistorical, isEditable,
+    }), [canvas, isPending, isStarting, isActive, isRunning, isHistorical, isEditable, isAdjustable,
         hasSharePermission, hasWritePermission, isStopping, start, stop, exit, canChangeRunState])
 }
 

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -142,6 +142,7 @@ class CanvasModule extends React.PureComponent {
         } = this.props
 
         const { layout } = this.state
+        const { isAdjustable, isEditable } = this.context
 
         const isSelected = module.hash === this.props.selectedModuleHash
 
@@ -159,7 +160,7 @@ class CanvasModule extends React.PureComponent {
                 onFocus={() => api.selectModule({ hash: module.hash })}
                 className={cx(className, styles.CanvasModule, ModuleStyles.ModuleBase, ...moduleSpecificStyles, {
                     [ModuleStyles.isSelected]: isSelected,
-                    [ModuleStyles.disabled]: this.context.isPending, // disable edits while loading
+                    [ModuleStyles.disabled]: !isAdjustable, // disable edits while loading
                 })}
                 width={parseInt(layout.width, 10)}
                 height={parseInt(layout.height, 10)}
@@ -171,11 +172,11 @@ class CanvasModule extends React.PureComponent {
                     <Probe group="ModuleHeight" height="auto" />
                     <ModuleHeader
                         className={cx(styles.header, ModuleStyles.dragHandle)}
-                        editable={!isRunning}
+                        editable={isEditable}
                         label={module.displayName || module.name}
                         onLabelChange={this.onChangeModuleName}
                     >
-                        {isRunning && !!module.canRefresh && (
+                        {!!isRunning && !!module.canRefresh && (
                             <ModuleHeaderButton
                                 className={ModuleStyles.dragCancel}
                                 onFocus={this.onFocusOptionsButton}

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -159,6 +159,7 @@ class CanvasModule extends React.PureComponent {
                 onFocus={() => api.selectModule({ hash: module.hash })}
                 className={cx(className, styles.CanvasModule, ModuleStyles.ModuleBase, ...moduleSpecificStyles, {
                     [ModuleStyles.isSelected]: isSelected,
+                    [ModuleStyles.disabled]: this.context.isPending, // disable edits while loading
                 })}
                 width={parseInt(layout.width, 10)}
                 height={parseInt(layout.height, 10)}

--- a/app/src/editor/canvas/components/ModuleSidebar.jsx
+++ b/app/src/editor/canvas/components/ModuleSidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useContext, useRef } from 'react'
 import cx from 'classnames'
 import startCase from 'lodash/startCase'
 
@@ -7,10 +7,12 @@ import { Header, Content, Section } from '$editor/shared/components/Sidebar'
 import TextControl from '$shared/components/TextControl'
 
 import * as CanvasState from '../state'
+import * as RunController from './CanvasController/Run'
 import styles from './ModuleSidebar.pcss'
 import ModuleHelp from './ModuleHelp'
 
 export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOptions, onClose }) {
+    const { isEditable } = useContext(RunController.Context)
     const onChange = (name) => (_value) => {
         if (selectedModuleHash == null) { return }
         const module = CanvasState.getModule(canvas, selectedModuleHash)
@@ -61,7 +63,6 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
     }
 
     const optionsKeys = Object.keys(module.options || {})
-    const isRunning = canvas.state === CanvasState.RunStates.Running
     return (
         <React.Fragment>
             <Header
@@ -89,7 +90,7 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
                                                     <option
                                                         key={value}
                                                         value={value}
-                                                        disabled={!!isRunning}
+                                                        disabled={!isEditable}
                                                     >
                                                         {text}
                                                     </option>
@@ -103,12 +104,12 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
                                                     checked={option.value}
                                                     type="checkbox"
                                                     onChange={onChangeChecked(name)}
-                                                    disabled={!!isRunning}
+                                                    disabled={!isEditable}
                                                 />
                                             )) || (
                                                 /* Text */
                                                 <TextControl
-                                                    disabled={!!isRunning}
+                                                    disabled={!isEditable}
                                                     id={id}
                                                     onCommit={onChange(name)}
                                                     value={option.value}

--- a/app/src/editor/canvas/components/PortDragger.jsx
+++ b/app/src/editor/canvas/components/PortDragger.jsx
@@ -141,6 +141,7 @@ class DraggablePort extends React.Component {
                 onStop={this.onDropPort}
                 onStart={this.onStartDragPort}
                 onDrag={this.onDragPort}
+                disabled={this.props.disabled}
             >
                 {this.props.children}
             </Draggable>
@@ -148,11 +149,19 @@ class DraggablePort extends React.Component {
     }
 }
 
-export function DragSource({ api, port, onValueChange, className }) {
+export function DragSource({
+    api,
+    port,
+    onValueChange,
+    className,
+    disabled,
+}) {
     return (
-        <DraggablePort api={api} port={port} onValueChange={onValueChange}>
+        <DraggablePort api={api} port={port} onValueChange={onValueChange} disabled={disabled}>
             <div
-                className={cx(Dragger.styles.root, Dragger.styles.source, Dragger.styles.dragHandle, className)}
+                className={cx(Dragger.styles.root, Dragger.styles.source, Dragger.styles.dragHandle, className, {
+                    [Dragger.styles.disabled]: disabled,
+                })}
             />
         </DraggablePort>
     )
@@ -187,7 +196,9 @@ export class DropTarget extends React.PureComponent {
             /* eslint-disable-next-line max-len */
             /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-noninteractive-tabindex */
             <div
-                className={cx(Dragger.styles.root, Dragger.styles.target, this.props.className, this.props.className)}
+                className={cx(Dragger.styles.root, Dragger.styles.target, this.props.className, this.props.className, {
+                    [Dragger.styles.disabled]: this.props.disabled,
+                })}
                 onMouseOver={this.onMouseOverTarget}
                 onMouseOut={this.onMouseOutTarget}
             />

--- a/app/src/editor/canvas/components/Ports/Dragger/dragger.pcss
+++ b/app/src/editor/canvas/components/Ports/Dragger/dragger.pcss
@@ -10,6 +10,10 @@
   z-index: 1;
 }
 
+.root.disabled {
+  cursor: initial;
+}
+
 .source::after {
   background-color: #EFEFEF;
   border: 1px solid #ADADAD;

--- a/app/src/editor/canvas/components/Ports/Plug/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Plug/index.jsx
@@ -15,6 +15,7 @@ type Props = {
     canvas: any,
     className?: ?string,
     port: any,
+    disabled?: boolean,
     register?: ?(any, ?HTMLDivElement) => void,
 }
 
@@ -23,6 +24,7 @@ const Plug = ({
     canvas,
     className,
     port,
+    disabled,
     register,
     onValueChange,
     ...props
@@ -56,6 +58,7 @@ const Plug = ({
                 [styles.idle]: !dragInProgress,
                 [styles.ignoreDrop]: draggingFromSamePort,
                 [styles.rejectDrop]: dragInProgress && !draggingFromSamePort && !canDrop,
+                [styles.disabled]: disabled,
             })}
         >
             <div
@@ -72,12 +75,14 @@ const Plug = ({
             <DropTarget
                 className={cx(styles.dragger, styles.dropTarget)}
                 port={port}
+                disabled={disabled}
             />
             <DragSource
                 api={api}
                 onValueChange={onValueChange}
                 className={cx(styles.dragger, styles.dragSource)}
                 port={port}
+                disabled={disabled}
             />
         </div>
     )

--- a/app/src/editor/canvas/components/Ports/Plug/plug.pcss
+++ b/app/src/editor/canvas/components/Ports/Plug/plug.pcss
@@ -89,7 +89,7 @@
   transform: scale(1.5);
 }
 
-.idle:hover .inner {
+.idle:not(.disabled):hover .inner {
   box-shadow: 0 0 0 calc(0.125 * var(--um)) #ADF5FF;
 }
 

--- a/app/src/editor/canvas/components/Ports/Plug/plug.pcss
+++ b/app/src/editor/canvas/components/Ports/Plug/plug.pcss
@@ -10,6 +10,10 @@
   position: relative;
 }
 
+.disabled {
+  pointer-events: none;
+}
+
 .inner {
   border: 1px solid #ADADAD;
   box-sizing: border-box;

--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -94,6 +94,18 @@ const Port = ({
         onSizeChange()
     }, [port.id, onValueChangeProp, onSizeChange])
 
+    useEffect(() => {
+        window.addEventListener('blur', onWindowBlur)
+
+        return () => {
+            window.removeEventListener('blur', onWindowBlur)
+        }
+    }, [onWindowBlur])
+
+    useEffect(() => {
+        onSizeChange()
+    }, [port.value, onSizeChange])
+
     const { isDragging, data } = useContext(DragDropContext)
     const { portId } = data || {}
     const dragInProgress = !!isDragging && portId != null
@@ -106,20 +118,9 @@ const Port = ({
             onValueChange={onValueChangeProp}
             port={port}
             register={onPort}
+            disabled={!isEditable}
         />
     )
-
-    useEffect(() => {
-        window.addEventListener('blur', onWindowBlur)
-
-        return () => {
-            window.removeEventListener('blur', onWindowBlur)
-        }
-    }, [onWindowBlur])
-
-    useEffect(() => {
-        onSizeChange()
-    }, [port.value, onSizeChange])
 
     const isInvisible = isPortInvisible(canvas, port.id)
     const isRenameDisabled = !isEditable || isPortRenameDisabled(canvas, port.id)

--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -9,6 +9,7 @@ import useKeyDown from '$shared/hooks/useKeyDown'
 
 import { isPortInvisible, isPortRenameDisabled } from '../../../state'
 import { DragDropContext } from '../../DragDropContext'
+import * as RunController from '../../CanvasController/Run'
 import Option from '../Option'
 import Plug from '../Plug'
 import Menu from '../Menu'
@@ -35,7 +36,7 @@ const Port = ({
     port,
     setOptions,
 }: Props) => {
-    const isRunning = canvas.state === 'RUNNING'
+    const { isEditable } = useContext(RunController.Context)
     const isInput = !!port.acceptedTypes
     const isParam = 'defaultValue' in port
     const hasInputField = isParam || port.canHaveInitialValue
@@ -121,7 +122,7 @@ const Port = ({
     }, [port.value, onSizeChange])
 
     const isInvisible = isPortInvisible(canvas, port.id)
-    const isRenameDisabled = isPortRenameDisabled(canvas, port.id)
+    const isRenameDisabled = !isEditable || isPortRenameDisabled(canvas, port.id)
 
     return (
         <div
@@ -144,7 +145,7 @@ const Port = ({
                 <Option
                     activated={!!port.drivingInput}
                     className={styles.portOption}
-                    disabled={!!isRunning}
+                    disabled={!isEditable}
                     name="drivingInput"
                     onToggle={onOptionToggle}
                 />
@@ -168,6 +169,7 @@ const Port = ({
                         canvas={canvas}
                         port={port}
                         onChange={onValueChange}
+                        disabled={!isEditable}
                     />
                 </Cell>
             )}
@@ -176,7 +178,7 @@ const Port = ({
                 <Option
                     activated={!!port.noRepeat}
                     className={styles.portOption}
-                    disabled={!!isRunning}
+                    disabled={!isEditable}
                     name="noRepeat"
                     onToggle={onOptionToggle}
                 />

--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -11,6 +11,7 @@ import Text from './Text'
 import styles from './value.pcss'
 
 type Props = {
+    disabled: boolean,
     canvas: any,
     port: any,
     onChange: (any) => void,
@@ -40,14 +41,14 @@ export type CommonProps = {
     placeholder: any,
 }
 
-const Value = ({ canvas, port, onChange }: Props) => {
+const Value = ({ canvas, disabled, port, onChange }: Props) => {
     // Enable non-running input whether connected or not if port.canHaveInitialValue
-    const disabled = State.isPortValueEditDisabled(canvas, port.id)
+    const editDisabled = disabled || State.isPortValueEditDisabled(canvas, port.id)
     const type = getPortType(port)
     const value = State.getPortValue(canvas, port.id)
     const placeholder = State.getPortPlaceholder(canvas, port.id)
     const commonProps: CommonProps = {
-        disabled,
+        disabled: editDisabled,
         onChange,
         value,
         placeholder,

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -307,6 +307,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                 </div>
             )
         }
+        const { isEditable } = runController
         const { moduleSidebarIsOpen, keyboardShortcutIsOpen } = this.state
         const { settings } = canvas
         const resendFrom = settings.beginDate
@@ -331,7 +332,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                     updateModule={this.updateModule}
                     renameModule={this.renameModule}
                     moduleSidebarOpen={this.moduleSidebarOpen}
-                    moduleSidebarIsOpen={moduleSidebarIsOpen && !keyboardShortcutIsOpen}
+                    moduleSidebarIsOpen={isEditable && moduleSidebarIsOpen && !keyboardShortcutIsOpen}
                     setCanvas={this.setCanvas}
                     pushNewDefinition={this.pushNewDefinition}
                 >
@@ -364,14 +365,14 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                 </ModalProvider>
                 <Sidebar
                     className={styles.ModuleSidebar}
-                    isOpen={moduleSidebarIsOpen}
+                    isOpen={isEditable && moduleSidebarIsOpen}
                 >
-                    {moduleSidebarIsOpen && keyboardShortcutIsOpen && (
+                    {isEditable && moduleSidebarIsOpen && keyboardShortcutIsOpen && (
                         <KeyboardShortcutsSidebar
                             onClose={() => this.keyboardShortcutOpen(false)}
                         />
                     )}
-                    {moduleSidebarIsOpen && !keyboardShortcutIsOpen && (
+                    {isEditable && moduleSidebarIsOpen && !keyboardShortcutIsOpen && (
                         <ModuleSidebar
                             onClose={this.moduleSidebarClose}
                             canvas={canvas}
@@ -382,7 +383,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                 </Sidebar>
                 <ModuleSearch
                     addModule={this.addAndSelectModule}
-                    isOpen={runController.isEditable && this.state.moduleSearchIsOpen}
+                    isOpen={isEditable && this.state.moduleSearchIsOpen}
                     open={this.moduleSearchOpen}
                     canvas={canvas}
                 />

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -383,7 +383,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                 </Sidebar>
                 <ModuleSearch
                     addModule={this.addAndSelectModule}
-                    isOpen={this.state.moduleSearchIsOpen}
+                    isOpen={runController.isEditable && this.state.moduleSearchIsOpen}
                     open={this.moduleSearchOpen}
                     canvas={canvas}
                 />

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -94,8 +94,9 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         if (Number.isNaN(hash)) {
             return
         }
+        const { runController } = this.props
 
-        if (event.code === 'Backspace' || event.code === 'Delete') {
+        if ((event.code === 'Backspace' || event.code === 'Delete') && runController.isEditable) {
             this.removeModule({ hash })
         }
     }

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -42,7 +42,7 @@ const { RunStates } = CanvasState
 
 const CanvasEditComponent = class CanvasEdit extends Component {
     state = {
-        moduleSearchIsOpen: this.props.runController.isEditable,
+        moduleSearchIsOpen: true,
         moduleSidebarIsOpen: false,
         keyboardShortcutIsOpen: false,
     }

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -38,8 +38,6 @@ import * as CanvasState from './state'
 
 import styles from './index.pcss'
 
-const { RunStates } = CanvasState
-
 const CanvasEditComponent = class CanvasEdit extends Component {
     state = {
         moduleSearchIsOpen: true,
@@ -401,14 +399,17 @@ const CanvasEdit = withRouter(({ canvas, ...props }) => {
     useAutosaveEffect()
 
     return (
-        <CanvasEditComponent
-            {...props}
-            canvas={canvas}
-            runController={runController}
-            canvasController={canvasController}
-            updated={updated}
-            setUpdated={setUpdated}
-        />
+        <React.Fragment>
+            <UndoControls disabled={!runController.isEditable} />
+            <CanvasEditComponent
+                {...props}
+                canvas={canvas}
+                runController={runController}
+                canvasController={canvasController}
+                updated={updated}
+                setUpdated={setUpdated}
+            />
+        </React.Fragment>
     )
 })
 
@@ -440,14 +441,9 @@ const CanvasEditWrap = () => {
     )
 }
 
-function isDisabled({ state: canvas }) {
-    return !canvas || (canvas.state === RunStates.Running || canvas.adhoc)
-}
-
 const CanvasContainer = withRouter(withErrorBoundary(ErrorComponentView)((props) => (
     <ClientProvider>
         <UndoContext.Provider key={props.match.params.id}>
-            <UndoControls disabled={isDisabled} />
             <CanvasController.Provider>
                 <CanvasEditWrap />
             </CanvasController.Provider>

--- a/app/src/editor/shared/components/Module.pcss
+++ b/app/src/editor/shared/components/Module.pcss
@@ -15,6 +15,10 @@
   color: #323232;
 }
 
+.disabled {
+  pointer-events: none;
+}
+
 .selectionDecorator {
   border-radius: 4px;
   height: 100%;


### PR DESCRIPTION
This is an initial step towards embeds. 

Currently there are some UI editing features left enabled when they should not be (see list below). The server permissions system will block the changes from being applied, but the UI does still allow changes. Shared canvases need to have all editing features disabled. Embedded canvases are shared canvases.

This PR prevents "adjustments" when a canvas is "not adjustable" and prevents "edits" when the canvas is "not editable". This PR also hides the module search whenever the canvas is "not editable".

Modules may be repositioned or resized so long as the canvas is "adjustable", but edits to the following are blocked while "not editable":
* Sidebar option changes
* Port connections
* Port value changes
* Module deletion via Delete key
* Port right-click menu
* Port renaming
* Module renaming
* Canvas renaming
* Historical/Realtime switch
* Save State switch

Currently a canvas is "not editable":
* while canvas is running
* while the user does not have the "write" permission
* temporarily while there are pending start/stop/load operations i.e. canvas is "not adjustable" 

A canvas is "not adjustable":
* while there are pending async operations canvas such as starting, stopping & loading (e.g. after stopping). 

Note autosaving does not block adjustments. All edits are blocked while the canvas is "not adjustable" in order to prevent changes from being clobbered e.g. should not be able to make changes while a canvas is starting.

----

### To Test

1. Enable a few seconds of network latency via devtools
2. Start any canvas
3. Ensure all edits prevented while canvas is stopping or starting.
4. Try editing any of the items in the above list while the canvas is running.
5. Try find other things which are editable but should not be. 
6. Note modules can be moved and resized while running, but also note such changes are lost on stopping (TODO later).
7. Test for both realtime and historical canvases.

----

There are actually some features which can/should be able to be changed while the canvas is running, but these shouldn't be applied the same way as regular edits. This can be tackled in another PR, this PR is simply about disabling any editability which won't/shouldn't actually work.