### PR TITLE
[PLATFORM-1060] Make 'View on streamr' button open in new tab

### DIFF
--- a/app/src/editor/canvas/components/EmbedToolbar.jsx
+++ b/app/src/editor/canvas/components/EmbedToolbar.jsx
@@ -6,6 +6,14 @@ import LogoItem from '$shared/components/Logo'
 import links from '../../../links'
 import routes from '$routes'
 
+function inIframe() {
+    try {
+        return window.self !== window.top
+    } catch (e) {
+        return true
+    }
+}
+
 export default function EmbedToolbar({ canvas }) {
     return (
         <div className={styles.root}>
@@ -20,11 +28,15 @@ export default function EmbedToolbar({ canvas }) {
                 href={routes.login({
                     redirect: `${links.editor.canvasEditor}/${canvas.id}`,
                 })}
-                target="_blank"
-                rel="noopener noreferrer"
+                {...(inIframe() ? {
+                    // open in new tab if in iframe
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                } : {})}
             >
                 View on Streamr
             </a>
         </div>
     )
 }
+

--- a/app/src/editor/canvas/components/EmbedToolbar.jsx
+++ b/app/src/editor/canvas/components/EmbedToolbar.jsx
@@ -20,6 +20,8 @@ export default function EmbedToolbar({ canvas }) {
                 href={routes.login({
                     redirect: `${links.editor.canvasEditor}/${canvas.id}`,
                 })}
+                target="_blank"
+                rel="noopener noreferrer"
             >
                 View on Streamr
             </a>


### PR DESCRIPTION
Opens embed mode "View on Streamr" links in a new tab, but only if viewing from within an iframe.

### To Test

1. Go to any canvas, open share dialog. 
1. Copy link.
1. Make public.
1. Paste copied link into new tab.
1. Click "View on Streamr" button, should open login in current tab.
1. Close tab, go back to canvas editor.
1. Open share dialog.
1. Go to embed
1. Copy embed code, paste into new html file or whatever. (or hack `<div dangerouslySetInnerHTML={{__html: embedCode}} />` into `EmbedDialogContent.jsx`) 
1. View embedded iframe.
1. Click "View on Streamr" button within iframe, should open login in new tab.