### PR TITLE
[PLATFORM-1104] Make ports unique on paste

### DIFF
--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -719,10 +719,20 @@ function getHash(canvas, iterations = 0) {
 }
 
 /**
- * Create new module from data
+ * Create new module from data, makes module unique first
+ * Simple uniqifying wrapper around addModuleData.
  */
 
 export function addModule(canvas, moduleData) {
+    return addModuleData(canvas, makeModuleUnique(moduleData))
+}
+
+/**
+ * Adds moduleData to canvas as-is.
+ * Does not ensure module port ids etc are unique.
+ */
+
+function addModuleData(canvas, moduleData) {
     if (!moduleData || !moduleData.id) {
         throw createError(`trying to add bad module: ${moduleData}`, {
             canvas,
@@ -1454,6 +1464,11 @@ export function applyChanges({ sent, received, current }) {
         ))
     })
     return nextCanvas
+}
+
+export function makeModuleUnique(moduleData) {
+    const tempCanvas = addModuleData(emptyCanvas(), moduleData)
+    return getModuleCopy(tempCanvas, tempCanvas.modules[0].hash)
 }
 
 export function getModuleCopy(canvas, moduleHash) {

--- a/app/src/editor/canvas/tests/copyPaste.test.js
+++ b/app/src/editor/canvas/tests/copyPaste.test.js
@@ -61,6 +61,22 @@ describe('copy/paste with getModuleCopy', () => {
         expect(State.moduleHasConnections(canvas, toLowerCase2.hash)).not.toBeTruthy()
     })
 
+    it('gives unique port ids for multiple pastes', async () => {
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('ToLowerCase'))
+        const [toLowerCase1] = canvas.modules
+        const toLowerCaseDefn = State.getModuleCopy(canvas, toLowerCase1.hash)
+        canvas = State.addModule(canvas, toLowerCaseDefn)
+        canvas = State.addModule(canvas, toLowerCaseDefn)
+        const [, toLowerCase2, toLowerCase3] = canvas.modules
+        const toLowerCase2Ports = State.getModulePorts(canvas, toLowerCase2.hash)
+        const toLowerCase3Ports = State.getModulePorts(canvas, toLowerCase3.hash)
+
+        toLowerCase2Ports.forEach((port) => {
+            expect(toLowerCase3Ports.find((p) => p.id === port.id)).not.toBeTruthy()
+        })
+    })
+
     it('does not copy uiChannel', async () => {
         let canvas = State.emptyCanvas()
         canvas = State.addModule(canvas, await loadModuleDefinition('Table'))

--- a/app/src/editor/canvas/tests/java.test.js
+++ b/app/src/editor/canvas/tests/java.test.js
@@ -90,5 +90,5 @@ describe('Java Module', () => {
         canvas = State.replaceModule(canvas, newModule)
         expect(State.arePortsConnected(canvas, constant1.outputs[0].id, javaModule.inputs[0].id)).toBeTruthy()
         expect(State.arePortsConnected(canvas, javaModule.outputs[0].id, constant2.params[0].id)).toBeTruthy()
-    })
+    }, 10000)
 })

--- a/app/src/editor/shared/components/ModuleUI.jsx
+++ b/app/src/editor/shared/components/ModuleUI.jsx
@@ -54,7 +54,7 @@ export default ({ autoSize, ...props }) => {
     const isRunning = useIsCanvasRunning()
 
     return (
-        <RunStateLoader {...props} isActive={isRunning} canvasId={canvasId}>
+        <RunStateLoader {...props} moduleHash={module.hash} isActive={isRunning} canvasId={canvasId}>
             {(props) => {
                 const Module = module.widget ? Widgets[module.widget] : Modules[module.jsModule]
 


### PR DESCRIPTION
This was silly on my part, was making ports unique on copy, not paste, so pasting again would do weird stuff because the port ids weren't unique.

I've fixed this and added a test.

Also:
* Java module test seems to time out sometimes, upped the timeout.
* Cherry-picked a fix for a regression in loading module runtime state
