### PR TITLE
Handle missing docs in canvas sidebar.

### DIFF
--- a/app/src/docs/components/CanvasModuleHelp/Empty.jsx
+++ b/app/src/docs/components/CanvasModuleHelp/Empty.jsx
@@ -1,0 +1,17 @@
+export default {
+    id: -1,
+    name: '',
+    path: '',
+    help: {
+        params: {},
+        paramNames: [],
+        inputs: {},
+        inputNames: [],
+        outputs: {},
+        outputNames: [],
+        helpText: 'There is no documentation for this module at this time.',
+    },
+    inputs: [],
+    outputs: [],
+    params: [],
+}

--- a/app/src/docs/components/CanvasModuleHelp/index.jsx
+++ b/app/src/docs/components/CanvasModuleHelp/index.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactMarkdown from 'react-markdown'
 import isEmpty from 'lodash/isEmpty'
 import get from 'lodash/get'
+import cx from 'classnames'
 
 import styles from './canvasModuleHelp.pcss'
 
@@ -65,11 +66,12 @@ type Props = {
     module: any,
     help: any,
     hideName?: boolean,
+    className?: string,
 }
 
-export default function CanvasModuleHelp({ module: m, help, hideName }: Props) {
+export default function CanvasModuleHelp({ module: m, help, hideName, className }: Props) {
     return (
-        <section key={m.id} className={styles.root}>
+        <section key={m.id} className={cx(styles.root, className)}>
             {hideName ? null : <h3>{m.name}</h3>}
             <ReactMarkdown source={help && help.helpText} />
             <div className={styles.ports}>

--- a/app/src/docs/content/canvasModules/Empty.jsx
+++ b/app/src/docs/content/canvasModules/Empty.jsx
@@ -1,0 +1,17 @@
+export default {
+    id: -1,
+    name: '',
+    path: '',
+    help: {
+        params: {},
+        paramNames: [],
+        inputs: {},
+        inputNames: [],
+        outputs: {},
+        outputNames: [],
+        helpText: 'There is no documentation for this module at this time.',
+    },
+    inputs: [],
+    outputs: [],
+    params: [],
+}

--- a/app/src/editor/canvas/components/ModuleHelp.jsx
+++ b/app/src/editor/canvas/components/ModuleHelp.jsx
@@ -2,23 +2,27 @@ import React, { useEffect, useCallback, useState } from 'react'
 import CanvasModuleHelp from '$docs/components/CanvasModuleHelp'
 import useIsMounted from '$shared/hooks/useIsMounted'
 
+const docs = require.context('$docs/content/canvasModules/', false, /\.jsx$/)
+
 function ModuleHelp({ module: m }) {
     const moduleId = m.id
-    const cleanedName = m.name.replace(/\s/g, '').replace(/\(/g, '_').replace(/\)/g, '')
     const isMounted = useIsMounted()
     const [helpContent, setHelpContent] = useState({})
     const currentHelpContent = helpContent[moduleId]
     const hasCurrentContent = currentHelpContent != null
 
     const loadHelp = useCallback(() => {
-        import(`$docs/content/canvasModules/${cleanedName}-${moduleId}.jsx`).then((result) => {
+        // ignore module name, just match on id
+        const path = docs.keys().find((d) => d.endsWith(`-${moduleId}.jsx`))
+        if (!path) { return }
+        import(`$docs/content/canvasModules/${path.slice(2)}`).then((result) => {
             if (!isMounted()) { return }
             setHelpContent((state) => ({
                 ...state,
                 [moduleId]: result.default.help,
             }))
         })
-    }, [moduleId, cleanedName, setHelpContent, isMounted])
+    }, [moduleId, setHelpContent, isMounted])
 
     useEffect(() => {
         if (hasCurrentContent) { return } // do nothing if already loaded help

--- a/app/src/editor/canvas/components/ModuleHelp.jsx
+++ b/app/src/editor/canvas/components/ModuleHelp.jsx
@@ -5,7 +5,7 @@ import Empty from '$docs/components/CanvasModuleHelp/Empty'
 
 const docs = require.context('$docs/content/canvasModules/', false, /\.jsx$/)
 
-function ModuleHelp({ module: m }) {
+function ModuleHelp({ className, module: m }) {
     const moduleId = m.id
     const isMounted = useIsMounted()
     const [helpContent, setHelpContent] = useState({})
@@ -39,7 +39,7 @@ function ModuleHelp({ module: m }) {
     if (!m) { return null }
 
     return (
-        <CanvasModuleHelp module={m} help={currentHelpContent} hideName />
+        <CanvasModuleHelp className={className} module={m} help={currentHelpContent} hideName />
     )
 }
 

--- a/app/src/editor/canvas/components/ModuleHelp.jsx
+++ b/app/src/editor/canvas/components/ModuleHelp.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useCallback, useState } from 'react'
 import CanvasModuleHelp from '$docs/components/CanvasModuleHelp'
 import useIsMounted from '$shared/hooks/useIsMounted'
+import Empty from '$docs/components/CanvasModuleHelp/Empty'
 
 const docs = require.context('$docs/content/canvasModules/', false, /\.jsx$/)
 
@@ -14,7 +15,13 @@ function ModuleHelp({ module: m }) {
     const loadHelp = useCallback(() => {
         // ignore module name, just match on id
         const path = docs.keys().find((d) => d.endsWith(`-${moduleId}.jsx`))
-        if (!path) { return }
+        if (!path) {
+            setHelpContent((state) => ({
+                ...state,
+                [moduleId]: Empty.help,
+            }))
+            return
+        }
         import(`$docs/content/canvasModules/${path.slice(2)}`).then((result) => {
             if (!isMounted()) { return }
             setHelpContent((state) => ({

--- a/app/src/editor/canvas/components/ModuleSidebar.jsx
+++ b/app/src/editor/canvas/components/ModuleSidebar.jsx
@@ -65,7 +65,7 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
                 title={module.displayName || module.name}
                 onClose={onClose}
             />
-            <Content>
+            <Content className={styles.content}>
                 {!optionsKeys.length ? null : (
                     <Section label="Options" initialIsOpen>
                         <div className={cx(styles.optionsFields)}>
@@ -117,7 +117,7 @@ export default function ModuleSidebar({ canvas, selectedModuleHash, setModuleOpt
                     </Section>
                 )}
                 <Section label="About" initialIsOpen>
-                    <ModuleHelp module={module} />
+                    <ModuleHelp className={styles.moduleHelp} module={module} />
                 </Section>
             </Content>
         </React.Fragment>

--- a/app/src/editor/canvas/components/ModuleSidebar.pcss
+++ b/app/src/editor/canvas/components/ModuleSidebar.pcss
@@ -30,10 +30,19 @@
   }
 }
 
+.content {
+
+}
+
 .helpContent {
   color: #525252;
   font-size: 14px;
   text-align: left;
   letter-spacing: 0;
   line-height: 24px;
+}
+
+body .content .moduleHelp {
+  margin-top: 0;
+  padding-top: 0;
 }

--- a/app/src/editor/shared/components/Sidebar/Content.jsx
+++ b/app/src/editor/shared/components/Sidebar/Content.jsx
@@ -7,10 +7,11 @@ import styles from './sidebar.pcss'
 
 type Props = {
     children?: Node,
+    className?: string,
 }
 
-const Content = ({ children }: Props) => (
-    <div className={cx(styles.content)}>
+const Content = ({ children, className }: Props) => (
+    <div className={cx(styles.content, className)}>
         {children}
     </div>
 )

--- a/app/src/editor/shared/components/Sidebar/Header.jsx
+++ b/app/src/editor/shared/components/Sidebar/Header.jsx
@@ -10,14 +10,15 @@ import styles from './sidebar.pcss'
 export type Props = {
     onClose: () => void,
     title: string,
+    className?: string,
 }
 
-const Header = ({ title, onClose }: Props) => {
+const Header = ({ title, onClose, className }: Props) => {
     const info = global.streamr.info()
     const { version, branch, hash } = info
 
     return (
-        <div className={cx(styles.header)}>
+        <div className={cx(styles.header, className)}>
             <div className={styles.titleRow}>
                 <h3 className={cx(styles.name)}>{title}</h3>
                 <button

--- a/app/src/editor/shared/components/Sidebar/Section.jsx
+++ b/app/src/editor/shared/components/Sidebar/Section.jsx
@@ -2,6 +2,7 @@
 
 import React, { type Node } from 'react'
 import { Collapse } from 'reactstrap'
+import cx from 'classnames'
 
 import SvgIcon from '$shared/components/SvgIcon'
 import styles from './sidebar.pcss'
@@ -10,6 +11,7 @@ type Props = {
     label: string,
     initialIsOpen?: boolean,
     children?: Node,
+    className?: string,
 }
 
 type State = {
@@ -29,9 +31,9 @@ class Section extends React.Component<Props, State> {
 
     render() {
         const { isOpen } = this.state
-        const { children, label } = this.props
+        const { children, label, className } = this.props
         return (
-            <div className={styles.sidebarSection}>
+            <div className={cx(styles.sidebarSection, className)}>
                 <button
                     className={styles.accordionToggle}
                     type="button"


### PR DESCRIPTION
Changes docs loader to match on module `id`,  rather than `name`ish & `id`. Name of file mainly there so the docs files are human readable, `id` is important part.

This also fixes `Canvas` module docs loading, since a subcanvas `module.name` is user-defined, not `"Canvas"`, so it never matches `Canvas-81.jsx`.

Shows "There is no documentation for this module at this time." if docs can't be loaded, rather than nothing.

Also prevents network error if the module help is not found e.g. currently no `Stream` docs.

Closes https://streamr.atlassian.net/browse/PLATFORM-908