### PR TITLE
[PLATFORM-993] Fix big input cursor in Safari

### DIFF
--- a/app/src/shared/components/EditableText/editableText.pcss
+++ b/app/src/shared/components/EditableText/editableText.pcss
@@ -14,17 +14,17 @@
 .inner input {
   color: inherit;
   font: inherit;
-  line-height: 2em;
 }
 
 .inner input {
   background: none;
   border: 0;
+  height: 100%;
+  line-height: normal;
   outline: 0;
   padding: 0;
   position: absolute;
   width: 100%;
-  overflow: visible;
 }
 
 .inner input::selection {


### PR DESCRIPTION
#### After

![safari-port-value-cursor](https://user-images.githubusercontent.com/43438/63756214-8c1b1b80-c8ea-11e9-857f-bf16a406537b.gif)

#### Before

![29f44878-5b79-4157-960c-324e9761c2cc](https://user-images.githubusercontent.com/43438/63756065-50805180-c8ea-11e9-8530-6aae8767298d.gif)

Possibly due to this bug, opened 11 years ago: https://bugs.webkit.org/show_bug.cgi?id=13820


