### PR TITLE
Copy port value

### DIFF
--- a/app/src/editor/canvas/components/Ports/Menu/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Menu/index.jsx
@@ -2,8 +2,10 @@
 
 import React, { useCallback } from 'react'
 import ContextMenu from '$shared/components/ContextMenu'
-import { disconnectAllFromPort, isPortConnected } from '../../../state'
+import { disconnectAllFromPort, isPortConnected, getPortValue } from '../../../state'
 import styles from './menu.pcss'
+
+import useCopy from '$shared/hooks/useCopy'
 
 type Props = {
     api: any,
@@ -37,6 +39,21 @@ const Menu = ({
         dismiss()
     }, [setPortOptions, port, dismiss])
 
+    const { copy, isCopied } = useCopy()
+
+    let portValue = getPortValue(canvas, port.id)
+    if (portValue === '' || typeof portValue === 'object') {
+        portValue = undefined
+    }
+
+    const copyDisabled = portValue == null
+
+    const onClickCopy = useCallback(() => {
+        // redundant check here because flow can't figure it out
+        if (copyDisabled || portValue == null) { return }
+        copy(portValue)
+    }, [copy, portValue, copyDisabled])
+
     return (
         <ContextMenu
             isOpen
@@ -53,6 +70,12 @@ const Menu = ({
                 className={styles.noAutoDismiss}
                 onClick={toggleExport}
                 text={port.export ? 'Disable export' : 'Enable export'}
+            />
+            <ContextMenu.Item
+                className={styles.noAutoDismiss}
+                onClick={onClickCopy}
+                text={isCopied ? 'Copied' : 'Copy value'}
+                disabled={copyDisabled}
             />
         </ContextMenu>
     )

--- a/app/src/editor/canvas/components/Ports/Menu/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Menu/index.jsx
@@ -2,11 +2,12 @@
 
 import React, { useCallback } from 'react'
 import ContextMenu from '$shared/components/ContextMenu'
-import { disconnectAllFromPort } from '../../../state'
+import { disconnectAllFromPort, isPortConnected } from '../../../state'
 import styles from './menu.pcss'
 
 type Props = {
     api: any,
+    canvas: any,
     dismiss: () => void,
     port: any,
     setPortOptions: (any, Object) => void,
@@ -15,6 +16,7 @@ type Props = {
 
 const Menu = ({
     api,
+    canvas,
     dismiss,
     port,
     setPortOptions,
@@ -45,6 +47,7 @@ const Menu = ({
                 className={styles.noAutoDismiss}
                 onClick={disconnectAll}
                 text="Disconnect all"
+                disabled={!isPortConnected(canvas, port.id)}
             />
             <ContextMenu.Item
                 className={styles.noAutoDismiss}

--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -137,6 +137,7 @@ const Port = ({
             {!!contextMenuTarget && (
                 <Menu
                     api={api}
+                    canvas={canvas}
                     dismiss={dismiss}
                     port={port}
                     setPortOptions={setOptions}

--- a/app/src/editor/shared/components/StreamSelector.jsx
+++ b/app/src/editor/shared/components/StreamSelector.jsx
@@ -138,7 +138,7 @@ export default class StreamSelector extends React.Component<Props, State> {
     }
 
     render() {
-        const { disabled, className } = this.props
+        const { disabled, className, value } = this.props
         const { isOpen, search, matchingStreams } = this.state
 
         return (
@@ -150,6 +150,7 @@ export default class StreamSelector extends React.Component<Props, State> {
                     onModeChange={this.toggleSearch}
                     placeholder="Value"
                     value={search}
+                    title={value}
                 />
                 {isOpen && (
                     <div className={styles.searchResults}>
@@ -160,10 +161,11 @@ export default class StreamSelector extends React.Component<Props, State> {
                                 key={stream.id}
                                 onMouseDown={() => this.onStreamClick(stream.id)}
                                 tabIndex="0"
+                                title={stream.id}
                             >
                                 <div>{stream.name}</div>
                                 {!!stream.description && (
-                                    <div className={styles.description}>{stream.description}</div>
+                                    <div title={stream.description} className={styles.description}>{stream.description}</div>
                                 )}
                             </div>
                         ))}

--- a/app/src/shared/components/ContextMenu/ContextMenuItem/contextMenuItem.pcss
+++ b/app/src/shared/components/ContextMenu/ContextMenuItem/contextMenuItem.pcss
@@ -6,6 +6,13 @@
   line-height: 20px;
   cursor: pointer;
   padding: 2px 16px;
+  transition-duration: 0.1s;
+  transition-property: background-color, color;
+}
+
+.item.disabled {
+  pointer-events: none;
+  opacity: 0.6;
 }
 
 .item:hover {

--- a/app/src/shared/components/ContextMenu/ContextMenuItem/index.jsx
+++ b/app/src/shared/components/ContextMenu/ContextMenuItem/index.jsx
@@ -7,27 +7,31 @@ import styles from './contextMenuItem.pcss'
 
 export type Props = {
     text: string,
-    onClick: () => void,
+    onClick: (e: SyntheticInputEvent<EventTarget>) => void,
     className?: ?string,
+    disabled?: boolean,
 }
 
 class ContextMenuItem extends React.Component<Props> {
     onClick = (e: SyntheticInputEvent<EventTarget>) => {
         e.preventDefault()
         if (this.props.onClick) {
-            this.props.onClick()
+            this.props.onClick(e)
         }
     }
 
     render = () => {
-        const { text, className } = this.props
+        const { text, className, disabled, ...props } = this.props
         return (
             // eslint-disable-next-line jsx-a11y/click-events-have-key-events
             <div
                 role="button"
-                className={cx(styles.item, className)}
+                className={cx(styles.item, className, {
+                    [styles.disabled]: disabled,
+                })}
                 onClick={this.onClick}
                 tabIndex="0"
+                {...props}
             >
                 {text}
             </div>

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -10,6 +10,7 @@ import styles from './editableText.pcss'
 type Props = {
     id?: string,
     autoFocus?: boolean,
+    title?: string,
     children?: string | number,
     className?: ?string,
     disabled?: boolean,
@@ -42,6 +43,7 @@ const EditableText = ({
     placeholder,
     probe,
     setEditing,
+    title,
     ...props
 }: Props) => {
     const children = (childrenProp == null) ? EditableText.defaultProps.children : childrenProp
@@ -105,6 +107,7 @@ const EditableText = ({
                 // we can't let the span be focusable when the input is.
                 tabIndex: (hasFocus ? -1 : 0),
             } : {})}
+            title={title}
         >
             <span className={styles.inner}>
                 {probe}


### PR DESCRIPTION


Currently there's no way to see or get access to the stream id for the selected stream in the stream module.

This PR adds a "Copy value" option to port context menu.
Useful for copying stream id for stream inputs. Not perfect ~~since you can't paste the id back into an input since the stream search doesn't work with ids~~ (update: added support for this), but better.
 
![image](https://user-images.githubusercontent.com/43438/64147270-562de800-ce52-11e9-9138-5b9a1c77417b.png)

Option will be disabled if connected or non-simple type of data.