### PR TITLE
Improve code coverage

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
   "license": "UNLICENSED",
   "jest": {
     "collectCoverage": true,
+    "coverageReporters": ["text-summary", "lcov-report"],
     "coverageThreshold": {
       "global": {
         "lines": 32

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --hot --host 0.0.0.0",
     "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack --progress --profile",
-    "test": "NODE_ENV=test jest ./test/* ./src/shared/test/* ./src/userpages/tests/* ./src/editor/shared/tests/* ./src/editor/canvas/tests/*",
+    "test": "NODE_ENV=test jest",
     "flow": "flow",
     "flow-stop": "flow stop",
     "eslint": "eslint .",
@@ -48,10 +48,17 @@
       }
     },
     "collectCoverageFrom": [
-      "src/**/*.{js,jsx}"
+      "src/**/*.{js,jsx}",
+      "!*.stories.*"
+    ],
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/src/docs/content/",
+      "<rootDir>/src/docs/scripts/",
+      "/flowtype/",
+      "/tests/"
     ],
     "moduleNameMapper": {
-      "\\.(css|scss|pcss)$": "identity-obj-proxy",
+      "\\.(css|scss|pcss|po|md|mdx)$": "identity-obj-proxy",
       "\\.(png)$": "empty/object",
       "\\$app/(.*)$": "<rootDir>/$1",
       "\\$auth/(.*)$": "<rootDir>/src/auth/$1",

--- a/app/package.json
+++ b/app/package.json
@@ -36,16 +36,10 @@
   "license": "UNLICENSED",
   "jest": {
     "collectCoverage": true,
-    "coverageReporters": ["text-summary", "lcov-report"],
+    "coverageReporters": ["text-summary", "lcov"],
     "coverageThreshold": {
       "global": {
-        "lines": 32
-      },
-      "./src/userpages/": {
-        "lines": 10
-      },
-      "./src/shared/": {
-        "lines": 10
+        "lines": 38
       }
     },
     "collectCoverageFrom": [

--- a/app/src/editor/canvas/components/ModuleRenderer/ModuleRenderer.test.jsx
+++ b/app/src/editor/canvas/components/ModuleRenderer/ModuleRenderer.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import * as modules from './modules'
+import ModuleRenderer from '.'
+
+const Module = ({ src }) => (
+    <ModuleRenderer
+        canvasEditable={false}
+        canvasAdjustable={false}
+        api={{
+            moduleSidebarOpen: () => {},
+            port: {
+                onChange: () => {},
+                setPortOptions: () => {},
+            },
+            updateModule: () => {},
+            selectModule: () => {},
+            setCanvas: () => {},
+        }}
+        module={src}
+        layout={src.layout}
+        style={{
+            position: 'static',
+            width: 'fit-content',
+        }}
+    />
+)
+
+const groupedModules = Object.values(modules).reduce((memo, mod) => (mod.path ? {
+    ...memo,
+    [mod.path]: [...(memo[mod.path] || []), mod],
+} : memo), {})
+
+describe('ModuleRenderer', () => {
+    const moduleTests = [].concat(...Object.keys(groupedModules).sort().map((key) => groupedModules[key].map((m) => [key, m.name, m])))
+    test.each(moduleTests)('render %s - %s', (group, name, m) => {
+        const result = mount((
+            <Module
+                src={Object.assign({
+                    params: [],
+                    inputs: [],
+                    outputs: [],
+                }, m, {
+                    name: m.name || '<Empty>',
+                })}
+            />
+        ))
+        expect(result).toBeTruthy()
+        result.unmount()
+    })
+})


### PR DESCRIPTION
There were a whole bunch of issues when trying to render our storybook via enzyme/jsdom, issues  seemed to come primarily from within 3rd party libs trying to attaching event handlers to missing refs, so I gave up on that for now.

Achieved something similar by using the module renderer to render every module, this improves global line coverage up to 41% and isn't an entirely dumb test to do.

Also:
* excluded docs content & .story/flowtype files from coverage reports.
* Switched default coverage reporter to `text-summary`, which should make test log output a lot easier to read:

![image](https://user-images.githubusercontent.com/43438/67192384-1339cb00-f426-11e9-9c67-be0fe4e9841a.png)
 
If you want to turn the full reporter back on, invoke `jest` like: 

```
npx jest --coverageReporters=text
```