### PR TITLE
Share dialog tweaks

### DIFF
--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/index.jsx
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/index.jsx
@@ -44,7 +44,6 @@ export class ShareDialogInputRow extends Component<Props, State> {
             <div className={styles.container}>
                 <input
                     className={styles.input}
-                    type="email"
                     placeholder={I18n.t('modal.shareResource.enterEmailAddress')}
                     name="email"
                     value={email}

--- a/app/src/userpages/hooks/useEmbed.js
+++ b/app/src/userpages/hooks/useEmbed.js
@@ -23,7 +23,7 @@ const getEmbedCode = (resourceType: ResourceType, resourceId: ResourceId) => {
 }
 
 const getLinks = (resourceId: ResourceId) => ({
-    CANVAS: `canvas/embed/${resourceId}`,
+    CANVAS: `canvas/editor/${resourceId}`,
     DASHBOARD: `dashboard/editor/${resourceId}`,
     STREAM: `core/stream/show/${resourceId}`,
 })

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -770,7 +770,7 @@ msgid "modal##shareResource##withLink"
 msgstr "Public — viewable by anyone with the link or via the API"
 
 msgid "modal##shareResource##enterEmailAddress"
-msgstr "Enter email address"
+msgstr "Enter email address or Ethereum account."
 
 msgid "modal##shareResource##permissions##read"
 msgstr "View only"

--- a/app/src/userpages/tests/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/shareDialogInputRow.test.jsx
+++ b/app/src/userpages/tests/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/shareDialogInputRow.test.jsx
@@ -27,7 +27,6 @@ describe('ShareDialogInputRow', () => {
                 addPermission={() => {}}
             />)
             const input = inputRow.find('input')
-            assert.equal(input.props().type, 'email')
             assert.equal(input.props().placeholder, 'enterEmailAddress')
             assert.equal(input.props().name, 'email')
         })


### PR DESCRIPTION
These changes were discussed in a meeting RE canvas sharing.

1. Adds mention of 'Ethereum account' in 'Enter email address' text.
2. Uses editor link, rather than embed link, for canvas "copy link" button in share dialog.

![image](https://user-images.githubusercontent.com/43438/65029360-2dd4dc00-d970-11e9-960c-d9f93a586d6d.png)