### PR TITLE
[PLATFORM-1074] Save pending changes

### DIFF
--- a/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
@@ -34,7 +34,8 @@ const buttonTitle = (product: Product, isValidSubscription: boolean) => {
 
 const ProductDetails = ({ product, isValidSubscription, onPurchase }: Props) => {
     const productDetailsRef = useRef(null)
-    const [truncated, setTruncatedState] = useState(!(product.description.length < 400))
+    const truncationRequired = !((product.description || '').length < 400)
+    const [truncated, setTruncatedState] = useState(truncationRequired)
 
     const setTruncated = useCallback(() => {
         setTruncatedState((prev) => !prev)
@@ -47,8 +48,6 @@ const ProductDetails = ({ product, isValidSubscription, onPurchase }: Props) => 
             })
         }
     }, [setTruncatedState])
-
-    const truncationRequired = !(product.description.length < 400)
 
     return (
         <div className={styles.root} ref={productDetailsRef}>

--- a/app/src/marketplace/containers/EditProductPage2/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/EditControllerProvider.jsx
@@ -113,8 +113,9 @@ function useEditController(product: Product) {
             // upload image
             if (nextProduct.newImageToUpload != null) {
                 try {
-                    const { imageUrl: newImageUrl } = await postImage(nextProduct.id || '', nextProduct.newImageToUpload)
+                    const { imageUrl: newImageUrl, thumbnailUrl: newThumbnailUrl } = await postImage(nextProduct.id || '', nextProduct.newImageToUpload)
                     nextProduct.imageUrl = newImageUrl
+                    nextProduct.thumbnailUrl = newThumbnailUrl
                     delete nextProduct.newImageToUpload
                 } catch (e) {
                     console.error('Could not upload image', e)

--- a/app/src/marketplace/containers/EditProductPage2/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/EditControllerProvider.jsx
@@ -113,7 +113,12 @@ function useEditController(product: Product) {
             // upload image
             if (nextProduct.newImageToUpload != null) {
                 try {
-                    const { imageUrl: newImageUrl, thumbnailUrl: newThumbnailUrl } = await postImage(nextProduct.id || '', nextProduct.newImageToUpload)
+                    /* eslint-disable object-curly-newline */
+                    const {
+                        imageUrl: newImageUrl,
+                        thumbnailUrl: newThumbnailUrl,
+                    } = await postImage(nextProduct.id || '', nextProduct.newImageToUpload)
+                    /* eslint-eanble object-curly-newline */
                     nextProduct.imageUrl = newImageUrl
                     nextProduct.thumbnailUrl = newThumbnailUrl
                     delete nextProduct.newImageToUpload
@@ -122,7 +127,7 @@ function useEditController(product: Product) {
                 }
             }
 
-            // save product
+            // save product (don't need to abort if unmounted)
             await putProduct(State.update(originalProduct, () => ({
                 ...nextProduct,
             })), nextProduct.id || '')

--- a/app/src/marketplace/containers/EditProductPage2/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/EditControllerProvider.jsx
@@ -15,6 +15,7 @@ import useProductActions from '../ProductController/useProductActions'
 import { isEthereumAddress } from '$mp/utils/validate'
 import { areAddressesEqual } from '$mp/utils/smartContract'
 
+import useOriginalProduct from '../ProductController/useOriginalProduct'
 import useModal from '$shared/hooks/useModal'
 
 type ContextProps = {
@@ -35,6 +36,7 @@ function useEditController(product: Product) {
     const isMounted = useIsMounted()
     const savePending = usePending('product.SAVE')
     const { updateBeneficiaryAddress } = useProductActions()
+    const originalProduct = useOriginalProduct()
 
     useEffect(() => {
         const handleBeforeunload = (event) => {
@@ -103,6 +105,7 @@ function useEditController(product: Product) {
         const savedSuccessfully = await savePending.wrap(async () => {
             const p = productRef.current
 
+            console.log(originalProduct)
             // save product
             await putProduct(p, p.id || '')
 
@@ -126,6 +129,7 @@ function useEditController(product: Product) {
     }, [
         savePending,
         redirectToProduct,
+        originalProduct,
     ])
 
     const validate = useCallback(() => {

--- a/app/src/marketplace/containers/EditProductPage2/state.js
+++ b/app/src/marketplace/containers/EditProductPage2/state.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { productStates } from '$shared/utils/constants'
-import type { Product } from '$mp/flowtype/product-types'
+import type { Product, PendingChanges } from '$mp/flowtype/product-types'
 
 export const PENDING_CHANGE_FIELDS = [
     'name',
@@ -22,7 +22,7 @@ export function isPublished(product: Product) {
     return !!(state === productStates.DEPLOYED || state === productStates.DEPLOYING)
 }
 
-export const getPendingObject = (product: Product): Object => {
+export const getPendingObject = (product: Product | PendingChanges): Object => {
     const allowedChanges = new Set(PENDING_CHANGE_FIELDS)
 
     return Object.fromEntries(Object.entries(product).filter(([key, value]) => allowedChanges.has(key) && value !== undefined))

--- a/app/src/marketplace/containers/EditProductPage2/state.js
+++ b/app/src/marketplace/containers/EditProductPage2/state.js
@@ -4,9 +4,23 @@ import { productStates } from '$shared/utils/constants'
 import type { Product } from '$mp/flowtype/product-types'
 
 export function isPublished(product: Product) {
-    const { state } = product
+    const { state } = product || {}
 
     return !!(state === productStates.DEPLOYED || state === productStates.DEPLOYING)
+}
+
+export function getPendingChanges(product: Product) {
+    if (isPublished(product)) {
+        return product.pendingChanges || {}
+    }
+
+    return {}
+}
+
+export function hasPendingChange(product: Product, field: string) {
+    const pendingChanges = getPendingChanges(product)
+
+    return !!pendingChanges[field]
 }
 
 export function update(product: Product, fn: Function) {
@@ -26,16 +40,8 @@ export function update(product: Product, fn: Function) {
     }
 }
 
-export function getPendingChanges(product: Product) {
-    if (isPublished(product)) {
-        return product.pendingChanges || {}
-    }
-
-    return {}
-}
-
 export function withPendingChanges(product: Product) {
-    if (isPublished(product)) {
+    if (product && isPublished(product)) {
         return {
             ...product,
             ...getPendingChanges(product),

--- a/app/src/marketplace/containers/EditProductPage2/state.js
+++ b/app/src/marketplace/containers/EditProductPage2/state.js
@@ -1,0 +1,46 @@
+// @flow
+
+import { productStates } from '$shared/utils/constants'
+import type { Product } from '$mp/flowtype/product-types'
+
+export function isPublished(product: Product) {
+    const { state } = product
+
+    return !!(state === productStates.DEPLOYED || state === productStates.DEPLOYING)
+}
+
+export function update(product: Product, fn: Function) {
+    const result = fn(product)
+
+    if (isPublished(product)) {
+        return {
+            ...product,
+            pendingChanges: {
+                ...result,
+            },
+        }
+    }
+
+    return {
+        ...result,
+    }
+}
+
+export function getPendingChanges(product: Product) {
+    if (isPublished(product)) {
+        return product.pendingChanges || {}
+    }
+
+    return {}
+}
+
+export function withPendingChanges(product: Product) {
+    if (isPublished(product)) {
+        return {
+            ...product,
+            ...getPendingChanges(product),
+        }
+    }
+
+    return product
+}

--- a/app/src/marketplace/containers/EditProductPage2/state.js
+++ b/app/src/marketplace/containers/EditProductPage2/state.js
@@ -3,15 +3,38 @@
 import { productStates } from '$shared/utils/constants'
 import type { Product } from '$mp/flowtype/product-types'
 
+export const PENDING_CHANGE_FIELDS = [
+    'name',
+    'description',
+    'imageUrl',
+    'thumbnailUrl',
+    'category',
+    'streams',
+    'previewStream',
+    'beneficiaryAddress',
+    'pricePerSecond',
+    'priceCurrency',
+]
+
 export function isPublished(product: Product) {
     const { state } = product || {}
 
     return !!(state === productStates.DEPLOYED || state === productStates.DEPLOYING)
 }
 
+export const getPendingObject = (product: Product): Object => {
+    const allowedChanges = new Set(PENDING_CHANGE_FIELDS)
+
+    return Object.fromEntries(Object.entries(product).filter(([key, value]) => allowedChanges.has(key) && value !== undefined))
+}
+
+export const getChangeObject = (original: Product, next: Product): Object => (
+    Object.fromEntries(Object.entries(getPendingObject(next)).filter(([key, value]) => value !== original[key]))
+)
+
 export function getPendingChanges(product: Product) {
     if (isPublished(product)) {
-        return product.pendingChanges || {}
+        return getPendingObject(product.pendingChanges || {})
     }
 
     return {}
@@ -30,7 +53,7 @@ export function update(product: Product, fn: Function) {
         return {
             ...product,
             pendingChanges: {
-                ...result,
+                ...getChangeObject(product, result),
             },
         }
     }

--- a/app/src/marketplace/containers/EditProductPage2/tests/productState.test.js
+++ b/app/src/marketplace/containers/EditProductPage2/tests/productState.test.js
@@ -1,0 +1,157 @@
+import * as State from '../state'
+import { productStates } from '$shared/utils/constants'
+
+describe('Product State', () => {
+    describe('isPublished', () => {
+        it('detects published state', () => {
+            expect(State.isPublished({
+                state: productStates.DEPLOYED,
+            })).toBe(true)
+            expect(State.isPublished({
+                state: productStates.DEPLOYING,
+            })).toBe(true)
+            expect(State.isPublished({
+                state: productStates.NOT_DEPLOYED,
+            })).toBe(false)
+            expect(State.isPublished({
+                state: productStates.UNDEPLOYING,
+            })).toBe(false)
+        })
+    })
+
+    describe('update', () => {
+        it('updates unpublished product', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.NOT_DEPLOYED,
+            }
+            expect(State.update(product, (p) => ({
+                ...p,
+                name: 'newName',
+                description: 'A better description',
+            }))).toMatchObject({
+                id: '1',
+                name: 'newName',
+                description: 'A better description',
+                state: productStates.NOT_DEPLOYED,
+            })
+        })
+
+        it('puts updates as pending changes for published product', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.DEPLOYED,
+            }
+            expect(State.update(product, (p) => ({
+                ...p,
+                name: 'Better Name',
+                description: 'A better description',
+            }))).toMatchObject({
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.DEPLOYED,
+                pendingChanges: {
+                    name: 'Better Name',
+                    description: 'A better description',
+                },
+            })
+        })
+
+        it('puts updates as pending changes for product that is deploying', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.DEPLOYING,
+            }
+            expect(State.update(product, (p) => ({
+                ...p,
+                name: 'Better Name',
+                description: 'A better description',
+            }))).toMatchObject({
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.DEPLOYING,
+                pendingChanges: {
+                    name: 'Better Name',
+                    description: 'A better description',
+                },
+            })
+        })
+    })
+
+    describe('getPendingChanges', () => {
+        it('returns empty object for unpublished product', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.NOT_DEPLOYED,
+            }
+            expect(State.getPendingChanges(product)).toMatchObject({})
+        })
+
+        it('returns pending changes for published product', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.DEPLOYED,
+            }
+            expect(State.getPendingChanges(State.update(product, (p) => ({
+                ...p,
+                name: 'Better Name',
+                description: 'A better description',
+            })))).toMatchObject({
+                name: 'Better Name',
+                description: 'A better description',
+            })
+        })
+    })
+
+    describe('withPendingChanges', () => {
+        it('it returns the current data for unpublished product', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.NOT_DEPLOYED,
+            }
+            expect(State.withPendingChanges(State.update(product, (p) => ({
+                ...p,
+                name: 'Better Name',
+                description: 'A better description',
+            })))).toMatchObject({
+                id: '1',
+                name: 'Better Name',
+                description: 'A better description',
+                state: productStates.NOT_DEPLOYED,
+            })
+        })
+
+        it('it returns the current data for published product', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.DEPLOYED,
+            }
+            expect(State.withPendingChanges(State.update(product, (p) => ({
+                ...p,
+                name: 'Better Name',
+                description: 'A better description',
+            })))).toMatchObject({
+                id: '1',
+                name: 'Better Name',
+                description: 'A better description',
+                state: productStates.DEPLOYED,
+            })
+        })
+    })
+})

--- a/app/src/marketplace/containers/EditProductPage2/tests/productState.test.js
+++ b/app/src/marketplace/containers/EditProductPage2/tests/productState.test.js
@@ -17,6 +17,11 @@ describe('Product State', () => {
                 state: productStates.UNDEPLOYING,
             })).toBe(false)
         })
+
+        it('detects published state for empty product', () => {
+            expect(State.isPublished({})).toBe(false)
+            expect(State.isPublished(undefined)).toBe(false)
+        })
     })
 
     describe('update', () => {
@@ -112,6 +117,40 @@ describe('Product State', () => {
                 name: 'Better Name',
                 description: 'A better description',
             })
+        })
+    })
+
+    describe('hasPendingChange', () => {
+        it('it returns false for unpublished product change', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.NOT_DEPLOYED,
+            }
+            const nextProduct = State.update(product, (p) => ({
+                ...p,
+                name: 'Better Name',
+                description: 'A better description',
+            }))
+            expect(State.hasPendingChange(nextProduct, 'name')).toBe(false)
+            expect(State.hasPendingChange(nextProduct, 'description')).toBe(false)
+        })
+
+        it('it returns true for published product change', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.DEPLOYED,
+            }
+            const nextProduct = State.update(product, (p) => ({
+                ...p,
+                name: 'Better Name',
+                description: 'A better description',
+            }))
+            expect(State.hasPendingChange(nextProduct, 'name')).toBe(true)
+            expect(State.hasPendingChange(nextProduct, 'description')).toBe(true)
         })
     })
 

--- a/app/src/marketplace/containers/EditProductPage2/tests/productState.test.js
+++ b/app/src/marketplace/containers/EditProductPage2/tests/productState.test.js
@@ -24,6 +24,54 @@ describe('Product State', () => {
         })
     })
 
+    describe('getPendingObject', () => {
+        it('returns only the allowed fields', () => {
+            const allowed = Object.fromEntries(State.PENDING_CHANGE_FIELDS.map((key) => [key, key]))
+            const notAllowed = Object.fromEntries(['id', 'newImageToUpload', 'state'].map((key) => [key, key]))
+
+            expect(State.getPendingObject({
+                ...allowed,
+                ...notAllowed,
+            })).toMatchObject(allowed)
+        })
+
+        it('it returns only defined values', () => {
+            expect(State.getPendingObject({
+                id: '1',
+                name: 'new name',
+                description: 'new description',
+                imageUrl: undefined,
+                thumbanilUrl: undefined,
+                streams: [],
+                previewStream: '',
+                updated: '2019-10-01 09:51:00',
+            })).toMatchObject({
+                name: 'new name',
+                description: 'new description',
+                streams: [],
+                previewStream: '',
+            })
+        })
+    })
+
+    describe('getChangeObject', () => {
+        it('returns the changed fields', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                state: productStates.NOT_DEPLOYED,
+            }
+            expect(State.getChangeObject(product, {
+                id: '2',
+                name: 'New Name',
+                state: 'DEPLOYED',
+            })).toMatchObject({
+                name: 'New Name',
+            })
+        })
+    })
+
     describe('update', () => {
         it('updates unpublished product', () => {
             const product = {

--- a/app/src/marketplace/containers/ProductController/useOriginalProduct.js
+++ b/app/src/marketplace/containers/ProductController/useOriginalProduct.js
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+
+import { Context as UndoContext } from '$shared/components/UndoContextProvider'
+
+export default function useOriginalProduct() {
+    const { initialState } = useContext(UndoContext)
+    return initialState
+}

--- a/app/src/marketplace/containers/ProductController/useProductActions.js
+++ b/app/src/marketplace/containers/ProductController/useProductActions.js
@@ -6,6 +6,7 @@ import BN from 'bignumber.js'
 
 import { Context as UndoContext } from '$shared/components/UndoContextProvider'
 import { Context as ValidationContext } from './ValidationContextProvider'
+
 import useProductUpdater from '../ProductController/useProductUpdater'
 import { pricePerSecondFromTimeUnit, convert } from '$mp/utils/price'
 import { currencies, timeUnits } from '$shared/utils/constants'

--- a/app/src/marketplace/containers/ProductController/useProductLoadCallback.js
+++ b/app/src/marketplace/containers/ProductController/useProductLoadCallback.js
@@ -40,6 +40,7 @@ export default function useProductLoadCallback() {
                 price: product.price || priceForTimeUnits(product.pricePerSecond || '0', 1, timeUnits.hour),
             }
 
+            productUpdater.initialize(() => nextProduct)
             productUpdater.replaceProduct(() => State.withPendingChanges(nextProduct))
         })
     ), [wrap, productUpdater, history, isMountedRef])

--- a/app/src/marketplace/containers/ProductController/useProductLoadCallback.js
+++ b/app/src/marketplace/containers/ProductController/useProductLoadCallback.js
@@ -12,6 +12,7 @@ import { isPaidProduct } from '$mp/utils/product'
 import { timeUnits, DEFAULT_CURRENCY } from '$shared/utils/constants'
 import { priceForTimeUnits } from '$mp/utils/price'
 
+import * as State from '../EditProductPage2/state'
 import useProductUpdater from './useProductUpdater'
 
 export default function useProductLoadCallback() {
@@ -39,7 +40,7 @@ export default function useProductLoadCallback() {
                 price: product.price || priceForTimeUnits(product.pricePerSecond || '0', 1, timeUnits.hour),
             }
 
-            productUpdater.replaceProduct(() => nextProduct)
+            productUpdater.replaceProduct(() => State.withPendingChanges(nextProduct))
         })
     ), [wrap, productUpdater, history, isMountedRef])
 }

--- a/app/src/marketplace/containers/ProductController/useProductUpdater.js
+++ b/app/src/marketplace/containers/ProductController/useProductUpdater.js
@@ -14,14 +14,14 @@ function productUpdater(fn) {
 }
 
 export default function useProductUpdater() {
-    const { push, replace } = useContext(UndoContext)
+    const { push, reset } = useContext(UndoContext)
 
     const updateProduct = useOnlyIfMountedCallback((action, fn, done) => {
         push(action, productUpdater(fn), done)
     }, [push, productUpdater])
 
     const replaceProduct = useOnlyIfMountedCallback((fn, done) => {
-        replace(productUpdater(fn), done)
+        reset(productUpdater(fn), done)
     }, [push, productUpdater])
 
     return useMemo(() => ({

--- a/app/src/marketplace/containers/ProductController/useProductUpdater.js
+++ b/app/src/marketplace/containers/ProductController/useProductUpdater.js
@@ -14,18 +14,23 @@ function productUpdater(fn) {
 }
 
 export default function useProductUpdater() {
-    const { push, reset } = useContext(UndoContext)
+    const { push, replace, setInitialState } = useContext(UndoContext)
+
+    const initialize = useOnlyIfMountedCallback((fn, done) => {
+        setInitialState(fn, done)
+    }, [setInitialState])
 
     const updateProduct = useOnlyIfMountedCallback((action, fn, done) => {
         push(action, productUpdater(fn), done)
     }, [push, productUpdater])
 
     const replaceProduct = useOnlyIfMountedCallback((fn, done) => {
-        reset(productUpdater(fn), done)
+        replace(productUpdater(fn), done)
     }, [push, productUpdater])
 
     return useMemo(() => ({
+        initialize,
         updateProduct,
         replaceProduct,
-    }), [updateProduct, replaceProduct])
+    }), [initialize, updateProduct, replaceProduct])
 }

--- a/app/src/shared/components/UndoContextProvider/UndoContext.test.jsx
+++ b/app/src/shared/components/UndoContextProvider/UndoContext.test.jsx
@@ -18,13 +18,10 @@ describe('UndoContext', () => {
             ))
         })
 
-        it('can take a value', () => {
-            const initialState = {
-                initial: true,
-            }
+        it('can modify initial state', async () => {
             let props
             mount((
-                <UndoContext.Provider initialState={initialState}>
+                <UndoContext.Provider>
                     <UndoContext.Context.Consumer>
                         {(containerProps) => {
                             props = containerProps
@@ -33,8 +30,60 @@ describe('UndoContext', () => {
                     </UndoContext.Context.Consumer>
                 </UndoContext.Provider>
             ))
-            expect(props.state).toEqual(initialState)
+            expect(props.initialState).toBe(undefined)
+
+            const action = {
+                type: 'action',
+            }
+            const nextState = {
+                next: true,
+            }
+            await props.push(action, () => nextState)
+            expect(props.state).toBe(nextState)
+            expect(props.initialState).toBe(undefined)
+            const newInitialState = {
+                initial: true,
+            }
+            await props.reset(() => newInitialState)
+            expect(props.state).toBe(newInitialState)
+            expect(props.initialState).toBe(newInitialState)
             expect(props.action).toBe(UndoContext.initialAction)
+        })
+
+        it('can add handler to reset', async () => {
+            let props
+            mount((
+                <UndoContext.Provider>
+                    <UndoContext.Context.Consumer>
+                        {(containerProps) => {
+                            props = containerProps
+                            return null
+                        }}
+                    </UndoContext.Context.Consumer>
+                </UndoContext.Provider>
+            ))
+            expect(props.initialState).toBe(undefined)
+
+            const action = {
+                type: 'action',
+            }
+            const nextState = {
+                next: true,
+            }
+            await props.push(action, () => nextState)
+            expect(props.state).toBe(nextState)
+            expect(props.initialState).toBe(undefined)
+            const newInitialState = {
+                initial: true,
+            }
+            await props.reset(
+                () => newInitialState,
+                () => {
+                    expect(props.state).toBe(newInitialState)
+                    expect(props.initialState).toBe(newInitialState)
+                    expect(props.action).toBe(UndoContext.initialAction)
+                },
+            )
         })
 
         describe('undo/redo with initial state', () => {
@@ -61,15 +110,12 @@ describe('UndoContext', () => {
 
     describe('push/undo/redo', () => {
         it('can push new state', async () => {
-            const initialState = {
-                initial: true,
-            }
             const nextState = {
                 next: true,
             }
             let props
             mount((
-                <UndoContext.Provider initialState={initialState}>
+                <UndoContext.Provider>
                     <UndoContext.Context.Consumer>
                         {(containerProps) => {
                             props = containerProps
@@ -84,7 +130,7 @@ describe('UndoContext', () => {
                 type: 'action',
             }
             await props.push(action, (prevState) => {
-                expect(prevState).toEqual(initialState) // history pointer should not change
+                expect(prevState).toEqual(undefined) // history pointer should not change
                 return nextState
             })
             expect(props.state).toEqual(nextState)
@@ -93,15 +139,12 @@ describe('UndoContext', () => {
         })
 
         it('push/replace does nothing if return null/same', async () => {
-            const initialState = {
-                initial: true,
-            }
             const action = {
                 type: 'action',
             }
             let props
             mount((
-                <UndoContext.Provider initialState={initialState}>
+                <UndoContext.Provider>
                     <UndoContext.Context.Consumer>
                         {(containerProps) => {
                             props = containerProps
@@ -125,15 +168,12 @@ describe('UndoContext', () => {
         })
 
         it('can undo then redo after pushing state', async () => {
-            const initialState = {
-                initial: true,
-            }
             const nextState = {
                 next: true,
             }
             let props
             mount((
-                <UndoContext.Provider initialState={initialState}>
+                <UndoContext.Provider>
                     <UndoContext.Context.Consumer>
                         {(containerProps) => {
                             props = containerProps
@@ -149,12 +189,12 @@ describe('UndoContext', () => {
             }
             // add item
             await props.push(action, (prevState) => {
-                expect(prevState).toEqual(initialState) // history pointer should not change
+                expect(prevState).toEqual(undefined) // history pointer should not change
                 return nextState
             })
             // undo
             await props.undo()
-            expect(props.state).toEqual(initialState)
+            expect(props.state).toEqual(undefined)
             expect(props.pointer).toBe(initialProps.pointer)
             expect(props.action).toBe(UndoContext.initialAction)
             // redo
@@ -182,16 +222,13 @@ describe('UndoContext', () => {
     })
 
     it('can replace initial state', async () => {
-        const initialState = {
-            initial: true,
-        }
         const replaceState = {
             replaced: true,
         }
         let props
         mount((
             <UndoContext.Provider>
-                <UndoContext.Context.Consumer initialState={initialState}>
+                <UndoContext.Context.Consumer>
                     {(containerProps) => {
                         props = containerProps
                         return null
@@ -208,15 +245,12 @@ describe('UndoContext', () => {
     })
 
     it('can replace top item after push', async () => {
-        const initialState = {
-            initial: true,
-        }
         const nextState = {
             next: true,
         }
         let props
         mount((
-            <UndoContext.Provider initialState={initialState}>
+            <UndoContext.Provider>
                 <UndoContext.Context.Consumer>
                     {(containerProps) => {
                         props = containerProps
@@ -242,9 +276,6 @@ describe('UndoContext', () => {
     })
 
     it('can reset history', async () => {
-        const initialState = {
-            initial: true,
-        }
         const nextState = {
             next: true,
         }
@@ -254,7 +285,7 @@ describe('UndoContext', () => {
 
         let props
         mount((
-            <UndoContext.Provider initialState={initialState}>
+            <UndoContext.Provider>
                 <UndoContext.Context.Consumer>
                     {(containerProps) => {
                         props = containerProps

--- a/app/src/shared/components/UndoContextProvider/UndoContext.test.jsx
+++ b/app/src/shared/components/UndoContextProvider/UndoContext.test.jsx
@@ -18,7 +18,7 @@ describe('UndoContext', () => {
             ))
         })
 
-        it('can modify initial state', async () => {
+        it('can set initial state', async () => {
             let props
             mount((
                 <UndoContext.Provider>
@@ -32,21 +32,37 @@ describe('UndoContext', () => {
             ))
             expect(props.initialState).toBe(undefined)
 
-            const action = {
-                type: 'action',
-            }
-            const nextState = {
-                next: true,
-            }
-            await props.push(action, () => nextState)
-            expect(props.state).toBe(nextState)
-            expect(props.initialState).toBe(undefined)
-            const newInitialState = {
+            const initialState = {
                 initial: true,
             }
-            await props.reset(() => newInitialState)
-            expect(props.state).toBe(newInitialState)
-            expect(props.initialState).toBe(newInitialState)
+            await props.setInitialState(() => initialState)
+            expect(props.initialState).toBe(initialState)
+        })
+
+        it('resets to new initial state', async () => {
+            let props
+            mount((
+                <UndoContext.Provider>
+                    <UndoContext.Context.Consumer>
+                        {(containerProps) => {
+                            props = containerProps
+                            return null
+                        }}
+                    </UndoContext.Context.Consumer>
+                </UndoContext.Provider>
+            ))
+            expect(props.initialState).toBe(undefined)
+            await props.reset()
+            expect(props.state).toBe(undefined)
+
+            const initialState = {
+                initial: true,
+            }
+            await props.setInitialState(() => initialState)
+            expect(props.initialState).toBe(initialState)
+
+            await props.reset()
+            expect(props.state).toBe(initialState)
             expect(props.action).toBe(UndoContext.initialAction)
         })
 

--- a/app/src/shared/components/UndoContextProvider/index.jsx
+++ b/app/src/shared/components/UndoContextProvider/index.jsx
@@ -204,9 +204,8 @@ class UndoContextProvider extends Component<Props, State> {
     }
 
     /**
-     * Reset to initialState
+     * Set initialState which is used as the "reset" state value
      */
-
     setInitialState = (fn: Function, done: Function) => {
         const p: Promise<void> = new Promise((resolve) => (
             this.setState(({ initialState }) => {
@@ -220,6 +219,9 @@ class UndoContextProvider extends Component<Props, State> {
         return p
     }
 
+    /**
+     * Reset to initialState
+     */
     reset = (done: Function) => {
         const p: Promise<void> = new Promise((resolve) => (
             this.setState(({ initialState }) => ({


### PR DESCRIPTION
You'll need to update to latest version of e&e to test this (ie. icludes fix https://github.com/streamr-dev/engine-and-editor/commit/b9c140b07f9c9de2ff49fca924b0e8943336cf97)

To test, create a free published product and edit some fields. Product page should show the original information but going back to edit will display the edited changes. When editing an unpublished version, all changes are saved immediately to the product. 

Not included here:
- Publishing pending changes
- Notification icons for pending changes in editor navigation or product page
- Saving pending changes when unpublishing