### PR TITLE
[PLATFORM-1067] Community product statistics

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2295,6 +2295,22 @@
         }
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.6.2.tgz",
+      "integrity": "sha512-FX1ddj2gf7psgslvkkKeyxftnslUFDY9OHGnp+wJ+4JIKSEABB1fKVZiE7/2n+C9RVTPfPwpOqGmFf5TGvg0Bw==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.44",
       "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
@@ -9210,15 +9226,6 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-    },
-    "babel-plugin-transform-builtin-extend": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-builtin-extend/-/babel-plugin-transform-builtin-extend-1.1.2.tgz",
-      "integrity": "sha1-Xpb+z1i4+h7XTvytiEdbKvPJEW4=",
-      "requires": {
-        "babel-runtime": "^6.2.0",
-        "babel-template": "^6.3.0"
-      }
     },
     "babel-plugin-transform-flow-comments": {
       "version": "6.22.0",
@@ -23261,22 +23268,6 @@
       "resolved": "https://registry.npmjs.org/node-ask/-/node-ask-1.0.1.tgz",
       "integrity": "sha1-yqoQdsxY4DZCZ6CQPj6t+sFYOWs="
     },
-    "node-cache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.0.tgz",
-      "integrity": "sha512-obRu6/f7S024ysheAjoYFEEBqqDWv4LOMNJEuO8vMeEw2AT4z+NCzO4hlc2lhI4vATzbCQv6kke9FVdx0RbCOw==",
-      "requires": {
-        "clone": "2.x",
-        "lodash": "4.x"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-        }
-      }
-    },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -30601,6 +30592,21 @@
         }
       }
     },
+    "receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "requires": {
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -33032,25 +33038,33 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "streamr-client": {
-      "version": "2.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-2.0.0-beta.7.tgz",
-      "integrity": "sha512-USuvJ2fOlsABmLSYm/FOQjZdFIu1foyUdm9hpUebY2VEoJjJMlbACPNKd6peCB7fHIPR9yOI1hv1Tp9Da+aygA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-2.2.2.tgz",
+      "integrity": "sha512-EpzWVy6tTE1oLXDo7OmGg9c/MAfErLy+aYNj+nqRVTFb60k6NWNLJe3/gjY1Hnsx9cLCuW2arKme0EhyhxXeXA==",
       "requires": {
-        "debug": "^3.1.0",
-        "ethers": "^4.0.27",
-        "eventemitter3": "^3.0.1",
-        "node-cache": "^4.2.0",
-        "node-fetch": "^2.1.2",
+        "babel-runtime": "^6.26.0",
+        "debug": "^4.1.1",
+        "ethers": "^4.0.37",
+        "eventemitter3": "^4.0.0",
+        "heap": "^0.2.6",
+        "node-fetch": "^2.6.0",
         "once": "^1.4.0",
-        "qs": "^6.6.0",
-        "querystring": "^0.2.0",
+        "qs": "^6.7.0",
         "randomstring": "^1.1.5",
-        "streamr-client-protocol": "^2.1.0",
+        "receptacle": "^1.3.2",
+        "streamr-client-protocol": "^2.2.10",
         "webpack-node-externals": "^1.7.2",
-        "websocket": "^1.0.28",
-        "ws": "^6.1.2"
+        "ws": "^7.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "elliptic": {
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
@@ -33063,9 +33077,9 @@
           }
         },
         "ethers": {
-          "version": "4.0.27",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
-          "integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
+          "version": "4.0.37",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.37.tgz",
+          "integrity": "sha512-B7bDdyQ45A5lPr6k2HOkEKMtYOuqlfy+nNf8glnRvWidkDQnToKw1bv7UyrwlbsIgY2mE03UxTVtouXcT6Vvcw==",
           "requires": {
             "@types/node": "^10.3.2",
             "aes-js": "3.0.0",
@@ -33079,6 +33093,11 @@
             "xmlhttprequest": "1.8.0"
           }
         },
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        },
         "hash.js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -33088,25 +33107,20 @@
             "minimalistic-assert": "^1.0.0"
           }
         },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-fetch": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
+          "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
         },
         "setimmediate": {
           "version": "1.0.4",
@@ -33119,23 +33133,31 @@
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
+          "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
           "requires": {
-            "async-limiter": "~1.0.0"
+            "async-limiter": "^1.0.0"
           }
         }
       }
     },
     "streamr-client-protocol": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-2.1.0.tgz",
-      "integrity": "sha512-tbtQFpZ8s24rgzOIlKBQbEzaNS+BAH95pwT6KyT4reFFIikrhd+SMA1OfI/WV3Gt9M+9jxkrv9wn3MM4t0gDHA==",
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-2.2.14.tgz",
+      "integrity": "sha512-RjvQvFZU5cfwaRLrPTBu6PwCz4tGbYFGRjARF3ffYdaaAYe+FgPA8LM7Gy3kmlo9ezksO59nzi9ON04XSDaVnA==",
       "requires": {
-        "babel-plugin-transform-builtin-extend": "^1.1.2",
-        "babel-runtime": "^6.26.0",
-        "debug": "^3.1.0"
+        "@babel/runtime-corejs3": "^7.4.5",
+        "debug": "^3.1.0",
+        "eventemitter3": "^4.0.0",
+        "heap": "^0.2.6"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        }
       }
     },
     "strict-uri-encode": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11745,6 +11745,115 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
+      "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
+    },
+    "d3-contour": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz",
+      "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
+      "requires": {
+        "d3-array": "^1.1.1"
+      }
+    },
+    "d3-format": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.1.tgz",
+      "integrity": "sha512-TUswGe6hfguUX1CtKxyG2nymO+1lyThbkS1ifLX0Sr+dOQtAD5gkrffpHnx+yHNKUZ0Bmg5T4AjUQwugPDrm0g=="
+    },
+    "d3-geo": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.6.tgz",
+      "integrity": "sha512-z0J8InXR9e9wcgNtmVnPTj0TU8nhYT6lD/ak9may2PdKqXIeHUr8UbFLoCtrPYNsjv6YaLvSDQVl578k6nm7GA==",
+      "requires": {
+        "d3-array": "1"
+      }
+    },
+    "d3-hexbin": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/d3-hexbin/-/d3-hexbin-0.2.2.tgz",
+      "integrity": "sha1-nFg32s/UcasFM3qeke8Qv8T5iDE="
+    },
+    "d3-hierarchy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
+      "integrity": "sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w=="
+    },
+    "d3-interpolate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
+      "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.8.tgz",
+      "integrity": "sha512-J6EfUNwcMQ+aM5YPOB8ZbgAZu6wc82f/0WFxrxwV6Ll8wBwLaHLKCqQ5Imub02JriCVVdPjgI+6P3a4EWJCxAg=="
+    },
+    "d3-sankey": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.7.1.tgz",
+      "integrity": "sha1-0imDImj8aaf+yEgD6WwiVqYUxSE=",
+      "requires": {
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-shape": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.5.tgz",
+      "integrity": "sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
+      "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -29573,6 +29682,23 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-motion": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
+      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
+      "requires": {
+        "performance-now": "^0.2.0",
+        "prop-types": "^15.5.8",
+        "raf": "^3.1.0"
+      },
+      "dependencies": {
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        }
+      }
+    },
     "react-notification-system": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/react-notification-system/-/react-notification-system-0.2.17.tgz",
@@ -30063,6 +30189,38 @@
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
           "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
+    "react-vis": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/react-vis/-/react-vis-1.11.7.tgz",
+      "integrity": "sha512-vJqS12l/6RHeSq8DVl4PzX0j8iPgbT8H8PtgTRsimKsBNcPjPseO4RICw1FUPrwj8MPrrna34LBtzyC4ATd5Ow==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "^1.0.3",
+        "d3-color": "^1.0.3",
+        "d3-contour": "^1.1.0",
+        "d3-format": "^1.2.0",
+        "d3-geo": "^1.6.4",
+        "d3-hexbin": "^0.2.2",
+        "d3-hierarchy": "^1.1.4",
+        "d3-interpolate": "^1.1.4",
+        "d3-sankey": "^0.7.1",
+        "d3-scale": "^1.0.5",
+        "d3-shape": "^1.1.0",
+        "d3-voronoi": "^1.1.2",
+        "deep-equal": "^1.0.1",
+        "global": "^4.3.1",
+        "hoek": "4.2.1",
+        "prop-types": "^15.5.8",
+        "react-motion": "^0.5.2"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         }
       }
     },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2295,22 +2295,6 @@
         }
       }
     },
-    "@babel/runtime-corejs3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.6.2.tgz",
-      "integrity": "sha512-FX1ddj2gf7psgslvkkKeyxftnslUFDY9OHGnp+wJ+4JIKSEABB1fKVZiE7/2n+C9RVTPfPwpOqGmFf5TGvg0Bw==",
-      "requires": {
-        "core-js-pure": "^3.0.0",
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-        }
-      }
-    },
     "@babel/template": {
       "version": "7.0.0-beta.44",
       "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
@@ -9226,6 +9210,15 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+    },
+    "babel-plugin-transform-builtin-extend": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-builtin-extend/-/babel-plugin-transform-builtin-extend-1.1.2.tgz",
+      "integrity": "sha1-Xpb+z1i4+h7XTvytiEdbKvPJEW4=",
+      "requires": {
+        "babel-runtime": "^6.2.0",
+        "babel-template": "^6.3.0"
+      }
     },
     "babel-plugin-transform-flow-comments": {
       "version": "6.22.0",
@@ -23268,6 +23261,27 @@
       "resolved": "https://registry.npmjs.org/node-ask/-/node-ask-1.0.1.tgz",
       "integrity": "sha1-yqoQdsxY4DZCZ6CQPj6t+sFYOWs="
     },
+    "node-cache": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
+      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
+      "requires": {
+        "clone": "2.x",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -30592,21 +30606,6 @@
         }
       }
     },
-    "receptacle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-      "requires": {
-        "ms": "^2.1.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -33038,80 +33037,25 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "streamr-client": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-2.2.2.tgz",
-      "integrity": "sha512-EpzWVy6tTE1oLXDo7OmGg9c/MAfErLy+aYNj+nqRVTFb60k6NWNLJe3/gjY1Hnsx9cLCuW2arKme0EhyhxXeXA==",
+      "version": "2.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-2.0.0-beta.7.tgz",
+      "integrity": "sha512-USuvJ2fOlsABmLSYm/FOQjZdFIu1foyUdm9hpUebY2VEoJjJMlbACPNKd6peCB7fHIPR9yOI1hv1Tp9Da+aygA==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "debug": "^4.1.1",
-        "ethers": "^4.0.37",
-        "eventemitter3": "^4.0.0",
-        "heap": "^0.2.6",
-        "node-fetch": "^2.6.0",
+        "debug": "^3.1.0",
+        "ethers": "^4.0.27",
+        "eventemitter3": "^3.0.1",
+        "node-cache": "^4.2.0",
+        "node-fetch": "^2.1.2",
         "once": "^1.4.0",
-        "qs": "^6.7.0",
+        "qs": "^6.6.0",
+        "querystring": "^0.2.0",
         "randomstring": "^1.1.5",
-        "receptacle": "^1.3.2",
-        "streamr-client-protocol": "^2.2.10",
+        "streamr-client-protocol": "^2.1.0",
         "webpack-node-externals": "^1.7.2",
-        "ws": "^7.0.1"
+        "websocket": "^1.0.28",
+        "ws": "^6.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "elliptic": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
-          }
-        },
-        "ethers": {
-          "version": "4.0.37",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.37.tgz",
-          "integrity": "sha512-B7bDdyQ45A5lPr6k2HOkEKMtYOuqlfy+nNf8glnRvWidkDQnToKw1bv7UyrwlbsIgY2mE03UxTVtouXcT6Vvcw==",
-          "requires": {
-            "@types/node": "^10.3.2",
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.3.3",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "eventemitter3": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
         "node-fetch": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -33122,42 +33066,24 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
           "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
         },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        },
         "ws": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
-          "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "requires": {
-            "async-limiter": "^1.0.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
     },
     "streamr-client-protocol": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-2.2.14.tgz",
-      "integrity": "sha512-RjvQvFZU5cfwaRLrPTBu6PwCz4tGbYFGRjARF3ffYdaaAYe+FgPA8LM7Gy3kmlo9ezksO59nzi9ON04XSDaVnA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-2.1.0.tgz",
+      "integrity": "sha512-tbtQFpZ8s24rgzOIlKBQbEzaNS+BAH95pwT6KyT4reFFIikrhd+SMA1OfI/WV3Gt9M+9jxkrv9wn3MM4t0gDHA==",
       "requires": {
-        "@babel/runtime-corejs3": "^7.4.5",
-        "debug": "^3.1.0",
-        "eventemitter3": "^4.0.0",
-        "heap": "^0.2.6"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
-        }
+        "babel-plugin-transform-builtin-extend": "^1.1.2",
+        "babel-runtime": "^6.26.0",
+        "debug": "^3.1.0"
       }
     },
     "strict-uri-encode": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21730,7 +21730,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -21898,7 +21898,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "lines": 33
+        "lines": 32
       },
       "./src/userpages/": {
         "lines": 10

--- a/app/package.json
+++ b/app/package.json
@@ -236,7 +236,7 @@
     "storybook-addon-jsx": "^5.4.0",
     "storybook-chromatic": "^1.2.0",
     "storybook-react-router": "^1.0.1",
-    "streamr-client": "^2.0.0-beta.7",
+    "streamr-client": "^2.2.2",
     "stringify-object": "^3.2.2",
     "style-loader": "^0.21.0",
     "stylelint": "^10.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "lines": 34
+        "lines": 33
       },
       "./src/userpages/": {
         "lines": 10
@@ -236,7 +236,7 @@
     "storybook-addon-jsx": "^5.4.0",
     "storybook-chromatic": "^1.2.0",
     "storybook-react-router": "^1.0.1",
-    "streamr-client": "^2.2.2",
+    "streamr-client": "^2.0.0-beta.7",
     "stringify-object": "^3.2.2",
     "style-loader": "^0.21.0",
     "stylelint": "^10.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -222,6 +222,7 @@
     "react-syntax-highlighter": "^10.1.2",
     "react-toggle-switch": "^3.0.4",
     "react-transition-group": "^2.2.1",
+    "react-vis": "^1.11.7",
     "reactstrap": "^6.5.0",
     "redux": "^4.0.0",
     "redux-actions": "^2.6.1",

--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -139,7 +139,7 @@ const CommunityProductsRouter = () => ([
     <Route exact path={routes.createProduct2()} component={CreateProductAuth2} key="CreateProduct2" />,
     <Route exact path={formatPath(marketplace.products, ':id', 'purchase2')} component={ProductPurchasePage2} key="ProductPurchasePage2" />,
     <Route exact path={formatPath(marketplace.products, ':id', 'publish2')} component={ProductPublishPage2} key="ProductPublishPage2" />,
-    <Route exact path={formatPath(`${marketplace.products}2`, ':id')} component={ProductPage2} key="ProductPage2" />,
+    <Route exact path={formatPath(marketplace.products2, ':id')} component={ProductPage2} key="ProductPage2" />,
     <Route exact path={routes.editProduct2()} component={EditProductAuth2} key="EditProduct2" />,
 ])
 

--- a/app/src/editor/canvas/components/Status.jsx
+++ b/app/src/editor/canvas/components/Status.jsx
@@ -1,67 +1,6 @@
 import React from 'react'
-
+import { ago } from '$shared/utils/time'
 import styles from './Status.pcss'
-
-function format(diff, divisor, unit, prev) {
-    const val = Math.round(diff / divisor)
-    return val <= 1 ? prev : `${val} ${unit}s ago`
-}
-
-const units = [
-    {
-        max: 2760000,
-        value: 60000,
-        name: 'minute',
-        prev: 'a minute ago',
-    },
-    {
-        max: 72000000,
-        value: 3600000,
-        name: 'hour',
-        prev: 'an hour ago',
-    },
-    {
-        max: 518400000,
-        value: 86400000,
-        name: 'day',
-        prev: 'yesterday',
-    },
-    {
-        max: 2419200000,
-        value: 604800000,
-        name: 'week',
-        prev: 'last week',
-    },
-    {
-        max: 28512000000,
-        value: 2592000000,
-        name: 'month',
-        prev: 'last month',
-    }, // max: 11 months
-]
-
-function ago(date) {
-    const diff = Math.abs(Date.now() - date.getTime())
-    // less than a minute
-    if (diff < 60000) {
-        return 'just now'
-    }
-
-    for (let i = 0; i < units.length; i += 1) {
-        if (diff < units[i].max) {
-            return format(diff, units[i].value, units[i].name, units[i].prev)
-        }
-    }
-    // `year` is the final unit.
-    // same as:
-    //  {
-    //    max: Infinity,
-    //    value: 31536000000,
-    //    name: 'year',
-    //    prev: 'last year'
-    //  }
-    return format(diff, 31536000000, 'year', 'last year')
-}
 
 export default class Status extends React.Component {
     componentDidMount() {

--- a/app/src/links.js
+++ b/app/src/links.js
@@ -29,6 +29,7 @@ module.exports = {
     marketplace: {
         main: '/marketplace',
         products: '/marketplace/products',
+        products2: '/marketplace/products2',
         createProduct: '/marketplace/products/create',
         createProductPreview: '/marketplace/products/preview',
     },

--- a/app/src/marketplace/components/Hero/index.jsx
+++ b/app/src/marketplace/components/Hero/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react'
+import cx from 'classnames'
 import ProductContainer from '$shared/components/Container/Product'
 
 import styles from './hero.pcss'
@@ -8,11 +9,13 @@ import styles from './hero.pcss'
 type Props = {
     leftContent: React.Node,
     rightContent: React.Node,
+    className?: string,
+    containerClassName?: string,
 }
 
-const Hero = ({ leftContent, rightContent }: Props) => (
-    <div className={styles.hero}>
-        <ProductContainer className={styles.container}>
+const Hero = ({ leftContent, rightContent, containerClassName, className }: Props) => (
+    <div className={cx(styles.hero, className)}>
+        <ProductContainer className={cx(styles.container, containerClassName)}>
             <div className={styles.leftColumn}>
                 {leftContent}
             </div>

--- a/app/src/marketplace/components/ProductPage/MembersGraph/index.jsx
+++ b/app/src/marketplace/components/ProductPage/MembersGraph/index.jsx
@@ -1,7 +1,6 @@
 // @flow
 
-import React, { useEffect, useState, useRef, useCallback } from 'react'
-import StreamrClient from 'streamr-client'
+import React, { useEffect, useState, useCallback } from 'react'
 import {
     XYPlot,
     LineSeries,
@@ -9,36 +8,15 @@ import {
     YAxis,
     HorizontalGridLines,
 } from 'react-vis'
-import '../../../../../node_modules/react-vis/dist/style.css'
-
-import type { ResourceKeyId } from '$shared/flowtype/resource-key-types'
+import '$app/node_modules/react-vis/dist/style.css'
+import Subscription from '$editor/shared/components/Subscription'
+import { ClientProvider } from '$editor/shared/components/Client'
 
 type Props = {
     className?: string,
     joinPartStreamId: string,
-    authApiKeyId: ?ResourceKeyId,
     memberCount: number,
     shownDays: number,
-}
-
-const getDiffCoefficient = (type) => {
-    if (type === 'join') {
-        return 1
-    } else if (type === 'part') {
-        return -1
-    }
-    return 0
-}
-
-const getResendOptions = (resendDays) => {
-    const fromDate = Date.now() - (resendDays * 24 * 60 * 60 * 1000)
-    return {
-        resend: {
-            from: {
-                timestamp: fromDate,
-            },
-        },
-    }
 }
 
 const axisStyle = {
@@ -52,24 +30,30 @@ const axisStyle = {
     },
 }
 
-const MembersGraph = ({
-    className,
-    joinPartStreamId,
-    authApiKeyId,
-    memberCount,
-    shownDays,
-}: Props) => {
+const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
+
+const MembersGraph = ({ className, joinPartStreamId, memberCount, shownDays }: Props) => {
     const [memberCountUpdatedAt, setMemberCountUpdatedAt] = useState(Date.now())
     const [memberData, setMemberData] = useState([])
     const [graphData, setGraphData] = useState([])
 
-    const clientRef = useRef()
-    const subscriptionRef = useRef()
-
     const onMessage = useCallback((data, metadata) => {
+        // Check if message type is 'join' or 'part' and
+        // calculate member count diff based on the type.
+        // E.g. 'join' with 3 addresses means +3 diff in member count.
+        let diffCoefficient = 0
+        if (data.type === 'join') {
+            diffCoefficient = 1
+        } else if (data.type === 'part') {
+            diffCoefficient = -1
+        } else {
+            // Reject other message types.
+            return
+        }
+
         const entry = {
             timestamp: metadata.messageId.timestamp,
-            diff: data.addresses.length * getDiffCoefficient(data.type),
+            diff: data.addresses.length * diffCoefficient,
         }
         setMemberData((oldArray) => [
             ...oldArray,
@@ -77,48 +61,19 @@ const MembersGraph = ({
         ])
     }, [])
 
-    const createClient = useCallback((authKey) => {
-        const client = new StreamrClient({
-            url: process.env.STREAMR_WS_URL,
-            restUrl: process.env.STREAMR_API_URL,
-            auth: {
-                apiKey: authKey || undefined,
-            },
-            autoConnect: true,
-            autoDisconnect: false,
-        })
-        return client
-    }, [])
-
-    const subscribe = useCallback((client, streamId: string) => {
-        setMemberData([])
-        const sub = client.subscribe({
-            stream: streamId,
-            ...getResendOptions(shownDays),
-        }, (data, metadata) => {
-            onMessage(data, metadata)
-        })
-        return sub
-    }, [onMessage, shownDays])
-
-    useEffect(() => {
-        const client = createClient(authApiKeyId)
-        clientRef.current = client
-    }, [authApiKeyId, createClient])
-
-    useEffect(() => {
-        if (clientRef.current) {
-            const sub = subscribe(clientRef.current, joinPartStreamId)
-            subscriptionRef.current = sub
-        }
-    }, [joinPartStreamId, clientRef, subscribe])
-
     useEffect(() => {
         memberData.sort((a, b) => b.timestamp - a.timestamp)
+
+        // Only thing we know at the beginning is total member count
+        // at given timestamp.
         const initialData = [{
             x: memberCountUpdatedAt,
             y: memberCount,
         }]
+
+        // Because we cannot read the whole joinPartStream, we have to
+        // work backwards from the initial state and calculate graph points
+        // using the member count diff.
         const data = memberData.reduce((acc, element, index) => {
             acc.push({
                 x: element.timestamp,
@@ -133,8 +88,26 @@ const MembersGraph = ({
         setMemberCountUpdatedAt(Date.now())
     }, [memberCount])
 
+    useEffect(() => {
+        // Clear member data when we change shownDays because
+        // resubscription to stream will happen and data will
+        // be resent
+        setMemberData([])
+    }, [shownDays])
+
     return (
         <div className={className}>
+            <ClientProvider>
+                <Subscription
+                    key={`${joinPartStreamId}-${shownDays}`}
+                    uiChannel={{
+                        id: joinPartStreamId,
+                    }}
+                    resendFrom={Date.now() - (shownDays * MILLISECONDS_IN_DAY)}
+                    onMessage={onMessage}
+                    isActive
+                />
+            </ClientProvider>
             <XYPlot
                 xType="time"
                 width={540}

--- a/app/src/marketplace/components/ProductPage/MembersGraph/index.jsx
+++ b/app/src/marketplace/components/ProductPage/MembersGraph/index.jsx
@@ -14,7 +14,7 @@ import { ClientProvider } from '$editor/shared/components/Client'
 
 type Props = {
     className?: string,
-    joinPartStreamId: string,
+    joinPartStreamId: ?string,
     memberCount: number,
     shownDays: number,
 }
@@ -98,15 +98,17 @@ const MembersGraph = ({ className, joinPartStreamId, memberCount, shownDays }: P
     return (
         <div className={className}>
             <ClientProvider>
-                <Subscription
-                    key={`${joinPartStreamId}-${shownDays}`}
-                    uiChannel={{
-                        id: joinPartStreamId,
-                    }}
-                    resendFrom={Date.now() - (shownDays * MILLISECONDS_IN_DAY)}
-                    onMessage={onMessage}
-                    isActive
-                />
+                {joinPartStreamId && (
+                    <Subscription
+                        key={`${joinPartStreamId}-${shownDays}`}
+                        uiChannel={{
+                            id: joinPartStreamId,
+                        }}
+                        resendFrom={Date.now() - (shownDays * MILLISECONDS_IN_DAY)}
+                        onMessage={onMessage}
+                        isActive
+                    />
+                )}
             </ClientProvider>
             <XYPlot
                 xType="time"

--- a/app/src/marketplace/components/ProductPage/MembersGraph/index.jsx
+++ b/app/src/marketplace/components/ProductPage/MembersGraph/index.jsx
@@ -1,0 +1,170 @@
+// @flow
+
+import React, { useEffect, useState, useRef, useCallback } from 'react'
+import StreamrClient from 'streamr-client'
+import {
+    XYPlot,
+    LineSeries,
+    XAxis,
+    YAxis,
+    HorizontalGridLines,
+} from 'react-vis'
+import '../../../../../node_modules/react-vis/dist/style.css'
+
+import type { ResourceKeyId } from '$shared/flowtype/resource-key-types'
+
+type Props = {
+    className?: string,
+    joinPartStreamId: string,
+    authApiKeyId: ?ResourceKeyId,
+    memberCount: number,
+}
+
+const axisStyle = {
+    ticks: {
+        fontSize: '12px',
+        fontFamily: "'IBM Plex Sans', sans-serif",
+        color: '#A3A3A3',
+        strokeOpacity: '0',
+        opacity: '0.5',
+        letterSpacing: '0px',
+    },
+}
+
+const MembersGraph = ({ className, joinPartStreamId, authApiKeyId, memberCount }: Props) => {
+    const [shownDays, setShownDays] = useState(7)
+    const [memberData, setMemberData] = useState([])
+    const [graphData, setGraphData] = useState([])
+
+    const clientRef = useRef()
+    const subscriptionRef = useRef()
+
+    const onMessage = useCallback((data, metadata) => {
+        console.log('Got data from stream:', data, metadata)
+        const entry = {
+            timestamp: metadata.messageId.timestamp,
+            diff: data.addresses.length * (data.type === 'join' ? 1 : -1),
+        }
+        setMemberData((oldArray) => [
+            ...oldArray,
+            entry,
+        ])
+    }, [])
+
+    const createClient = useCallback((authKey) => {
+        const client = new StreamrClient({
+            url: process.env.STREAMR_WS_URL,
+            restUrl: process.env.STREAMR_API_URL,
+            auth: {
+                apiKey: authKey || undefined,
+            },
+            autoConnect: true,
+            autoDisconnect: false,
+        })
+        console.log('Created streamr-client')
+        return client
+    }, [])
+
+    const subscribe = useCallback((client, streamId) => {
+        // get 90 days of data
+        // const fromDate = Date.now() - (90 * 24 * 60 * 60 * 1000)
+        const sub = client.subscribe({
+            stream: streamId,
+            resend: {
+                last: 100,
+                /*
+                from: {
+                    timestamp: fromDate,
+                },
+                */
+            },
+        }, (data, metadata) => {
+            onMessage(data, metadata)
+        })
+        console.log('Subscribed to', streamId)
+        return sub
+    }, [onMessage])
+
+    useEffect(() => {
+        const client = createClient(authApiKeyId)
+        clientRef.current = client
+    }, [authApiKeyId, createClient])
+
+    useEffect(() => {
+        if (clientRef.current) {
+            const sub = subscribe(clientRef.current, joinPartStreamId)
+            subscriptionRef.current = sub
+        }
+
+        setShownDays(7)
+        /*
+        setMemberData([
+            {
+                timestamp: new Date('2019-09-09T07:00:00').getTime(),
+                diff: -1,
+            },
+            {
+                timestamp: new Date('2019-09-05T07:00:00').getTime(),
+                diff: 3,
+            },
+            {
+                timestamp: new Date('2019-09-01T07:00:00').getTime(),
+                diff: 1,
+            },
+        ])
+        */
+    }, [joinPartStreamId, clientRef, subscribe])
+
+    useEffect(() => {
+        memberData.sort((a, b) => b.timestamp - a.timestamp)
+        const initialData = [{
+            x: Date.now(),
+            y: memberCount,
+        }]
+        const data = memberData.reduce((acc, element, index) => {
+            acc.push({
+                x: element.timestamp,
+                y: acc[index].y + element.diff,
+            })
+            return acc
+        }, initialData)
+        setGraphData(data)
+    }, [memberData, memberCount])
+
+    return (
+        <XYPlot
+            xType="time"
+            width={570}
+            height={200}
+            margin={{
+                left: 0,
+                right: 50,
+            }}
+            className={className}
+        >
+            <HorizontalGridLines />
+            <LineSeries
+                curve={null}
+                color="#0324FF"
+                opacity={1}
+                strokeStyle="solid"
+                strokeWidth="4"
+                data={graphData}
+            />
+            <XAxis
+                hideLine
+                style={axisStyle}
+                /* tickFormat={(value, index, scale, tickTotal) => formatXAxisTicks(value, index, scale, tickTotal)} */
+                tickTotal={shownDays}
+            />
+            <YAxis
+                hideLine
+                style={axisStyle}
+                position="start"
+                orientation="right"
+            />
+        </XYPlot>
+    )
+}
+
+export default MembersGraph

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -118,6 +118,7 @@ const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
                                     selectedItem={shownDays.toString()}
                                     onChange={(item) => setShownDays(Number(item))}
                                     className={styles.memberGraphDropdown}
+                                    toggleStyle="small"
                                 >
                                     <Dropdown.Item value="7">Last 7 days</Dropdown.Item>
                                     <Dropdown.Item value="28">Last 28 days</Dropdown.Item>

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -10,6 +10,7 @@ import { getCommunityStats } from '$mp/modules/communityProduct/services'
 import useInterval from '$shared/hooks/useInterval'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import DonutChart from '$shared/components/DonutChart'
+import Dropdown from '$shared/components/Dropdown'
 import MembersGraph from '../MembersGraph'
 
 import styles from './productOverview.pcss'
@@ -26,6 +27,7 @@ const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
     const isMounted = useIsMounted()
     const [isDeploying, setIsDeploying] = useState(true)
     const [stats, setStats] = useState(null)
+    const [shownDays, setShownDays] = useState(7)
 
     const getStats = useCallback(async () => {
         try {
@@ -108,13 +110,26 @@ const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
                         </div>
                     </div>
                     <div className={styles.graphs}>
-                        <div>
-                            <div className={styles.statHeading}>Members</div>
+                        <div className={styles.memberContainer}>
+                            <div className={styles.memberHeadingContainer}>
+                                <div className={styles.statHeading}>Members</div>
+                                <Dropdown
+                                    title=""
+                                    selectedItem={shownDays.toString()}
+                                    onChange={(item) => setShownDays(Number(item))}
+                                    className={styles.memberGraphDropdown}
+                                >
+                                    <Dropdown.Item value="7">Last 7 days</Dropdown.Item>
+                                    <Dropdown.Item value="28">Last 28 days</Dropdown.Item>
+                                    <Dropdown.Item value="90">Last 90 days</Dropdown.Item>
+                                </Dropdown>
+                            </div>
                             <MembersGraph
                                 className={styles.graph}
                                 authApiKeyId={authApiKeyId}
                                 joinPartStreamId="DRaCVLn1TOWpe7I76gN8hA"
                                 memberCount={stats.memberCount.total}
+                                shownDays={shownDays}
                             />
                         </div>
                         <div className={styles.memberDonut}>
@@ -137,9 +152,7 @@ const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
                             />
                         </div>
                     </div>
-                    <div className={styles.footer}>
-                        TODO
-                    </div>
+                    <div className={styles.footer} />
                 </div>
             )}
         </div>

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -19,6 +19,7 @@ type Props = {
     product: Product,
     authApiKeyId?: ?ResourceKeyId,
     adminFee: number,
+    joinPartStreamId: ?string,
     subscriberCount: number,
     className?: string,
 }
@@ -29,6 +30,7 @@ const ProductOverview = ({
     product,
     authApiKeyId,
     adminFee,
+    joinPartStreamId,
     subscriberCount,
     className,
 }: Props) => {
@@ -145,7 +147,7 @@ const ProductOverview = ({
                             <MembersGraph
                                 className={styles.graph}
                                 authApiKeyId={authApiKeyId}
-                                joinPartStreamId="naRkiCAURDibPs-YNc5IFg"
+                                joinPartStreamId={joinPartStreamId}
                                 memberCount={stats.memberCount.total}
                                 shownDays={shownDays}
                             />

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -66,9 +66,18 @@ const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
     return (
         <div className={cx(styles.root, className)}>
             {isDeploying && (
-                <div className={styles.spinnerContainer}>
-                    <div className={styles.spinner}>
-                        <DeploySpinner isRunning showCounter={false} />
+                <div className={styles.grid}>
+                    <div className={styles.header}>
+                        <span>Overview</span>
+                    </div>
+                    <div className={styles.deployingGrid}>
+                        <div>
+                            <DeploySpinner isRunning showCounter={false} />
+                        </div>
+                        <div>
+                            <div className={styles.deployMessageHeading}>Deploying your Community Product</div>
+                            <div className={styles.deployMessage}>It will be ready soon, thanks for your patience.</div>
+                        </div>
                     </div>
                 </div>
             )}

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -145,7 +145,7 @@ const ProductOverview = ({
                             <MembersGraph
                                 className={styles.graph}
                                 authApiKeyId={authApiKeyId}
-                                joinPartStreamId="DRaCVLn1TOWpe7I76gN8hA"
+                                joinPartStreamId="naRkiCAURDibPs-YNc5IFg"
                                 memberCount={stats.memberCount.total}
                                 shownDays={shownDays}
                             />

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -18,12 +18,20 @@ import styles from './productOverview.pcss'
 type Props = {
     product: Product,
     authApiKeyId?: ?ResourceKeyId,
+    adminFee: number,
+    subscriberCount: number,
     className?: string,
 }
 
 const CP_SERVER_POLL_INTERVAL_MS = 10000
 
-const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
+const ProductOverview = ({
+    product,
+    authApiKeyId,
+    adminFee,
+    subscriberCount,
+    className,
+}: Props) => {
     const isMounted = useIsMounted()
     const [isDeploying, setIsDeploying] = useState(true)
     const [stats, setStats] = useState(null)
@@ -107,11 +115,11 @@ const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
                         </div>
                         <div>
                             <div className={styles.statHeading}>Subscribers</div>
-                            <div className={styles.statValue}>TODO</div>
+                            <div className={styles.statValue}>{subscriberCount}</div>
                         </div>
                         <div>
                             <div className={styles.statHeading}>Admin fee</div>
-                            <div className={styles.statValue}>TODO</div>
+                            <div className={styles.statValue}>{adminFee}</div>
                         </div>
                         <div>
                             <div className={styles.statHeading}>Product created</div>

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -1,0 +1,147 @@
+// @flow
+
+import React, { useState, useEffect, useCallback } from 'react'
+import cx from 'classnames'
+
+import type { Product } from '$mp/flowtype/product-types'
+import type { ResourceKeyId } from '$shared/flowtype/resource-key-types'
+import DeploySpinner from '$shared/components/DeploySpinner'
+import { getCommunityStats } from '$mp/modules/communityProduct/services'
+import useInterval from '$shared/hooks/useInterval'
+import useIsMounted from '$shared/hooks/useIsMounted'
+import DonutChart from '$shared/components/DonutChart'
+import MembersGraph from '../MembersGraph'
+
+import styles from './productOverview.pcss'
+
+type Props = {
+    product: Product,
+    authApiKeyId?: ?ResourceKeyId,
+    className?: string,
+}
+
+const CP_SERVER_POLL_INTERVAL_MS = 10000
+
+const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
+    const isMounted = useIsMounted()
+    const [isDeploying, setIsDeploying] = useState(true)
+    const [stats, setStats] = useState(null)
+
+    const getStats = useCallback(async () => {
+        try {
+            setIsDeploying(true)
+            const result = await getCommunityStats(product.beneficiaryAddress)
+            if (!isMounted) {
+                return
+            }
+            result.totalEarnings = 100
+            result.memberCount = {
+                total: 100,
+                active: 80,
+                inactive: 20,
+            }
+            setStats(result)
+            setIsDeploying(false)
+        } catch (e) {
+            console.error(e)
+        }
+    }, [product, isMounted])
+
+    useInterval(() => {
+        if (isDeploying) {
+            getStats()
+        }
+    }, CP_SERVER_POLL_INTERVAL_MS)
+
+    useEffect(() => {
+        getStats()
+    }, [getStats])
+
+    const productAgeMs = Date.now() - new Date(product.created || 0).getTime()
+    const revenuePerMonth = (stats && stats.totalEarnings) ? Math.floor(stats.totalEarnings / (productAgeMs / (1000 * 60 * 60 * 24 * 30))) : 0
+    const revenuePerMonthPerMember = (stats && stats.memberCount) ? revenuePerMonth / stats.memberCount.total : 0
+
+    return (
+        <div className={cx(styles.root, className)}>
+            {isDeploying && (
+                <div className={styles.spinner}>
+                    <DeploySpinner isRunning showCounter={false} />
+                </div>
+            )}
+            {!isDeploying && stats != null && (
+                <div className={styles.grid}>
+                    <div className={styles.header}>
+                        <span>Overview</span>
+                    </div>
+                    <div className={styles.stats}>
+                        <div>
+                            <div className={styles.statHeading}>Total product revenue</div>
+                            <div className={styles.statValue}>
+                                {stats.totalEarnings}
+                                <span className={styles.currency}> DATA</span>
+                            </div>
+                        </div>
+                        <div>
+                            <div className={styles.statHeading}>Active Members</div>
+                            <div className={styles.statValue}>{stats.memberCount.active}</div>
+                        </div>
+                        <div>
+                            <div className={styles.statHeading}>Avg rev member / month</div>
+                            <div className={styles.statValue}>
+                                {Math.floor(revenuePerMonthPerMember)}
+                                <span className={styles.currency}> DATA</span>
+                            </div>
+                        </div>
+                        <div>
+                            <div className={styles.statHeading}>Subscribers</div>
+                            <div className={styles.statValue}>TODO</div>
+                        </div>
+                        <div>
+                            <div className={styles.statHeading}>Admin fee</div>
+                            <div className={styles.statValue}>TODO</div>
+                        </div>
+                        <div>
+                            <div className={styles.statHeading}>Product created</div>
+                            <div className={styles.statValue}>{product && product.created && new Date(product.created).toLocaleDateString()}</div>
+                        </div>
+                    </div>
+                    <div className={styles.graphs}>
+                        <div>
+                            <div className={styles.statHeading}>Members</div>
+                            <MembersGraph
+                                className={styles.graph}
+                                authApiKeyId={authApiKeyId}
+                                joinPartStreamId="DRaCVLn1TOWpe7I76gN8hA"
+                                memberCount={stats.memberCount.total}
+                            />
+                        </div>
+                        <div className={styles.memberDonut}>
+                            <div className={styles.statHeading}>Members by status</div>
+                            <DonutChart
+                                className={styles.graph}
+                                strokeWidth={3}
+                                data={[
+                                    {
+                                        title: 'Active',
+                                        value: stats.memberCount.active,
+                                        color: '#0324FF',
+                                    },
+                                    {
+                                        title: 'Inactive',
+                                        value: stats.memberCount.inactive,
+                                        color: '#FB0606',
+                                    },
+                                ]}
+                            />
+                        </div>
+                    </div>
+                    <div className={styles.footer}>
+                        TODO
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+export default ProductOverview

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -46,12 +46,6 @@ const ProductOverview = ({
             if (!isMounted) {
                 return
             }
-            result.totalEarnings = 100
-            result.memberCount = {
-                total: 100,
-                active: 80,
-                inactive: 20,
-            }
             setStats(result)
             setIsDeploying(false)
         } catch (e) {
@@ -71,7 +65,7 @@ const ProductOverview = ({
 
     const productAgeMs = Date.now() - new Date(product.created || 0).getTime()
     const revenuePerMonth = (stats && stats.totalEarnings) ? Math.floor(stats.totalEarnings / (productAgeMs / (1000 * 60 * 60 * 24 * 30))) : 0
-    const revenuePerMonthPerMember = (stats && stats.memberCount) ? revenuePerMonth / stats.memberCount.total : 0
+    const revenuePerMonthPerMember = (stats && stats.memberCount && stats.memberCount.total > 0) ? (revenuePerMonth / stats.memberCount.total) : 0
 
     return (
         <div className={cx(styles.root, className)}>

--- a/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/index.jsx
@@ -64,8 +64,10 @@ const ProductOverview = ({ product, authApiKeyId, className }: Props) => {
     return (
         <div className={cx(styles.root, className)}>
             {isDeploying && (
-                <div className={styles.spinner}>
-                    <DeploySpinner isRunning showCounter={false} />
+                <div className={styles.spinnerContainer}>
+                    <div className={styles.spinner}>
+                        <DeploySpinner isRunning showCounter={false} />
+                    </div>
                 </div>
             )}
             {!isDeploying && stats != null && (

--- a/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
@@ -1,0 +1,98 @@
+.root {
+  margin: 4em 0;
+  background-color: #F8F8F8;
+  color: #525252;
+}
+
+.grid {
+  display: grid;
+  grid-template-rows: 4.5em auto auto 4.5em;
+}
+
+.spinner {
+  width: 160px;
+  height: 160px;
+}
+
+.header {
+  display: flex;
+  padding: 0 2em;
+  background-color: #EFEFEF;
+  color: #323232;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: var(--medium);
+  letter-spacing: 1.17px;
+  line-height: 16px;
+  text-transform: uppercase;
+}
+
+.header > span {
+  align-self: center;
+}
+
+.stats {
+  padding: 4em 2em 2.875em 2em;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  grid-column-gap: 3em;
+}
+
+.statHeading {
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0;
+  line-height: 24px;
+  white-space: nowrap;
+}
+
+.statValue {
+  font-family: var(--sans);
+  font-weight: 200;
+  font-size: 32px;
+  line-height: 42px;
+  letter-spacing: -0.67px;
+  color: #323232;
+}
+
+.currency {
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: var(--regular);
+  line-height: 42px;
+  letter-spacing: 0;
+}
+
+.graphs {
+  padding: 3em 2em 0 2em;
+  border-top: 1px solid #E7E7E7;
+  border-bottom: 1px solid #E7E7E7;
+  display: grid;
+  height: 22.5em;
+  grid-template-columns: 60% 40%;
+}
+
+.graph {
+  margin-top: 3em;
+}
+
+.memberDonut {
+  border-left: 1px solid #E7E7E7;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .statHeading {
+    padding-left: 2em;
+  }
+
+  .graph {
+    width: 160px;
+    height: 160px;
+    align-self: center;
+  }
+}
+
+.footer {
+  padding: 0 2em;
+}

--- a/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
@@ -105,6 +105,10 @@
 .memberHeadingContainer {
   display: grid;
   grid-template-columns: 1fr auto;
+
+  .statHeading {
+    align-self: center;
+  }
 }
 
 .memberGraphDropdown {

--- a/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
@@ -98,6 +98,19 @@
   }
 }
 
+.memberContainer {
+  margin-right: 2em;
+}
+
+.memberHeadingContainer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+}
+
+.memberGraphDropdown {
+  text-align: right;
+}
+
 .footer {
   padding: 0 2em;
 }

--- a/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
@@ -9,9 +9,14 @@
   grid-template-rows: 4.5em auto auto 4.5em;
 }
 
+.spinnerContainer {
+  padding: 3em;
+}
+
 .spinner {
   width: 160px;
   height: 160px;
+  margin: 0 auto;
 }
 
 .header {

--- a/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
@@ -69,6 +69,7 @@
   line-height: 42px;
   letter-spacing: -0.67px;
   color: #323232;
+  white-space: nowrap;
 }
 
 .currency {

--- a/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
+++ b/app/src/marketplace/components/ProductPage/ProductOverview/productOverview.pcss
@@ -9,14 +9,25 @@
   grid-template-rows: 4.5em auto auto 4.5em;
 }
 
-.spinnerContainer {
-  padding: 3em;
-}
+.deployingGrid {
+  display: grid;
+  grid-template-columns: 160px 500px;
+  grid-column-gap: 4em;
+  align-items: center;
+  justify-content: center;
+  padding-top: 4em;
 
-.spinner {
-  width: 160px;
-  height: 160px;
-  margin: 0 auto;
+  .deployMessageHeading {
+    font-size: 30px;
+    letter-spacing: 0;
+    line-height: 32px;
+  }
+
+  .deployMessage {
+    font-size: 18px;
+    letter-spacing: 0;
+    line-height: 30px;
+  }
 }
 
 .header {

--- a/app/src/marketplace/components/ProductPage/StreamListing/streamListing.pcss
+++ b/app/src/marketplace/components/ProductPage/StreamListing/streamListing.pcss
@@ -26,8 +26,14 @@
 }
 
 .headerRow {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: var(--medium);
+  line-height: 16px;
   letter-spacing: 1.17px;
+  background-color: #EFEFEF;
+  height: 4.5rem;
+  align-items: center;
 }
 
 .streamCount {

--- a/app/src/marketplace/components/ProductTile/index.jsx
+++ b/app/src/marketplace/components/ProductTile/index.jsx
@@ -112,7 +112,9 @@ class ProductTile extends Component<Props, State> {
                     />
                 }
                 <Link
-                    to={formatPath(links.marketplace.products, id || '')}
+                    to={process.env.COMMUNITY_PRODUCTS ?
+                        formatPath(links.marketplace.products2, id || '') :
+                        formatPath(links.marketplace.products, id || '')}
                     className={classnames({
                         [styles.loading]: !this.state.loaded,
                     })}

--- a/app/src/marketplace/containers/ProductPage2/Page.jsx
+++ b/app/src/marketplace/containers/ProductPage2/Page.jsx
@@ -18,6 +18,7 @@ import FallbackImage from '$shared/components/FallbackImage'
 import ProductContainer from '$shared/components/Container/Product'
 import Tile from '$shared/components/Tile'
 import { isCommunityProduct } from '$mp/utils/product'
+import { ago } from '$shared/utils/time'
 
 import ProductDetails from './ProductDetails'
 import CollapsedText from './CollapsedText'
@@ -128,7 +129,7 @@ class ProductDetailsPage extends Component<Props> {
                                 {mostRecentPurchaseTimestamp && (
                                     <div>
                                         <div className={styles.subheading}>Most recent purchase</div>
-                                        <div>{mostRecentPurchaseTimestamp.toLocaleDateString()}</div>
+                                        <div>{ago(mostRecentPurchaseTimestamp)}</div>
                                     </div>
                                 )}
                             </div>

--- a/app/src/marketplace/containers/ProductPage2/Page.jsx
+++ b/app/src/marketplace/containers/ProductPage2/Page.jsx
@@ -12,6 +12,7 @@ import Hero from '$mp/components/Hero'
 import type { Product, Subscription } from '../../flowtype/product-types'
 import type { StreamList } from '$shared/flowtype/stream-types'
 import type { ButtonActions } from '$shared/components/Buttons'
+import type { ResourceKeyId } from '$shared/flowtype/resource-key-types'
 import Products from '$mp/components/Products'
 import FallbackImage from '$shared/components/FallbackImage'
 import ProductContainer from '$shared/components/Container/Product'
@@ -21,6 +22,7 @@ import { isCommunityProduct } from '$mp/utils/product'
 import ProductDetails from './ProductDetails'
 import CollapsedText from './CollapsedText'
 import StreamListing from '$mp/components/ProductPage/StreamListing'
+import ProductOverview from '$mp/components/ProductPage/ProductOverview'
 import styles from './page.pcss'
 
 const { md } = breakpoints
@@ -37,6 +39,7 @@ export type Props = {
     isLoggedIn?: boolean,
     isProductSubscriptionValid?: boolean,
     productSubscription?: Subscription,
+    authApiKeyId?: ?ResourceKeyId,
     onPurchase?: () => void,
 }
 
@@ -59,6 +62,7 @@ class ProductDetailsPage extends Component<Props> {
             isLoggedIn,
             isProductSubscriptionValid,
             productSubscription,
+            authApiKeyId,
             onPurchase,
             toolbarStatus,
         } = this.props
@@ -121,6 +125,14 @@ class ProductDetailsPage extends Component<Props> {
                         </div>
                     </ProductContainer>
                 </div>
+                {isCommunityProduct && (
+                    <ProductContainer>
+                        <ProductOverview
+                            product={product}
+                            authApiKeyId={authApiKeyId}
+                        />
+                    </ProductContainer>
+                )}
                 <StreamListing
                     product={product}
                     streams={streams}

--- a/app/src/marketplace/containers/ProductPage2/Page.jsx
+++ b/app/src/marketplace/containers/ProductPage2/Page.jsx
@@ -85,6 +85,7 @@ class ProductDetailsPage extends Component<Props> {
                 )}
                 <Hero
                     className={styles.hero}
+                    containerClassName={styles.heroContainer}
                     product={product}
                     leftContent={
                         <div className={styles.productImageWrapper}>
@@ -120,13 +121,13 @@ class ProductDetailsPage extends Component<Props> {
                                     <div className={styles.subheading}>Product category</div>
                                     <div>{product.category}</div>
                                 </div>
-                                {isCommunity && (
+                                {subscriberCount != null && (
                                     <div>
                                         <div className={styles.subheading}>Active subscribers</div>
                                         <div>{subscriberCount}</div>
                                     </div>
                                 )}
-                                {mostRecentPurchaseTimestamp && (
+                                {mostRecentPurchaseTimestamp != null && (
                                     <div>
                                         <div className={styles.subheading}>Most recent purchase</div>
                                         <div>{ago(mostRecentPurchaseTimestamp)}</div>

--- a/app/src/marketplace/containers/ProductPage2/Page.jsx
+++ b/app/src/marketplace/containers/ProductPage2/Page.jsx
@@ -125,7 +125,7 @@ class ProductDetailsPage extends Component<Props> {
                         </div>
                     </ProductContainer>
                 </div>
-                {isCommunityProduct && (
+                {isCommunity && (
                     <ProductContainer>
                         <ProductOverview
                             product={product}

--- a/app/src/marketplace/containers/ProductPage2/Page.jsx
+++ b/app/src/marketplace/containers/ProductPage2/Page.jsx
@@ -41,6 +41,10 @@ export type Props = {
     productSubscription?: Subscription,
     authApiKeyId?: ?ResourceKeyId,
     onPurchase?: () => void,
+    adminFee?: ?number,
+    joinPartStreamId?: ?string,
+    subscriberCount?: ?number,
+    mostRecentPurchaseTimestamp?: ?Date,
 }
 
 class ProductDetailsPage extends Component<Props> {
@@ -65,10 +69,13 @@ class ProductDetailsPage extends Component<Props> {
             authApiKeyId,
             onPurchase,
             toolbarStatus,
+            adminFee,
+            joinPartStreamId,
+            subscriberCount,
+            mostRecentPurchaseTimestamp,
         } = this.props
         const isProductFree = (product && BN(product.pricePerSecond).isEqualTo(0)) || false
         const isCommunity = !!(product && isCommunityProduct(product))
-        const subscriberCount = 0
 
         return !!product && (
             <div className={classNames(styles.productPage, !!showToolbar && styles.withToolbar)}>
@@ -118,10 +125,12 @@ class ProductDetailsPage extends Component<Props> {
                                         <div>{subscriberCount}</div>
                                     </div>
                                 )}
-                                <div>
-                                    <div className={styles.subheading}>Most recent purchase</div>
-                                    <div>TODO</div>
-                                </div>
+                                {mostRecentPurchaseTimestamp && (
+                                    <div>
+                                        <div className={styles.subheading}>Most recent purchase</div>
+                                        <div>{mostRecentPurchaseTimestamp.toLocaleDateString()}</div>
+                                    </div>
+                                )}
                             </div>
                         </div>
                     </ProductContainer>
@@ -131,8 +140,9 @@ class ProductDetailsPage extends Component<Props> {
                         <ProductOverview
                             product={product}
                             authApiKeyId={authApiKeyId}
-                            adminFee={0}
-                            subscriberCount={subscriberCount}
+                            adminFee={adminFee || 0}
+                            subscriberCount={subscriberCount || 0}
+                            joinPartStreamId={joinPartStreamId}
                         />
                     </ProductContainer>
                 )}

--- a/app/src/marketplace/containers/ProductPage2/Page.jsx
+++ b/app/src/marketplace/containers/ProductPage2/Page.jsx
@@ -68,6 +68,7 @@ class ProductDetailsPage extends Component<Props> {
         } = this.props
         const isProductFree = (product && BN(product.pricePerSecond).isEqualTo(0)) || false
         const isCommunity = !!(product && isCommunityProduct(product))
+        const subscriberCount = 0
 
         return !!product && (
             <div className={classNames(styles.productPage, !!showToolbar && styles.withToolbar)}>
@@ -114,7 +115,7 @@ class ProductDetailsPage extends Component<Props> {
                                 {isCommunity && (
                                     <div>
                                         <div className={styles.subheading}>Active subscribers</div>
-                                        <div>TODO</div>
+                                        <div>{subscriberCount}</div>
                                     </div>
                                 )}
                                 <div>
@@ -130,6 +131,8 @@ class ProductDetailsPage extends Component<Props> {
                         <ProductOverview
                             product={product}
                             authApiKeyId={authApiKeyId}
+                            adminFee={0}
+                            subscriberCount={subscriberCount}
                         />
                     </ProductContainer>
                 )}

--- a/app/src/marketplace/containers/ProductPage2/ProductDetails.jsx
+++ b/app/src/marketplace/containers/ProductPage2/ProductDetails.jsx
@@ -81,17 +81,22 @@ const ProductDetails = ({ product, isValidSubscription, productSubscription, onP
                 &nbsp;
                 {product.owner}
             </div>
-            <div>
-                <span className={styles.subheading}>Website</span>
-                &nbsp;
-                TODO
-            </div>
-            <div>
-                <Link href="#TODO">Contact seller</Link>
-            </div>
-            <div>
-                <Link href="#TODO">View other products</Link>
-            </div>
+            {/* Hide these until we have a place to read them from */}
+            {false && (
+                <React.Fragment>
+                    <div>
+                        <span className={styles.subheading}>Website</span>
+                        &nbsp;
+                        TODO
+                    </div>
+                    <div>
+                        <Link href="#TODO">Contact seller</Link>
+                    </div>
+                    <div>
+                        <Link href="#TODO">View other products</Link>
+                    </div>
+                </React.Fragment>
+            )}
         </div>
     </div>
 )

--- a/app/src/marketplace/containers/ProductPage2/index.jsx
+++ b/app/src/marketplace/containers/ProductPage2/index.jsx
@@ -118,9 +118,12 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
         if (isCommunityProduct(p) && p.beneficiaryAddress) {
             setAdminFee(await getAdminFee(p.beneficiaryAddress))
             setJoinPartStreamId(await getJoinPartStreamId(p.beneficiaryAddress))
-            setSubscriberCount(await getSubscriberCount(p.id))
-            setRecentPurchaseTimestamp(await getMostRecentPurchase(p.id))
         }
+    }, [])
+
+    const loadBlockchainData = useCallback(async (p) => {
+        setSubscriberCount(await getSubscriberCount(p.id))
+        setRecentPurchaseTimestamp(await getMostRecentPurchase(p.id))
     }, [])
 
     const onPurchase = useCallback((id: ProductId) => {
@@ -160,8 +163,9 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
     }, [product, overlayPurchaseDialog, isPurchaseAllowed, deniedRedirect])
 
     useEffect(() => {
+        loadBlockchainData(product)
         loadCPData(product)
-    }, [product, loadCPData])
+    }, [product, loadCPData, loadBlockchainData])
 
     const overlay = () => {
         if (product) {

--- a/app/src/marketplace/containers/ProductPage2/index.jsx
+++ b/app/src/marketplace/containers/ProductPage2/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useEffect, useCallback, useContext } from 'react'
+import React, { useEffect, useCallback, useContext, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { push, replace } from 'connected-react-router'
 import { I18n } from 'react-redux-i18n'
@@ -16,9 +16,11 @@ import PurchaseDialog from '$mp/containers/ProductPage/PurchaseDialog'
 import PublishOrUnpublishDialog from '$mp/containers/ProductPage/PublishOrUnpublishDialog'
 import { getProductById, getProductSubscription, purchaseProduct, getUserProductPermissions } from '$mp/modules/product/actions'
 import BackButton from '$shared/components/BackButton'
+import { getAdminFee, getJoinPartStreamId } from '$mp/modules/communityProduct/services'
+import { getSubscriberCount, getMostRecentPurchase } from '$mp/modules/contractProduct/services'
 
 import { getRelatedProducts } from '../../modules/relatedProducts/actions'
-import { isPaidProduct } from '../../utils/product'
+import { isPaidProduct, isCommunityProduct } from '../../utils/product'
 import Page from './Page'
 
 import {
@@ -54,6 +56,10 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
     const isProductSubscriptionValid = useSelector(selectSubscriptionIsValid)
     const subscription = useSelector(selectContractSubscription)
     const authApiKeyId = useSelector(selectAuthApiKeyId)
+    const [adminFee, setAdminFee] = useState(null)
+    const [joinPartStreamId, setJoinPartStreamId] = useState(null)
+    const [subscriberCount, setSubscriberCount] = useState(null)
+    const [recentPurchaseTimestamp, setRecentPurchaseTimestamp] = useState(null)
 
     const { match } = useContext(RouterContext.Context)
 
@@ -99,7 +105,7 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
         }
     }
 
-    const loadProduct = useCallback((id: ProductId) => {
+    const loadProduct = useCallback(async (id: ProductId) => {
         dispatch(getProductById(id))
         dispatch(getUserProductPermissions(id))
         dispatch(getRelatedProducts(id))
@@ -107,6 +113,15 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
             dispatch(getProductSubscription(id))
         }
     }, [dispatch, isLoggedIn])
+
+    const loadCPData = useCallback(async (p) => {
+        if (isCommunityProduct(p) && p.beneficiaryAddress) {
+            setAdminFee(await getAdminFee(p.beneficiaryAddress))
+            setJoinPartStreamId(await getJoinPartStreamId(p.beneficiaryAddress))
+            setSubscriberCount(await getSubscriberCount(p.id))
+            setRecentPurchaseTimestamp(await getMostRecentPurchase(p.id))
+        }
+    }, [])
 
     const onPurchase = useCallback((id: ProductId) => {
         if (isLoggedIn) {
@@ -143,6 +158,10 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
             deniedRedirect(product.id || '0')
         }
     }, [product, overlayPurchaseDialog, isPurchaseAllowed, deniedRedirect])
+
+    useEffect(() => {
+        loadCPData(product)
+    }, [product, loadCPData])
 
     const overlay = () => {
         if (product) {
@@ -191,6 +210,10 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
                 toolbarStatus={<BackButton />}
                 showStreamLiveDataDialog={(streamId) => noHistoryRedirect(links.marketplace.products, product.id, 'streamPreview', streamId)}
                 authApiKeyId={authApiKeyId}
+                adminFee={adminFee}
+                joinPartStreamId={joinPartStreamId}
+                subscriberCount={subscriberCount}
+                mostRecentPurchaseTimestamp={recentPurchaseTimestamp}
             />
             {overlay()}
         </Layout>

--- a/app/src/marketplace/containers/ProductPage2/index.jsx
+++ b/app/src/marketplace/containers/ProductPage2/index.jsx
@@ -31,6 +31,7 @@ import {
     selectContractSubscription,
 } from '$mp/modules/product/selectors'
 import { selectUserData } from '$shared/modules/user/selectors'
+import { selectAuthApiKeyId } from '$shared/modules/resourceKey/selectors'
 import links from '$mp/../links'
 import routes from '$routes'
 import { selectRelatedProductList } from '$mp/modules/relatedProducts/selectors'
@@ -52,6 +53,7 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
     const editPermission = useSelector(selectProductEditPermission)
     const isProductSubscriptionValid = useSelector(selectSubscriptionIsValid)
     const subscription = useSelector(selectContractSubscription)
+    const authApiKeyId = useSelector(selectAuthApiKeyId)
 
     const { match } = useContext(RouterContext.Context)
 
@@ -188,6 +190,7 @@ const ProductPage = ({ overlayPurchaseDialog, overlayPublishDialog }: Props) => 
                 onPurchase={() => onPurchase(product.id || '')}
                 toolbarStatus={<BackButton />}
                 showStreamLiveDataDialog={(streamId) => noHistoryRedirect(links.marketplace.products, product.id, 'streamPreview', streamId)}
+                authApiKeyId={authApiKeyId}
             />
             {overlay()}
         </Layout>

--- a/app/src/marketplace/containers/ProductPage2/page.pcss
+++ b/app/src/marketplace/containers/ProductPage2/page.pcss
@@ -26,13 +26,17 @@
     padding-bottom: 0;
   }
 
+  .heroContainer {
+    grid-column-gap: 4rem;
+  }
+
   .container {
     background-color: #F8F8F8;
     padding-bottom: 6em;
   }
 
   .section {
-    margin-top: 3em;
+    margin-top: 4em;
   }
 
   .productImageWrapper {
@@ -41,7 +45,7 @@
 
   .productImage {
     width: 100%;
-    max-height: 410px;
+    max-height: 307px;
     object-fit: cover;
   }
 

--- a/app/src/marketplace/modules/communityProduct/services.js
+++ b/app/src/marketplace/modules/communityProduct/services.js
@@ -152,3 +152,8 @@ export const getJoinPartStreamId = (address: Address, usePublicNode: boolean = f
 
 export const getCommunityStats = (id: string): ApiResult<Object> =>
     get(formatApiUrl('communities', id, 'stats'))
+
+export const getStreamData = (id: string, fromTimestamp: number): ApiResult<Object> =>
+    get(formatApiUrl('streams', id, 'data', 'partitions', 0, 'from', {
+        fromTimestamp,
+    }))

--- a/app/src/marketplace/modules/communityProduct/services.js
+++ b/app/src/marketplace/modules/communityProduct/services.js
@@ -14,7 +14,7 @@ import type { Permission } from '$userpages/flowtype/permission-types'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import { gasLimits } from '$shared/utils/constants'
 
-import { post, del } from '$shared/utils/api'
+import { post, del, get } from '$shared/utils/api'
 import { formatApiUrl } from '$shared/utils/url'
 import { postStream /* , getMyStreamPermissions */ } from '$userpages/modules/userPageStreams/services'
 import { addStreamResourceKey } from '$shared/modules/resourceKey/services'
@@ -146,3 +146,6 @@ export const setAdminFee = (address: Address, adminFee: number): SmartContractTr
         gas: gasLimits.UPDATE_ADMIN_FEE,
     })
 )
+
+export const getCommunityStats = (id: string): ApiResult<Object> =>
+    get(formatApiUrl('communities', id, 'stats'))

--- a/app/src/marketplace/modules/communityProduct/services.js
+++ b/app/src/marketplace/modules/communityProduct/services.js
@@ -147,5 +147,8 @@ export const setAdminFee = (address: Address, adminFee: number): SmartContractTr
     })
 )
 
+export const getJoinPartStreamId = (address: Address, usePublicNode: boolean = false) =>
+    call(getCommunityContract(address, usePublicNode).methods.joinPartStream())
+
 export const getCommunityStats = (id: string): ApiResult<Object> =>
     get(formatApiUrl('communities', id, 'stats'))

--- a/app/src/marketplace/modules/contractProduct/services.js
+++ b/app/src/marketplace/modules/contractProduct/services.js
@@ -32,7 +32,10 @@ export const getSubscriberCount = async (id: ProductId, usePublicNode: boolean =
         fromBlock: 0,
         toBlock: 'latest',
     })
-    return events.length
+    const validSubs = events.filter((e) => (
+        e.returnValues && e.returnValues.endTimestamp && ((e.returnValues.endTimestamp.toNumber() * 1000) > Date.now())
+    ))
+    return validSubs.length
 }
 
 export const getMostRecentPurchase = async (id: ProductId, usePublicNode: boolean = false) => {
@@ -52,5 +55,9 @@ export const getMostRecentPurchase = async (id: ProductId, usePublicNode: boolea
 
     const lastEvent = events[events.length - 1]
     const lastBlock = await web3.eth.getBlock(lastEvent.blockHash)
-    return new Date(lastBlock.timestamp * 1000)
+    if (lastBlock && lastBlock.timestamp) {
+        return new Date(lastBlock.timestamp * 1000)
+    }
+
+    return null
 }

--- a/app/src/marketplace/modules/contractProduct/services.js
+++ b/app/src/marketplace/modules/contractProduct/services.js
@@ -7,6 +7,7 @@ import getConfig from '$shared/web3/config'
 import type { SmartContractProduct, ProductId } from '$mp/flowtype/product-types'
 import type { SmartContractCall } from '$shared/flowtype/web3-types'
 import { getValidId, mapProductFromContract } from '$mp/utils/product'
+import { getWeb3, getPublicWeb3 } from '$shared/web3/web3Provider'
 
 const contractMethods = (usePublicNode: boolean = false) => getContract(getConfig().marketplace, usePublicNode).methods
 
@@ -21,3 +22,35 @@ export const getProductFromContract = async (id: ProductId, usePublicNode: boole
             return mapProductFromContract(id, result)
         })
 )
+
+export const getSubscriberCount = async (id: ProductId, usePublicNode: boolean = false) => {
+    const contract = getContract(getConfig().marketplace, usePublicNode)
+    const events = await contract.getPastEvents('Subscribed', {
+        filter: {
+            productId: getValidId(id),
+        },
+        fromBlock: 0,
+        toBlock: 'latest',
+    })
+    return events.length
+}
+
+export const getMostRecentPurchase = async (id: ProductId, usePublicNode: boolean = false) => {
+    const web3 = usePublicNode ? getPublicWeb3() : getWeb3()
+    const contract = getContract(getConfig().marketplace, usePublicNode)
+    const events = await contract.getPastEvents('Subscribed', {
+        filter: {
+            productId: getValidId(id),
+        },
+        fromBlock: 0,
+        toBlock: 'latest',
+    })
+
+    if (events.length === 0) {
+        return null
+    }
+
+    const lastEvent = events[events.length - 1]
+    const lastBlock = await web3.eth.getBlock(lastEvent.blockHash)
+    return new Date(lastBlock.timestamp * 1000)
+}

--- a/app/src/shared/components/DonutChart/donutChart.pcss
+++ b/app/src/shared/components/DonutChart/donutChart.pcss
@@ -1,0 +1,39 @@
+.root {
+  position: relative;
+}
+
+.total {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  color: #323232;
+  font-family: var(--sans);
+  font-size: 32px;
+  font-weight: 200;
+  letter-spacing: -0.67px;
+}
+
+.labelContainer {
+  margin-top: 2em;
+  display: flex;
+  justify-content: center;
+}
+
+.label {
+  color: #A3A3A3;
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0;
+}
+
+.label:not(:last-child) {
+  margin-right: 1em;
+}
+
+.labelCircle {
+  vertical-align: baseline;
+  width: 8px;
+  height: 8px;
+  margin-right: 4px;
+}

--- a/app/src/shared/components/DonutChart/index.jsx
+++ b/app/src/shared/components/DonutChart/index.jsx
@@ -1,0 +1,109 @@
+// @flow
+
+import React from 'react'
+import cx from 'classnames'
+
+import styles from './donutChart.pcss'
+
+type Segment = {
+    title: string,
+    value: number,
+    color: string,
+}
+
+type DonutSegment = {
+    percentage: number,
+    offset: number,
+    color: string,
+}
+
+type Props = {
+    className?: string,
+    data: Array<Segment>,
+    strokeWidth: number,
+}
+
+const CIRCLE_RADIUS = 50
+const CIRCLE_CIRCUMFERENCE = 2 * Math.PI * CIRCLE_RADIUS
+
+const DonutChart = ({ className, strokeWidth, data }: Props) => {
+    const calculateSegments = (parts: Array<Segment>) => {
+        const segments = []
+        let currentProgress = 0
+        const valueSum = parts.reduce((acc, val) => acc + val.value, 0)
+
+        parts.forEach((item) => {
+            const val = item.value / valueSum
+            segments.push({
+                percentage: val,
+                offset: currentProgress,
+                color: item.color,
+            })
+            currentProgress += val
+        })
+        return segments
+    }
+
+    const renderSegments = (segments: Array<DonutSegment>) => (
+        segments.map((segment, index) => (
+            <circle
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                cx="50"
+                cy="50"
+                r={CIRCLE_RADIUS - strokeWidth}
+                fill="transparent"
+                strokeWidth={strokeWidth}
+                stroke={segment.color}
+                strokeDasharray={`${segment.percentage * CIRCLE_CIRCUMFERENCE} ${(1 - segment.percentage) * CIRCLE_CIRCUMFERENCE}`}
+                strokeDashoffset={(1 - segment.offset) * CIRCLE_CIRCUMFERENCE}
+                transform="rotate(-90 50 50)"
+            />
+        ))
+    )
+
+    const renderLabels = (segments: Array<Segment>) => (
+        segments.map((segment, index) => (
+            <span
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                className={styles.label}
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 10 10"
+                    className={styles.labelCircle}
+                >
+                    <circle
+                        cx="5"
+                        cy="5"
+                        r={4}
+                        fill={segment.color}
+                        strokeWidth={1}
+                        stroke={segment.color}
+                    />
+                </svg>
+                {segment.title}
+            </span>
+        ))
+    )
+
+    return (
+        <div className={cx(styles.root, className)}>
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 100 100"
+            >
+                {renderSegments(calculateSegments(data))}
+            </svg>
+            <div className={styles.total}>
+                {data.reduce((acc, val) => acc + val.value, 0)}
+            </div>
+            <div className={styles.labelContainer}>
+                {renderLabels(data)}
+            </div>
+        </div>
+    )
+}
+
+export default DonutChart

--- a/app/src/shared/components/DonutChart/index.jsx
+++ b/app/src/shared/components/DonutChart/index.jsx
@@ -33,7 +33,7 @@ const DonutChart = ({ className, strokeWidth, data }: Props) => {
         const valueSum = parts.reduce((acc, val) => acc + val.value, 0)
 
         parts.forEach((item) => {
-            const val = item.value / valueSum
+            const val = valueSum !== 0 ? item.value / valueSum : 0
             segments.push({
                 percentage: val,
                 offset: currentProgress,

--- a/app/src/shared/components/Dropdown/dropdown.pcss
+++ b/app/src/shared/components/Dropdown/dropdown.pcss
@@ -36,6 +36,9 @@
   }
 }
 
+/*
+  Normal toggle styles
+*/
 .toggle {
   font-family: 'IBM Plex Mono', sans-serif;
   font-size: 12px;
@@ -69,6 +72,47 @@
 
 :global(.btn).toggle,
 :global(.btn-secondary).toggle {
+  border: none;
+  padding: 0;
+  transition: none;
+
+  &,
+  &:--idle {
+    color: #A3A3A3;
+  }
+
+  &:--enter {
+    color: var(--greyDark) !important;
+  }
+}
+
+/*
+  Small toggle styles
+*/
+.toggleSmall {
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: var(--regular);
+  letter-spacing: 0;
+  line-height: 24px;
+  text-decoration: none;
+  text-transform: none;
+
+  &,
+  &:--idle,
+  &:--enter {
+    color: #525252;
+    outline: 0;
+    cursor: pointer;
+  }
+
+  &:--enter {
+    color: var(--greyDark);
+  }
+}
+
+:global(.btn).toggleSmall,
+:global(.btn-secondary).toggleSmall {
   border: none;
   padding: 0;
   transition: none;

--- a/app/src/shared/components/Dropdown/index.jsx
+++ b/app/src/shared/components/Dropdown/index.jsx
@@ -13,11 +13,14 @@ import SvgIcon from '$shared/components/SvgIcon'
 import DropdownItem from './DropdownItem'
 import styles from './dropdown.pcss'
 
+type ToggleStyle = 'normal' | 'small'
+
 type Props = {
     title: Node,
     selectedItem?: ?string,
     children: ChildrenArray<Element<typeof DropdownItem>>,
     className?: string,
+    toggleStyle?: ToggleStyle,
     onChange: (string) => void,
     disabled?: boolean,
 }
@@ -73,6 +76,7 @@ export default class Dropdown extends Component<Props, State> {
             title,
             children,
             className,
+            toggleStyle,
             selectedItem,
             disabled,
         } = this.props
@@ -91,7 +95,7 @@ export default class Dropdown extends Component<Props, State> {
                 })}
                 disabled={disabled}
             >
-                <RsDropdownToggle className={cx(styles.toggle)} disabled={disabled}>
+                <RsDropdownToggle className={toggleStyle === 'small' ? styles.toggleSmall : styles.toggle} disabled={disabled}>
                     {currentItem || title}
                     <SvgIcon name="caretUp" className={styles.caret} />
                 </RsDropdownToggle>

--- a/app/src/shared/utils/time.js
+++ b/app/src/shared/utils/time.js
@@ -1,0 +1,62 @@
+// @flow
+
+const units = [
+    {
+        max: 2760000,
+        value: 60000,
+        name: 'minute',
+        prev: 'a minute ago',
+    },
+    {
+        max: 72000000,
+        value: 3600000,
+        name: 'hour',
+        prev: 'an hour ago',
+    },
+    {
+        max: 518400000,
+        value: 86400000,
+        name: 'day',
+        prev: 'yesterday',
+    },
+    {
+        max: 2419200000,
+        value: 604800000,
+        name: 'week',
+        prev: 'last week',
+    },
+    {
+        max: 28512000000,
+        value: 2592000000,
+        name: 'month',
+        prev: 'last month',
+    }, // max: 11 months
+]
+
+function format(diff, divisor, unit, prev) {
+    const val = Math.round(diff / divisor)
+    return val <= 1 ? prev : `${val} ${unit}s ago`
+}
+
+export function ago(date: Date) {
+    const diff = Math.abs(Date.now() - date.getTime())
+    // less than a minute
+    if (diff < 60000) {
+        return 'just now'
+    }
+
+    for (let i = 0; i < units.length; i += 1) {
+        if (diff < units[i].max) {
+            return format(diff, units[i].value, units[i].name, units[i].prev)
+        }
+    }
+    // `year` is the final unit.
+    // same as:
+    //  {
+    //    max: Infinity,
+    //    value: 31536000000,
+    //    name: 'year',
+    //    prev: 'last year'
+    //  }
+    return format(diff, 31536000000, 'year', 'last year')
+}

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -45,6 +45,8 @@ import Toolbar from '$shared/components/Toolbar'
 import DeploySpinner from '$shared/components/DeploySpinner'
 import Label from '$shared/components/Label'
 import Tile from '$shared/components/Tile'
+import DonutChart from '$shared/components/DonutChart'
+import LineChart from '$shared/components/LineChart'
 
 import sharedStyles from './shared.pcss'
 
@@ -847,4 +849,48 @@ story('Tile')
                 </Tile.Status>
             </Tile>
         </div>
+    ))
+
+story('DonutChart')
+    .addWithJSX('basic', () => (
+        <DonutChart
+            strokeWidth={5}
+            data={[
+                {
+                    title: '1',
+                    value: 50,
+                    color: 'red',
+                },
+                {
+                    title: '2',
+                    value: 25,
+                    color: 'blue',
+                },
+                {
+                    title: '3',
+                    value: 25,
+                    color: 'green',
+                },
+            ]}
+        />
+    ))
+
+story('LineChart')
+    .addWithJSX('basic', () => (
+        <LineChart
+            data={[
+                {
+                    x: 1,
+                    y: 10,
+                },
+                {
+                    x: 2,
+                    y: 5,
+                },
+                {
+                    x: 3,
+                    y: 15,
+                },
+            ]}
+        />
     ))

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -46,7 +46,6 @@ import DeploySpinner from '$shared/components/DeploySpinner'
 import Label from '$shared/components/Label'
 import Tile from '$shared/components/Tile'
 import DonutChart from '$shared/components/DonutChart'
-import LineChart from '$shared/components/LineChart'
 
 import sharedStyles from './shared.pcss'
 
@@ -870,26 +869,6 @@ story('DonutChart')
                     title: '3',
                     value: 25,
                     color: 'green',
-                },
-            ]}
-        />
-    ))
-
-story('LineChart')
-    .addWithJSX('basic', () => (
-        <LineChart
-            data={[
-                {
-                    x: 1,
-                    y: 10,
-                },
-                {
-                    x: 2,
-                    y: 5,
-                },
-                {
-                    x: 3,
-                    y: 15,
                 },
             ]}
         />


### PR DESCRIPTION
Add overview section for product page that gets shown when we're dealing with a community product. It will query `/stats` endpoint. Member graph uses `joinPartStream` to plot member count as a function of time.

Missing features:
 - getting subscriber count and admin fee from blockchain (https://github.com/streamr-dev/streamr-platform/pull/696 will enable us to get at least admin fee)

Here's some test data for joinPartStream. Basically you have to deploy a CP and use stream editor to upload this data for the joinPartStream.
https://www.dropbox.com/s/sw50bef3vrxbh7b/joinpart_data.csv?dl=0