### PR TITLE
Coerce non-null/undefined table values to strings.

### DIFF
--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -181,7 +181,7 @@ export default class TableModule extends React.Component {
                                         /* eslint-disable-next-line react/no-array-index-key */
                                         <td key={index}>
                                             <div className={styles.cell}>
-                                                {item}
+                                                {item != null ? String(item) : item}
                                             </div>
                                         </td>
                                     ))}


### PR DESCRIPTION
Table module receives all row values as strings, but the backend module `MapAsTable` doesn't seem to perform the same String coercion before sending row values, so booleans don't render in the frontend. 

This should really be fixed on the backend so the table modules are consistent, but here's a workaround that forcibly coerces non-undefined/null table row values to `String`s.

# After

The "true" and "false" values appear in the `MapAsTable`'s table.

![map-as-table-booleans](https://user-images.githubusercontent.com/43438/64233724-695eb780-cf27-11e9-9984-61043745f447.gif)

# Before

No values appear in the `MapAsTable`'s table.

![map-as-table-booleans-before](https://user-images.githubusercontent.com/43438/64233725-695eb780-cf27-11e9-852a-33d9952c349f.gif)
