### PR TITLE
[PLATFORM-1081] Fix code editor text focus bug 

### DIFF
--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -77,7 +77,7 @@ export default class CodeEditorWindow extends React.Component {
         })
     }
 
-    onMouseDownTitle = (event) => {
+    onClickTitle = (event) => {
         // need to cancel event otherwise editor focus doesn't stick
         event.preventDefault()
         event.stopPropagation()
@@ -101,7 +101,7 @@ export default class CodeEditorWindow extends React.Component {
             <DraggableCanvasWindow {...canvasWindowProps}>
                 <div className={styles.editorDialog}>
                     <DraggableCanvasWindow.Dialog onClose={onClose}>
-                        <DraggableCanvasWindow.Title onClose={onClose} onMouseDown={this.onMouseDownTitle}>Code Editor</DraggableCanvasWindow.Title>
+                        <DraggableCanvasWindow.Title onClose={onClose} onClick={this.onClickTitle}>Code Editor</DraggableCanvasWindow.Title>
                         <div className={styles.editorContainer}>
                             <AceEditor
                                 ref={this.editor}

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -77,7 +77,10 @@ export default class CodeEditorWindow extends React.Component {
         })
     }
 
-    onMouseDownTitle = () => {
+    onMouseDownTitle = (event) => {
+        // need to cancel event otherwise editor focus doesn't stick
+        event.preventDefault()
+        event.stopPropagation()
         // forward title clicks to editor focus
         this.editor.current.editor.focus()
     }


### PR DESCRIPTION
Clicking the title to focus the editor was losing the editor focus immediately after setting it. Oops.

#### To Test

1. Add Java Module
2. Edit Code
3. Click canvas background to ensure code editor is not focussed.
4. Click Code Editor title bar
5. Focus should be in the code editor, you should be able to type to change code content