### PR TITLE
[PLATFORM-994] Module sidebar tweaks updated

### DIFF
--- a/app/src/editor/canvas/components/ModuleSidebar.jsx
+++ b/app/src/editor/canvas/components/ModuleSidebar.jsx
@@ -83,6 +83,7 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
                                             /* Select */
                                             <Select
                                                 id={id}
+                                                className={styles.select}
                                                 value={opts.filter((opt) => opt.value === option.value)}
                                                 onChange={onSelectChange(name)}
                                                 options={opts}

--- a/app/src/editor/canvas/components/ModuleSidebar.jsx
+++ b/app/src/editor/canvas/components/ModuleSidebar.jsx
@@ -91,6 +91,7 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
                                             (option.type === 'boolean' && (
                                                 <Toggle
                                                     id={id}
+                                                    className={styles.toggle}
                                                     value={option.value}
                                                     onChange={onChange(name)}
                                                     disabled={!isEditable}

--- a/app/src/editor/canvas/components/ModuleSidebar.jsx
+++ b/app/src/editor/canvas/components/ModuleSidebar.jsx
@@ -98,6 +98,7 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
                                             )) || (
                                                 /* Text */
                                                 <Text
+                                                    id={id}
                                                     className={styles.input}
                                                     value={option.value}
                                                     onChange={onChange(name)}

--- a/app/src/editor/canvas/components/ModuleSidebar.jsx
+++ b/app/src/editor/canvas/components/ModuleSidebar.jsx
@@ -82,6 +82,7 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
                                         {option.possibleValues ? (
                                             /* Select */
                                             <Select
+                                                id={id}
                                                 value={opts.filter((opt) => opt.value === option.value)}
                                                 onChange={onSelectChange(name)}
                                                 options={opts}

--- a/app/src/editor/canvas/components/ModuleSidebar.pcss
+++ b/app/src/editor/canvas/components/ModuleSidebar.pcss
@@ -21,15 +21,7 @@
   }
 
   .select {
-    select {
-      margin-left: calc(-0.5 * var(--um));
-    }
 
-    select:hover,
-    select:focus {
-      color: #525252;
-      background: none;
-    }
   }
 
   .toggle {

--- a/app/src/editor/canvas/components/ModuleSidebar.pcss
+++ b/app/src/editor/canvas/components/ModuleSidebar.pcss
@@ -1,8 +1,9 @@
 .optionsFields {
   display: grid;
-  grid-template-columns: auto 100px;
+  grid-template-columns: auto 105px;
   align-items: center;
   grid-row-gap: 20px;
+  grid-column-gap: 20px;
 
   label {
     font-family: var(--sans);

--- a/app/src/editor/canvas/components/ModuleSidebar.pcss
+++ b/app/src/editor/canvas/components/ModuleSidebar.pcss
@@ -20,14 +20,12 @@
     margin: 0 calc(-0.5 * var(--um));
   }
 
-  select {
+  .select {
     width: auto;
     color: #525252;
     font-size: 12px;
     font-family: inherit;
-    background: #F5F5F5;
-    border-radius: 2px;
-    border: none;
+    background: transparent;
   }
 
   .toggle {

--- a/app/src/editor/canvas/components/ModuleSidebar.pcss
+++ b/app/src/editor/canvas/components/ModuleSidebar.pcss
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-columns: auto 100px;
   align-items: center;
-  grid-column-gap: 40px;
+  grid-row-gap: 20px;
 
   label {
     font-family: var(--sans);
@@ -10,7 +10,6 @@
     font-size: 14px;
     text-align: left;
     letter-spacing: 0;
-    line-height: 40px;
     color: #525252;
     margin: 0;
   }
@@ -28,6 +27,11 @@
     background: #F5F5F5;
     border-radius: 2px;
     border: none;
+  }
+
+  .toggle {
+    display: flex;
+    align-items: center;
   }
 }
 

--- a/app/src/editor/canvas/components/ModuleSidebar.pcss
+++ b/app/src/editor/canvas/components/ModuleSidebar.pcss
@@ -21,11 +21,6 @@
   }
 
   .select {
-    width: auto;
-    color: #525252;
-    font-size: 12px;
-    font-family: inherit;
-    background: transparent;
   }
 
   .toggle {

--- a/app/src/editor/canvas/components/ModuleSidebar.pcss
+++ b/app/src/editor/canvas/components/ModuleSidebar.pcss
@@ -21,6 +21,15 @@
   }
 
   .select {
+    select {
+      margin-left: calc(-0.5 * var(--um));
+    }
+
+    select:hover,
+    select:focus {
+      color: #525252;
+      background: none;
+    }
   }
 
   .toggle {

--- a/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { useCallback, useMemo } from 'react'
+import cx from 'classnames'
 import { type CommonProps } from '..'
 import styles from './select.pcss'
 
@@ -13,6 +14,7 @@ type Props = CommonProps & {
 }
 
 const Select = ({
+    className,
     disabled,
     onChange: onChangeProp,
     value,
@@ -35,7 +37,7 @@ const Select = ({
     ), [options])
 
     return (
-        <div className={styles.root}>
+        <div className={cx(styles.root, className)}>
             <div className={styles.inner}>
                 <select
                     {...props}

--- a/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
@@ -6,7 +6,8 @@ import styles from './select.pcss'
 
 type Props = CommonProps & {
     options: Array<{
-        name: string,
+        name?: string,
+        text?: string, // sidebar options use 'text' instead of 'name' :/
         value: any,
     }>,
 }
@@ -15,6 +16,7 @@ const Select = ({
     disabled,
     onChange: onChangeProp,
     value,
+    title,
     options,
     ...props
 }: Props) => {
@@ -25,9 +27,9 @@ const Select = ({
     if (value == null) { value = undefined } // select doesn't want null value
 
     const optionMap = useMemo(() => (
-        options.reduce((memo, { name, value }) => {
+        options.reduce((memo, { name, text, value }) => {
             if (value == null) { value = undefined }
-            memo.set(value, name)
+            memo.set(value, name != null ? name : text)
             return memo
         }, new Map())
     ), [options])
@@ -37,13 +39,14 @@ const Select = ({
             <div className={styles.inner}>
                 <select
                     {...props}
+                    title={title != null ? title : value}
                     className={styles.control}
                     value={value}
                     disabled={disabled}
                     onChange={onChange}
                 >
-                    {options.map(({ name, value }) => (
-                        <option key={value} value={value}>{name}</option>
+                    {options.map(({ name, text, value }) => (
+                        <option key={value} value={value}>{name != null ? name : text}</option>
                     ))}
                 </select>
                 {/* `select` holding a currently selected value. This hidden (`visibility: hidden`) control

--- a/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Select/index.jsx
@@ -41,7 +41,7 @@ const Select = ({
             <div className={styles.inner}>
                 <select
                     {...props}
-                    title={title != null ? title : value}
+                    title={title != null ? String(title) : String(value)}
                     className={styles.control}
                     value={value}
                     disabled={disabled}

--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -39,6 +39,9 @@ export type CommonProps = {
     onChange: (any) => void,
     value: any,
     placeholder: any,
+    title?: string,
+    id?: string,
+    className?: string,
 }
 
 const Value = ({ canvas, disabled, port, onChange }: Props) => {

--- a/app/src/editor/shared/components/Sidebar/sidebar.pcss
+++ b/app/src/editor/shared/components/Sidebar/sidebar.pcss
@@ -27,7 +27,7 @@
   }
 
   .header {
-    padding: 21px 48px 12px;
+    padding: 21px 39px 12px;
     user-select: none;
 
     .titleRow {
@@ -95,7 +95,7 @@
 .sidebarSection {
   border-bottom: 1px solid #EFEFEF;
   border-top: 1px solid #EFEFEF;
-  padding: 24px 48px;
+  padding: 25px 39px;
 
   & + & {
     border-top: none;

--- a/app/src/editor/shared/components/Sidebar/sidebar.pcss
+++ b/app/src/editor/shared/components/Sidebar/sidebar.pcss
@@ -144,13 +144,14 @@
   line-height: 24px;
 }
 
-.select {
-  .tick {
-    width: 10px;
-    height: 8px;
-    position: absolute;
-    top: 50%;
-    right: 0.5rem;
-    transform: translate(-50%, -50%);
-  }
+.tick {
+  display: inline-block;
+  font-size: 8px;
+  fill: red;
+  width: 10px;
+  height: 8px;
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  transform: translate(-50%, -50%);
 }

--- a/app/src/shared/components/EditableText/editableText.pcss
+++ b/app/src/shared/components/EditableText/editableText.pcss
@@ -63,3 +63,11 @@
   /* ensures right-hand side of italic spaceholder text is not cut off */
   padding-right: 0.25em; /* also balance extra width added by input when editing */
 }
+
+.hiddenInput {
+  width: 0;
+  height: 0;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -8,6 +8,7 @@ import TextControl from '../TextControl'
 import styles from './editableText.pcss'
 
 type Props = {
+    id?: string,
     autoFocus?: boolean,
     children?: string | number,
     className?: ?string,
@@ -128,7 +129,13 @@ const EditableText = ({
                             {renderValue(value)}
                         </span>
                     </Fragment>
-                ) : renderValue(children)}
+                ) : (
+                    <React.Fragment>
+                        {renderValue(children)}
+                        {/* fake input to capture focus from label click */}
+                        <input className={styles.hiddenInput} id={props.id} onFocus={onFocus} />
+                    </React.Fragment>
+                )}
             </span>
         </div>
     )


### PR DESCRIPTION
@tumppi added a few tweaks on top your sidebar PR:

* Repurposed Port `Select` component for sidebar, doesn't match mock but better than unstyled.
* Did some magic to allow label clicks to give focus to `EditableText` inputs like normal inputs.
* Adjusted line-height & whitespace

## Before 
![image](https://user-images.githubusercontent.com/43438/63430769-f7c73980-c44f-11e9-9ccf-91cf19216370.png)

## After
![image](https://user-images.githubusercontent.com/43438/63432064-eb90ab80-c452-11e9-8074-007318ddcd50.png)





