### PR TITLE
[PLATFORM-1063] Fix read-only select to show selected `name`, not `value`

### DIFF
--- a/app/src/editor/canvas/components/Ports/Value/index.jsx
+++ b/app/src/editor/canvas/components/Ports/Value/index.jsx
@@ -5,7 +5,7 @@ import cx from 'classnames'
 import * as State from '../../../state'
 import Color from './Color'
 import Map from './Map'
-import Select from './Select'
+import Select, { useSelectOptions } from './Select'
 import Stream from './Stream'
 import Text from './Text'
 import List from './List'
@@ -79,19 +79,24 @@ const BooleanPossibleValues = [{
 
 function PortSelect({ canvas, port, value, ...props }) {
     const portValueEditDisabled = State.isPortValueEditDisabled(canvas, port.id)
-    value = value == null ? undefined : String(value) /* coerce option value to string or undefined */
+    let { possibleValues: options } = port
+
+    const selectConfig = useSelectOptions({
+        value,
+        options,
+    })
+
     if (portValueEditDisabled) {
         // always render as disabled text box if value editing is disabled
         return (
             <Text
-                value={value}
+                value={selectConfig.name}
                 {...props}
                 disabled
             />
         )
     }
 
-    let { possibleValues: options } = port
     if (!options) {
         // inject boolean dropdown if no options and type appears to be boolean
         options = State.isPortBoolean(canvas, port.id) ? BooleanPossibleValues : []


### PR DESCRIPTION
Fixes `PLATFORM-1063` where a select port is showing the `value` rather than the `name`. 

Issue was the wrapper that displays a TextInput instead of a Select when the control is disabled didn't use the same `name` extracting code as the Select.

### To Test

1. Add "Moving Average" module.
2. Start canvas
3. Notice moving average module stays reporting "events" as value, rather than "EVENTS".

Also to test (things which are very sensitive to the `select` config/styles):

1. Should be able to change select value
2. Canvas module select should work
3. Module resizes appropriately after selection
