### PR TITLE
[PLATFORM-990] Minimal embeds canvases

### DIFF
--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -170,7 +170,7 @@ const UserpagesRouter = () => ([
 const EditorRouter = () => ([
     <Route exact path="/" component={Products} key="root" />, // edge case for localhost
     <Route exact path={formatPath(editor.canvasEditor, ':id?')} component={CanvasEditorAuth} key="CanvasEditor" />,
-    <Route exact path={formatPath(editor.canvasEmbed, ':id?')} component={CanvasEmbed} key="CanvasEmbed" />,
+    <Route exact path={formatPath(editor.canvasEmbed)} component={CanvasEmbed} key="CanvasEmbed" />,
     <Route exact path={formatPath(editor.dashboardEditor, ':id?')} component={DashboardEditorAuth} key="DashboardEditor" />,
 ])
 

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -5,12 +5,19 @@
 import axios from 'axios'
 import routes from '$routes'
 import { formatApiUrl } from '$shared/utils/url'
+import { matchPath } from 'react-router-dom'
 
 const meURL = formatApiUrl('users', 'me')
 
 function shouldRedirect(error) {
     // ignore redirect to login logic for login route
     if (window.location.pathname === routes.login()) { return false }
+    // no redirects for embeds
+    if (matchPath(window.location.pathname, {
+        path: routes.canvasEmbed(),
+    })) {
+        return false
+    }
     if (error.response && error.response.status === 401) {
         const url = new window.URL(error.config.url)
         const me = new window.URL(meURL)

--- a/app/src/editor/canvas/components/CanvasController/Run.jsx
+++ b/app/src/editor/canvas/components/CanvasController/Run.jsx
@@ -16,6 +16,7 @@ import * as CanvasLinking from '../../state/linking'
 
 import useCanvasStateChangeEffect from '../../hooks/useCanvasStateChangeEffect'
 import useCanvasUpdater from './useCanvasUpdater'
+import { useEmbedMode } from './index'
 
 export const RunControllerContext = React.createContext()
 
@@ -28,6 +29,7 @@ function isStateNotAllowedError(error) {
 }
 
 function useRunController(canvas = EMPTY) {
+    const isEmbedMode = useEmbedMode()
     const subscriptionStatus = useContext(SubscriptionStatus.Context)
     const { permissions } = useContext(PermissionContext)
     const { replaceCanvas } = useCanvasUpdater()
@@ -51,7 +53,7 @@ function useRunController(canvas = EMPTY) {
     const hasSharePermission = permissions &&
         permissions.some((p) => p.operation === 'share')
 
-    const hasWritePermission = permissions &&
+    const hasWritePermission = !isEmbedMode && permissions &&
         permissions.some((p) => p.operation === 'write')
 
     const start = useCallback(async (canvas, options) => {
@@ -147,6 +149,7 @@ function useRunController(canvas = EMPTY) {
 
     // write commits
     const isEditable = (
+        !isEmbedMode &&
         !isActive &&
         isAdjustable &&
         !canvas.adhoc &&
@@ -155,6 +158,7 @@ function useRunController(canvas = EMPTY) {
 
     // controls whether user can currently start/stop canvas
     const canChangeRunState = (
+        !isEmbedMode && // can't change run state when in embed mode
         !isPending && // no pending
         hasWritePermission && ( // has write perms
             // check historical settings ok if historical

--- a/app/src/editor/canvas/components/CanvasController/index.jsx
+++ b/app/src/editor/canvas/components/CanvasController/index.jsx
@@ -18,6 +18,12 @@ import useModuleLoadCallback from './useModuleLoadCallback'
 
 import styles from './CanvasController.pcss'
 
+const EmbedModeContext = React.createContext(false)
+
+export function useEmbedMode() {
+    return useContext(EmbedModeContext)
+}
+
 const CanvasControllerContext = React.createContext()
 
 function useCanvasLoadEffect() {
@@ -102,17 +108,19 @@ function ControllerProvider({ children }) {
     )
 }
 
-const CanvasControllerProvider = ({ children }) => (
+const CanvasControllerProvider = ({ children, embed }) => (
     <RouterContext.Provider>
-        <PendingProvider>
-            <PermissionsProvider>
-                <ControllerProvider>
-                    <CanvasLoadingIndicator />
-                    <CanvasEffects />
-                    {children || null}
-                </ControllerProvider>
-            </PermissionsProvider>
-        </PendingProvider>
+        <EmbedModeContext.Provider value={!!embed}>
+            <PendingProvider>
+                <PermissionsProvider>
+                    <ControllerProvider embed={embed}>
+                        <CanvasLoadingIndicator />
+                        <CanvasEffects />
+                        {children || null}
+                    </ControllerProvider>
+                </PermissionsProvider>
+            </PendingProvider>
+        </EmbedModeContext.Provider>
     </RouterContext.Provider>
 )
 

--- a/app/src/editor/canvas/components/Embed.jsx
+++ b/app/src/editor/canvas/components/Embed.jsx
@@ -3,8 +3,6 @@
 import React from 'react'
 import CanvasContainer from '../'
 
-const CanvasEmbedPage = () => (
-    <CanvasContainer embed />
-)
-
-export default CanvasEmbedPage
+export default function CanvasEmbedPage() {
+    return <CanvasContainer embed />
+}

--- a/app/src/editor/canvas/components/Embed.jsx
+++ b/app/src/editor/canvas/components/Embed.jsx
@@ -1,53 +1,10 @@
 // @flow
 
 import React from 'react'
-import { Container } from 'reactstrap'
-import { Link } from 'react-router-dom'
-import { Translate, I18n } from 'react-redux-i18n'
-
-import BodyClass, { PAGE_SECONDARY } from '$shared/components/BodyClass'
-import EmptyState from '$shared/components/EmptyState'
-import Layout from '$shared/components/Layout'
-import links from '../../../links'
-import pageNotFoundPic from '$shared/assets/images/404_blocks.png'
-import pageNotFoundPic2x from '$shared/assets/images/404_blocks@2x.png'
-import styles from './Embed.pcss'
+import CanvasContainer from '../'
 
 const CanvasEmbedPage = () => (
-    <Layout className={styles.canvasEmbedPage}>
-        <BodyClass className={PAGE_SECONDARY} />
-        <Container>
-            <EmptyState
-                image={(
-                    <img
-                        src={pageNotFoundPic}
-                        srcSet={`${pageNotFoundPic2x} 2x`}
-                        alt={I18n.t('error.notFound')}
-                    />
-                )}
-                link={(
-                    <React.Fragment>
-                        <Link
-                            to={links.userpages.main}
-                            className="btn btn-special"
-                        >
-                            <Translate value="notFoundPage.coreApp" />
-                        </Link>
-                        <Link
-                            to={links.root}
-                            className="btn btn-special"
-                        >
-                            <Translate value="notFoundPage.publicSite" />
-                        </Link>
-                    </React.Fragment>
-                )}
-                linkOnMobile
-            >
-                <p>Whoops! Embeds are disabled in the beta for now.</p>
-                <small>We’re working on it, so please check back again soon.</small>
-            </EmptyState>
-        </Container>
-    </Layout>
+    <CanvasContainer embed />
 )
 
 export default CanvasEmbedPage

--- a/app/src/editor/canvas/components/Embed.pcss
+++ b/app/src/editor/canvas/components/Embed.pcss
@@ -1,4 +1,0 @@
-.canvasEmbedPage {
-  text-align: center;
-  width: 100%;
-}

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -459,7 +459,7 @@ const CanvasContainer = withRouter(withErrorBoundary(ErrorComponentView)((props)
 )))
 
 export default ({ embed }) => (
-    <Layout className={styles.layout} footer={false} hideNavOnDesktop={!!embed}>
+    <Layout className={styles.layout} footer={false} nav={!embed} hideNavOnDesktop>
         <BodyClass className="editor" />
         <CanvasContainer embed={embed} />
     </Layout>

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -459,7 +459,7 @@ const CanvasContainer = withRouter(withErrorBoundary(ErrorComponentView)((props)
 )))
 
 export default ({ embed }) => (
-    <Layout className={styles.layout} footer={false} nav={!embed} hideNavOnDesktop>
+    <Layout className={styles.layout} footer={false} nav={!embed}>
         <BodyClass className="editor" />
         <CanvasContainer embed={embed} />
     </Layout>

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -299,7 +299,7 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 
     render() {
-        const { canvas, runController } = this.props
+        const { canvas, runController, isEmbedMode } = this.props
         if (!canvas) {
             return (
                 <div className={styles.CanvasEdit}>
@@ -342,51 +342,55 @@ const CanvasEditComponent = class CanvasEdit extends Component {
                         <CannotSaveStatus />
                     )}
                 </Canvas>
-                <ModalProvider>
-                    <CanvasToolbar
-                        className={styles.CanvasToolbar}
-                        canvas={canvas}
-                        setCanvas={this.setCanvas}
-                        renameCanvas={this.renameCanvas}
-                        deleteCanvas={this.deleteCanvas}
-                        newCanvas={this.newCanvas}
-                        duplicateCanvas={this.duplicateCanvas}
-                        moduleSearchIsOpen={this.state.moduleSearchIsOpen}
-                        moduleSearchOpen={this.moduleSearchOpen}
-                        setRunTab={this.setRunTab}
-                        setHistorical={this.setHistorical}
-                        setSpeed={this.setSpeed}
-                        setSaveState={this.setSaveState}
-                        canvasStart={this.canvasStart}
-                        canvasStop={this.canvasStop}
-                        keyboardShortcutOpen={this.keyboardShortcutOpen}
-                        canvasExit={this.canvasExit}
-                    />
-                </ModalProvider>
-                <Sidebar
-                    className={styles.ModuleSidebar}
-                    isOpen={isEditable && moduleSidebarIsOpen}
-                >
-                    {isEditable && moduleSidebarIsOpen && keyboardShortcutIsOpen && (
-                        <KeyboardShortcutsSidebar
-                            onClose={() => this.keyboardShortcutOpen(false)}
-                        />
-                    )}
-                    {isEditable && moduleSidebarIsOpen && !keyboardShortcutIsOpen && (
-                        <ModuleSidebar
-                            onClose={this.moduleSidebarClose}
+                {isEmbedMode ? null : (
+                    <React.Fragment>
+                        <ModalProvider>
+                            <CanvasToolbar
+                                className={styles.CanvasToolbar}
+                                canvas={canvas}
+                                setCanvas={this.setCanvas}
+                                renameCanvas={this.renameCanvas}
+                                deleteCanvas={this.deleteCanvas}
+                                newCanvas={this.newCanvas}
+                                duplicateCanvas={this.duplicateCanvas}
+                                moduleSearchIsOpen={this.state.moduleSearchIsOpen}
+                                moduleSearchOpen={this.moduleSearchOpen}
+                                setRunTab={this.setRunTab}
+                                setHistorical={this.setHistorical}
+                                setSpeed={this.setSpeed}
+                                setSaveState={this.setSaveState}
+                                canvasStart={this.canvasStart}
+                                canvasStop={this.canvasStop}
+                                keyboardShortcutOpen={this.keyboardShortcutOpen}
+                                canvasExit={this.canvasExit}
+                            />
+                        </ModalProvider>
+                        <Sidebar
+                            className={styles.ModuleSidebar}
+                            isOpen={isEditable && moduleSidebarIsOpen}
+                        >
+                            {isEditable && moduleSidebarIsOpen && keyboardShortcutIsOpen && (
+                                <KeyboardShortcutsSidebar
+                                    onClose={() => this.keyboardShortcutOpen(false)}
+                                />
+                            )}
+                            {isEditable && moduleSidebarIsOpen && !keyboardShortcutIsOpen && (
+                                <ModuleSidebar
+                                    onClose={this.moduleSidebarClose}
+                                    canvas={canvas}
+                                    selectedModuleHash={this.state.selectedModuleHash}
+                                    setModuleOptions={this.setModuleOptions}
+                                />
+                            )}
+                        </Sidebar>
+                        <ModuleSearch
+                            addModule={this.addAndSelectModule}
+                            isOpen={isEditable && this.state.moduleSearchIsOpen}
+                            open={this.moduleSearchOpen}
                             canvas={canvas}
-                            selectedModuleHash={this.state.selectedModuleHash}
-                            setModuleOptions={this.setModuleOptions}
                         />
-                    )}
-                </Sidebar>
-                <ModuleSearch
-                    addModule={this.addAndSelectModule}
-                    isOpen={isEditable && this.state.moduleSearchIsOpen}
-                    open={this.moduleSearchOpen}
-                    canvas={canvas}
-                />
+                    </React.Fragment>
+                )}
             </div>
         )
     }
@@ -396,6 +400,7 @@ const CanvasEdit = withRouter(({ canvas, ...props }) => {
     const runController = useContext(RunController.Context)
     const canvasController = CanvasController.useController()
     const [updated, setUpdated] = useUpdatedTime(canvas.updated)
+    const isEmbedMode = CanvasController.useEmbedMode()
     useCanvasNotifications(canvas)
     useAutosaveEffect()
 
@@ -404,6 +409,7 @@ const CanvasEdit = withRouter(({ canvas, ...props }) => {
             <UndoControls disabled={!runController.isEditable} />
             <CanvasEditComponent
                 {...props}
+                isEmbedMode={isEmbedMode}
                 canvas={canvas}
                 runController={runController}
                 canvasController={canvasController}
@@ -445,16 +451,16 @@ const CanvasEditWrap = () => {
 const CanvasContainer = withRouter(withErrorBoundary(ErrorComponentView)((props) => (
     <ClientProvider>
         <UndoContext.Provider key={props.match.params.id}>
-            <CanvasController.Provider>
+            <CanvasController.Provider embed={!!props.embed}>
                 <CanvasEditWrap />
             </CanvasController.Provider>
         </UndoContext.Provider>
     </ClientProvider>
 )))
 
-export default () => (
-    <Layout className={styles.layout} footer={false}>
+export default ({ embed }) => (
+    <Layout className={styles.layout} footer={false} hideNavOnDesktop={!!embed}>
         <BodyClass className="editor" />
-        <CanvasContainer />
+        <CanvasContainer embed={embed} />
     </Layout>
 )

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -1,6 +1,6 @@
 {
     "canvasEditor": "/canvas/editor",
-    "canvasEmbed": "/canvas/embed",
+    "canvasEmbed": "/canvas/embed/:id",
     "canvases": "/core/canvases",
     "communityGithub": "https://github.com/streamr-dev",
     "communityLinkedin": "https://www.linkedin.com/company/streamr-ltd-/",

--- a/app/src/shared/components/Layout/index.jsx
+++ b/app/src/shared/components/Layout/index.jsx
@@ -12,17 +12,22 @@ import styles from './layout.pcss'
 
 type Props = {
     footer?: boolean,
+    nav?: boolean,
     hideNavOnDesktop?: boolean,
 }
 
-const Layout = ({ footer = true, hideNavOnDesktop = false, ...props }: Props = {}) => (
+const Layout = ({ footer = true, nav = true, hideNavOnDesktop = false, ...props }: Props = {}) => (
     <div className={styles.framed}>
         <div className={styles.inner}>
-            <Nav className={cx(styles.desktopNav, {
-                [styles.hideNavOnDesktop]: !!hideNavOnDesktop,
-            })}
-            />
-            <MobileNav className={styles.mobileNav} />
+            {!!nav && (
+                <React.Fragment>
+                    <Nav className={cx(styles.desktopNav, {
+                        [styles.hideNavOnDesktop]: !!hideNavOnDesktop,
+                    })}
+                    />
+                    <MobileNav className={styles.mobileNav} />
+                </React.Fragment>
+            )}
             <div {...props} />
         </div>
         {!!footer && <Footer />}

--- a/app/src/userpages/hooks/useEmbed.js
+++ b/app/src/userpages/hooks/useEmbed.js
@@ -4,19 +4,25 @@ import { useMemo } from 'react'
 
 import { formatExternalUrl } from '$shared/utils/url'
 import type { ResourceType, ResourceId } from '$userpages/flowtype/permission-types'
+import routes from '$routes'
 
 const streamrRoot = process.env.STREAMR_URL || ''
 
-// TODO: fix embed codes
-const getEmbedCodes = (resourceType: ResourceType, resourceId: ResourceId) => ({
-    // $FlowFixMe It's alright but Flow doesn't get it
-    CANVAS: String.raw`<iframe title="streamr-embed"
-src="http://streamr.com/embed/${resourceType}/${resourceId}"
-width="640" height="360"
-frameborder="0"></iframe>`,
-    DASHBOARD: '',
-    STREAM: '',
-})
+const getEmbedCode = (resourceType: ResourceType, resourceId: ResourceId) => {
+    if (resourceType === 'CANVAS') {
+        const src = formatExternalUrl(process.env.PLATFORM_ORIGIN_URL, routes.canvasEmbed({
+            id: resourceId,
+        }))
+        // $FlowFixMe It's alright but Flow doesn't get it
+        return `
+            <iframe title="streamr-embed"
+            src="${src}"
+            width="640" height="360"
+            frameborder="0"></iframe>
+        `.replace(/\s+/g, ' ').trim()
+    }
+    return ''
+}
 
 const getLinks = (resourceId: ResourceId) => ({
     CANVAS: `canvas/editor/${resourceId}`,
@@ -25,11 +31,7 @@ const getLinks = (resourceId: ResourceId) => ({
 })
 
 export function useEmbed(resourceType: ResourceType, resourceId: ResourceId) {
-    const embedCode = useMemo(() => {
-        const codes = getEmbedCodes(resourceType, resourceId)
-
-        return codes[resourceType] || ''
-    }, [resourceType, resourceId])
+    const embedCode = getEmbedCode(resourceType, resourceId)
 
     const link = useMemo(() => {
         const links = getLinks(resourceId)


### PR DESCRIPTION
Prevents edits, hides nav & toolbar in embed mode.
Fixes generated embed code.
Prevents redirecting to login for embed urls.

To test:
* Share a canvas publicly.
* Get embed code.
* Access the url in embed code directly while logged in & logged out (i.e. incognito mode). e.g. http://localhost/canvas/embed/sUc-jCKxSKaVx4KFJGZ75wjOTJOzEfTnWFwiJJRRsgEA
* Drop embed code iframe on a docs page, access docs page see iframe works logged in & logged out.

~~*update*: Just noticed running canvases have a recursive loop issue if user is logged out.~~ Fixed