### PR TITLE
[PLATFORM-998] Chart Performance

### DIFF
--- a/app/src/editor/shared/components/Chart/index.jsx
+++ b/app/src/editor/shared/components/Chart/index.jsx
@@ -23,7 +23,7 @@ type Props = {
     series: any,
 }
 
-const Chart = ({ className, series, datapoints, options }: Props) => {
+const Chart = ({ className, series = {}, datapoints = [], options }: Props) => {
     const [chart, setChart] = useState(null)
 
     const seriesData = useMemo(() => (
@@ -69,18 +69,21 @@ const Chart = ({ className, series, datapoints, options }: Props) => {
     }, [])
 
     useEffect(() => {
-        if (chart) {
-            seriesData.forEach((data) => {
-                const series = chart.get(data.id)
-                if (series) {
-                    series.update(data)
-                } else {
-                    chart.addSeries(data)
-                }
-            })
-            chart.redraw()
-        }
-    }, [chart, seriesData])
+        if (!chart) { return }
+        seriesData.forEach((data) => {
+            const series = chart.get(data.id)
+            if (!series) {
+                chart.addSeries(data)
+            } else {
+                const points = datapoints[data.idx] || []
+                // $FlowFixMe
+                points.forEach((p) => {
+                    series.addPoint(p, false)
+                })
+            }
+        })
+        chart.redraw()
+    }, [chart, seriesData, datapoints])
 
     const { height } = useContext(UiSizeContext)
 

--- a/app/src/editor/shared/components/modules/Chart.jsx
+++ b/app/src/editor/shared/components/modules/Chart.jsx
@@ -48,13 +48,14 @@ const ChartModule2 = (props) => {
         const queued = queuedDatapointsRef.current || []
         queuedDatapointsRef.current = []
 
-        setSeriesData((seriesData) => queued.reduce((memo, { s, x, y }) => ({
-            ...memo,
-            [s]: [
-                ...(memo[s] || []),
-                [x, y],
-            ],
-        }), seriesData))
+        setSeriesData(() => queued.reduce((o, { s, x, y }) => {
+            const series = (o[s] || [])
+            series.push([x, y])
+            return Object.assign(o, {
+                ...o,
+                [s]: series,
+            })
+        }, {}))
     }, 250))
 
     const onDatapoint = useCallback((payload) => {


### PR DESCRIPTION
Reproduced issue reported in https://streamr.atlassian.net/browse/PLATFORM-998
At around 800 points the current chart implementation slows to a crawl. Unusable. 

This PR moves data handling out of React into the chart lib.

Diff updates are pushed on each change rather than the entire dataset.

### To Test

1. Create Canvas with a `Clock` set to 1s, plugged into the trigger on a `RandomNumber`, plugged into a Chart.
2. Run in Historical mode, 10x speed.
3. Before this PR it would slow to a crawl in <30s, now it appears to continue working indefinitely. Chart also seems to survive 100x & 1000x speeds.

Below screenshot shows similar setup to above description:

![image](https://user-images.githubusercontent.com/43438/62851491-d318e680-bd18-11e9-80bf-495fca31cba0.png)
