### PR TITLE
[PLATFORM-1034] Prevent autosave on duplicate if not writable

### DIFF
--- a/app/src/editor/canvas/components/CanvasController/Run.jsx
+++ b/app/src/editor/canvas/components/CanvasController/Run.jsx
@@ -7,7 +7,6 @@ import get from 'lodash/get'
 
 import useIsMountedRef from '$shared/hooks/useIsMountedRef'
 import * as SubscriptionStatus from '$editor/shared/components/SubscriptionStatus'
-import { Context as PermissionContext } from '$editor/canvas/hooks/useCanvasPermissions'
 import usePending from '$shared/hooks/usePending'
 
 import * as services from '../../services'
@@ -17,6 +16,7 @@ import * as CanvasLinking from '../../state/linking'
 import useCanvasStateChangeEffect from '../../hooks/useCanvasStateChangeEffect'
 import useCanvasUpdater from './useCanvasUpdater'
 import useEmbedMode from './useEmbedMode'
+import useCanvasPermissions from './useCanvasPermissions'
 
 export const RunControllerContext = React.createContext()
 
@@ -31,7 +31,7 @@ function isStateNotAllowedError(error) {
 function useRunController(canvas = EMPTY) {
     const isEmbedMode = useEmbedMode()
     const subscriptionStatus = useContext(SubscriptionStatus.Context)
-    const { permissions } = useContext(PermissionContext)
+    const { hasWritePermission, hasSharePermission } = useCanvasPermissions()
     const { replaceCanvas } = useCanvasUpdater()
     const isMountedRef = useIsMountedRef()
 
@@ -53,12 +53,6 @@ function useRunController(canvas = EMPTY) {
     // historical subscription should start as soon as starting.
     // realtime subscription starts after canvas is runnning
     const isSubscriptionActive = canvas.adhoc ? isActive : isRunning
-
-    const hasSharePermission = permissions &&
-        permissions.some((p) => p.operation === 'share')
-
-    const hasWritePermission = !isEmbedMode && permissions &&
-        permissions.some((p) => p.operation === 'write')
 
     const start = useCallback(async (canvas, options) => {
         if (isHistorical && !canvas.adhoc) {

--- a/app/src/editor/canvas/components/CanvasController/Run.jsx
+++ b/app/src/editor/canvas/components/CanvasController/Run.jsx
@@ -16,7 +16,7 @@ import * as CanvasLinking from '../../state/linking'
 
 import useCanvasStateChangeEffect from '../../hooks/useCanvasStateChangeEffect'
 import useCanvasUpdater from './useCanvasUpdater'
-import { useEmbedMode } from './index'
+import useEmbedMode from './useEmbedMode'
 
 export const RunControllerContext = React.createContext()
 

--- a/app/src/editor/canvas/components/CanvasController/index.jsx
+++ b/app/src/editor/canvas/components/CanvasController/index.jsx
@@ -6,19 +6,13 @@ import { usePending } from '$shared/hooks/usePending'
 import { Provider as PermissionsProvider } from '$editor/canvas/hooks/useCanvasPermissions'
 
 import * as CanvasState from '../../state'
-
 import useCanvas from './useCanvas'
 import useCanvasLoadCallback from './useCanvasLoadCallback'
 import useCanvasCreateCallback from './useCanvasCreateCallback'
 import useCanvasRemoveCallback from './useCanvasRemoveCallback'
 import useCanvasDuplicateCallback from './useCanvasDuplicateCallback'
 import useModuleLoadCallback from './useModuleLoadCallback'
-
-const EmbedModeContext = React.createContext(false)
-
-export function useEmbedMode() {
-    return useContext(EmbedModeContext)
-}
+import { EmbedModeContext } from './useEmbedMode'
 
 const CanvasControllerContext = React.createContext()
 

--- a/app/src/editor/canvas/components/CanvasController/index.jsx
+++ b/app/src/editor/canvas/components/CanvasController/index.jsx
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet'
 
 import * as RouterContext from '$shared/components/RouterContextProvider'
 import { usePending } from '$shared/hooks/usePending'
-import { Provider as PermissionsProvider } from '$editor/canvas/hooks/useCanvasPermissions'
 
 import * as CanvasState from '../../state'
 import useCanvas from './useCanvas'
@@ -13,6 +12,7 @@ import useCanvasRemoveCallback from './useCanvasRemoveCallback'
 import useCanvasDuplicateCallback from './useCanvasDuplicateCallback'
 import useModuleLoadCallback from './useModuleLoadCallback'
 import { EmbedModeContext } from './useEmbedMode'
+import { Provider as PermissionsProvider } from './useCanvasPermissions'
 
 const CanvasControllerContext = React.createContext()
 
@@ -55,10 +55,11 @@ function CanvasEffects() {
     const { isPending: isPendingCreate } = usePending('canvas.CREATE')
     const { isPending: isPendingLoad } = usePending('canvas.LOAD')
     const { isPending: isPendingRemove } = usePending('canvas.REMOVE')
+    const { isPending: isPendingLoadPermissions } = usePending('canvas.PERMISSIONS')
     return (
         <React.Fragment>
             {!!isPendingCreate && <Helmet title="Creating New Canvas..." />}
-            {!!isPendingLoad && <Helmet title="Loading Canvas..." />}
+            {!!(isPendingLoad || isPendingLoadPermissions) && <Helmet title="Loading Canvas..." />}
             {!!isPendingRemove && <Helmet title="Removing Canvas..." />}
         </React.Fragment>
     )

--- a/app/src/editor/canvas/components/CanvasController/useCanvasLoadCallback.js
+++ b/app/src/editor/canvas/components/CanvasController/useCanvasLoadCallback.js
@@ -3,14 +3,12 @@ import { useContext, useCallback } from 'react'
 import { Context as RouterContext } from '$shared/components/RouterContextProvider'
 import useIsMountedRef from '$shared/hooks/useIsMountedRef'
 import usePending from '$shared/hooks/usePending'
-import { Context as PermissionContext } from '$editor/canvas/hooks/useCanvasPermissions'
 
 import * as services from '../../services'
 import useCanvasUpdater from './useCanvasUpdater'
 
 export default function useCanvasLoadCallback() {
     const { history } = useContext(RouterContext)
-    const { setPermissions } = useContext(PermissionContext)
     const canvasUpdater = useCanvasUpdater()
     const { wrap } = usePending('canvas.LOAD')
     const isMountedRef = useIsMountedRef()
@@ -25,10 +23,8 @@ export default function useCanvasLoadCallback() {
                 history.replace('/404') // 404
                 return
             }
-            const permissions = await services.getCanvasPermissions({ id: canvas.id })
-            setPermissions(permissions)
             if (!isMountedRef.current) { return }
             canvasUpdater.replaceCanvas(() => canvas)
         })
-    ), [wrap, setPermissions, canvasUpdater, history, isMountedRef])
+    ), [wrap, canvasUpdater, history, isMountedRef])
 }

--- a/app/src/editor/canvas/components/CanvasController/useCanvasPermissions.jsx
+++ b/app/src/editor/canvas/components/CanvasController/useCanvasPermissions.jsx
@@ -1,0 +1,63 @@
+import React, { useMemo, useCallback, useState, useEffect, useContext } from 'react'
+import useIsMountedRef from '$shared/hooks/useIsMountedRef'
+import usePending from '$shared/hooks/usePending'
+import * as services from '../../services'
+import useCanvas from './useCanvas'
+import useEmbedMode from './useEmbedMode'
+
+const PermissionContext = React.createContext({
+    permissions: [],
+})
+
+function usePermissionContextValue() {
+    const isEmbedMode = useEmbedMode()
+    const [permissions, setPermissions] = useState()
+    const isMountedRef = useIsMountedRef()
+    const { wrap, isPending } = usePending('canvas.PERMISSIONS')
+    const canvas = useCanvas()
+    const canvasId = !!canvas && canvas.id
+    const loadPermissions = useCallback(async (canvasId) => (
+        wrap(async () => {
+            const permissions = await services.getCanvasPermissions({ id: canvasId })
+            if (!isMountedRef.current) { return }
+            setPermissions(permissions)
+        })
+    ), [wrap, setPermissions, isMountedRef])
+    const hasPermissions = !!permissions
+    // load permissions if needed
+    useEffect(() => {
+        if (!canvasId || isPending || hasPermissions) { return }
+        loadPermissions(canvasId)
+    }, [canvasId, hasPermissions, isPending, loadPermissions])
+
+    const hasSharePermission = !!permissions &&
+        permissions.some((p) => p.operation === 'share')
+
+    const hasWritePermission = !isEmbedMode && !!permissions &&
+        permissions.some((p) => p.operation === 'write')
+
+    return useMemo(() => ({
+        permissions,
+        hasSharePermission,
+        hasWritePermission,
+    }), [permissions, hasSharePermission, hasWritePermission])
+}
+
+function PermissionContextProvider({ children }) {
+    return (
+        <PermissionContext.Provider value={usePermissionContextValue()}>
+            {children || null}
+        </PermissionContext.Provider>
+    )
+}
+
+function usePermissionContext() {
+    return useContext(PermissionContext)
+}
+
+export default usePermissionContext
+
+export {
+    PermissionContextProvider as Provider,
+    PermissionContext as Context,
+}

--- a/app/src/editor/canvas/components/CanvasController/useEmbedMode.jsx
+++ b/app/src/editor/canvas/components/CanvasController/useEmbedMode.jsx
@@ -1,0 +1,9 @@
+import React, { useContext } from 'react'
+
+export const EmbedModeContext = React.createContext(false)
+
+export function useEmbedMode() {
+    return useContext(EmbedModeContext)
+}
+
+export default useEmbedMode

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -484,7 +484,10 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 }
 
-const CanvasEdit = withRouter(({ canvas, ...props }) => {
+const CanvasEdit = withRouter((props) => {
+    const canvas = useCanvas()
+    const { replaceCanvas, setCanvas } = useCanvasUpdater()
+    const { undo } = useContext(UndoContext.Context)
     const runController = useContext(RunController.Context)
     const canvasController = CanvasController.useController()
     const [updated, setUpdated] = useUpdatedTime(canvas.updated)
@@ -498,6 +501,9 @@ const CanvasEdit = withRouter(({ canvas, ...props }) => {
             <UndoControls disabled={!runController.isEditable} />
             <CanvasEditComponent
                 {...props}
+                replace={replaceCanvas}
+                push={setCanvas}
+                undo={undo}
                 isEmbedMode={isEmbedMode}
                 canvas={canvas}
                 runController={runController}
@@ -511,8 +517,6 @@ const CanvasEdit = withRouter(({ canvas, ...props }) => {
 })
 
 const CanvasEditWrap = () => {
-    const { replaceCanvas, setCanvas } = useCanvasUpdater()
-    const { undo } = useContext(UndoContext.Context)
     const canvas = useCanvas()
     if (!canvas) {
         return (
@@ -527,12 +531,7 @@ const CanvasEditWrap = () => {
     return (
         <SubscriptionStatus.Provider key={key}>
             <RunController.Provider canvas={canvas}>
-                <CanvasEdit
-                    replace={replaceCanvas}
-                    push={setCanvas}
-                    undo={undo}
-                    canvas={canvas}
-                />
+                <CanvasEdit />
             </RunController.Provider>
         </SubscriptionStatus.Provider>
     )

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -33,6 +33,7 @@ import useCanvas from './components/CanvasController/useCanvas'
 import useCanvasUpdater from './components/CanvasController/useCanvasUpdater'
 import useAutosaveEffect from './components/CanvasController/useAutosaveEffect'
 import useUpdatedTime from './components/CanvasController/useUpdatedTime'
+import useEmbedMode from './components/CanvasController/useEmbedMode'
 
 import PendingLoadingIndicator from './components/PendingLoadingIndicator'
 import Canvas from './components/Canvas'
@@ -487,7 +488,7 @@ const CanvasEdit = withRouter(({ canvas, ...props }) => {
     const runController = useContext(RunController.Context)
     const canvasController = CanvasController.useController()
     const [updated, setUpdated] = useUpdatedTime(canvas.updated)
-    const isEmbedMode = CanvasController.useEmbedMode()
+    const isEmbedMode = useEmbedMode()
     useCanvasNotifications(canvas)
     useAutosaveEffect()
     const selection = useCanvasSelection()

--- a/app/src/editor/canvas/services.js
+++ b/app/src/editor/canvas/services.js
@@ -6,7 +6,7 @@ import analytics from '$shared/../analytics'
 import api from '$editor/shared/utils/api'
 import Autosave from '$editor/shared/utils/autosave'
 import { nextUniqueName, nextUniqueCopyName } from '$editor/shared/utils/uniqueName'
-import { emptyCanvas, isRunning, RunStates, isHistoricalModeSelected } from './state'
+import { emptyCanvas, RunStates, isHistoricalModeSelected } from './state'
 import { link, unlink, getLink } from './state/linking'
 
 const getData = ({ data }) => data
@@ -62,10 +62,6 @@ export async function create(config) {
 }
 
 export async function duplicateCanvas(canvas) {
-    if (!isRunning(canvas) && !canvas.adhoc) {
-        canvas = await saveNow(canvas) // ensure canvas saved before duplicating
-    }
-
     return createCanvas({
         ...canvas,
         adhoc: false, // duplicate canvases are never adhoc


### PR DESCRIPTION
Prevents attempt to save before duplicating if user doesn't have write permission.

#### To Test

1. Create Canvas with `tester1@streamr.com`
2. Share canvas as read-only with `tester2@streamr.com`
3. Login in different window with `tester2@streamr.com`
4. Open the shared canvas
5. Duplicate Canvas should work, no errors in network panel or console due to trying to save unwritable canvas first.