### PR TITLE
[PLATFORM-976] Fix glitching cables

### DIFF
--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -55,7 +55,22 @@ class Cables extends React.PureComponent {
         if (this.props.isDragging && this.props.data.portId != null) {
             return this.getCablesDraggingPort()
         }
+
         return this.getStaticCables()
+    }
+
+    getPositions() {
+        // cache positions while drag operation is in progress
+        if (this.props.isDragging) {
+            if (!this.positions) {
+                this.positions = this.props.positions
+            }
+            return this.positions
+        }
+        if (this.positions) {
+            this.positions = undefined
+        }
+        return this.props.positions
     }
 
     /**
@@ -63,7 +78,8 @@ class Cables extends React.PureComponent {
      */
 
     getStaticCables() {
-        const { canvas, positions } = this.props
+        const { canvas } = this.props
+        const positions = this.getPositions()
         return canvas.modules
             .reduce((c, m) => {
                 [].concat(m.params, m.inputs, m.outputs).forEach((port) => {
@@ -141,7 +157,8 @@ class Cables extends React.PureComponent {
     }
 
     getDragCable() {
-        const { positions, data, diff, isDragging } = this.props
+        const { data, diff, isDragging } = this.props
+        const positions = this.getPositions()
         const { portId, sourceId } = data
         if (!isDragging || portId == null) {
             return null


### PR DESCRIPTION
Problem looks like this:

![1ffc5848-22c4-4cba-bd4e-35de4c725f1f](https://user-images.githubusercontent.com/43438/63029239-c5af5800-bee2-11e9-9bec-46d6bd05ef5b.gif)

Issue is caused by a delayed canvas update arriving during a drag operation e.g. autosave. This canvas update triggers re-reading port positions, which then applies the drag offset which was calculated from the previous position of the module. 

This is a quick fix that disallows position updates for cables during a drag operation. Cables can still get out of alignment if port positions actually change (e.g. multi-user env). Not perfect, but better.

## To Test

1. Connect some stuff
2. Move something
3. Before autosave kicks in, start dragging a module around.
4. Keep dragging, cables should not get out of alignment once autosave is done.