### PR TITLE
[PLATFORM-660] Fix code editor position & window behaviour

### DIFF
--- a/app/src/editor/canvas/components/Canvas.jsx
+++ b/app/src/editor/canvas/components/Canvas.jsx
@@ -6,6 +6,7 @@ import * as CanvasState from '../state'
 
 import Module from './Module'
 import { DragDropProvider } from './DragDropContext'
+import { CanvasWindowProvider } from './CanvasWindow'
 import Cables from './Cables'
 
 import styles from './Canvas.pcss'
@@ -73,17 +74,19 @@ export default class Canvas extends React.PureComponent {
         } = this.props
 
         return (
-            <div className={cx(styles.Canvas, className)}>
-                <CanvasElements
-                    key={canvas.id}
-                    canvas={canvas}
-                    api={this.api}
-                    selectedModuleHash={selectedModuleHash}
-                    moduleSidebarIsOpen={moduleSidebarIsOpen}
-                    {...this.api.module}
-                />
-                {children}
-            </div>
+            <CanvasWindowProvider className={styles.CanvasWindow}>
+                <div className={cx(styles.Canvas, className)}>
+                    <CanvasElements
+                        key={canvas.id}
+                        canvas={canvas}
+                        api={this.api}
+                        selectedModuleHash={selectedModuleHash}
+                        moduleSidebarIsOpen={moduleSidebarIsOpen}
+                        {...this.api.module}
+                    />
+                    {children}
+                </div>
+            </CanvasWindowProvider>
         )
     }
 }
@@ -180,7 +183,6 @@ function CanvasElements(props) {
                     selectedModuleHash={selectedModuleHash}
                 />
             </DragDropProvider>
-            <div id="canvas-windows" />
         </div>
     )
 }

--- a/app/src/editor/canvas/components/Canvas.pcss
+++ b/app/src/editor/canvas/components/Canvas.pcss
@@ -57,3 +57,7 @@ svg.Cables path.highlight {
   stroke: #2AC437;
   stroke-width: 1.5;
 }
+
+.CanvasWindow {
+  z-index: 13;
+}

--- a/app/src/editor/canvas/components/CanvasWindow.jsx
+++ b/app/src/editor/canvas/components/CanvasWindow.jsx
@@ -1,7 +1,8 @@
-import React, { useRef, useContext, useLayoutEffect } from 'react'
+import React, { useRef, useContext, useCallback, useLayoutEffect, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import cx from 'classnames'
-
+import { useSelectionContext, SelectionProvider } from '$editor/shared/hooks/useSelection'
+import useUniqueId from '$editor/shared/hooks/useUniqueId'
 import styles from './CanvasWindow.pcss'
 
 export const CanvasWindowContext = React.createContext()
@@ -10,15 +11,62 @@ export function CanvasWindowProvider({ className, children }) {
     const elRef = useRef()
     return (
         <CanvasWindowContext.Provider value={elRef}>
-            {children || null}
-            <div className={cx(className, styles.root)} ref={elRef} />
+            <SelectionProvider>
+                {children || null}
+                <div className={cx(className, styles.root)} ref={elRef} />
+            </SelectionProvider>
         </CanvasWindowContext.Provider>
     )
 }
 
-export default function CanvasWindow({ children }) {
+function useSelectHandlers({ uid, elRef }) {
+    const Selection = useSelectionContext()
+    const onSelected = useCallback((event) => {
+        const { current: el } = elRef
+        if (!el.contains(event.target)) { return }
+        Selection.only(uid)
+    }, [elRef, Selection, uid])
+    useEffect(() => {
+        const { current: containerEl } = elRef
+        containerEl.addEventListener('mousedown', onSelected, true)
+        containerEl.addEventListener('focus', onSelected, true)
+        return () => {
+            containerEl.removeEventListener('mousedown', onSelected, true)
+            containerEl.removeEventListener('focus', onSelected, true)
+        }
+    }, [onSelected, elRef])
+}
+
+export default function CanvasWindow({ className, children }) {
+    const uid = useUniqueId()
     const containerElRef = useContext(CanvasWindowContext)
     const elRef = useRef(document.createElement('div'))
+    const Selection = useSelectionContext()
+    const isSelected = Selection.has(uid)
+    useSelectHandlers({
+        uid,
+        elRef,
+    })
+
+    const selectionRef = useRef()
+    selectionRef.current = Selection
+    useEffect(() => {
+        // select on mount, deselect on unmount
+        const { current: selection } = selectionRef
+        selection.only(uid)
+        return () => {
+            const { current: selection } = selectionRef
+            selection.remove(uid)
+        }
+    }, [uid, selectionRef])
+
+    useLayoutEffect(() => {
+        const { current: el } = elRef
+        el.className = cx(className, styles.CanvasWindow, {
+            [styles.isSelected]: isSelected,
+        })
+    }, [className, isSelected])
+
     useLayoutEffect(() => {
         const { current: containerEl } = containerElRef
         const { current: el } = elRef
@@ -30,6 +78,5 @@ export default function CanvasWindow({ children }) {
             containerEl.removeChild(el)
         }
     }, [containerElRef, elRef])
-
     return createPortal(children, elRef.current)
 }

--- a/app/src/editor/canvas/components/CanvasWindow.pcss
+++ b/app/src/editor/canvas/components/CanvasWindow.pcss
@@ -1,0 +1,15 @@
+.root {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.root > * {
+  pointer-events: auto;
+}

--- a/app/src/editor/canvas/components/CanvasWindow.pcss
+++ b/app/src/editor/canvas/components/CanvasWindow.pcss
@@ -13,3 +13,9 @@
 .root > * {
   pointer-events: auto;
 }
+
+.CanvasWindow:focus,
+.CanvasWindow:focus-within,
+.CanvasWindow.isSelected:not(:focus):not(:focus-within) {
+  z-index: 2;
+}

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -77,6 +77,11 @@ export default class CodeEditorWindow extends React.Component {
         })
     }
 
+    onMouseDownTitle = () => {
+        // forward title clicks to editor focus
+        this.editor.current.editor.focus()
+    }
+
     render() {
         const { editorResetKey, errors, sending } = this.state
         const {
@@ -92,10 +97,8 @@ export default class CodeEditorWindow extends React.Component {
         return (
             <DraggableCanvasWindow {...canvasWindowProps}>
                 <div className={styles.editorDialog}>
-                    <DraggableCanvasWindow.Dialog
-                        title="Code Editor"
-                        onClose={onClose}
-                    >
+                    <DraggableCanvasWindow.Dialog onClose={onClose}>
+                        <DraggableCanvasWindow.Title onClose={onClose} onMouseDown={this.onMouseDownTitle}>Code Editor</DraggableCanvasWindow.Title>
                         <div className={styles.editorContainer}>
                             <AceEditor
                                 ref={this.editor}

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -8,7 +8,7 @@ import DraggableCanvasWindow from '../DraggableCanvasWindow'
 
 import styles from './CodeEditorWindow.pcss'
 
-class CodeEditorWindow extends React.Component {
+export default class CodeEditorWindow extends React.Component {
     state = {
         editorResetKey: uniqueId('CodeEditorWindow'),
         code: undefined,
@@ -147,5 +147,3 @@ class CodeEditorWindow extends React.Component {
         )
     }
 }
-
-export default CodeEditorWindow

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.pcss
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.pcss
@@ -1,7 +1,6 @@
 .editorDialog {
   position: absolute;
   z-index: 1;
-  transform: none;
 
   :global(.react-resizable-handle) {
     width: 24px;

--- a/app/src/editor/canvas/components/CodeEditor/DebugWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/DebugWindow.jsx
@@ -7,45 +7,39 @@ import DraggableCanvasWindow from '../DraggableCanvasWindow'
 import windowStyles from './CodeEditorWindow.pcss'
 import styles from './DebugWindow.pcss'
 
-class DebugWindow extends React.Component {
-    render() {
-        const { onClose, onClear, messages, ...canvasWindowProps } = this.props
-
-        return (
-            <DraggableCanvasWindow {...canvasWindowProps}>
-                <div className={windowStyles.editorDialog}>
-                    <DraggableCanvasWindow.Dialog
-                        title="Debug Messages"
-                        onClose={onClose}
-                    >
-                        <div className={cx(windowStyles.editorContainer, styles.messages)}>
-                            {messages.map((m) => (
-                                <div key={m.t}>
-                                    {dateFormatter('YYYY-MM-DD HH:mm:ss')(new Date(m.t * 1000))}
-                                    &nbsp;
-                                    {m.msg}
-                                </div>
-                            ))}
-                        </div>
-                        <DraggableCanvasWindow.Toolbar>
-                            <button
-                                type="button"
-                                onClick={onClear}
-                            >
-                                Clear
-                            </button>
-                            <button
-                                type="button"
-                                onClick={onClose}
-                            >
-                                Close
-                            </button>
-                        </DraggableCanvasWindow.Toolbar>
-                    </DraggableCanvasWindow.Dialog>
-                </div>
-            </DraggableCanvasWindow>
-        )
-    }
+export default function DebugWindow({ onClose, onClear, messages, ...props }) {
+    return (
+        <DraggableCanvasWindow {...props}>
+            <div className={windowStyles.editorDialog}>
+                <DraggableCanvasWindow.Dialog
+                    title="Debug Messages"
+                    onClose={onClose}
+                >
+                    <div className={cx(windowStyles.editorContainer, styles.messages)}>
+                        {messages.map((m) => (
+                            <div key={m.t}>
+                                {dateFormatter('YYYY-MM-DD HH:mm:ss')(new Date(m.t * 1000))}
+                                &nbsp;
+                                {m.msg}
+                            </div>
+                        ))}
+                    </div>
+                    <DraggableCanvasWindow.Toolbar>
+                        <button
+                            type="button"
+                            onClick={onClear}
+                        >
+                            Clear
+                        </button>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                        >
+                            Close
+                        </button>
+                    </DraggableCanvasWindow.Toolbar>
+                </DraggableCanvasWindow.Dialog>
+            </div>
+        </DraggableCanvasWindow>
+    )
 }
-
-export default DebugWindow

--- a/app/src/editor/canvas/components/CodeEditor/index.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/index.jsx
@@ -39,7 +39,7 @@ export const CodeEditor = ({
 
     const onShowEditor = useCallback(() => {
         initEditorPosition()
-        setEditorOpen(true)
+        setEditorOpen((v) => !v) // show === toggle
     }, [setEditorOpen, initEditorPosition])
 
     const onCloseEditor = useCallback(() => {
@@ -49,7 +49,7 @@ export const CodeEditor = ({
     const onShowDebug = useCallback(() => {
         initEditorPosition() // just in case
         initDebugPosition()
-        setDebugOpen(true)
+        setDebugOpen((v) => !v) // show === toggle
     }, [setDebugOpen, initEditorPosition, initDebugPosition])
 
     const onCloseDebug = useCallback(() => {

--- a/app/src/editor/canvas/components/CodeEditor/index.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/index.jsx
@@ -1,10 +1,10 @@
-import React, { useState, useCallback, useContext, useEffect } from 'react'
+import React, { useState, useCallback, useContext } from 'react'
 
 import { useLayoutState } from '$editor/canvas/components/DraggableCanvasWindow'
 import { CanvasWindowContext } from '../CanvasWindow'
 import CodeEditorWindow from './CodeEditorWindow'
 import DebugWindow from './DebugWindow'
-import { useInitToCenter, useInitToPosition } from './useInitPosition'
+import { useInitToCenter, useInitToPosition, useOnResizeEffect } from './useInitPosition'
 
 export const CodeEditor = ({
     children,
@@ -56,10 +56,13 @@ export const CodeEditor = ({
         setDebugOpen(false)
     }, [setDebugOpen])
 
-    useEffect(() => {
-        if (debugOpen) { return }
-        initDebugPosition(true)
-    }, [debugOpen, initDebugPosition])
+    useOnResizeEffect(useCallback(() => {
+        // reset position on resize
+        debugLayout.setPosition([
+            editorLayout.position[0] + offset,
+            editorLayout.position[1] + offset,
+        ])
+    }, [editorLayout, debugLayout, offset]))
 
     return (
         <React.Fragment>

--- a/app/src/editor/canvas/components/CodeEditor/index.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/index.jsx
@@ -1,8 +1,53 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useContext, useRef, useEffect } from 'react'
+import debounce from 'lodash/debounce'
 
 import CodeEditorWindow from './CodeEditorWindow'
+import { CanvasWindowContext } from '../CanvasWindow'
 import DebugWindow from './DebugWindow'
 import { useLayoutState } from '$editor/canvas/components/DraggableCanvasWindow'
+
+/**
+ * Sets position to center of container once.
+ * Will recenter if window is resized.
+ */
+
+function useInitToCenter({ containerRef, width, height, setPosition }) {
+    const isInitializedRef = useRef(false)
+    const initToCenter = useCallback(() => {
+        if (isInitializedRef.current) { return }
+        const { current: container } = containerRef
+        if (!container) { return }
+        isInitializedRef.current = true
+        const rect = container.getBoundingClientRect()
+        setPosition([
+            (rect.width / 2) - (width / 2),
+            (rect.height / 2) - (height / 2),
+        ])
+    }, [containerRef, width, height, setPosition, isInitializedRef])
+
+    const onResize = useCallback(debounce(() => {
+        if (!isInitializedRef.current) { return }
+        // reset position to center after resize window
+        isInitializedRef.current = false
+        initToCenter()
+    }, 300), [isInitializedRef, initToCenter])
+
+    const onResizeRef = useRef()
+
+    useEffect(() => {
+        if (onResizeRef.current && onResize !== onResizeRef.current) {
+            onResizeRef.current.cancel()
+        }
+        onResizeRef.current = onResize
+        window.addEventListener('resize', onResize)
+        return () => {
+            onResize.cancel()
+            window.removeEventListener('resize', onResize)
+        }
+    }, [onResize, onResizeRef])
+
+    return initToCenter
+}
 
 export const CodeEditor = ({
     children,
@@ -15,18 +60,38 @@ export const CodeEditor = ({
 }) => {
     const [editorOpen, setEditorOpen] = useState(false)
     const [debugOpen, setDebugOpen] = useState(false)
-    const [editorLayout, setEditorSize, setEditorPosition] = useLayoutState()
-    const [debugLayout, setDebugSize, setDebugPosition] = useLayoutState()
+    const canvasWindowElRef = useContext(CanvasWindowContext)
+    const editorLayout = useLayoutState()
+    const debugLayout = useLayoutState()
+
+    const initEditorToCenter = useInitToCenter({
+        containerRef: canvasWindowElRef,
+        width: editorLayout.size[0],
+        height: editorLayout.size[1],
+        setPosition: editorLayout.setPosition,
+    })
+
+    const initDebugToCenter = useInitToCenter({
+        containerRef: canvasWindowElRef,
+        width: debugLayout.size[0],
+        height: debugLayout.size[1],
+        setPosition: debugLayout.setPosition,
+    })
 
     const onShowEditor = useCallback(() => {
+        initEditorToCenter()
         setEditorOpen(true)
-    }, [setEditorOpen])
+    }, [setEditorOpen, initEditorToCenter])
+
     const onCloseEditor = useCallback(() => {
         setEditorOpen(false)
     }, [setEditorOpen])
+
     const onShowDebug = useCallback(() => {
+        initDebugToCenter()
         setDebugOpen(true)
-    }, [setDebugOpen])
+    }, [setDebugOpen, initDebugToCenter])
+
     const onCloseDebug = useCallback(() => {
         setDebugOpen(false)
     }, [setDebugOpen])
@@ -36,27 +101,31 @@ export const CodeEditor = ({
             {children && (typeof children === 'function') && children(onShowEditor)}
             {!!editorOpen && (
                 <CodeEditorWindow
-                    position={editorLayout}
-                    onPositionUpdate={setEditorPosition}
-                    size={editorLayout}
-                    onSizeUpdate={setEditorSize}
                     code={code}
                     readOnly={readOnly}
                     onClose={onCloseEditor}
                     onApply={onApply}
                     onChange={onChange}
                     onShowDebug={onShowDebug}
+                    x={editorLayout.position[0]}
+                    y={editorLayout.position[1]}
+                    width={editorLayout.size[0]}
+                    height={editorLayout.size[1]}
+                    onChangePosition={editorLayout.setPosition}
+                    onChangeSize={editorLayout.setSize}
                 />
             )}
             {!!debugOpen && (
                 <DebugWindow
-                    onPositionUpdate={setDebugPosition}
-                    position={debugLayout}
-                    onSizeUpdate={setDebugSize}
-                    size={debugLayout}
                     messages={debugMessages}
                     onClear={onClearDebug}
                     onClose={onCloseDebug}
+                    x={debugLayout.position[0]}
+                    y={debugLayout.position[1]}
+                    width={debugLayout.size[0]}
+                    height={debugLayout.size[1]}
+                    onChangePosition={debugLayout.setPosition}
+                    onChangeSize={debugLayout.setSize}
                 />
             )}
         </React.Fragment>
@@ -64,3 +133,5 @@ export const CodeEditor = ({
 }
 
 export default CodeEditor
+
+export const CodeEditorContainer = () => <div id="canvas-windows" />

--- a/app/src/editor/canvas/components/CodeEditor/useInitPosition.js
+++ b/app/src/editor/canvas/components/CodeEditor/useInitPosition.js
@@ -1,0 +1,87 @@
+import { useCallback, useRef, useEffect } from 'react'
+import debounce from 'lodash/debounce'
+
+/**
+ * Runs debounced onResizeFn on window resize.
+ */
+
+function useOnResizeEffect(onResizeFn, timeout = 300) {
+    const onResize = useCallback(debounce(() => {
+        onResizeFn()
+    }, timeout), [onResizeFn])
+
+    const onResizeRef = useRef()
+
+    useEffect(() => {
+        if (onResizeRef.current && onResize !== onResizeRef.current) {
+            // cancel previous callback
+            onResizeRef.current.cancel()
+        }
+        onResizeRef.current = onResize
+        window.addEventListener('resize', onResize)
+        return () => {
+            // cancel if pending
+            onResize.cancel()
+            window.removeEventListener('resize', onResize)
+        }
+    }, [onResize, onResizeRef])
+}
+
+/**
+ * Returns a callback that runs initPosition once.
+ * Will call again on resize
+ */
+
+function useInitPosition(initPosition) {
+    const isInitializedRef = useRef(false)
+    const initPositionCallback = useCallback((init) => {
+        if (!init && isInitializedRef.current) { return }
+        isInitializedRef.current = true
+        initPosition(isInitializedRef)
+    }, [initPosition, isInitializedRef])
+
+    useOnResizeEffect(useCallback(() => {
+        if (!isInitializedRef.current) { return }
+        // reset position to center after resize window
+        isInitializedRef.current = false
+        initPositionCallback()
+    }, [isInitializedRef, initPositionCallback]))
+
+    return initPositionCallback
+}
+
+/**
+ * Returns callback that sets position to center of container once.
+ * Will recenter if window is resized.
+ */
+
+export function useInitToCenter({ containerRef, width, height, setPosition }) {
+    const initToCenter = useCallback((isInitializedRef) => {
+        const { current: container } = containerRef
+        if (!container) {
+            isInitializedRef.current = false
+            return
+        }
+        const rect = container.getBoundingClientRect()
+        setPosition([
+            ((rect.width / 2) - (width / 2)),
+            ((rect.height / 2) - (height / 2)),
+        ])
+    }, [containerRef, width, height, setPosition])
+
+    return useInitPosition(initToCenter)
+}
+
+/**
+ * Returns callback that sets position to provided x, y once,
+ * or again once after resize
+ */
+
+export function useInitToPosition({ x, y, setPosition }) {
+    return useInitPosition(useCallback(() => {
+        setPosition([
+            x,
+            y,
+        ])
+    }, [setPosition, x, y]))
+}

--- a/app/src/editor/canvas/components/DraggableCanvasWindow.jsx
+++ b/app/src/editor/canvas/components/DraggableCanvasWindow.jsx
@@ -99,9 +99,7 @@ export const DraggableCanvasWindow = ({
         height,
     })
 
-    // $FlowFixMe
     const [dragging, setDragging] = useState(false)
-    // $FlowFixMe
     const [resizing, setResizing] = useState(false)
 
     const canvasWindowElRef = useContext(CanvasWindowContext)

--- a/app/src/editor/canvas/components/DraggableCanvasWindow.jsx
+++ b/app/src/editor/canvas/components/DraggableCanvasWindow.jsx
@@ -63,7 +63,7 @@ function clamp(value, min, max) {
     return Math.max(min, Math.min(max, value))
 }
 
-export function useLayoutState({ x = 0, y = 0, width = 600, height = 600 }: Layout = {}) {
+export function useLayoutState({ x = 0, y = 0, width = 600, height = 400 }: Layout = {}) {
     // wtf flow. I don't know what it wants.
     // $FlowFixMe
     const [position, setPosition] = useState([x, y])

--- a/app/src/editor/canvas/components/DraggableCanvasWindow.jsx
+++ b/app/src/editor/canvas/components/DraggableCanvasWindow.jsx
@@ -18,8 +18,8 @@ type BaseProps = {
     children?: Node,
 }
 
-export const Title = ({ children, onClose }: BaseProps) => (
-    <div className={styles.titleContainer}>
+export const Title = ({ children, className, onClose, ...props }: BaseProps) => (
+    <div className={cx(className, styles.titleContainer)} {...props}>
         <div className={styles.title}>{children}</div>
         <button
             type="button"
@@ -31,8 +31,14 @@ export const Title = ({ children, onClose }: BaseProps) => (
     </div>
 )
 
-export const Dialog = ({ children, className, onClose, title }: BaseProps) => (
-    <div className={cx(styles.dialog, className)}>
+export const Dialog = ({
+    children,
+    className,
+    onClose,
+    title,
+    ...props
+}: BaseProps) => (
+    <div className={cx(styles.dialog, className)} {...props}>
         {!!title && (
             <Title onClose={onClose}>{title}</Title>
         )}
@@ -40,8 +46,8 @@ export const Dialog = ({ children, className, onClose, title }: BaseProps) => (
     </div>
 )
 
-export const Toolbar = ({ children, className }: BaseProps) => (
-    <div className={cx(styles.toolbar, className)}>
+export const Toolbar = ({ children, className, ...props }: BaseProps) => (
+    <div className={cx(styles.toolbar, className)} {...props}>
         {children}
     </div>
 )
@@ -159,7 +165,7 @@ export const DraggableCanvasWindow = ({
     }), [pos, dim])
 
     return (
-        <CanvasWindow>
+        <CanvasWindow className={styles.root}>
             <DraggableCore
                 handle={`.${styles.titleContainer}`}
                 onStart={onDragStart}

--- a/app/src/editor/canvas/components/DraggableCanvasWindow.pcss
+++ b/app/src/editor/canvas/components/DraggableCanvasWindow.pcss
@@ -1,3 +1,7 @@
+.root {
+  position: relative;
+}
+
 .dialog {
   width: 100%;
   border-radius: 4px;

--- a/app/src/editor/canvas/components/DraggableCanvasWindow.pcss
+++ b/app/src/editor/canvas/components/DraggableCanvasWindow.pcss
@@ -26,6 +26,7 @@
   user-select: none;
   display: flex;
   align-items: center;
+  cursor: grab;
 }
 
 .title {
@@ -40,7 +41,7 @@
   padding: 0;
   margin: 0;
   color: #CDCDCD;
-  cursor: pointer;
+  cursor: default;
   margin-right: 8px;
   width: 32px;
   height: 32px;

--- a/app/src/editor/shared/hooks/useUniqueId.jsx
+++ b/app/src/editor/shared/hooks/useUniqueId.jsx
@@ -1,0 +1,10 @@
+import { useRef } from 'react'
+import uniqueId from 'lodash/uniqueId'
+
+export default function useUniqueId(prefix = '') {
+    const idRef = useRef()
+    if (!idRef.current) {
+        idRef.current = uniqueId(prefix)
+    }
+    return idRef.current
+}


### PR DESCRIPTION
* Code Editor is always centered in the window by default. Not possible to not see an opened code window now (primary fix for original issue).
* Renders `CanvasWindow`s on own layer. `CanvasWindow`s now ignore the panning of canvas, like `ModuleSearch`. (secondary fix)

Also:
* Renders debug window offset slightly from code window by default (ensures it is visible). 
* Before, debug always rendered on top of code, now the last selected window will render on top.
* The "Edit code", and "show debug" buttons now toggle opened state.
* Window positions are bound to canvas dimensions.
* Window positions get reset on window resize (simple workaround to prevent windows disappearing)
* Various minor refactorings.