### PR TITLE
Improve stream edit page load/save behaviour

### DIFF
--- a/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
@@ -27,21 +27,29 @@ type State = {
 }
 
 export class PreviewView extends Component<Props, State> {
+    unmounted = false
+
     state = {
         isRunning: true,
         hasData: false,
     }
 
+    componentWillUnmount() {
+        this.unmounted = true
+    }
+
     onToggleRun = () => {
+        if (this.unmounted) { return }
         this.setState(({ isRunning }) => ({
             isRunning: !isRunning,
         }))
     }
 
     setHasData = () => {
-        this.setState(() => ({
+        if (this.unmounted) { return }
+        this.setState({
             hasData: true,
-        }))
+        })
     }
 
     render() {

--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -75,11 +75,6 @@ export const STREAM_FIELD_AUTODETECT_REQUEST = 'userpages/streams/STREAM_FIELD_A
 export const STREAM_FIELD_AUTODETECT_SUCCESS = 'userpages/streams/STREAM_FIELD_AUTODETECT_SUCCESS'
 export const STREAM_FIELD_AUTODETECT_FAILURE = 'userpages/streams/STREAM_FIELD_AUTODETECT_FAILURE'
 
-export const openStream = (id: ?StreamId) => ({
-    type: OPEN_STREAM,
-    id,
-})
-
 const getStreamFieldAutodetectRequest = () => ({
     type: STREAM_FIELD_AUTODETECT_REQUEST,
 })
@@ -632,3 +627,10 @@ export const streamFieldsAutodetect = (id: StreamId) => (dispatch: Function) => 
             }
         })
 }
+
+export const openStream = (id: ?StreamId) => ({
+    type: OPEN_STREAM,
+    id,
+})
+
+export const closeStream = () => openStream(null)


### PR DESCRIPTION
* Prevents flash of previous stream data before current stream data loads.
* Block field edits while loading stream data, prevents changing fields while saving or loading data.
* Show loading indicator on Stream show page.
* Prevents creation of new "Untitled Stream" if hitting the save button before the current stream loads.
* Prevent some "setState on unmount" errors.

## To Test

Try creating and editing streams before & after this PR with network latency set to 3s in devtools.