### PR TITLE
Fix preview cable rendering

### DIFF
--- a/app/src/editor/canvas/components/Cables.jsx
+++ b/app/src/editor/canvas/components/Cables.jsx
@@ -30,9 +30,9 @@ export function Cable({ className, cable, ...props }) {
         <path
             className={cx(styles.Connection, className)}
             d={curvedHorizontal(
-                from.left + (0.5 * from.width * direction), // connect to edge of from
+                from.left + (0.5 * (from.width || 0) * direction), // connect to edge of from
                 from.top,
-                to.left + (0.5 * to.width * -direction), // connect to edge of to
+                to.left + (0.5 * (to.width || 0) * -direction), // connect to edge of to
                 to.top,
             )}
             stroke="#525252"

--- a/app/src/editor/canvas/components/Preview.jsx
+++ b/app/src/editor/canvas/components/Preview.jsx
@@ -24,6 +24,8 @@ function getPortPosition(portId, canvas, preview, previewScale) {
         id: m.id,
         left: (p.left + (p.width / 2)) * previewScale,
         top: (p.top + (p.height / 2)) * previewScale,
+        width: p.width * previewScale,
+        height: p.height * previewScale,
     }
 }
 

--- a/app/src/editor/canvas/components/Preview.jsx
+++ b/app/src/editor/canvas/components/Preview.jsx
@@ -47,7 +47,7 @@ const PreviewCables = ({ canvas, preview, previewScale }) => (
             }
         }, []),
     }), {})).map(([key, cable]) => (
-        <Cable cable={cable} key={key} strokeWidth="0.5" />
+        <Cable cable={cable} key={key} strokeWidth="0.2" />
     ))
 )
 


### PR DESCRIPTION
* Fixes preview cable rendering. Wasn't working due to recent update to cable drawing code using `width` which wasn't being passed in preview cable's data.
* Also now draws cables from appropriate edge rather than middle of modules, which looks more like full version.

To Test:

The previews in the canvas list page cables should render. Cables should appear to emerge from vertical center+left/right edge of modules.

![image](https://user-images.githubusercontent.com/43438/63256361-fe1bb100-c2a9-11e9-8f51-151336405d1f.png)
