### PR TITLE
Add tests around `usePending` hook

### DIFF
--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -539,7 +539,7 @@ const CanvasEditWrap = () => {
 
 const CanvasContainer = withRouter(withErrorBoundary(ErrorComponentView)((props) => (
     <UndoContext.Provider key={props.match.params.id} enableBreadcrumbs>
-        <PendingProvider>
+        <PendingProvider name="canvas">
             <PendingLoadingIndicator />
             <ClientProvider>
                 <CanvasController.Provider embed={!!props.embed}>

--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -299,7 +299,7 @@ function DashboardLoadingIndicator() {
 export default withRouter((props) => (
     <Layout className={styles.layout} footer={false}>
         <UndoContextProvider key={props.match.params.id} enableBreadcrumbs>
-            <PendingProvider>
+            <PendingProvider name="dashboard">
                 <ClientProvider>
                     <DashboardLoadingIndicator />
                     <DashboardLoader>

--- a/app/src/marketplace/containers/ProductController/index.jsx
+++ b/app/src/marketplace/containers/ProductController/index.jsx
@@ -41,7 +41,7 @@ type ControllerProps = {
 
 const ProductController = ({ children }: ControllerProps) => (
     <RouterContext.Provider>
-        <PendingProvider>
+        <PendingProvider name="product">
             <ValidationContextProvider>
                 <ProductEffects />
                 {children || null}

--- a/app/src/shared/components/PendingContextProvider/index.jsx
+++ b/app/src/shared/components/PendingContextProvider/index.jsx
@@ -1,57 +1,107 @@
 // @flow
 
-import React, { useMemo, useCallback, useState, type Node, type Context } from 'react'
-import useIsMountedRef from '$shared/hooks/useIsMountedRef'
+import t from 'prop-types'
+import React, { useMemo, useCallback, useState, useContext, useEffect, type Node, type Context } from 'react'
+import useIsMounted from '$shared/hooks/useIsMounted'
 
 type ContextProps = {
+    name: string,
     isPending: boolean,
     setPending: (string, number) => any,
-    pending: Object,
+    checkPending: (string) => boolean,
+    updateChildren: (string, ContextProps) => any,
 }
 
-const PendingContext: Context<ContextProps> = React.createContext({
+const ROOT = {
+    name: '',
     isPending: false,
-    pending: {},
     setPending: () => {},
-})
+    checkPending: () => false,
+    updateChildren: () => {},
+}
 
-function usePendingContext(): ContextProps {
-    const [pending, setPendingState] = useState({})
-    const isMountedRef = useIsMountedRef()
-    const setPending: (string, number) => Object = useCallback((name, direction) => {
-        if (!isMountedRef.current) { return }
+function useNamedCounters() {
+    const isMounted = useIsMounted()
+    const [counters, setCountersState] = useState({})
+    const updateCounter: (string, number) => Object = useCallback((name, direction) => {
+        if (!isMounted()) { return }
         if (!name) {
-            throw new Error('pending needs a name')
+            throw new Error('counter needs a name')
         }
 
-        setPendingState((state) => {
+        setCountersState((state) => {
             const current = state[name] || 0
             return {
                 ...state,
                 [name]: Math.max(0, current + direction),
             }
         })
-    }, [setPendingState, isMountedRef])
+    }, [setCountersState, isMounted])
+    return [
+        counters,
+        updateCounter,
+    ]
+}
 
-    const isPending = Object.values(pending).some(Boolean)
+const PendingContext: Context<ContextProps> = React.createContext(ROOT)
+/* eslint-disable no-shadow */
+function usePendingContext(name): ContextProps {
+    const parentContext = useContext(PendingContext)
+    const isMounted = useIsMounted()
+    const path = [parentContext && parentContext.name, name].filter(Boolean).join('.')
+    const [pendingChildren, updatePendingChildren] = React.useState({})
+    const updateParent = parentContext !== ROOT && parentContext.updateChildren
+    const [selfPending, setPending] = useNamedCounters()
 
-    return useMemo(() => ({
-        setPending,
+    const updateChildren = useCallback((childName, value) => {
+        if (!isMounted()) { return }
+        updatePendingChildren((c) => ({
+            ...c,
+            [childName]: value,
+        }))
+    }, [updatePendingChildren, isMounted])
+    const isSelfPending = Object.values(selfPending).some((value) => !!value)
+    const pendingChildrenValues = Object.values(pendingChildren)
+    // $FlowFixMe
+    const isChildrenPending = !!pendingChildrenValues.length && pendingChildrenValues.some(({ isPending }) => isPending)
+    const isPending = isSelfPending || isChildrenPending
+
+    const checkPending = useCallback((key) => (
+        !!selfPending[key]
+    ), [selfPending])
+
+    const value = useMemo(() => ({
+        name,
+        path,
         isPending,
-        pending,
-    }), [pending, setPending, isPending])
+        checkPending,
+        setPending,
+        updateChildren,
+    }), [path, name, isPending, updateChildren, setPending, checkPending])
+
+    useEffect(() => {
+        if (!updateParent) { return }
+        updateParent(name, value)
+    }, [value, name, updateParent])
+
+    return value
 }
 
 type Props = {
     children?: Node,
+    name: string,
 }
 
-function PendingContextProvider({ children }: Props) {
+function PendingContextProvider({ name, children }: Props) {
     return (
-        <PendingContext.Provider value={usePendingContext()}>
+        <PendingContext.Provider key={name} value={usePendingContext(name)}>
             {children || null}
         </PendingContext.Provider>
     )
+}
+
+PendingContextProvider.propTypes = {
+    name: t.string.isRequired,
 }
 
 export {

--- a/app/src/shared/components/PendingContextProvider/index.jsx
+++ b/app/src/shared/components/PendingContextProvider/index.jsx
@@ -4,11 +4,13 @@ import React, { useMemo, useCallback, useState, type Node, type Context } from '
 import useIsMountedRef from '$shared/hooks/useIsMountedRef'
 
 type ContextProps = {
+    isPending: boolean,
     setPending: (string, number) => any,
     pending: Object,
 }
 
 const PendingContext: Context<ContextProps> = React.createContext({
+    isPending: false,
     pending: {},
     setPending: () => {},
 })
@@ -31,10 +33,13 @@ function usePendingContext(): ContextProps {
         })
     }, [setPendingState, isMountedRef])
 
+    const isPending = Object.values(pending).some(Boolean)
+
     return useMemo(() => ({
         setPending,
+        isPending,
         pending,
-    }), [pending, setPending])
+    }), [pending, setPending, isPending])
 }
 
 type Props = {

--- a/app/src/shared/hooks/usePending.jsx
+++ b/app/src/shared/hooks/usePending.jsx
@@ -1,20 +1,61 @@
 // @flow
 
-import { useContext, useMemo, useCallback } from 'react'
+import { useContext, useMemo, useCallback, useState, useLayoutEffect, useRef } from 'react'
 
+import useIsMounted from '$shared/hooks/useIsMounted'
 import { Context as PendingContext } from '$shared/components/PendingContextProvider'
 
+function useCounter() {
+    const [counter, setCounterState] = useState(0)
+    const updateCounter = useCallback((direction: number) => {
+        setCounterState((state) => {
+            const current = state || 0
+            return Math.max(0, current + direction)
+        })
+    }, [])
+    return [counter, updateCounter]
+}
+
+function useDiff(val) {
+    const lastValRef = useRef(val)
+    useLayoutEffect(() => {
+        lastValRef.current = val
+    }, [val, lastValRef])
+    return val - lastValRef.current
+}
+
 export function usePending(name: string) {
-    const { pending, setPending } = useContext(PendingContext)
+    const [selfPending, setSelfPending] = useCounter()
+    const { checkPending, setPending } = useContext(PendingContext)
+    const isMounted = useIsMounted()
 
     const start = useCallback(() => {
-        setPending(name, 1)
-    }, [setPending, name])
+        if (!isMounted()) { return }
+        setSelfPending(1)
+    }, [setSelfPending, isMounted])
 
     const end = useCallback(() => {
-        setPending(name, -1)
-    }, [setPending, name])
+        if (!isMounted()) { return }
+        setSelfPending(-1)
+    }, [setSelfPending, isMounted])
 
+    const diff = useDiff(selfPending)
+    const pendingRef = useRef(selfPending)
+    // update context when diff changes
+    useLayoutEffect(() => {
+        if (!diff) { return }
+        setPending(name, diff)
+        pendingRef.current += diff
+    }, [diff, setPending, name])
+
+    // undo any outstanding pending counts on unmount
+    const setPendingRef = useRef(setPending)
+    setPendingRef.current = setPending
+    useLayoutEffect(() => () => {
+        setPendingRef.current(name, -1 * pendingRef.current)
+    }, [name, pendingRef, setPendingRef])
+
+    // call start() and end() around some async fn
     const wrap = useCallback(async (fn: Function) => {
         start()
         try {
@@ -24,7 +65,7 @@ export function usePending(name: string) {
         }
     }, [start, end])
 
-    const isCurrentPending = !!pending[name]
+    const isCurrentPending = !!checkPending(name)
 
     return useMemo(() => ({
         isPending: isCurrentPending,

--- a/app/src/shared/hooks/usePending.jsx
+++ b/app/src/shared/hooks/usePending.jsx
@@ -35,8 +35,8 @@ export function usePending(name: string) {
 }
 
 export function useAnyPending() {
-    const { pending } = useContext(PendingContext)
-    return Object.values(pending).some((isPending) => isPending)
+    const { isPending } = useContext(PendingContext)
+    return isPending
 }
 
 export default usePending

--- a/app/src/shared/test/hooks/usePending.test.jsx
+++ b/app/src/shared/test/hooks/usePending.test.jsx
@@ -1,0 +1,84 @@
+import React, { useEffect } from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import usePending from '$shared/hooks/usePending'
+import * as PendingContext from '$shared/components/PendingContextProvider'
+
+function wait(timeout) {
+    return new Promise((resolve) => setTimeout(resolve, timeout))
+}
+
+describe('usePending', () => {
+    it('is pending while waiting for wrapped function', async (done) => {
+        let currentContext
+        const timeout = 50
+        const fn = jest.fn()
+        function Test() {
+            currentContext = usePending('test')
+            const { wrap } = currentContext
+            useEffect(() => {
+                fn()
+                wrap(() => wait(timeout))
+            }, [wrap])
+            return null
+        }
+
+        await act(async () => {
+            const result = mount((
+                <PendingContext.Provider>
+                    <Test />
+                </PendingContext.Provider>
+            ))
+            expect(currentContext.isPending).not.toBeTruthy()
+            await wait(timeout * 0.1)
+            expect(currentContext.isPending).toBeTruthy()
+            await wait(timeout * 1.1)
+            expect(currentContext.isPending).not.toBeTruthy()
+            expect(fn).toHaveBeenCalledTimes(1)
+            result.unmount()
+        })
+        done()
+    })
+
+    it('can call wrapped function multiple times, will wait for all to complete', async (done) => {
+        let currentContext
+        const timeout = 100
+        const started = jest.fn()
+        const ended = jest.fn()
+        function Test() {
+            currentContext = usePending('test')
+            const { wrap } = currentContext
+            useEffect(() => {
+                started(1)
+                wrap(() => wait(timeout * 0.5)).then(() => ended(1))
+            }, [wrap])
+
+            useEffect(() => {
+                started(2)
+                wrap(() => wait(timeout)).then(() => ended(2))
+            }, [wrap])
+            return null
+        }
+
+        await act(async () => {
+            const result = mount((
+                <PendingContext.Provider>
+                    <Test />
+                </PendingContext.Provider>
+            ))
+            expect(currentContext.isPending).not.toBeTruthy()
+            await wait(timeout * 0.6)
+            expect(started).toHaveBeenCalledWith(1)
+            expect(started).toHaveBeenCalledWith(2)
+            expect(ended).toHaveBeenCalledWith(1)
+            expect(ended).not.toHaveBeenCalledWith(2)
+            expect(currentContext.isPending).toBeTruthy()
+            await wait(timeout * 1.1)
+            expect(currentContext.isPending).not.toBeTruthy()
+            expect(started).toHaveBeenCalledTimes(2)
+            expect(ended).toHaveBeenCalledTimes(2)
+            result.unmount()
+        })
+        done()
+    })
+})

--- a/app/src/shared/test/hooks/usePending.test.jsx
+++ b/app/src/shared/test/hooks/usePending.test.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext, useState } from 'react'
 import { mount } from 'enzyme'
 import { act } from 'react-dom/test-utils'
-import usePending from '$shared/hooks/usePending'
+import usePending, { useAnyPending } from '$shared/hooks/usePending'
 import * as PendingContext from '$shared/components/PendingContextProvider'
 
 function wait(timeout) {
@@ -26,8 +26,10 @@ describe('usePending', () => {
         let currentPendingState
         const timeout = 50
         const fn = jest.fn()
+        let isAnyPending
         function Test() {
             currentPendingState = usePending('test')
+            isAnyPending = useAnyPending()
             const { wrap } = currentPendingState
             useEffect(() => {
                 fn()
@@ -43,10 +45,13 @@ describe('usePending', () => {
                 </PendingContext.Provider>
             ))
             expect(currentPendingState.isPending).not.toBeTruthy()
+            expect(isAnyPending).not.toBeTruthy()
             await wait(timeout * 0.1)
             expect(currentPendingState.isPending).toBeTruthy()
+            expect(isAnyPending).toBeTruthy()
             await wait(timeout * 1.1)
             expect(currentPendingState.isPending).not.toBeTruthy()
+            expect(isAnyPending).not.toBeTruthy()
             expect(fn).toHaveBeenCalledTimes(1)
             result.unmount()
         })

--- a/app/src/shared/test/hooks/usePending.test.jsx
+++ b/app/src/shared/test/hooks/usePending.test.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useContext } from 'react'
 import { mount } from 'enzyme'
 import { act } from 'react-dom/test-utils'
 import usePending from '$shared/hooks/usePending'
@@ -10,12 +10,12 @@ function wait(timeout) {
 
 describe('usePending', () => {
     it('is pending while waiting for wrapped function', async (done) => {
-        let currentContext
+        let currentPendingState
         const timeout = 50
         const fn = jest.fn()
         function Test() {
-            currentContext = usePending('test')
-            const { wrap } = currentContext
+            currentPendingState = usePending('test')
+            const { wrap } = currentPendingState
             useEffect(() => {
                 fn()
                 wrap(() => wait(timeout))
@@ -29,11 +29,11 @@ describe('usePending', () => {
                     <Test />
                 </PendingContext.Provider>
             ))
-            expect(currentContext.isPending).not.toBeTruthy()
+            expect(currentPendingState.isPending).not.toBeTruthy()
             await wait(timeout * 0.1)
-            expect(currentContext.isPending).toBeTruthy()
+            expect(currentPendingState.isPending).toBeTruthy()
             await wait(timeout * 1.1)
-            expect(currentContext.isPending).not.toBeTruthy()
+            expect(currentPendingState.isPending).not.toBeTruthy()
             expect(fn).toHaveBeenCalledTimes(1)
             result.unmount()
         })
@@ -41,13 +41,13 @@ describe('usePending', () => {
     })
 
     it('can call wrapped function multiple times, will wait for all to complete', async (done) => {
-        let currentContext
+        let currentPendingState
         const timeout = 100
         const started = jest.fn()
         const ended = jest.fn()
         function Test() {
-            currentContext = usePending('test')
-            const { wrap } = currentContext
+            currentPendingState = usePending('test')
+            const { wrap } = currentPendingState
             useEffect(() => {
                 started(1)
                 wrap(() => wait(timeout * 0.5)).then(() => ended(1))
@@ -66,17 +66,53 @@ describe('usePending', () => {
                     <Test />
                 </PendingContext.Provider>
             ))
-            expect(currentContext.isPending).not.toBeTruthy()
+            expect(currentPendingState.isPending).not.toBeTruthy()
             await wait(timeout * 0.6)
             expect(started).toHaveBeenCalledWith(1)
             expect(started).toHaveBeenCalledWith(2)
             expect(ended).toHaveBeenCalledWith(1)
             expect(ended).not.toHaveBeenCalledWith(2)
-            expect(currentContext.isPending).toBeTruthy()
+            expect(currentPendingState.isPending).toBeTruthy()
             await wait(timeout * 1.1)
-            expect(currentContext.isPending).not.toBeTruthy()
+            expect(currentPendingState.isPending).not.toBeTruthy()
             expect(started).toHaveBeenCalledTimes(2)
             expect(ended).toHaveBeenCalledTimes(2)
+            result.unmount()
+        })
+        done()
+    })
+
+    it('can detect any pending', async (done) => {
+        let currentPendingContext
+        const timeout = 100
+        function Test({ name }) {
+            const { wrap } = usePending(name)
+            useEffect(() => {
+                wrap(() => wait(timeout))
+            }, [wrap])
+            return null
+        }
+
+        function Inspector() {
+            currentPendingContext = useContext(PendingContext.Context)
+            return null
+        }
+
+        await act(async () => {
+            const result = mount((
+                <PendingContext.Provider>
+                    <Test name="test1" timeout={timeout * 0.5} />
+                    <Test name="test2" timeout={timeout} />
+                    <Inspector />
+                </PendingContext.Provider>
+            ))
+            expect(currentPendingContext.isPending).not.toBeTruthy()
+            await wait(timeout * 0.1)
+            expect(currentPendingContext.isPending).toBeTruthy()
+            await wait(timeout * 0.6)
+            expect(currentPendingContext.isPending).toBeTruthy()
+            await wait(timeout * 1.1)
+            expect(currentPendingContext.isPending).not.toBeTruthy()
             result.unmount()
         })
         done()


### PR DESCRIPTION
Adds some tests around the `usePending` hook, possible now that we have async `act`.

Also:

* Fixes issue with pending count being incorrect when sub-components unmount
* Adds support for "nested" pending contexts e.g. creating a pending context within a pending context, the parent context is considered still pending if the child context(s) is pending.

