### PR TITLE
[PLATFORM-1003] Fix loading of stream resource keys

### DIFF
--- a/app/src/shared/modules/resourceKey/actions.js
+++ b/app/src/shared/modules/resourceKey/actions.js
@@ -220,8 +220,10 @@ export const addStreamResourceKey = (id: StreamId, name: string, permission: Res
             type: 'STREAM',
         }))
         .then(handleEntities(resourceKeySchema, dispatch))
-        .then((result) => dispatch(addStreamResourceKeySuccess(id, result)))
-        .catch((e) => {
+        .then((result) => {
+            dispatch(addStreamResourceKeySuccess(id, result))
+            dispatch(getStreamResourceKeys(id))
+        }, (e) => {
             const error = {
                 title: 'Error!',
                 message: e.message,

--- a/app/src/shared/test/modules/resourceKey/actions.test.js
+++ b/app/src/shared/test/modules/resourceKey/actions.test.js
@@ -235,6 +235,8 @@ describe('resourceKey - actions', () => {
                     id: streamId,
                     key,
                 },
+            }, {
+                type: constants.GET_RESOURCE_KEYS_REQUEST,
             }]
 
             const store = mockStore()

--- a/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
@@ -36,26 +36,26 @@ type Props = OwnProps & StateProps & DispatchProps
 
 export class KeyView extends Component<Props> {
     componentDidMount() {
-        if (!this.props.disabled && this.props.streamId) {
-            this.props.getKeys(this.props.streamId)
+        this.getKeys()
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        // get keys if streamId/disabled changes
+        if (prevProps.streamId !== this.props.streamId || prevProps.disabled !== this.props.disabled) {
+            this.getKeys()
         }
     }
 
-    componentWillReceiveProps(props: Props) {
-        if (!this.props.disabled && props.streamId && props.streamId !== this.props.streamId) {
-            this.props.getKeys(props.streamId)
-        }
+    getKeys = () => {
+        if (this.props.disabled || this.props.streamId == null) { return }
+        this.props.getKeys(this.props.streamId)
     }
 
-    addKey = (key: string, permission: ?ResourcePermission): Promise<void> => new Promise((resolve, reject) => {
-        if (this.props.streamId) {
-            const keyPermission = permission || 'read'
-            this.props.addKey(this.props.streamId, key, keyPermission)
-                .then(resolve, reject)
-        } else {
-            resolve()
-        }
-    })
+    addKey = async (key: string, permission: ?ResourcePermission): Promise<void> => {
+        if (this.props.streamId == null) { return }
+        const keyPermission = permission || 'read'
+        return this.props.addKey(this.props.streamId, key, keyPermission)
+    }
 
     editStreamResourceKey = (streamId: StreamId, keyId: ResourceKeyId, keyName: string, keyPermission: ResourcePermission): Promise<void> => (
         this.props.editStreamResourceKey(streamId, keyId, keyName, keyPermission)


### PR DESCRIPTION
Ensures resource keys are always fetched. Fixes bug where sometimes (most times) resource keys weren't loading because the `disabled` state was removed after `streamId` was added, but component didn't trigger resource key load.

Also fixes another bug where a resource keys wouldn't appear after adding it.