### PR TITLE
[PLATFORM-995] Click canvas background/esc to close KeyboardShortcutsSidebar

### DIFF
--- a/app/src/editor/canvas/components/KeyboardShortcutsSidebar.jsx
+++ b/app/src/editor/canvas/components/KeyboardShortcutsSidebar.jsx
@@ -161,6 +161,13 @@ class KeyboardShortcuts extends React.Component {
             return
         }
 
+        // close on esc
+        const { onClose } = this.props
+        if (event.key === 'Escape' && typeof onClose === 'function') {
+            onClose()
+            return
+        }
+
         this.setState(({ pressedKeys, modifiedKeys }) => {
             const key = getEventKey(event)
             const newModifiedKeys = {

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -87,10 +87,18 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 
     selectModule = async ({ hash } = {}) => {
-        this.setState(({ moduleSidebarIsOpen, keyboardShortcutIsOpen }) => ({
-            // close sidebar if no selection
-            moduleSidebarIsOpen: hash == null ? keyboardShortcutIsOpen : moduleSidebarIsOpen,
-        }))
+        this.setState(({ moduleSidebarIsOpen, keyboardShortcutIsOpen }) => {
+            // this logic is nonsense, please redo the sidebar code
+            const noSelection = hash == null
+            const keyboardShortcutIsOpenNew = (noSelection && keyboardShortcutIsOpen) ? false : keyboardShortcutIsOpen
+            const moduleSidebarIsOpenNew = noSelection ? keyboardShortcutIsOpenNew : moduleSidebarIsOpen
+            return {
+                selectedModuleHash: hash,
+                // close sidebar if no selection
+                moduleSidebarIsOpen: moduleSidebarIsOpenNew,
+                keyboardShortcutIsOpen: !moduleSidebarIsOpenNew && keyboardShortcutIsOpenNew,
+            }
+        })
         this.props.selection.only(hash)
     }
 


### PR DESCRIPTION
Quick fix.
Terrible, confusing logic. The worst.
Canvas sidebar logic needs reworking at some point. Whatever, seems to work.