### PR TITLE
Highlight cables related to selected module

### DIFF
--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -210,7 +210,7 @@ class Cables extends React.PureComponent {
         return (
             <React.Fragment>
                 <svg
-                    className={styles.Cables}
+                    className={cx(styles.Cables, styles.layer0)}
                     preserveAspectRatio="xMidYMid meet"
                     height="100%"
                     width="100%"
@@ -227,7 +227,7 @@ class Cables extends React.PureComponent {
                     ))}
                 </svg>
                 <svg
-                    className={styles.Cables}
+                    className={cx(styles.Cables, styles.layer1)}
                     preserveAspectRatio="xMidYMid meet"
                     height="100%"
                     width="100%"

--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -64,6 +64,8 @@ class Cables extends React.PureComponent {
         const { selectedModuleHash } = this.props
         // no highlight if no selection
         if (selectedModuleHash == null) { return false }
+        // no highlight if dragging cable
+        if (a.id === DRAG_CABLE_ID || b.id === DRAG_CABLE_ID) { return false }
         return !this.shouldFade([a, b])
     }
 

--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -19,6 +19,9 @@ function curvedHorizontal(x1, y1, x2, y2) {
 const LAYER_0 = 0
 const LAYER_1 = 1
 
+// offset cables from edge of port
+const PORT_OFFSET = 4
+
 export function Cable({ className, cable, ...props }) {
     if (!cable) { return null }
     const [from, to] = cable
@@ -26,9 +29,9 @@ export function Cable({ className, cable, ...props }) {
         <path
             className={cx(styles.Connection, className)}
             d={curvedHorizontal(
-                from.left,
+                from.left + PORT_OFFSET,
                 from.top,
-                to.left,
+                to.left - PORT_OFFSET,
                 to.top,
             )}
             stroke="#525252"

--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -43,6 +43,8 @@ export function getCableKey([from, to] = []) {
     return `${from && from.id}-${to && to.id}`
 }
 
+const DRAG_CABLE_ID = 'DRAG_CABLE_ID'
+
 class Cables extends React.PureComponent {
     el = React.createRef()
 
@@ -52,6 +54,8 @@ class Cables extends React.PureComponent {
         const { canvas, selectedModuleHash } = this.props
         // no fade if no selection
         if (selectedModuleHash == null) { return false }
+        // no fade if dragging cable
+        if (a.id === DRAG_CABLE_ID || b.id === DRAG_CABLE_ID) { return false }
         // fade if not connected to selection
         return !isConnectedToModule(canvas, selectedModuleHash, a.id, b.id)
     }
@@ -180,7 +184,7 @@ class Cables extends React.PureComponent {
         return [
             positions[sourceId || portId],
             {
-                id: 'drag',
+                id: DRAG_CABLE_ID,
                 top: p.top + diff.y,
                 left: p.left + diff.x,
                 bottom: p.bottom + diff.y,

--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -55,7 +55,22 @@ class Cables extends React.PureComponent {
         if (this.props.isDragging && this.props.data.portId != null) {
             return this.getCablesDraggingPort()
         }
+
         return this.getStaticCables()
+    }
+
+    getPositions() {
+        // cache positions while drag operation is in progress
+        if (this.props.isDragging) {
+            if (!this.positions) {
+                this.positions = this.props.positions
+            }
+            return this.positions
+        }
+        if (this.positions) {
+            this.positions = undefined
+        }
+        return this.props.positions
     }
 
     /**
@@ -63,7 +78,8 @@ class Cables extends React.PureComponent {
      */
 
     getStaticCables() {
-        const { canvas, positions } = this.props
+        const { canvas } = this.props
+        const positions = this.getPositions()
         return canvas.modules
             .reduce((c, m) => {
                 [].concat(m.params, m.inputs, m.outputs).forEach((port) => {
@@ -141,7 +157,8 @@ class Cables extends React.PureComponent {
     }
 
     getDragCable() {
-        const { positions, data, diff, isDragging } = this.props
+        const { data, diff, isDragging } = this.props
+        const positions = this.getPositions()
         const { portId, sourceId } = data
         if (!isDragging || portId == null) {
             return null

--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -19,19 +19,20 @@ function curvedHorizontal(x1, y1, x2, y2) {
 const LAYER_0 = 0
 const LAYER_1 = 1
 
-// offset cables from edge of port
-const PORT_OFFSET = 4
-
 export function Cable({ className, cable, ...props }) {
     if (!cable) { return null }
     const [from, to] = cable
+    // adjust offset to edge based on curve direction
+    // i.e. connect to left edge if curve going L->R,
+    // connect to right edge if curve going R->L
+    const direction = from.left < to.left ? 1 : -1
     return (
         <path
             className={cx(styles.Connection, className)}
             d={curvedHorizontal(
-                from.left + PORT_OFFSET,
+                from.left + (0.5 * from.width * direction), // connect to edge of from
                 from.top,
-                to.left - PORT_OFFSET,
+                to.left + (0.5 * to.width * -direction), // connect to edge of to
                 to.top,
             )}
             stroke="#525252"
@@ -138,7 +139,7 @@ class Cables extends React.PureComponent {
             let layer = LAYER_0
             if (ports[from.id]) {
                 fromNew = {
-                    id: from.id,
+                    ...from,
                     top: from.top + diff.y,
                     left: from.left + diff.x,
                 }
@@ -146,7 +147,7 @@ class Cables extends React.PureComponent {
             }
             if (ports[to.id]) {
                 toNew = {
-                    id: to.id,
+                    ...to,
                     top: to.top + diff.y,
                     left: to.left + diff.x,
                 }
@@ -196,6 +197,7 @@ class Cables extends React.PureComponent {
         return [
             positions[sourceId || portId],
             {
+                ...p,
                 id: DRAG_CABLE_ID,
                 top: p.top + diff.y,
                 left: p.left + diff.x,

--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -60,6 +60,13 @@ class Cables extends React.PureComponent {
         return !isConnectedToModule(canvas, selectedModuleHash, a.id, b.id)
     }
 
+    shouldHighlight = ([a, b]) => {
+        const { selectedModuleHash } = this.props
+        // no highlight if no selection
+        if (selectedModuleHash == null) { return false }
+        return !this.shouldFade([a, b])
+    }
+
     getCables() {
         const hasMoved = this.props.isDragging && !(this.props.diff.x === 0 && this.props.diff.y === 0)
         if (this.props.isDragging && this.props.data.moduleHash != null && hasMoved) {
@@ -212,6 +219,7 @@ class Cables extends React.PureComponent {
                             cable={cable}
                             className={cx({
                                 [styles.fade]: this.shouldFade(cable),
+                                [styles.highlight]: this.shouldHighlight(cable),
                             })}
                         />
                     ))}
@@ -228,6 +236,7 @@ class Cables extends React.PureComponent {
                             cable={cable}
                             className={cx({
                                 [styles.fade]: this.shouldFade(cable),
+                                [styles.highlight]: this.shouldHighlight(cable),
                             })}
                         />
                     ))}

--- a/app/src/editor/canvas/components/Canvas.jsx
+++ b/app/src/editor/canvas/components/Canvas.jsx
@@ -177,6 +177,7 @@ class CanvasElements extends React.PureComponent {
                     <Cables
                         canvas={canvas}
                         positions={this.state.positions}
+                        selectedModuleHash={selectedModuleHash}
                     />
                 </DragDropProvider>
                 <div id="canvas-windows" />

--- a/app/src/editor/canvas/components/Canvas.jsx
+++ b/app/src/editor/canvas/components/Canvas.jsx
@@ -168,7 +168,7 @@ class CanvasElements extends React.PureComponent {
                                 canvas={canvas}
                                 onPort={this.onPort}
                                 api={api}
-                                selectedModuleHash={selectedModuleHash}
+                                isSelected={selectedModuleHash === m.hash}
                                 moduleSidebarIsOpen={moduleSidebarIsOpen}
                                 {...api.module}
                             />

--- a/app/src/editor/canvas/components/Canvas.pcss
+++ b/app/src/editor/canvas/components/Canvas.pcss
@@ -34,6 +34,10 @@
   pointer-events: none;
 }
 
+.Cables.layer1 {
+  z-index: 2;
+}
+
 svg.Cables {
   overflow: visible;
 }

--- a/app/src/editor/canvas/components/Canvas.pcss
+++ b/app/src/editor/canvas/components/Canvas.pcss
@@ -39,10 +39,16 @@ svg.Cables {
 }
 
 svg.Cables path {
-  transition: opacity 0.5s;
+  transition: opacity 0.5s, stroke 0.5s, stroke-width 0.75s;
   opacity: 1;
 }
 
 svg.Cables path.fade {
   opacity: 0.2;
+}
+
+svg.Cables path.highlight {
+  opacity: 1;
+  stroke: #2AC437;
+  stroke-width: 1.5;
 }

--- a/app/src/editor/canvas/components/Canvas.pcss
+++ b/app/src/editor/canvas/components/Canvas.pcss
@@ -37,3 +37,12 @@
 svg.Cables {
   overflow: visible;
 }
+
+svg.Cables path {
+  transition: opacity 0.5s;
+  opacity: 1;
+}
+
+svg.Cables path.fade {
+  opacity: 0.2;
+}

--- a/app/src/editor/canvas/components/DragDropContext.jsx
+++ b/app/src/editor/canvas/components/DragDropContext.jsx
@@ -133,7 +133,7 @@ class EditorDraggable extends React.PureComponent {
     }
 
     getDiff(data) {
-        const { initialPosition } = this.state
+        const initialPosition = this.initialPosition || this.state.initialPosition
 
         return {
             x: data.x - initialPosition.x,
@@ -155,17 +155,7 @@ class EditorDraggable extends React.PureComponent {
 
     onStart = (event, data) => {
         if (this.unmounted) { return }
-        this.setState({
-            initialPosition: data,
-        })
-
-        if (!this.props.onStart) {
-            return this.context.onStart()
-        }
-
-        // pass on props.onStart to context
-        const startData = this.props.onStart(event, data)
-        return this.context.onStart(startData)
+        this.initialPosition = data
     }
 
     onStop = (event, data) => {
@@ -210,6 +200,30 @@ class EditorDraggable extends React.PureComponent {
         }
 
         const diff = this.getDiff(data)
+        // only trigger start after moving
+        if (!this.context.isDragging) {
+            if (diff.x === 0 && diff.y === 0) {
+                return
+            }
+            this.setState({
+                initialPosition: this.initialPosition,
+            }, () => {
+                this.initialPosition = undefined
+            })
+            if (!this.props.onStart) {
+                const shouldContinue = this.context.onStart()
+                if (shouldContinue === false) {
+                    return false
+                }
+            }
+
+            // pass on props.onStart to context
+            const startData = this.props.onStart(event, data)
+            const shouldContinue = this.context.onStart(startData)
+            if (shouldContinue === false) {
+                return false
+            }
+        }
 
         if (!this.props.onDrag) {
             return this.context.onDrag(diff)
@@ -217,7 +231,7 @@ class EditorDraggable extends React.PureComponent {
 
         const shouldContinue = this.props.onDrag(event, data, diff)
 
-        if (!shouldContinue) {
+        if (!shouldContinue === false) {
             return false
         }
 

--- a/app/src/editor/canvas/components/DragDropContext.jsx
+++ b/app/src/editor/canvas/components/DragDropContext.jsx
@@ -11,8 +11,8 @@ export class DragDropProvider extends React.PureComponent {
 
     initialState = {
         isDragging: false,
-        isCancelled: undefined,
-        diff: undefined,
+        isCancelled: false,
+        diff: null,
         data: {},
     }
 
@@ -165,6 +165,7 @@ class EditorDraggable extends React.PureComponent {
         }
 
         if (this.context.isCancelled) {
+            this.context.onStop()
             this.setState({
                 initialPosition: undefined,
             })

--- a/app/src/editor/canvas/components/PortDragger.jsx
+++ b/app/src/editor/canvas/components/PortDragger.jsx
@@ -41,6 +41,7 @@ class DraggablePort extends React.Component {
         const triggeredPorts = []
         const { data } = this.context
         const { sourceId, portId, overId } = data
+        if (overId === portId) { return } // do nothing, already connected
         this.props.api.setCanvas({ type: 'Connect Ports' }, (canvas) => {
             if (!this.canConnectPorts(canvas)) { return null } // noop if incompatible
             let nextCanvas = canvas

--- a/app/src/editor/canvas/components/Ports/Dragger/dragger.pcss
+++ b/app/src/editor/canvas/components/Ports/Dragger/dragger.pcss
@@ -25,6 +25,7 @@
   top: 50%;
   transform: translate(-50%, -50%);
   width: calc(0.5 * var(--um));
+  z-index: 3;
 }
 
 .target {

--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -142,7 +142,7 @@ const Port = ({
                     target={contextMenuTarget}
                 />
             )}
-            {!!port.canToggleDrivingInput && (
+            {!dragInProgress && !!port.canToggleDrivingInput && (
                 <Option
                     activated={!!port.drivingInput}
                     className={styles.portOption}
@@ -175,7 +175,7 @@ const Port = ({
                 </Cell>
             )}
             {!isInput && plug}
-            {!!port.canBeNoRepeat && (
+            {!dragInProgress && !!port.canBeNoRepeat && (
                 <Option
                     activated={!!port.noRepeat}
                     className={styles.portOption}

--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -188,6 +188,9 @@ const Port = ({
     )
 }
 
-Port.styles = styles
-
-export default Port
+// $FlowFixMe
+const PortExport = React.memo(Port)
+// $FlowFixMe
+PortExport.styles = styles
+// $FlowFixMe
+export default PortExport

--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -27,6 +27,8 @@ type Props = {
     setOptions: any,
 }
 
+const EMPTY = {}
+
 const Port = ({
     api,
     canvas,
@@ -36,10 +38,14 @@ const Port = ({
     port,
     setOptions,
 }: Props) => {
-    const { isEditable } = useContext(RunController.Context)
+    const { isDragging, data } = useContext(DragDropContext)
+    const { portId } = data || EMPTY
+    const dragInProgress = !!isDragging && portId != null
+    const { isEditable: isCanvasEditable } = useContext(RunController.Context)
+    const isContentEditable = !dragInProgress && isCanvasEditable
     const isInput = !!port.acceptedTypes
     const isParam = 'defaultValue' in port
-    const hasInputField = isParam || port.canHaveInitialValue
+    const hasInputField = !!(isParam || port.canHaveInitialValue)
     const [contextMenuTarget, setContextMenuTarget] = useState(null)
     const [editingName, setEditingName] = useState(false)
 
@@ -106,10 +112,6 @@ const Port = ({
         onSizeChange()
     }, [port.value, onSizeChange])
 
-    const { isDragging, data } = useContext(DragDropContext)
-    const { portId } = data || {}
-    const dragInProgress = !!isDragging && portId != null
-
     const plug = (
         <Plug
             api={api}
@@ -118,17 +120,16 @@ const Port = ({
             onValueChange={onValueChangeProp}
             port={port}
             register={onPort}
-            disabled={!isEditable}
+            disabled={!isCanvasEditable}
         />
     )
 
     const isInvisible = isPortInvisible(canvas, port.id)
-    const isRenameDisabled = !isEditable || isPortRenameDisabled(canvas, port.id)
+    const isRenameDisabled = !isContentEditable || isPortRenameDisabled(canvas, port.id)
 
     return (
         <div
             className={cx(styles.root, {
-                [styles.dragInProgress]: !!dragInProgress,
                 [styles.dragInProgress]: !!dragInProgress,
                 [styles.isInvisible]: isInvisible,
             })}
@@ -146,7 +147,7 @@ const Port = ({
                 <Option
                     activated={!!port.drivingInput}
                     className={styles.portOption}
-                    disabled={!isEditable}
+                    disabled={!isContentEditable}
                     name="drivingInput"
                     onToggle={onOptionToggle}
                 />
@@ -170,7 +171,7 @@ const Port = ({
                         canvas={canvas}
                         port={port}
                         onChange={onValueChange}
-                        disabled={!isEditable}
+                        disabled={!isContentEditable}
                     />
                 </Cell>
             )}
@@ -179,7 +180,7 @@ const Port = ({
                 <Option
                     activated={!!port.noRepeat}
                     className={styles.portOption}
-                    disabled={!isEditable}
+                    disabled={!isContentEditable}
                     name="noRepeat"
                     onToggle={onOptionToggle}
                 />

--- a/app/src/editor/canvas/components/Ports/index.jsx
+++ b/app/src/editor/canvas/components/Ports/index.jsx
@@ -75,4 +75,5 @@ const Ports = ({
     )
 }
 
-export default Ports
+// $FlowFixMe
+export default React.memo(Ports)

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -319,6 +319,22 @@ export function getConnectedPortIds(canvas, portId) {
         .map(({ id }) => id)
 }
 
+function moduleHasPort(canvas, moduleHash, portId) {
+    if (!hasPort(canvas, portId)) { return false }
+    const m = getModuleForPort(canvas, portId)
+    return m.hash === moduleHash
+}
+
+export function isConnectedToModule(canvas, moduleHash, portIdA, portIdB) {
+    if (moduleHash == null || !getModuleIfExists(canvas, moduleHash)) {
+        return false
+    }
+    return (
+        (moduleHasPort(canvas, moduleHash, portIdA) || moduleHasPort(canvas, moduleHash, portIdB)) &&
+        arePortsConnected(canvas, portIdA, portIdB)
+    )
+}
+
 export function isPortConnected(canvas, portId) {
     if (!hasPort(canvas, portId)) { return false }
     const conn = getConnectedPortIds(canvas, portId)


### PR DESCRIPTION
Helps you more clearly see what's connected to what on messy canvases.

* Shows currently dragged cable on top of modules
* Shows cables of currently dragged module on top of other modules
* Hides port "options" during drag (DI/NR buttons)
* Fixes regression where after cancelling a drag with esc, dragging was permanently cancelled.
* Fixes regression where reconnecting to same port after starting a drag would disconnect the port.

![highlight-cable-drag](https://user-images.githubusercontent.com/43438/63151654-91e84580-c03c-11e9-98fe-52e734090d7f.gif)

Includes commits from glitching cables PR #634.
