### PR TITLE
Use sans font for port values

### DIFF
--- a/app/src/editor/canvas/components/Ports/Value/value.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/value.pcss
@@ -2,6 +2,7 @@
   font-family: var(--sans);
   margin-left: calc(0.5 * var(--um));
   min-width: 0.5em;
+  overflow: hidden;
 }
 
 .disabled {

--- a/app/src/editor/canvas/components/Ports/Value/value.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/value.pcss
@@ -1,4 +1,5 @@
 .root {
+  font-family: var(--sans);
   margin-left: calc(0.5 * var(--um));
   min-width: 0.5em;
 }

--- a/app/src/editor/shared/components/StreamSelector.pcss
+++ b/app/src/editor/shared/components/StreamSelector.pcss
@@ -20,8 +20,8 @@
   color: #323232;
   text-transform: none;
   letter-spacing: 0;
-  line-height: 28px;
-  padding: 5px 24px;
+  line-height: 16px;
+  padding: 5px 12px;
   border-bottom: 1px solid #EFEFEF;
   cursor: pointer;
 }
@@ -33,10 +33,10 @@
 .description {
   font-size: 10px;
   font-weight: 400;
-  color: #ADADAD;
+  color: #A3A3A3;
   line-height: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  padding-bottom: 6px;
+  margin-top: 6px;
 }

--- a/app/src/editor/shared/components/StreamSelector.pcss
+++ b/app/src/editor/shared/components/StreamSelector.pcss
@@ -16,7 +16,6 @@
 
 .result {
   font-size: 12px;
-  font-family: 'IBM Plex Mono', monospace;
   font-weight: 400;
   color: #323232;
   text-transform: none;
@@ -33,7 +32,6 @@
 
 .description {
   font-size: 10px;
-  font-family: 'IBM Plex Mono', monospace;
   font-weight: 400;
   color: #ADADAD;
   line-height: 12px;


### PR DESCRIPTION
Sans matches design.

![image](https://user-images.githubusercontent.com/43438/64146069-064d2200-ce4e-11e9-8319-1b18a203e77b.png)

![image](https://user-images.githubusercontent.com/43438/64226673-e03d8580-cf12-11e9-85b0-1169c2560f65.png)

Also tweaked stream selector dropdown to be a bit friendlier to multi-line values:

![image](https://user-images.githubusercontent.com/43438/64146085-1bc24c00-ce4e-11e9-8d35-3a068cb446fd.png)
