### PR TITLE
[PLATFORM-981] Force the default possible value do display “correctly”

### DIFF
--- a/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
@@ -32,6 +32,8 @@ const Select = ({
         }, new Map())
     ), [options])
 
+    const selectionText = optionMap.get(value)
+
     return (
         <div className={styles.root}>
             <div className={styles.inner}>
@@ -53,7 +55,7 @@ const Select = ({
                         to a value that's not on the list of possible values (casing mismatch
                         such as `events` vs `EVENTS`). In that case we simply display the raw
                         value here instead of nothing. */}
-                    <option>{optionMap.get(value) || value}</option>
+                    <option>{selectionText != null ? selectionText : value}</option>
                 </select>
             </div>
         </div>

--- a/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
@@ -49,6 +49,10 @@ const Select = ({
                 {/* `select` holding a currently selected value. This hidden (`visibility: hidden`) control
                     dictates the width of the actual (visible) control above. */}
                 <select className={styles.spaceholder}>
+                    {/* Some inputs like `windowType` come with a default value set by the server
+                        to a value that's not on the list of possible values (casing mismatch
+                        such as `events` vs `EVENTS`). In that case we simply display the raw
+                        value here instead of nothing. */}
                     <option>{optionMap.get(value) || value}</option>
                 </select>
             </div>

--- a/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
@@ -49,7 +49,7 @@ const Select = ({
                 {/* `select` holding a currently selected value. This hidden (`visibility: hidden`) control
                     dictates the width of the actual (visible) control above. */}
                 <select className={styles.spaceholder}>
-                    <option>{optionMap.get(value)}</option>
+                    <option>{optionMap.get(value) || value}</option>
                 </select>
             </div>
         </div>

--- a/app/src/editor/canvas/components/Ports/Value/Select/select.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/Select/select.pcss
@@ -19,8 +19,7 @@
   outline: 0;
   padding: 0 calc(0.5 * var(--um));
   transition: 200ms linear;
-  transition-property: background-color, color, width, box-shadow;
-  width: 100%;
+  transition-property: background-color, color, box-shadow;
 }
 
 .root select:hover,


### PR DESCRIPTION
What do you think @timoxley?

The `optionMap.get(value) || value` really isn't perfect. It seems to work tho. And I think we should address the issue at its core (e&e). This should do it for now tho.

Please try to break it.