### PR TITLE
[PLATFORM-969] Clearing search results on close

### DIFF
--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -395,7 +395,7 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                     resetOnDefault
                     renderDefault={() => this.renderMenu()}
                 >
-                    {!!isSearching && this.renderSearchResults()}
+                    {isOpen && !!isSearching && this.renderSearchResults()}
                 </SearchPanel>
                 <div className={styles.dragElement} id="dragElement">
                     <SvgIcon className={styles.dragImage} name="dropPlus" />

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -394,8 +394,9 @@ export class ModuleSearch extends React.PureComponent<Props, State> {
                     panelRef={this.selfRef}
                     resetOnDefault
                     renderDefault={() => this.renderMenu()}
+                    resetOnClose
                 >
-                    {isOpen && !!isSearching && this.renderSearchResults()}
+                    {!!isSearching && this.renderSearchResults()}
                 </SearchPanel>
                 <div className={styles.dragElement} id="dragElement">
                     <SvgIcon className={styles.dragImage} name="dropPlus" />

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -162,7 +162,15 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                             <div className={cx(styles.ToolbarLeft, styles.OpenAddButtons)}>
                                 <R.Button
                                     className={cx(styles.ToolbarButton, styles.OpenCanvasButton)}
-                                    onClick={() => this.canvasSearchOpen(!this.state.canvasSearchIsOpen)}
+                                    onMouseDown={(event) => {
+                                        // required to prevent mouseDown causing open search panel to blur
+                                        // which closes the search panel, only to be opened again on mouseup (click)
+                                        // also somehow strangely affected by realtime/historical button ? nfi.
+                                        event.preventDefault()
+                                    }}
+                                    onClick={() => {
+                                        this.canvasSearchOpen(!this.state.canvasSearchIsOpen)
+                                    }}
                                 >
                                     Open
                                 </R.Button>

--- a/app/src/editor/shared/components/SearchPanel/index.jsx
+++ b/app/src/editor/shared/components/SearchPanel/index.jsx
@@ -329,4 +329,6 @@ SearchPanel.defaultProps = {
     defaultPosY: (window.innerHeight / 2) - (DEFAULT_HEIGHT / 2) - 80, // center vertically (take header into account)
 }
 
-export default SearchPanel
+export default function ({ resetOnClose, isOpen, ...props }) {
+    return <SearchPanel key={resetOnClose ? isOpen : ''} isOpen={isOpen} {...props} />
+}


### PR DESCRIPTION
When module search results are closed e.g. via X button or automatically when a canvas starts, upon reopening, search is in a weird state where the search input is still set, but no search results are shown.

This fixes that by resetting the state via `key` whenever a `SearchPanel` with a `resetOnClose` flag set is closed.

Also fixed an issue where the canvas search "open" button was not toggling the visibility of the canvas search panel. It was closing the search on button mousedown (due to "close on blur" behaviour) and reopening it on mouseup (i.e. click).