### PR TITLE
[PLATFORM-438] Disable user-select when dragging SortableList items

### DIFF
--- a/app/src/shared/components/BodyClass/index.jsx
+++ b/app/src/shared/components/BodyClass/index.jsx
@@ -45,8 +45,10 @@ function removeClass(className) {
     }
 }
 
-function BodyClass({ className }: Props) {
+function BodyClass({ className: classNameProp }: Props) {
+    const className = classNameProp && classNameProp.trim()
     useLayoutEffect(() => {
+        if (!className) { return }
         addClass(className)
         return () => { // eslint-disable-line consistent-return
             removeClass(className)

--- a/app/src/shared/components/SortableList/SortableList.pcss
+++ b/app/src/shared/components/SortableList/SortableList.pcss
@@ -1,0 +1,4 @@
+.isSorting,
+.isSorting * {
+  user-select: none !important;
+}

--- a/app/src/shared/components/SortableList/index.jsx
+++ b/app/src/shared/components/SortableList/index.jsx
@@ -1,9 +1,11 @@
 // @flow
 
-import * as React from 'react'
-import { SortableContainer } from 'react-sortable-hoc'
-
+import React, { type Node, useState, useCallback } from 'react'
+import { SortableContainer, type SortableContainerProps } from 'react-sortable-hoc'
+import cx from 'classnames'
+import BodyClass from '$shared/components/BodyClass'
 import SortableItem from './SortableItem'
+import styles from './SortableList.pcss'
 
 export type SortProps = {
     oldIndex: number,
@@ -11,7 +13,7 @@ export type SortProps = {
 }
 
 type Props = {
-    children: React.Node,
+    children: Node,
 }
 
 const SortableList = ({ children, ...props }: Props) => (
@@ -24,4 +26,33 @@ const SortableList = ({ children, ...props }: Props) => (
     </div>
 )
 
-export default SortableContainer(SortableList)
+const Sortable = SortableContainer(SortableList)
+
+export default function ({ onSortStart: onSortStartProp, onSortEnd: onSortEndProp, ...props }: SortableContainerProps) {
+    // wrap onSort{Start,End} with setSorting flag setter
+    const [isSorting, setSorting] = useState(false)
+    const onSortStart = useCallback((...args) => {
+        setSorting(true)
+        if (typeof onSortStartProp !== 'function') { return undefined }
+        return onSortStartProp(...args)
+    }, [onSortStartProp])
+    const onSortEnd = useCallback((...args) => {
+        setSorting(false)
+        if (typeof onSortEndProp !== 'function') { return undefined }
+        return onSortEndProp(...args)
+    }, [onSortEndProp])
+    return (
+        <React.Fragment>
+            <BodyClass
+                className={cx({
+                    [styles.isSorting]: isSorting, /* disable user-select on body when sorting */
+                })}
+            />
+            <Sortable
+                onSortStart={onSortStart}
+                onSortEnd={onSortEnd}
+                {...props}
+            />
+        </React.Fragment>
+    )
+}


### PR DESCRIPTION
### To Test

1. Use Safari/Firefox
2. Create stream
3. Add two fields
4. Drag to reorder fields
5. No selection highlight should be visible.