### PR TITLE
[PLATFORM-1080] Prevent losing connections on module definition update

### DIFF
--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -260,7 +260,8 @@ const CanvasEditComponent = class CanvasEdit extends Component {
         if (this.unmounted) { return }
 
         this.replaceCanvas((canvas) => (
-            CanvasState.updateModule(canvas, hash, () => newModule)
+            // use replaceModule to maintain connections & other state as much as possible
+            CanvasState.replaceModule(canvas, newModule)
         ))
     }
 

--- a/app/src/editor/canvas/tests/java.test.js
+++ b/app/src/editor/canvas/tests/java.test.js
@@ -1,0 +1,94 @@
+import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/tests/utils'
+import * as SharedServices from '$editor/shared/services'
+
+import * as State from '../state'
+import * as Services from '../services'
+
+import './utils'
+
+const footer = `
+public void initialize() {
+  // Initialize local variables
+}
+
+public void sendOutput() {
+  //Write your module code here
+}
+
+public void clearState() {
+  // Clear internal state
+}
+`.trim()
+
+function defineStubModule({ inputs = 0, outputs = 0 }) {
+    const lines = []
+    for (let i = 0; i < inputs; i += 1) {
+        lines.push(`TimeSeriesInput input${i} = new TimeSeriesInput(this,"in${i}");`)
+    }
+    for (let i = 0; i < outputs; i += 1) {
+        lines.push(`TimeSeriesOutput output${i} = new TimeSeriesOutput(this,"out${i}");`)
+    }
+    lines.push(footer)
+    return lines.join('\n')
+}
+
+describe('Java Module', () => {
+    let teardown
+
+    beforeAll(async () => {
+        teardown = await setupAuthorizationHeader()
+    }, 60000)
+
+    afterAll(async () => {
+        await Services.deleteAllCanvases()
+        await teardown()
+    })
+
+    it('will maintain connections when java module updated', async () => {
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('Constant'))
+        canvas = State.addModule(canvas, await loadModuleDefinition('JavaModule'))
+
+        const javaModuleInitial = canvas.modules[canvas.modules.length - 1]
+        // create a module with 1 input and 1 output
+        canvas = State.updateModule(canvas, javaModuleInitial.hash, (m) => ({
+            ...m,
+            code: defineStubModule({
+                inputs: 1,
+                outputs: 1,
+            }),
+        }))
+        // server response will provide updated module definition
+        canvas = State.updateCanvas(await Services.create(canvas))
+
+        // connect constant1.out -> java.in & java.out -> constant2.in
+        const [constant1, constant2, javaModule] = canvas.modules
+        canvas = State.updateCanvas(State.connectPorts(canvas, constant1.outputs[0].id, javaModule.inputs[0].id))
+        canvas = State.updateCanvas(State.connectPorts(canvas, javaModule.outputs[0].id, constant2.params[0].id))
+
+        // check connections are ok, this shouldn't fail
+        expect(State.arePortsConnected(canvas, constant1.outputs[0].id, javaModule.inputs[0].id)).toBeTruthy()
+        expect(State.arePortsConnected(canvas, javaModule.outputs[0].id, constant2.params[0].id)).toBeTruthy()
+
+        // add new inputs & outputs (old inputs/outputs should remain)
+        canvas = State.updateModule(canvas, javaModule.hash, (m) => ({
+            ...m,
+            code: defineStubModule({
+                inputs: 2,
+                outputs: 1,
+            }),
+        }))
+        // simulate pressing 'apply' button in java editor
+        const javaModuleUpdated = canvas.modules[canvas.modules.length - 1]
+        const newModule = await SharedServices.getModule({
+            id: javaModuleUpdated.id,
+            configuration: javaModuleUpdated,
+        })
+
+        // use of replaceModule should maintain existing connections (important)
+        canvas = State.replaceModule(canvas, newModule)
+        expect(State.arePortsConnected(canvas, constant1.outputs[0].id, javaModule.inputs[0].id)).toBeTruthy()
+        expect(State.arePortsConnected(canvas, javaModule.outputs[0].id, constant2.params[0].id)).toBeTruthy()
+    })
+})


### PR DESCRIPTION
Ensures module connections are maintained when updating definition. e.g. java/solidity 

### To Test

This flow is basically what happens in [the tests](https://github.com/streamr-dev/streamr-platform/pull/703/files#diff-eeb66bc30681825cb00bb921b0ea946bR47-R93).

1. Add `Java` module
2. Add two `Constant` modules
3. "Edit Code" of `Java` module. Uncomment the first two lines, i.e.:

```java
TimeSeriesInput input = new TimeSeriesInput(this,"in");
TimeSeriesOutput output = new TimeSeriesOutput(this,"out");
```
4. Apply change.
5. Connect constants to the new input & output.
6. Add a new input & output i.e. add these lines after the previous lines

```java
TimeSeriesInput input2 = new TimeSeriesInput(this,"in2");
TimeSeriesOutput output2 = new TimeSeriesOutput(this,"out2");
```

7. Apply change.
8. Notice existing connections are maintained when the new ports are added. Previously the input would be disconnected.
9. Also note default/initial port values are maintained. 

Should look something like:

![image](https://user-images.githubusercontent.com/43438/65850778-c3199c80-e382-11e9-83a2-629df2f79362.png)
