### PR TITLE
[PLATFORM-1110] Ensure stream fields are replaced rather than merged.

### DIFF
--- a/app/src/shared/modules/entities/reducer.js
+++ b/app/src/shared/modules/entities/reducer.js
@@ -22,9 +22,9 @@ export const initialState: EntitiesState = {
     resourceKeys: {},
 }
 
-// Empty arrays do not replace the destination value by default, use customizer to handle
+// Arrays do not replace the destination value by default, use customizer to handle
 // that special case. If customizer returns undefined, merging is handled by the default method instead
-const mergeCustomizer = (obj, src) => ((Array.isArray(src) && src.length <= 0) ? src : undefined)
+const mergeCustomizer = (obj, src) => (Array.isArray(src) ? src : undefined)
 
 const reducer: (EntitiesState) => EntitiesState = handleActions({
     [UPDATE_ENTITIES]: (state: EntitiesState, action: UpdateEntitiesAction) => mergeWith({}, state, action.payload.entities, mergeCustomizer),

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -48,43 +48,47 @@ if (!isProduction()) {
     /* eslint-enable no-underscore-dangle */
 }
 
-const store = createStore(
-    combineReducers({
-        allowance: allowanceReducer,
-        categories: categoriesReducer,
-        contractProduct: contractProductReducer,
-        createContractProduct: createContractProductReducer,
-        updateContractProduct: updateContractProductReducer,
-        editProduct: editProductReducer,
-        entities: entitiesReducer,
-        global: globalReducer,
-        myProductList: myProductsReducer,
-        myPurchaseList: myPurchasesReducer,
-        product: productReducer,
-        productList: productsReducer,
-        publish: publishReducer,
-        unpublish: unpublishReducer,
-        publishDialog: publishDialogReducer,
-        purchase: purchaseReducer,
-        purchaseDialog: purchaseDialogReducer,
-        saveProductDialog: saveProductReducer,
-        router: connectRouter(history),
-        streams: streamsReducer,
-        user: userReducer,
-        integrationKey: integrationKeyReducer,
-        resourceKey: resourceKeyReducer,
-        web3: web3Reducer,
-        i18n: i18nReducer,
-        relatedProducts: relatedProductsReducer,
-        transactions: transactionsReducer,
-        // TODO: RE-ENABLE THESE WHEN USERPAGES ARE READY
-        // userpages
-        ...userpagesReducers,
-    }),
-    compose(...toBeComposed),
-)
+export function initStore() {
+    const store = createStore(
+        combineReducers({
+            allowance: allowanceReducer,
+            categories: categoriesReducer,
+            contractProduct: contractProductReducer,
+            createContractProduct: createContractProductReducer,
+            updateContractProduct: updateContractProductReducer,
+            editProduct: editProductReducer,
+            entities: entitiesReducer,
+            global: globalReducer,
+            myProductList: myProductsReducer,
+            myPurchaseList: myPurchasesReducer,
+            product: productReducer,
+            productList: productsReducer,
+            publish: publishReducer,
+            unpublish: unpublishReducer,
+            publishDialog: publishDialogReducer,
+            purchase: purchaseReducer,
+            purchaseDialog: purchaseDialogReducer,
+            saveProductDialog: saveProductReducer,
+            router: connectRouter(history),
+            streams: streamsReducer,
+            user: userReducer,
+            integrationKey: integrationKeyReducer,
+            resourceKey: resourceKeyReducer,
+            web3: web3Reducer,
+            i18n: i18nReducer,
+            relatedProducts: relatedProductsReducer,
+            transactions: transactionsReducer,
+            // TODO: RE-ENABLE THESE WHEN USERPAGES ARE READY
+            // userpages
+            ...userpagesReducers,
+        }),
+        compose(...toBeComposed),
+    )
 
-syncTranslationWithStore(store)
-store.dispatch(loadTranslations(translations))
+    syncTranslationWithStore(store)
 
-export default store
+    store.dispatch(loadTranslations(translations))
+    return store
+}
+
+export default initStore()

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
@@ -9,7 +9,7 @@ import TextInput from '$shared/components/TextInput'
 import type { StreamField } from '$shared/flowtype/stream-types'
 import SplitControl from '$userpages/components/SplitControl'
 
-import { fieldTypes } from '../../../constants'
+import { fieldTypes } from '$userpages/modules/userPageStreams/selectors'
 import styles from './newFieldEditor.pcss'
 
 type Props = {

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
@@ -15,12 +15,10 @@ import FieldList from '$shared/components/FieldList'
 import FieldItem from '$shared/components/FieldList/FieldItem'
 import Dropdown from '$shared/components/Dropdown'
 import { updateEditStreamField, updateEditStream, streamFieldsAutodetect } from '$userpages/modules/userPageStreams/actions'
-import { selectEditedStream, selectFieldsAutodetectFetching } from '$userpages/modules/userPageStreams/selectors'
+import { selectEditedStream, selectFieldsAutodetectFetching, fieldTypes } from '$userpages/modules/userPageStreams/selectors'
 import TextInput from '$shared/components/TextInput'
 import Toggle from '$shared/components/Toggle'
 import SplitControl from '$userpages/components/SplitControl'
-
-import { fieldTypes } from '../../constants'
 
 import styles from './configureView.pcss'
 import NewFieldEditor from './NewFieldEditor'

--- a/app/src/userpages/components/StreamPage/constants.js
+++ b/app/src/userpages/components/StreamPage/constants.js
@@ -12,5 +12,3 @@ export const rightColumn = {
     },
     sm: 12,
 }
-
-export const fieldTypes = ['number', 'boolean', 'map', 'list', 'string', 'timestamp']

--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -585,8 +585,8 @@ export const initEditStream = () => (dispatch: Function, getState: Function) => 
     }
 }
 
-export const initNewStream = () => (dispatch: Function) => {
-    dispatch(updateEditStream({
+export const initNewStream = (initData: ?any) => (dispatch: Function) => {
+    dispatch(updateEditStream(Object.assign({}, {
         id: '',
         name: '',
         description: '',
@@ -599,7 +599,7 @@ export const initNewStream = () => (dispatch: Function) => {
         requireEncryptedData: false,
         storageDays: 365,
         uiChannel: false,
-    }))
+    }, initData)))
 }
 
 export const streamFieldsAutodetect = (id: StreamId) => (dispatch: Function) => {

--- a/app/src/userpages/modules/userPageStreams/selectors.js
+++ b/app/src/userpages/modules/userPageStreams/selectors.js
@@ -16,6 +16,8 @@ import { selectEntities } from '$shared/modules/entities/selectors'
 import { streamsSchema, streamSchema, resourceKeysSchema } from '$shared/modules/entities/schema'
 import { selectStreamResourceKeys } from '$shared/modules/resourceKey/selectors'
 
+export const fieldTypes = ['number', 'boolean', 'map', 'list', 'string', 'timestamp']
+
 const selectUserPageStreamsState = (state: StoreState): UserPageStreamsState => state.userPageStreams
 
 export const selectStreamIds: (StoreState) => StreamIdList = createSelector(

--- a/app/src/userpages/tests/modules/userPagesStreams/update.test.js
+++ b/app/src/userpages/tests/modules/userPagesStreams/update.test.js
@@ -1,0 +1,80 @@
+import uuid from 'uuid'
+
+import * as actions from '$userpages/modules/userPageStreams/actions'
+import * as selectors from '$userpages/modules/userPageStreams/selectors'
+import { initStore } from '$shared/../store'
+
+import { streamsSchema, streamSchema } from '$shared/modules/entities/schema'
+import { handleEntities } from '$shared/utils/entities'
+
+describe('updateEditStream', () => {
+    let store
+
+    beforeEach(() => {
+        store = initStore()
+    })
+
+    it('can add/remove fields', async () => {
+        const id = uuid()
+        await store.dispatch(actions.initNewStream({ id }))
+
+        let editedStream = selectors.selectEditedStream(store.getState())
+        expect(editedStream).toBeTruthy()
+
+        // hack stream id into userPageStreams state
+        store.dispatch({
+            type: actions.GET_STREAMS_SUCCESS,
+            streams: [editedStream.id],
+        })
+
+        const field1 = {
+            name: 'field1',
+            type: selectors.fieldTypes[0],
+            id: uuid(),
+        }
+        const field2 = {
+            name: 'field2',
+            type: selectors.fieldTypes[1],
+            id: uuid(),
+        }
+
+        store.dispatch(actions.updateEditStream({
+            ...editedStream,
+            config: {
+                ...editedStream.config,
+                fields: [field1, field2],
+            },
+        }))
+
+        editedStream = selectors.selectEditedStream(store.getState())
+        expect(editedStream.config.fields).toEqual([field1, field2])
+
+        // update the stored stream
+        handleEntities(streamSchema, store.dispatch)(editedStream)
+        let streams = selectors.selectStreams(store.getState())
+
+        // ensure stored stream fields match
+        expect(streams[0].config.fields).toEqual([field1, field2])
+
+        // remove field 2
+        // if the updater tries to merge the array elements rather than
+        // replace them, then this will lead to both field1 & field2
+        // still in the config, when only field1 should be
+        store.dispatch(actions.updateEditStream({
+            ...editedStream,
+            config: {
+                ...editedStream.config,
+                fields: [field1],
+            },
+        }))
+
+        editedStream = selectors.selectEditedStream(store.getState())
+
+        expect(editedStream.config.fields).toEqual([field1])
+
+        handleEntities(streamSchema, store.dispatch)(editedStream)
+        streams = selectors.selectStreams(store.getState())
+        // ensure stored stream fields match
+        expect(streams[0].config.fields).toEqual([field1])
+    })
+})


### PR DESCRIPTION
When the edit stream is updated into the `entities.streams`, it was *merging* the array items rather than replacing them, so if the old stream had `[field1, field2]`, then  removing `field2` would make it merge `[field1]`  with `[field1, field2]` to become `[field1, field2]` rather than `[field2]`.

Changed the update entities logic to it never merges array items, and added a test at the stream update level, but I'm not sure if this breaks something elsewhere that was depending on the array merge behaviour. No tests break but that's not very reassuring because the current userpages test suite is so heavily mocked out that the tests there don't really verify anything particularly insightful about the the state of the app actually working.

### To Test

1. Add 2 fields to a stream
2. Save and Exit stream
3. Edit stream again, remove one field.
4. Save and exit
3. Edit stream again, only one field should be visible