### PR TITLE
[PLATFORM-1036] Add support for 'List' type ports

### DIFF
--- a/app/src/editor/canvas/components/Ports/Value/List/ListEntry/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/List/ListEntry/index.jsx
@@ -16,7 +16,6 @@ type Props = {
     onChange: (Index, Value) => void,
     onRemoveClick?: ?(Index) => void,
     removable?: boolean,
-    addable?: boolean,
     value: Value,
 }
 
@@ -28,7 +27,6 @@ const ListEntry = ({
     onChange: onChangeProp,
     onRemoveClick: onRemoveClickProp,
     removable,
-    addable,
     value,
 }: Props) => {
     const onValueChange = useCallback((newValue) => {
@@ -41,13 +39,14 @@ const ListEntry = ({
     }, [index, value, onChangeProp])
 
     const onRemoveClick = useCallback(() => {
-        if (removable && onRemoveClickProp) {
+        if (onRemoveClickProp) {
             onRemoveClickProp(index)
         }
-    }, [index, removable, onRemoveClickProp])
+    }, [index, onRemoveClickProp])
 
     return (
         <Fragment>
+            {/* Use empty text input as 'label' */}
             <Text
                 className={styles.label}
                 disabled
@@ -65,7 +64,6 @@ const ListEntry = ({
             <div>
                 {removable ? (
                     <button
-                        key="remove"
                         className={mapStyles.button}
                         type="button"
                         onClick={onRemoveClick}
@@ -74,9 +72,8 @@ const ListEntry = ({
                             <path d="M11.2 8H4.8" stroke="#323232" fill="none" strokeLinecap="round" />
                         </svg>
                     </button>
-                ) : (!!addable && (
+                ) : (
                     <button
-                        key="add"
                         className={mapStyles.button}
                         type="button"
                         onClick={onAddClick}
@@ -89,7 +86,7 @@ const ListEntry = ({
                             </g>
                         </svg>
                     </button>
-                ))}
+                )}
             </div>
         </Fragment>
     )

--- a/app/src/editor/canvas/components/Ports/Value/List/ListEntry/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/List/ListEntry/index.jsx
@@ -1,0 +1,98 @@
+// @flow
+
+import React, { useCallback, Fragment } from 'react'
+import Text from '../../Text'
+import mapStyles from '../../Map/MapEntry/mapEntry.pcss'
+import styles from './listEntry.pcss'
+
+type Index = number
+
+type Value = string
+
+type Props = {
+    disabled?: boolean,
+    index: Index,
+    onAddClick?: ?(Index) => void,
+    onChange: (Index, Value) => void,
+    onRemoveClick?: ?(Index) => void,
+    removable?: boolean,
+    addable?: boolean,
+    value: Value,
+}
+
+const noop = () => {}
+
+const ListEntry = ({
+    disabled,
+    index,
+    onChange: onChangeProp,
+    onRemoveClick: onRemoveClickProp,
+    removable,
+    addable,
+    value,
+}: Props) => {
+    const onValueChange = useCallback((newValue) => {
+        onChangeProp(index, newValue)
+    }, [index, onChangeProp])
+
+    const onAddClick = useCallback(() => {
+        // convert empty to value
+        onChangeProp(index, value == null ? '' : value)
+    }, [index, value, onChangeProp])
+
+    const onRemoveClick = useCallback(() => {
+        if (removable && onRemoveClickProp) {
+            onRemoveClickProp(index)
+        }
+    }, [index, removable, onRemoveClickProp])
+
+    return (
+        <Fragment>
+            <Text
+                className={styles.label}
+                disabled
+                tabIndex="-1"
+                value={`${index}:`}
+                onChange={noop}
+            />
+            <Text
+                disabled={!!disabled}
+                onChange={onValueChange}
+                placeholder={`Item ${index}`}
+                value={value}
+            />
+            {/* Unnamed possibly empty div. It's the 3rd column in Map's 3-column grid. Keep it. */}
+            <div>
+                {removable ? (
+                    <button
+                        key="remove"
+                        className={mapStyles.button}
+                        type="button"
+                        onClick={onRemoveClick}
+                    >
+                        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M11.2 8H4.8" stroke="#323232" fill="none" strokeLinecap="round" />
+                        </svg>
+                    </button>
+                ) : (!!addable && (
+                    <button
+                        key="add"
+                        className={mapStyles.button}
+                        type="button"
+                        onClick={onAddClick}
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+                            <g fill="none" fillRule="evenodd">
+                                <g stroke="#323232" strokeLinecap="round">
+                                    <path d="M8 4.8v6.4M11.2 8H4.8" />
+                                </g>
+                            </g>
+                        </svg>
+                    </button>
+                ))}
+            </div>
+        </Fragment>
+    )
+}
+
+export default ListEntry

--- a/app/src/editor/canvas/components/Ports/Value/List/ListEntry/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/List/ListEntry/index.jsx
@@ -15,7 +15,7 @@ type Props = {
     onAddClick?: ?(Index) => void,
     onChange: (Index, Value) => void,
     onRemoveClick?: ?(Index) => void,
-    removable?: boolean,
+    isLast?: boolean,
     value: Value,
 }
 
@@ -26,7 +26,7 @@ const ListEntry = ({
     index,
     onChange: onChangeProp,
     onRemoveClick: onRemoveClickProp,
-    removable,
+    isLast,
     value,
 }: Props) => {
     const onValueChange = useCallback((newValue) => {
@@ -59,11 +59,19 @@ const ListEntry = ({
                 onChange={onValueChange}
                 placeholder={`Item ${index}`}
                 value={value}
+                autoFocus
             />
             {/* Unnamed possibly empty div. It's the 3rd column in Map's 3-column grid. Keep it. */}
             <div>
-                {removable ? (
+                {/*
+                    Note: Added keys to these buttons.
+                    This prevents a mousedown/blur on the add button triggering the add button to change to a remove button
+                    and then following mouseup then being treated as if it was a click on the remove button
+                    i.e. prevents it from immediately removing rows after adding them.
+                */}
+                {isLast ? (
                     <button
+                        key="remove"
                         className={mapStyles.button}
                         type="button"
                         onClick={onRemoveClick}
@@ -74,6 +82,7 @@ const ListEntry = ({
                     </button>
                 ) : (
                     <button
+                        key="add"
                         className={mapStyles.button}
                         type="button"
                         onClick={onAddClick}

--- a/app/src/editor/canvas/components/Ports/Value/List/ListEntry/listEntry.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/List/ListEntry/listEntry.pcss
@@ -1,0 +1,3 @@
+.label {
+  padding-right: 0;
+}

--- a/app/src/editor/canvas/components/Ports/Value/List/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/List/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
-import React, { useState, useCallback, useMemo, useEffect } from 'react'
+import isEqual from 'lodash/isEqual'
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { type CommonProps } from '..'
 import ListEntry from './ListEntry'
 import styles from './list.pcss'
@@ -13,37 +14,44 @@ const EMPTY = []
 
 const List = ({ disabled, onChange, value: valuesProp }: Props) => {
     valuesProp = valuesProp || EMPTY
+    const valuesPropRef = useRef()
+    valuesPropRef.current = valuesProp
     const [values, setValues] = useState(valuesProp)
 
     const commit = useCallback((values) => {
-        onChange(values.map((v) => v.trim()).filter((v) => v != null))
+        onChange(values.filter((v) => v != null).map((v) => v.trim()))
     }, [onChange])
 
     const onRemoveClick = useCallback((index: number) => {
-        const newValues = [...values]
+        const newValues = values.slice()
         newValues.splice(index, 1)
         setValues(newValues)
-
-        commit(newValues)
-    }, [commit, values])
+    }, [values])
 
     const onEntryChange = useCallback((index: number, entryValue: string) => {
-        const newValues = [...values]
+        const newValues = values.slice()
         entryValue = entryValue.trim()
         newValues[index] = entryValue
         setValues(newValues)
-        commit(newValues)
-    }, [values, commit])
+    }, [values])
 
     const finalValues = useMemo(() => [
         ...values,
         // Append an extra entry at the end…
-        undefined,
+        null,
     ], [values])
 
     useEffect(() => {
-        setValues(valuesProp.map((v) => v.trim()).filter((v) => v != null))
+        setValues((values) => {
+            if (isEqual(valuesProp, values)) { return values }
+            return valuesProp
+        })
     }, [valuesProp])
+
+    useEffect(() => {
+        if (isEqual(valuesPropRef.current, values)) { return }
+        commit(values)
+    }, [values, commit])
 
     return (
         <div className={styles.root}>
@@ -59,7 +67,6 @@ const List = ({ disabled, onChange, value: valuesProp }: Props) => {
                         onChange={onEntryChange}
                         onRemoveClick={onRemoveClick}
                         removable={index !== finalValues.length - 1}
-                        addable={index === finalValues.length - 1 && finalValues[index] == null}
                         value={v}
                     />
                 )

--- a/app/src/editor/canvas/components/Ports/Value/List/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/List/index.jsx
@@ -66,7 +66,7 @@ const List = ({ disabled, onChange, value: valuesProp }: Props) => {
                         key={index}
                         onChange={onEntryChange}
                         onRemoveClick={onRemoveClick}
-                        removable={index !== finalValues.length - 1}
+                        isLast={index !== finalValues.length - 1}
                         value={v}
                     />
                 )

--- a/app/src/editor/canvas/components/Ports/Value/List/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/List/index.jsx
@@ -1,0 +1,71 @@
+// @flow
+
+import React, { useState, useCallback, useMemo, useEffect } from 'react'
+import { type CommonProps } from '..'
+import ListEntry from './ListEntry'
+import styles from './list.pcss'
+
+type Props = CommonProps & {
+    port: any,
+}
+
+const EMPTY = []
+
+const List = ({ disabled, onChange, value: valuesProp }: Props) => {
+    valuesProp = valuesProp || EMPTY
+    const [values, setValues] = useState(valuesProp)
+
+    const commit = useCallback((values) => {
+        onChange(values.map((v) => v.trim()).filter((v) => v != null))
+    }, [onChange])
+
+    const onRemoveClick = useCallback((index: number) => {
+        const newValues = [...values]
+        newValues.splice(index, 1)
+        setValues(newValues)
+
+        commit(newValues)
+    }, [commit, values])
+
+    const onEntryChange = useCallback((index: number, entryValue: string) => {
+        const newValues = [...values]
+        entryValue = entryValue.trim()
+        newValues[index] = entryValue
+        setValues(newValues)
+        commit(newValues)
+    }, [values, commit])
+
+    const finalValues = useMemo(() => [
+        ...values,
+        // Append an extra entry at the end…
+        undefined,
+    ], [values])
+
+    useEffect(() => {
+        setValues(valuesProp.map((v) => v.trim()).filter((v) => v != null))
+    }, [valuesProp])
+
+    return (
+        <div className={styles.root}>
+            {finalValues.map((val, index) => {
+                const v: any = val
+
+                return (
+                    <ListEntry
+                        disabled={disabled}
+                        index={index}
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={index}
+                        onChange={onEntryChange}
+                        onRemoveClick={onRemoveClick}
+                        removable={index !== finalValues.length - 1}
+                        addable={index === finalValues.length - 1 && finalValues[index] == null}
+                        value={v}
+                    />
+                )
+            })}
+        </div>
+    )
+}
+
+export default List

--- a/app/src/editor/canvas/components/Ports/Value/List/list.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/List/list.pcss
@@ -1,0 +1,8 @@
+.root {
+  display: grid;
+  grid-column-gap: calc(0.25 * var(--um));
+  grid-row-gap: calc(0.25 * var(--um));
+  grid-template-columns: auto auto var(--um);
+  padding: calc(0.125 * var(--um)) 0;
+  align-items: center;
+}

--- a/app/src/editor/canvas/components/Ports/Value/Text/text.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/Text/text.pcss
@@ -6,6 +6,7 @@
   padding: 0 calc(0.5 * var(--um));
   transition: 200ms linear;
   transition-property: background-color, color, box-shadow;
+  line-height: inherit;
 }
 
 .root:hover,

--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -8,6 +8,7 @@ import Map from './Map'
 import Select from './Select'
 import Stream from './Stream'
 import Text from './Text'
+import List from './List'
 import styles from './value.pcss'
 
 type Props = {
@@ -17,7 +18,7 @@ type Props = {
     onChange: (any) => void,
 }
 
-type PortType = 'map' | 'color' | 'select' | 'text' | 'stream'
+type PortType = 'map' | 'color' | 'select' | 'text' | 'stream' | 'list'
 
 const getPortValueType = (canvas: any, port: any): PortType => {
     const { type } = port
@@ -35,6 +36,8 @@ const getPortValueType = (canvas: any, port: any): PortType => {
         // straight type mapping
         case portTypes.has('Map'):
             return 'map'
+        case portTypes.has('List'):
+            return 'list'
         case portTypes.has('Color'):
             return 'color'
         case portTypes.has('Stream'):
@@ -49,7 +52,7 @@ export type CommonProps = {
     disabled: boolean,
     onChange: (any) => void,
     value: any,
-    placeholder: any,
+    placeholder?: any,
     title?: string,
     id?: string,
     className?: string,
@@ -139,6 +142,12 @@ const Value = ({ canvas, disabled, port, onChange }: Props) => {
             )}
             {valueType === 'map' && (
                 <Map
+                    {...commonProps}
+                    port={port}
+                />
+            )}
+            {valueType === 'list' && (
+                <List
                     {...commonProps}
                     port={port}
                 />

--- a/app/src/editor/canvas/components/Ports/Value/value.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/value.pcss
@@ -2,7 +2,6 @@
   font-family: var(--sans);
   margin-left: calc(0.5 * var(--um));
   min-width: 0.5em;
-  overflow: hidden;
 }
 
 .disabled {

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -876,7 +876,7 @@ export function getPortUserValue(canvas, portId) {
 }
 
 function isBlank(value) {
-    return value == null || String(value).trim() === ''
+    return value == null || (!Array.isArray(value) && String(value).trim() === '')
 }
 
 export function getPortDefaultValue(canvas, portId) {


### PR DESCRIPTION
Currently it's not possible to set List type values, the UI was never implemented. It was on the TODO for a while but… disappeared.

To quickly remedy this missing functionality I've done up an adaption of the current Map type port UI for List type ports so it's at least possible to input something of the correct type. We'll need proper designs for this eventually, but the Map port UI will need an update at the same time and I think there are some more discussions to be had on how that should work.

This closes 3 tickets:

https://streamr.atlassian.net/browse/PLATFORM-1035
https://streamr.atlassian.net/browse/PLATFORM-1036
https://streamr.atlassian.net/browse/PLATFORM-1037

![list-port](https://user-images.githubusercontent.com/43438/64334184-9b951580-d00a-11e9-951f-e4366941fa82.gif)
