### PR TITLE
[PLATFORM-996] Fix active tab colour

### DIFF
--- a/app/src/userpages/components/Header/Tab/tab.pcss
+++ b/app/src/userpages/components/Header/Tab/tab.pcss
@@ -7,8 +7,12 @@
   outline: 0;
   padding: 1.25um 0;
   position: relative;
-  text-decoration: none !important;
   text-transform: uppercase;
+  transition: color 200ms ease-in-out;
+}
+
+a.root {
+  text-decoration: none;
 }
 
 .root,
@@ -24,6 +28,9 @@
   left: 0;
   position: absolute;
   width: 100%;
+  background-color: #323232;
+  opacity: 0;
+  transition: opacity 200ms ease-in-out;
 }
 
 .root,
@@ -31,13 +38,13 @@
   color: #989898;
 }
 
-.active,
-.root:--enter {
+.root:--enter,
+.root.active {
   color: #323232;
 }
 
-.active::after {
-  background-color: #323232;
+.root.active::after {
+  opacity: 1;
 }
 
 .root + .root {


### PR DESCRIPTION
Active tab text colour should look the same as hover.
The style was set but wasn't specific enough.
Also added text colour transition on hover.
 
![image](https://user-images.githubusercontent.com/43438/63756335-c71d4f00-c8ea-11e9-86d5-67c1ad53f5fb.png)

Also added an "underline" transition, though it doesn't currently work because the app is remounting the entire content area on navigation, but the transition should just work if/when we ever fix that.