### PR TITLE
Minor canvas port styling tweaks

### DIFF
--- a/app/src/editor/canvas/components/Ports/Port/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Port/index.jsx
@@ -158,6 +158,7 @@ const Port = ({
             ) : plug}
             <Cell>
                 <EditableText
+                    className={styles.name}
                     disabled={!!isRenameDisabled}
                     editing={editingName}
                     onCommit={onNameChange}

--- a/app/src/editor/canvas/components/Ports/Port/port.pcss
+++ b/app/src/editor/canvas/components/Ports/Port/port.pcss
@@ -17,3 +17,7 @@
   opacity: 0;
   pointer-events: none;
 }
+
+.root .name {
+  color: #525252;
+}

--- a/app/src/editor/canvas/components/Ports/Value/Text/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/Text/index.jsx
@@ -26,6 +26,7 @@ const Text = ({
                 [styles.editing]: editing,
                 [styles.disabled]: disabled,
             })}
+            blankClassName={styles.blank}
             commitEmpty
             disabled={disabled}
             editing={editing}

--- a/app/src/editor/canvas/components/Ports/Value/Text/text.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/Text/text.pcss
@@ -22,3 +22,9 @@
   box-shadow: inset 0 0 0 1px #6AEDFF;
   color: #323232;
 }
+
+.root.blank,
+.root input::placeholder {
+  font-style: normal;
+  color: #D8D8D8;
+}

--- a/app/src/editor/canvas/components/Ports/Value/Text/text.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/Text/text.pcss
@@ -23,11 +23,6 @@
   color: #323232;
 }
 
-.root input {
-  /* prevent input content jumping down 1px when entering edit mode */
-  margin-top: -1px;
-}
-
 .root.blank,
 .root input::placeholder {
   font-style: normal;

--- a/app/src/editor/canvas/components/Ports/Value/Text/text.pcss
+++ b/app/src/editor/canvas/components/Ports/Value/Text/text.pcss
@@ -23,6 +23,11 @@
   color: #323232;
 }
 
+.root input {
+  /* prevent input content jumping down 1px when entering edit mode */
+  margin-top: -1px;
+}
+
 .root.blank,
 .root input::placeholder {
   font-style: normal;

--- a/app/src/shared/assets/stylesheets/fonts/ibm-plex.css
+++ b/app/src/shared/assets/stylesheets/fonts/ibm-plex.css
@@ -1,1 +1,1 @@
-@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Mono:400,500,600|IBM+Plex+Sans:300,400,500,600,700');
+@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Mono:400,500,600|IBM+Plex+Sans:300,400,400i,500,500i,600,700&display=swap');

--- a/app/src/shared/components/EditableText/editableText.pcss
+++ b/app/src/shared/components/EditableText/editableText.pcss
@@ -25,6 +25,9 @@
   padding: 0;
   position: absolute;
   width: 100%;
+
+  /* prevent input content jumping down 1px when entering edit mode */
+  margin-top: -1px;
 }
 
 .inner input::selection {

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -18,6 +18,7 @@ type Props = {
     editOnFocus?: boolean,
     selectAllOnFocus?: boolean,
     onChange?: (string) => void,
+    blankClassName?: string,
     onCommit?: (string) => void,
     onModeChange?: ?(boolean) => void,
     placeholder?: ?string,
@@ -38,6 +39,7 @@ const EditableText = ({
     editOnFocus,
     selectAllOnFocus,
     onChange: onChangeProp,
+    blankClassName,
     onCommit,
     onModeChange,
     placeholder,
@@ -91,15 +93,15 @@ const EditableText = ({
     const renderValue = useCallback((val) => (
         !isBlank(val) ? val : (placeholder || '')
     ), [placeholder])
-
+    const valueIsBlank = isBlank(editing ? value : children)
     return (
         <div
             className={cx(styles.root, className, {
                 [styles.idle]: !editing,
                 [styles.disabled]: disabled,
-                [styles.blank]: isBlank(editing ? value : children),
+                [styles.blank]: valueIsBlank,
                 [ModuleStyles.dragCancel]: !!editing,
-            })}
+            }, valueIsBlank ? blankClassName : undefined)}
             onDoubleClick={startEditing}
             {...((editOnFocus && !disabled) ? {
                 onFocus: startEditing,


### PR DESCRIPTION
Some minor styling tweaks to canvas ports:

* Adjusts port name's colour to match design (from #323232 to #525252).
* Adds some colour contrast between placeholder text and actual values.
* Prevents EditableText input content jumping down 1px when entering edit mode in ports.
* Adds real italic variant of IBM Plex Sans. We're using this in a few places and the real version looks a lot nicer than the pseudo-italics produced by the browser.