### PR TITLE
[PLATFORM-966] Reset search box location on window resize

### DIFF
--- a/app/src/shared/hooks/wrapCallback.js
+++ b/app/src/shared/hooks/wrapCallback.js
@@ -1,0 +1,32 @@
+import { useLayoutEffect, useMemo } from 'react'
+import debounce from 'lodash/debounce'
+import throttle from 'lodash/throttle'
+
+export default function wrapCallback(wrapperFn) {
+    return (fn, ...args) => {
+        const wrappedFn = useMemo(() => (
+            wrapperFn(fn, ...args)
+        ), [fn, ...args]) // eslint-disable-line react-hooks/exhaustive-deps
+
+        // cancel existing on unmount/change
+        useLayoutEffect(() => () => {
+            // useLayoutEffect to ensure cancel asap
+            if (wrappedFn && wrappedFn.cancel) {
+                wrappedFn.cancel()
+            }
+        }, [wrappedFn])
+
+        return wrappedFn
+    }
+}
+
+/**
+ * Usage:
+ * import { useDebounced } from '$shared/hooks/wrapCallback'
+ * ...
+ * const myCallback = useCallback(…)
+ * const myDebouncedCallback = useDebounced(myCallback, 500)
+ */
+
+export const useDebounced = wrapCallback(debounce)
+export const useThrottled = wrapCallback(throttle)


### PR DESCRIPTION
Doesn't fully fix [the underlying issue](https://streamr.atlassian.net/browse/PLATFORM-966) but there's [some limitations with react-draggable](https://github.com/mzabriskie/react-draggable/pull/392) that prevent us from solving this properly without forking or reimplementing react-draggable's bounds calculation code. 

Quick solution is to just reset position of search box on resize.