### PR TITLE
[PLATFORM-1051] Disable custom module interactions when read-only.

### DIFF
--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -101,7 +101,7 @@ class CanvasModule extends React.PureComponent {
             ...props
         } = this.props
 
-        const { isEditable, isAdjustable, hasWritePermission } = this.context
+        const { isEditable, isAdjustable, hasWritePermission, isSubscriptionActive } = this.context
 
         const { layout } = this.state
 
@@ -115,7 +115,7 @@ class CanvasModule extends React.PureComponent {
                 hasWritePermission={hasWritePermission}
                 innerRef={this.el}
                 isSelected={isSelected}
-                isSubscriptionActive={this.context.isSubscriptionActive}
+                isSubscriptionActive={isSubscriptionActive}
                 layout={layout}
                 module={module}
                 onFocus={this.onFocus}

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -101,7 +101,7 @@ class CanvasModule extends React.PureComponent {
             ...props
         } = this.props
 
-        const { isEditable, isAdjustable } = this.context
+        const { isEditable, isAdjustable, hasWritePermission } = this.context
 
         const { layout } = this.state
 
@@ -112,6 +112,7 @@ class CanvasModule extends React.PureComponent {
                 canvas={canvas}
                 canvasAdjustable={isAdjustable}
                 canvasEditable={isEditable}
+                hasWritePermission={hasWritePermission}
                 innerRef={this.el}
                 isSelected={isSelected}
                 isSubscriptionActive={this.context.isSubscriptionActive}

--- a/app/src/editor/canvas/components/ModuleRenderer/index.jsx
+++ b/app/src/editor/canvas/components/ModuleRenderer/index.jsx
@@ -53,6 +53,7 @@ function ModuleRenderer({
         module: { hash, displayName, name, canRefresh },
         isCanvasEditable: isEditable,
         isCanvasAdjustable: isAdjustable,
+        hasWritePermission,
     } = useModule()
 
     const stopPropagation = useCallback((e) => {
@@ -156,6 +157,7 @@ function ModuleRenderer({
                 autoSize
                 className={styles.canvasModuleUI}
                 uiEmitter={uiEmitter}
+                hasWritePermission={hasWritePermission}
                 isSubscriptionActive={isSubscriptionActive}
             />
             <div className={ModuleStyles.selectionDecorator} />
@@ -168,13 +170,15 @@ export default ({
     module,
     canvasEditable: isCanvasEditable,
     canvasAdjustable: isCanvasAdjustable,
+    hasWritePermission,
     ...props
 }: any) => {
     const moduleManifest = useMemo(() => ({
         module,
         isCanvasEditable,
         isCanvasAdjustable,
-    }), [isCanvasAdjustable, isCanvasEditable, module])
+        hasWritePermission,
+    }), [isCanvasAdjustable, isCanvasEditable, hasWritePermission, module])
 
     return (
         <ModuleApiContext.Provider value={api}>

--- a/app/src/editor/canvas/components/ModuleRenderer/index.jsx
+++ b/app/src/editor/canvas/components/ModuleRenderer/index.jsx
@@ -159,6 +159,7 @@ function ModuleRenderer({
                 uiEmitter={uiEmitter}
                 hasWritePermission={hasWritePermission}
                 isSubscriptionActive={isSubscriptionActive}
+                isActive={isRunning}
             />
             <div className={ModuleStyles.selectionDecorator} />
         </Resizable>

--- a/app/src/editor/canvas/components/ModuleRenderer/index.jsx
+++ b/app/src/editor/canvas/components/ModuleRenderer/index.jsx
@@ -160,6 +160,7 @@ function ModuleRenderer({
                 hasWritePermission={hasWritePermission}
                 isSubscriptionActive={isSubscriptionActive}
                 isActive={isRunning}
+                isEditable={isEditable}
             />
             <div className={ModuleStyles.selectionDecorator} />
         </Resizable>

--- a/app/src/editor/canvas/components/ModuleRenderer/useModule.js
+++ b/app/src/editor/canvas/components/ModuleRenderer/useModule.js
@@ -23,24 +23,23 @@ type Canvas = {
     modules: Array<any>,
 }
 
-type UseModuleHook = {
-    canvas: Canvas,
-    isCanvasAdjustable?: boolean,
-    isCanvasEditable?: boolean,
-    isResizable?: boolean,
-    module: Module,
-    moduleClassNames?: Array<?string>,
-}
-
 type ModuleManifest = {
     isCanvasAdjustable?: boolean,
     isCanvasEditable?: boolean,
+    hasWritePermission?: boolean,
     module: Module,
 }
+
+type UseModuleHook = {
+    canvas: Canvas,
+    moduleClassNames?: Array<?string>,
+    isResizable?: boolean,
+} & ModuleManifest
 
 export const ModuleContext = (createContext({
     isCanvasEditable: false,
     isCanvasAdjustable: false,
+    hasWritePermission: false,
     module: {
         canRefresh: false,
         displayName: '',
@@ -55,7 +54,7 @@ export const ModuleContext = (createContext({
 }): Context<ModuleManifest>)
 
 export default (): UseModuleHook => {
-    const { module: mod, isCanvasAdjustable, isCanvasEditable } = useContext(ModuleContext)
+    const { module: mod, isCanvasAdjustable, isCanvasEditable, hasWritePermission } = useContext(ModuleContext)
 
     const canvas = useCanvas() || {
         id: '',
@@ -80,6 +79,7 @@ export default (): UseModuleHook => {
         canvas,
         isCanvasAdjustable,
         isCanvasEditable,
+        hasWritePermission,
         isResizable,
         module: mod,
         moduleClassNames,
@@ -87,6 +87,7 @@ export default (): UseModuleHook => {
         canvas,
         isCanvasAdjustable,
         isCanvasEditable,
+        hasWritePermission,
         isResizable,
         mod,
         moduleClassNames,

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -154,7 +154,9 @@ const CanvasEditComponent = class CanvasEdit extends Component {
             event.preventDefault()
             event.stopPropagation()
             copyToClipboard(JSON.stringify(CanvasState.getModuleCopy(this.props.canvas, hash)))
-            this.removeModule({ hash })
+            if (runController.isEditable) {
+                this.removeModule({ hash })
+            }
         }
     }
 
@@ -366,6 +368,8 @@ const CanvasEditComponent = class CanvasEdit extends Component {
     }
 
     onPaste = (event) => {
+        const { runController } = this.props
+        if (!runController.isEditable) { return } // ignore if not editable
         // prevent handling paste in form fields
         if (isEditableElement(event.target || event.srcElement)) { return }
         event.preventDefault()

--- a/app/src/editor/shared/components/ColorPicker.jsx
+++ b/app/src/editor/shared/components/ColorPicker.jsx
@@ -93,6 +93,10 @@ export default class ColorPicker extends React.Component<Props, State> {
         })
     }
 
+    toggle = () => {
+        this.setState(({ isOpen }) => ({ isOpen: !isOpen }))
+    }
+
     close = () => {
         const { onClose } = this.props
 
@@ -116,6 +120,7 @@ export default class ColorPicker extends React.Component<Props, State> {
                 disabled={disabled}
                 className={styles.root}
                 onBlur={this.onBlur}
+                onClick={this.toggle}
                 onFocus={this.onFocus}
                 onKeyDown={this.onKeyDown}
                 ref={this.ref}

--- a/app/src/editor/shared/components/ColorPicker.jsx
+++ b/app/src/editor/shared/components/ColorPicker.jsx
@@ -37,6 +37,7 @@ type Props = {
     onFocus?: ?(event: any) => void,
     onBlur?: ?(event: any) => void,
     onClose?: ?() => void,
+    disabled?: boolean,
 }
 
 type State = {
@@ -48,7 +49,7 @@ export default class ColorPicker extends React.Component<Props, State> {
         isOpen: false,
     }
 
-    ref: Ref<HTMLDivElement> = React.createRef()
+    ref: Ref<HTMLElement> = React.createRef()
 
     componentDidMount() {
         window.addEventListener('keydown', this.onKeyDown)
@@ -106,12 +107,13 @@ export default class ColorPicker extends React.Component<Props, State> {
 
     render() {
         const { isOpen } = this.state
-        const { value: backgroundColor } = this.props
+        const { disabled, value: backgroundColor } = this.props
         const color = convertRgbaToObject(backgroundColor)
 
         return (
-            /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
-            <div
+            <button
+                type="button"
+                disabled={disabled}
                 className={styles.root}
                 onBlur={this.onBlur}
                 onFocus={this.onFocus}
@@ -120,8 +122,6 @@ export default class ColorPicker extends React.Component<Props, State> {
                 style={{
                     backgroundColor,
                 }}
-                /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
-                tabIndex={0}
             >
                 {isOpen && (
                     <SketchPicker
@@ -131,7 +131,7 @@ export default class ColorPicker extends React.Component<Props, State> {
                         onChange={this.onChange}
                     />
                 )}
-            </div>
+            </button>
         )
     }
 }

--- a/app/src/editor/shared/components/ColorPicker.pcss
+++ b/app/src/editor/shared/components/ColorPicker.pcss
@@ -1,10 +1,19 @@
 .root {
   border-radius: calc(0.125 * var(--um));
-  cursor: pointer;
   height: var(--um);
   outline: 0;
   position: relative;
   width: calc(1.5 * var(--um));
+  display: block;
+  appearance: none;
+}
+
+.root:not(:disabled) {
+  cursor: pointer;
+}
+
+.root:focus {
+  outline: none;
 }
 
 .root > div {

--- a/app/src/editor/shared/components/ColorPicker.pcss
+++ b/app/src/editor/shared/components/ColorPicker.pcss
@@ -6,6 +6,7 @@
   width: calc(1.5 * var(--um));
   display: block;
   appearance: none;
+  border: none;
 }
 
 .root:not(:disabled) {

--- a/app/src/editor/shared/components/modules/Button.jsx
+++ b/app/src/editor/shared/components/modules/Button.jsx
@@ -60,6 +60,7 @@ export default class ButtonModule extends React.Component {
     }
 
     render() {
+        const { hasWritePermission, isActive } = this.props
         return (
             <div className={cx(this.props.className, styles.Button)}>
                 <ModuleSubscription
@@ -70,7 +71,12 @@ export default class ButtonModule extends React.Component {
                     onActiveChange={this.onActiveChange}
                     ref={this.subscription}
                 />
-                <button className={cx(styles.button, ButtonStyles.btn, ButtonStyles.btnPrimary)} onClick={this.onClick}>
+                <button
+                    type="button"
+                    disabled={!hasWritePermission || !isActive}
+                    className={cx(styles.button, ButtonStyles.btn, ButtonStyles.btnPrimary)}
+                    onClick={this.onClick}
+                >
                     {this.getValue()}
                 </button>
             </div>

--- a/app/src/editor/shared/components/modules/Comment.jsx
+++ b/app/src/editor/shared/components/modules/Comment.jsx
@@ -40,10 +40,12 @@ export default class CommentModule extends React.PureComponent {
     }
 
     render() {
+        const { isEditable } = this.props
         return (
             <UiSizeConstraint minWidth={100} minHeight={50}>
                 <div className={cx(this.props.className, styles.Comment)}>
                     <TextControl
+                        disabled={isEditable}
                         commitEmpty
                         flushHistoryOnBlur
                         onCommit={this.onChange}

--- a/app/src/editor/shared/components/modules/Comment.jsx
+++ b/app/src/editor/shared/components/modules/Comment.jsx
@@ -45,7 +45,7 @@ export default class CommentModule extends React.PureComponent {
             <UiSizeConstraint minWidth={100} minHeight={50}>
                 <div className={cx(this.props.className, styles.Comment)}>
                     <TextControl
-                        disabled={isEditable}
+                        disabled={!isEditable}
                         commitEmpty
                         flushHistoryOnBlur
                         onCommit={this.onChange}

--- a/app/src/editor/shared/components/modules/Custom.jsx
+++ b/app/src/editor/shared/components/modules/Custom.jsx
@@ -44,7 +44,7 @@ export default class CustomModule extends React.Component {
     }
 
     render() {
-        const { module, isActive } = this.props
+        const { module, isEditable } = this.props
         const { debugMessages } = this.state
 
         return (
@@ -56,7 +56,7 @@ export default class CustomModule extends React.Component {
                 />
                 <CodeEditor
                     code={module.code || ''}
-                    readOnly={isActive}
+                    readOnly={!isEditable}
                     onApply={this.onApply}
                     onChange={this.onChange}
                     debugMessages={debugMessages}

--- a/app/src/editor/shared/components/modules/Scheduler.jsx
+++ b/app/src/editor/shared/components/modules/Scheduler.jsx
@@ -67,7 +67,13 @@ const months = {
     '12': 'December',
 }
 
-const Select = ({ value, onChange, children, width }) => {
+const Select = ({
+    disabled,
+    value,
+    onChange,
+    children,
+    width,
+}) => {
     const style = {}
 
     if (width) {
@@ -76,6 +82,7 @@ const Select = ({ value, onChange, children, width }) => {
 
     return (
         <select
+            disabled={disabled}
             value={value}
             onChange={(e) => onChange(parseInt(e.target.value, 10))}
             className={styles.select}
@@ -152,10 +159,11 @@ const MonthSelect = (props) => (
     </Select>
 )
 
-const HourControl = ({ startDate, endDate, onChange }) => (
+const HourControl = ({ disabled, startDate, endDate, onChange }) => (
     <Fragment>
         From hour+ <MinuteAmountSelect
             value={startDate.minute}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: { minute: value },
             })}
@@ -163,6 +171,7 @@ const HourControl = ({ startDate, endDate, onChange }) => (
         <br />
         To hour+ <MinuteAmountSelect
             value={endDate.minute}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: { minute: value },
             })}
@@ -209,10 +218,11 @@ const DayControl = ({ startDate, endDate, onChange }) => (
     </Fragment>
 )
 
-const WeekControl = ({ startDate, endDate, onChange }) => (
+const WeekControl = ({ disabled, startDate, endDate, onChange }) => (
     <Fragment>
         From <WeekdaySelect
             value={startDate.weekday}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     weekday: value,
@@ -223,6 +233,7 @@ const WeekControl = ({ startDate, endDate, onChange }) => (
         />
         at <HourSelect
             value={startDate.hour}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     weekday: startDate.weekday,
@@ -232,6 +243,7 @@ const WeekControl = ({ startDate, endDate, onChange }) => (
             })}
         />:<MinuteSelect
             value={startDate.minute}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     weekday: startDate.weekday,
@@ -242,6 +254,7 @@ const WeekControl = ({ startDate, endDate, onChange }) => (
         /><br />
         To <WeekdaySelect
             value={endDate.weekday}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     weekday: value,
@@ -252,6 +265,7 @@ const WeekControl = ({ startDate, endDate, onChange }) => (
         />
         at <HourSelect
             value={endDate.hour}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     weekday: endDate.weekday,
@@ -261,6 +275,7 @@ const WeekControl = ({ startDate, endDate, onChange }) => (
             })}
         />:<MinuteSelect
             value={endDate.minute}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     weekday: endDate.weekday,
@@ -272,10 +287,11 @@ const WeekControl = ({ startDate, endDate, onChange }) => (
     </Fragment>
 )
 
-const MonthControl = ({ startDate, endDate, onChange }) => (
+const MonthControl = ({ disabled, startDate, endDate, onChange }) => (
     <Fragment>
         From <DaySelect
             value={startDate.day}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     day: value,
@@ -286,6 +302,7 @@ const MonthControl = ({ startDate, endDate, onChange }) => (
         />
         at <HourSelect
             value={startDate.hour}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     day: startDate.day,
@@ -295,6 +312,7 @@ const MonthControl = ({ startDate, endDate, onChange }) => (
             })}
         />:<MinuteSelect
             value={startDate.minute}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     day: startDate.day,
@@ -305,6 +323,7 @@ const MonthControl = ({ startDate, endDate, onChange }) => (
         /><br />
         To <DaySelect
             value={endDate.day}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     day: value,
@@ -315,6 +334,7 @@ const MonthControl = ({ startDate, endDate, onChange }) => (
         />
         at <HourSelect
             value={endDate.hour}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     day: endDate.day,
@@ -324,6 +344,7 @@ const MonthControl = ({ startDate, endDate, onChange }) => (
             })}
         />:<MinuteSelect
             value={endDate.minute}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     day: endDate.day,
@@ -335,10 +356,11 @@ const MonthControl = ({ startDate, endDate, onChange }) => (
     </Fragment>
 )
 
-const YearControl = ({ startDate, endDate, onChange }) => (
+const YearControl = ({ disabled, startDate, endDate, onChange }) => (
     <Fragment>
         From <DaySelect
             value={startDate.day}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     month: startDate.month,
@@ -350,6 +372,7 @@ const YearControl = ({ startDate, endDate, onChange }) => (
         />
         <MonthSelect
             value={startDate.month}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     month: value,
@@ -361,6 +384,7 @@ const YearControl = ({ startDate, endDate, onChange }) => (
         />
         at <HourSelect
             value={startDate.hour}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     month: startDate.month,
@@ -371,6 +395,7 @@ const YearControl = ({ startDate, endDate, onChange }) => (
             })}
         />:<MinuteSelect
             value={startDate.minute}
+            disabled={disabled}
             onChange={(value) => onChange({
                 startDate: {
                     month: startDate.month,
@@ -382,6 +407,7 @@ const YearControl = ({ startDate, endDate, onChange }) => (
         /><br />
         To <DaySelect
             value={endDate.day}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     month: endDate.month,
@@ -393,6 +419,7 @@ const YearControl = ({ startDate, endDate, onChange }) => (
         />
         <MonthSelect
             value={endDate.month}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     month: value,
@@ -404,6 +431,7 @@ const YearControl = ({ startDate, endDate, onChange }) => (
         />
         at <HourSelect
             value={endDate.hour}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     month: endDate.month,
@@ -414,6 +442,7 @@ const YearControl = ({ startDate, endDate, onChange }) => (
             })}
         />:<MinuteSelect
             value={endDate.minute}
+            disabled={disabled}
             onChange={(value) => onChange({
                 endDate: {
                     month: endDate.month,
@@ -510,7 +539,7 @@ export class RuleComponent extends React.Component {
     }
 
     render() {
-        const { isHovered, rule, isActive } = this.props
+        const { isHovered, rule, disabled } = this.props
 
         return (
             <div className={styles.ruleContainer}>
@@ -519,6 +548,7 @@ export class RuleComponent extends React.Component {
                         type="button"
                         onClick={this.onRemove}
                         className={styles.removeButton}
+                        disabled={disabled}
                     >
                         <SvgIcon name="crossHeavy" className={styles.removeIcon} />
                     </button>
@@ -528,12 +558,12 @@ export class RuleComponent extends React.Component {
                 <ValueInput
                     value={rule.value}
                     onChange={this.onValueChange}
-                    disabled={!!isActive}
+                    disabled={disabled}
                 />
                 <br />
                 Every
                 &nbsp;
-                <Select value={rule.intervalType} onChange={this.onIntervalChange}>
+                <Select value={rule.intervalType} onChange={this.onIntervalChange} disabled={disabled}>
                     {Object.keys(schedulerOptions).map((schedulerOption) => (
                         <option
                             key={schedulerOption}
@@ -545,19 +575,19 @@ export class RuleComponent extends React.Component {
                 </Select>
                 <br />
                 {rule.intervalType === IntervalTypes.HOUR && (
-                    <HourControl onChange={this.onUpdateDates} {...rule} />
+                    <HourControl disabled={disabled} onChange={this.onUpdateDates} {...rule} />
                 )}
                 {rule.intervalType === IntervalTypes.DAY && (
-                    <DayControl onChange={this.onUpdateDates} {...rule} />
+                    <DayControl disabled={disabled} onChange={this.onUpdateDates} {...rule} />
                 )}
                 {rule.intervalType === IntervalTypes.WEEK && (
-                    <WeekControl onChange={this.onUpdateDates} {...rule} />
+                    <WeekControl disabled={disabled} onChange={this.onUpdateDates} {...rule} />
                 )}
                 {rule.intervalType === IntervalTypes.MONTH && (
-                    <MonthControl onChange={this.onUpdateDates} {...rule} />
+                    <MonthControl disabled={disabled} onChange={this.onUpdateDates} {...rule} />
                 )}
                 {rule.intervalType === IntervalTypes.YEAR && (
-                    <YearControl onChange={this.onUpdateDates} {...rule} />
+                    <YearControl disabled={disabled} onChange={this.onUpdateDates} {...rule} />
                 )}
             </div>
         )
@@ -668,12 +698,13 @@ export default class SchedulerModule extends React.Component {
     }
 
     render() {
-        const { isActive } = this.props
+        const { isEditable } = this.props
         const { rules, defaultValue } = this.state
 
         return (
             <div className={styles.schedulerContainer}>
                 <SortableList
+                    disabled={!isEditable}
                     distance={1} /* This will allow clicks to pass through */
                     onSortEnd={this.onSortEnd}
                     lockAxis="y"
@@ -684,6 +715,7 @@ export default class SchedulerModule extends React.Component {
                             key={rule.id}
                             onChange={this.onChangeRule}
                             onRemove={this.onRemoveRule}
+                            disabled={!isEditable}
                             rule={rule}
                         />
                     ))}
@@ -695,7 +727,7 @@ export default class SchedulerModule extends React.Component {
                         <ValueInput
                             value={defaultValue}
                             onChange={this.onDefaultValueChange}
-                            disabled={!!isActive}
+                            disabled={!isEditable}
                         />
                     </div>
                     <div className={styles.addButtonContainer}>
@@ -703,6 +735,7 @@ export default class SchedulerModule extends React.Component {
                             type="button"
                             className={styles.addButton}
                             onClick={this.onAddRule}
+                            disabled={!isEditable}
                         >
                             + Add
                         </button>

--- a/app/src/editor/shared/components/modules/Solidity.jsx
+++ b/app/src/editor/shared/components/modules/Solidity.jsx
@@ -69,7 +69,7 @@ export default class SolidityModule extends React.Component {
     }
 
     render() {
-        const { module, isActive } = this.props
+        const { module, isEditable } = this.props
         const { debugMessages, deploying } = this.state
         const { contract } = module
 
@@ -82,7 +82,7 @@ export default class SolidityModule extends React.Component {
                 />
                 <CodeEditor
                     code={module.code || ''}
-                    readOnly={isActive}
+                    readOnly={!isEditable}
                     onApply={this.onApply}
                     onChange={this.onChange}
                     debugMessages={debugMessages}
@@ -101,7 +101,7 @@ export default class SolidityModule extends React.Component {
                                 type="button"
                                 className={styles.button}
                                 onClick={this.onDeploy}
-                                disabled={contract && (contract.address || deploying)}
+                                disabled={!isEditable || (contract && (contract.address || deploying))}
                             >
                                 {(!contract || (contract && !contract.address)) && !deploying && (
                                     'Deploy'

--- a/app/src/editor/shared/components/modules/Switcher.jsx
+++ b/app/src/editor/shared/components/modules/Switcher.jsx
@@ -59,7 +59,7 @@ export default class SwitcherModule extends React.Component {
     }
 
     render() {
-        const { className } = this.props
+        const { className, hasWritePermission } = this.props
         const value = this.getValue()
 
         return (
@@ -71,6 +71,7 @@ export default class SwitcherModule extends React.Component {
                     onActiveChange={this.onActiveChange}
                 />
                 <Toggle
+                    disabled={!hasWritePermission}
                     className={styles.Toggle}
                     value={value}
                     onChange={this.onChange}

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -59,7 +59,7 @@ export default class TextFieldModule extends React.Component {
     }
 
     render() {
-        const { isActive } = this.props
+        const { isActive, hasWritePermission } = this.props
         const value = this.getValue()
         return (
             <UiSizeConstraint minWidth={150} minHeight={75}>
@@ -78,7 +78,12 @@ export default class TextFieldModule extends React.Component {
                         tag="textarea"
                         value={value}
                     />
-                    <button type="button" className={styles.button} onClick={this.onClick} disabled={!isActive}>
+                    <button
+                        type="button"
+                        className={styles.button}
+                        onClick={this.onClick}
+                        disabled={!hasWritePermission || !isActive}
+                    >
                         Send
                     </button>
                 </div>

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -77,6 +77,7 @@ export default class TextFieldModule extends React.Component {
                         placeholder="Enter your text here"
                         tag="textarea"
                         value={value}
+                        disabled={!hasWritePermission}
                     />
                     <button
                         type="button"


### PR DESCRIPTION
Original ticket just about copy/paste when in read-only mode, expanded on this somewhat.

Changed:
* Copy works when running or no write permission (i.e. always).
* Cut becomes Copy when running or no write permission.
* Paste disabled when running or no write permission.

Also discovered other restrictions needed to be added:

Disables all edits/interactions when running or no write permissions except:
* Button enabled when running, disabled if no write permissions.
* Switcher enabled whether running or not, disabled if no write permissions.
* TextField send button only enabled when running, disabled if no write permissions.

Solidity/Java module:
* Code is read only when running or no write permissions.
* Edit/Apply/Deploy disabled when running or no write permissions.

Also:
* Adds support for disabled property on ColorPicker
* Toggles ColorPicker open state on click ColourPicker button.