### PR TITLE
[PLATFORM-1011] Consistent tile size

### DIFF
--- a/app/src/shared/components/Tile/tile.pcss
+++ b/app/src/shared/components/Tile/tile.pcss
@@ -18,6 +18,7 @@
     object-fit: cover;
     width: 100%;
     transition: filter 0.05s;
+    height: 200px;
   }
 
   &:hover {


### PR DESCRIPTION
Userpages tiles now always 200px high, across all break points (matches design).
Images seem to scale/crop appropriately if aspect ratio not right.