### PR TITLE
[PLATFORM-1072] Historical Date Strings vs Timestamps

### DIFF
--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -975,6 +975,21 @@ export function setHistoricalRange(canvas, update = {}) {
     })
 }
 
+/**
+ * Convert historical range date strings to numeric timestamps
+ */
+
+function convertHistoricalRange(canvas) {
+    return {
+        ...canvas,
+        settings: {
+            ...canvas.settings,
+            beginDate: canvas.settings.beginDate ? new Date(canvas.settings.beginDate).getTime() : canvas.settings.beginDate,
+            endDate: canvas.settings.endDate ? new Date(canvas.settings.endDate).getTime() : canvas.settings.endDate,
+        },
+    }
+}
+
 export function isHistoricalRunValid(canvas = {}) {
     const { settings = {} } = canvas
     const { beginDate, endDate } = settings
@@ -1330,7 +1345,7 @@ export function updateCanvas(canvas, path, fn) {
         // so let's skip update call altogether
         canvas = update(path, fn, canvas)
     }
-    return limitLayout(updateVariadic(updatePortConnections(workaroundInitialValueWeirdness(canvas))))
+    return convertHistoricalRange(limitLayout(updateVariadic(updatePortConnections(workaroundInitialValueWeirdness(canvas)))))
 }
 
 export function moduleCategoriesIndex(modules = [], path = [], index = []) {

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -953,14 +953,14 @@ export function setHistoricalRange(canvas, update = {}) {
     let { beginDate, endDate } = settings
     if (update.beginDate) {
         beginDate = update.beginDate // eslint-disable-line prefer-destructuring
-        if (endDate && Date.parse(update.beginDate) > Date.parse(endDate)) {
+        if (endDate && new Date(beginDate).getTime() > new Date(endDate).getTime()) {
             endDate = beginDate
         }
     }
 
     if (update.endDate) {
         endDate = update.endDate // eslint-disable-line prefer-destructuring
-        if (beginDate && Date.parse(beginDate) > Date.parse(update.endDate)) {
+        if (beginDate && new Date(beginDate).getTime() > new Date(endDate).getTime()) {
             beginDate = endDate
         }
     }
@@ -969,8 +969,8 @@ export function setHistoricalRange(canvas, update = {}) {
         ...canvas,
         settings: {
             ...canvas.settings,
-            beginDate: beginDate ? new Date(beginDate).toISOString() : canvas.settings.beginDate,
-            endDate: endDate ? new Date(endDate).toISOString() : canvas.settings.endDate,
+            beginDate: beginDate ? new Date(beginDate).getTime() : canvas.settings.beginDate,
+            endDate: endDate ? new Date(endDate).getTime() : canvas.settings.endDate,
         },
     })
 }
@@ -978,7 +978,7 @@ export function setHistoricalRange(canvas, update = {}) {
 export function isHistoricalRunValid(canvas = {}) {
     const { settings = {} } = canvas
     const { beginDate, endDate } = settings
-    return !!(beginDate && endDate && Date.parse(beginDate) <= Date.parse(endDate))
+    return !!(beginDate && endDate && new Date(beginDate).getTime() <= new Date(endDate).getTime())
 }
 
 /**

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -202,8 +202,8 @@ describe('Canvas State', () => {
             })
 
             describe('setHistoricalRange', () => {
-                const earlyDate = new Date(Date.now() - 9999999).toISOString()
-                const lateDate = new Date().toISOString()
+                const earlyDate = Date.now() - 9999999
+                const lateDate = Date.now()
                 it('should set endDate to beginDate when beginDate < endDate', () => {
                     let canvas = State.emptyCanvas()
                     const beginDate = earlyDate
@@ -244,6 +244,31 @@ describe('Canvas State', () => {
                     })
                     expect(canvas.settings.beginDate).toEqual(beginDate)
                     expect(canvas.settings.endDate).toEqual(beginDate)
+                })
+
+                it('should convert date strings to timestamps', () => {
+                    let canvas = State.emptyCanvas()
+                    const beginDate = earlyDate
+                    const endDate = lateDate
+                    canvas = State.setHistoricalRange(canvas, {
+                        beginDate: new Date(beginDate).toISOString(),
+                    })
+                    canvas = State.setHistoricalRange(canvas, {
+                        endDate: new Date(endDate).toISOString(),
+                    })
+                    expect(canvas.settings.beginDate).toEqual(beginDate)
+                    expect(canvas.settings.endDate).toEqual(endDate)
+                })
+
+                it('should convert date strings to timestamps in updateCanvas, even without setHistoricalRange', () => {
+                    let canvas = State.emptyCanvas()
+                    const beginDate = earlyDate
+                    const endDate = lateDate
+                    canvas.settings.beginDate = new Date(earlyDate).toISOString()
+                    canvas.settings.endDate = new Date(lateDate).toISOString()
+                    canvas = State.updateCanvas(canvas)
+                    expect(canvas.settings.beginDate).toEqual(beginDate)
+                    expect(canvas.settings.endDate).toEqual(endDate)
                 })
             })
 


### PR DESCRIPTION
Backend currently doesn’t parse the date string correctly, it doesn’t take the time offset into account so historical canvases start at 00:00 utc time, possibly on the wrong date, instead of in user’s timezone.

Backend does correctly parse timestamp format though, so this PR:

1. Sends new canvas start/end dates as timestamps instead of ISO 8601 strings.
2. Updates existing canvas ISO 8601 start/end dates to be timestamps.

## To Test

1. Plug a clock into a Table.
2. Switch to historical mode, pick a start and end date.
3. Start as historical canvas in 1x mode.
4. Note bottom entry in table should match the begin date you selected.

Also, old canvases with historical dates set as a date string should not break, should now run at correct date.

![image](https://user-images.githubusercontent.com/43438/65585898-d2c96780-dfb5-11e9-9eec-bb117afcecbf.png)

