### PR TITLE
[PLATFORM-1006] Improve Geo Map Autozoom UX

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29323,6 +29323,11 @@
         }
       }
     },
+    "react-leaflet-control": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet-control/-/react-leaflet-control-2.1.1.tgz",
+      "integrity": "sha512-3fx4uSRFtDaFNa1yq62DCxdc9kR3Lk4V7R0lHqbKfPTEIOvPR7VFvk3xzcSnSB/0LAYO8R96Pwcs1c6knyL/Hw=="
+    },
     "react-leaflet-heatmap-layer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-leaflet-heatmap-layer/-/react-leaflet-heatmap-layer-2.0.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -197,6 +197,7 @@
     "react-helmet": "^5.2.0",
     "react-image": "^1.4.0",
     "react-leaflet": "^2.2.0",
+    "react-leaflet-control": "^2.1.1",
     "react-leaflet-heatmap-layer": "^2.0.0",
     "react-loading-skeleton": "^0.5.0",
     "react-markdown": "^4.1.0",

--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -228,7 +228,7 @@ export default class Map extends React.PureComponent<Props, State> {
                                         color={markerColor}
                                     >
                                         <Tooltip direction="top">
-                                            {marker.id}
+                                            {marker.label || marker.id}
                                         </Tooltip>
                                     </CustomMarker>
                                     {tracePoints && tracePoints.length > 0 && (

--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -212,6 +212,7 @@ export default class Map extends React.PureComponent<Props, State> {
                                     onClick={this.resetTouched}
                                     aria-label="Restart Autozoom"
                                     title="Restart Autozoom"
+                                    type="button"
                                 >
                                     &#9678;
                                 </button>

--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -195,7 +195,7 @@ export default function Map(props: Props) {
                     onMoveEnd={onViewportChanged}
                     onZoomEnd={onViewportChanged}
                 >
-                    {(
+                    {!!autoZoom && (
                         <Control position="topleft">
                             <button
                                 className={cx(styles.control, {

--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -210,8 +210,8 @@ export default class Map extends React.PureComponent<Props, State> {
                                         [styles.disabledControl]: !this.state.touched,
                                     })}
                                     onClick={this.resetTouched}
-                                    aria-label="Recenter"
-                                    title="Recenter"
+                                    aria-label="Restart Autozoom"
+                                    title="Restart Autozoom"
                                 >
                                     &#9678;
                                 </button>

--- a/app/src/editor/shared/components/Map/Map.jsx
+++ b/app/src/editor/shared/components/Map/Map.jsx
@@ -150,13 +150,13 @@ export default class Map extends React.PureComponent<Props, State> {
         const mapCenter = [centerLat, centerLong]
 
         /* eslint-disable-next-line max-len */
-        let tileAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://cartodb.com/attributions">CartoDB</a>, Streamr'
-        let tileUrl = 'http://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png'
+        let tileAttribution = '&copy; <a href="//www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://cartodb.com/attributions">CartoDB</a>, Streamr'
+        let tileUrl = '//{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png'
 
         if (skin === 'cartoDark') {
             /* eslint-disable-next-line max-len */
-            tileAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://cartodb.com/attributions">CartoDB</a>, Streamr'
-            tileUrl = 'http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+            tileAttribution = '&copy; <a href="//www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://cartodb.com/attributions">CartoDB</a>, Streamr'
+            tileUrl = '//{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
         }
 
         // https://github.com/facebook/flow/issues/2221

--- a/app/src/editor/shared/components/Map/Map.pcss
+++ b/app/src/editor/shared/components/Map/Map.pcss
@@ -52,4 +52,5 @@
   background-color: #F4F4F4;
   color: #BBBBBB;
   cursor: default;
+  pointer-events: none;
 }

--- a/app/src/editor/shared/components/Map/Map.pcss
+++ b/app/src/editor/shared/components/Map/Map.pcss
@@ -19,4 +19,37 @@
   height: 1.5em !important;
   line-height: 1.25em !important;
   width: 1.5em !important;
+  color: #525252;
+}
+
+.control {
+  font-size: var(--um);
+  height: 1.5em;
+  width: 1.5em;
+  border: 0;
+  appearance: none;
+  box-shadow: 0 0 calc(0.3125 * var(--um)) rgba(0, 0, 0, 0.15) !important;
+  background: white;
+  border-radius: 1px;
+  text-align: center;
+  padding: 0;
+  display: block;
+  cursor: pointer;
+  color: #525252;
+  text-decoration: none;
+}
+
+.control:hover {
+  background-color: #F4F4F4;
+  color: #525252;
+}
+
+.control:focus {
+  outline: none;
+}
+
+.disabledControl {
+  background-color: #F4F4F4;
+  color: #BBBBBB;
+  cursor: default;
 }

--- a/app/src/editor/shared/components/modules/Map.jsx
+++ b/app/src/editor/shared/components/modules/Map.jsx
@@ -189,7 +189,7 @@ export default class MapModule extends React.PureComponent<Props, State> {
 
     getMarkerFromMessage = (msg: Message): Marker => ({
         id: msg.id,
-        label: msg.label || msg.id,
+        label: msg.label,
         lat: msg.lat,
         long: msg.lng,
         rotation: msg.dir,

--- a/app/src/editor/shared/components/modules/Map.jsx
+++ b/app/src/editor/shared/components/modules/Map.jsx
@@ -33,6 +33,7 @@ type State = {
 type Message = {
     t: string,
     color: string,
+    label?: string,
     id: string,
     lat: number,
     lng: number,
@@ -186,15 +187,14 @@ export default class MapModule extends React.PureComponent<Props, State> {
         }
     }
 
-    getMarkerFromMessage = (msg: Message): Marker => (
-        {
-            id: msg.id,
-            lat: msg.lat,
-            long: msg.lng,
-            rotation: msg.dir,
-            previousPositions: [],
-        }
-    )
+    getMarkerFromMessage = (msg: Message): Marker => ({
+        id: msg.id,
+        label: msg.label || msg.id,
+        lat: msg.lat,
+        long: msg.lng,
+        rotation: msg.dir,
+        previousPositions: [],
+    })
 
     addTracePoint = (id: string, lat: number, long: number, tracePointId: string) => {
         let posArray = this.positionHistory[id]


### PR DESCRIPTION
The autozoom feature causes the map to zoom and pan automatically so all the markers are visible. Autozoom currently gets disabled for a number of interaction events but doesn't get disabled when the user clicks the visible zoom buttons, so when a user manually adjusts the zoom, the next time a marker update arrives, their zoom level is clobbered by autozoom. 

This PR makes a few changes to improve the issues described in https://streamr.atlassian.net/browse/PLATFORM-1006:
* Adds 20% padding around the autozoomed points so they don't always sit at the edges of the map. This addresses @fonty1's "make it zoomed out more" request in the JIRA ticket.
* Disables autozoom when user clicks the zoom buttons
* Disables autozoom only if user presses keys that adjust zoom or pan (arrows and +/-), rather than any key press (not perfect, but better).
* Adds a button for restarting autozoom after manually changing zoom or pan. I used a font glyph ◎ as a placeholder in lieu of an icon from design. This button only exists if autozoom is enabled in the sidebar. *update*: Changed it so button is only visible when it's also enabled (i.e. autozoom can be resumed). i.e. the greyed out button shown in the screencaps below is now gone, button only shows if it can be clicked. *update 2*: changed it back on request from design

Also fixes:
* Mixed content http/https warnings when loading openstreetmap tiles from http:// on https://streamr.com
* Map marker `label` feature, which wasn't hooked up before. See second screencap, plugged the id into a toLowerCase then into the geo label input so id "STR2" becomes the label "str2".

![map-geo-autozoom2](https://user-images.githubusercontent.com/43438/63020093-b8d53900-becf-11e9-950a-ded1fe36119b.gif)

![map-geo-label](https://user-images.githubusercontent.com/43438/63020183-fd60d480-becf-11e9-8fb9-4bd87bb36974.gif)
