### PR TITLE
[PLATFORM-973] Prevent annoying scroll to module on selection

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10772,6 +10772,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz",
+      "integrity": "sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -31748,6 +31753,14 @@
         }
       }
     },
+    "scroll-into-view-if-needed": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.20.tgz",
+      "integrity": "sha512-P9kYMrhi9f6dvWwTGpO5I3HgjSU/8Mts7xL3lkoH5xlewK7O9Obdc5WmMCzppln7bCVGNmf3qfoZXrpCeyNJXw==",
+      "requires": {
+        "compute-scroll-into-view": "1.0.11"
+      }
+    },
     "scrypt": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
@@ -32186,6 +32199,14 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "smooth-scroll-into-view-if-needed": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/smooth-scroll-into-view-if-needed/-/smooth-scroll-into-view-if-needed-1.1.23.tgz",
+      "integrity": "sha512-52177sj5yR2novVCB+vJRCYEUkHFz2mq5UKmm5wwIWs0ZtC1sotVaTjKBsuNzBPF4nOV1NxMctyD4V/VMmivCQ==",
+      "requires": {
+        "scroll-into-view-if-needed": "2.2.20"
       }
     },
     "snake-case": {

--- a/app/package.json
+++ b/app/package.json
@@ -228,6 +228,7 @@
     "reselect": "^3.0.1",
     "sass-loader": "^7.0.1",
     "sinon": "^6.0.0",
+    "smooth-scroll-into-view-if-needed": "^1.1.23",
     "storybook-addon-jsx": "^5.4.0",
     "storybook-chromatic": "^1.2.0",
     "storybook-react-router": "^1.0.1",

--- a/app/src/docs/components/DocsLayout/Navigation/index.jsx
+++ b/app/src/docs/components/DocsLayout/Navigation/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { Link, withRouter, type Location } from 'react-router-dom'
+import scrollIntoView from 'smooth-scroll-into-view-if-needed'
 import { formatPath } from '$shared/utils/url'
 import cx from 'classnames'
 import Scrollspy from 'react-scrollspy'
@@ -45,7 +46,7 @@ class Navigation extends React.Component<Props, State> {
         if (root && window.pageYOffset > 2000) {
             window.scrollTo(0, 0)
         } else if (root) {
-            root.scrollIntoView({
+            scrollIntoView(root, {
                 behavior: 'smooth',
                 block: 'start',
                 inline: 'nearest',

--- a/app/src/editor/canvas/components/Canvas.pcss
+++ b/app/src/editor/canvas/components/Canvas.pcss
@@ -10,6 +10,7 @@
   bottom: 0;
   right: 0;
   overflow: auto;
+  scroll-behavior: smooth;
 }
 
 .Modules,

--- a/app/src/editor/canvas/components/CanvasController/useCanvasUpdater.jsx
+++ b/app/src/editor/canvas/components/CanvasController/useCanvasUpdater.jsx
@@ -6,6 +6,9 @@ import { Context as UndoContext } from '$shared/components/UndoContextProvider'
 import * as CanvasState from '../../state'
 
 function canvasUpdater(fn) {
+    if (typeof fn !== 'function') {
+        throw new Error(`canvasUpdater requires a function, given: ${typeof fn}`)
+    }
     return (canvas) => {
         const nextCanvas = fn(canvas)
         if (nextCanvas === null || nextCanvas === canvas) { return canvas }

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -1,7 +1,6 @@
 import cx from 'classnames'
 import React from 'react'
 import { Translate } from 'react-redux-i18n'
-import scrollIntoView from 'smooth-scroll-into-view-if-needed'
 
 import ModuleHeaderButton from '../../shared/components/ModuleHeaderButton'
 import ModuleHeader from '../../shared/components/ModuleHeader'
@@ -42,15 +41,9 @@ class CanvasModule extends React.PureComponent {
 
     onSelection() {
         if (!this.el.current) { return }
-        scrollIntoView(this.el.current, {
-            behavior: 'smooth',
-            scrollMode: 'if-needed',
-            block: 'center',
-            inline: 'center',
-        })
 
         // no direct access to normal focus ref, have to go via parentElement
-        this.el.current.parentElement.focus()
+        this.el.current.parentElement.focus() // focus should scroll element into view
     }
 
     componentDidMount() {

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -1,6 +1,7 @@
 import cx from 'classnames'
 import React from 'react'
 import { Translate } from 'react-redux-i18n'
+import scrollIntoView from 'smooth-scroll-into-view-if-needed'
 
 import ModuleHeaderButton from '../../shared/components/ModuleHeaderButton'
 import ModuleHeader from '../../shared/components/ModuleHeader'
@@ -41,11 +42,13 @@ class CanvasModule extends React.PureComponent {
 
     onSelection() {
         if (!this.el.current) { return }
-        this.el.current.scrollIntoView({
+        scrollIntoView(this.el.current, {
             behavior: 'smooth',
-            block: 'start',
-            inline: 'nearest',
+            scrollMode: 'if-needed',
+            block: 'center',
+            inline: 'center',
         })
+
         // no direct access to normal focus ref, have to go via parentElement
         this.el.current.parentElement.focus()
     }

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -6,6 +6,7 @@ import type { Match } from 'react-router-dom'
 import { push, replace } from 'connected-react-router'
 import { I18n } from 'react-redux-i18n'
 import { Helmet } from 'react-helmet'
+import scrollIntoView from 'smooth-scroll-into-view-if-needed'
 
 import ProductPageComponent from '$mp/components/ProductPage'
 import Layout from '$shared/components/Layout'
@@ -162,7 +163,7 @@ export class ProductPage extends Component<Props, State> {
             })
 
             if (this.productDetails) {
-                this.productDetails.scrollIntoView({
+                scrollIntoView(this.productDetails, {
                     behavior: 'smooth',
                     block: 'start',
                     inline: 'nearest',

--- a/app/src/shared/components/AutoScroll/index.jsx
+++ b/app/src/shared/components/AutoScroll/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react'
+import scrollIntoView from 'smooth-scroll-into-view-if-needed'
 
 import RouteWatcher from '$shared/containers/RouteWatcher'
 import ModalContext from '$shared/contexts/Modal'
@@ -17,7 +18,7 @@ class AutoScroll extends React.Component<{}> {
         if (root && !isModalOpen && window.pageYOffset > 2000) {
             window.scrollTo(0, 0)
         } else if (root && !isModalOpen) {
-            root.scrollIntoView({
+            scrollIntoView(root, {
                 behavior: 'smooth',
                 block: 'start',
                 inline: 'nearest',


### PR DESCRIPTION
Partial improvement for [PLATFORM-973](https://streamr.atlassian.net/browse/PLATFORM-973). Adds a ponyfill for scrolling items into view if needed, smoothly. https://caniuse.com/#feat=scrollintoview

Eliminates annoying jump on selecting a module:

> Scroll position also jumps annoyingly on simply selecting a module 

And partially addresses:

> On a high canvas (scrollable vertically), when I start dragging modules on the visible part of the canvas, the scroll position annoyingly changes

Not a full fix, needs something more sophisticated to handle dragging modules in and out of the canvas bounds, but this PR makes it less annoying.

Also fixes smooth-scrolling `SearchPanel` results in Safari.
