### PR TITLE
[PLATFORM-515] Remove autocomplete from stream edit form

### DIFF
--- a/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
@@ -109,6 +109,7 @@ export class InfoView extends Component<Props, State> {
                         onChange={this.onNameChange}
                         preserveLabelSpace
                         disabled={disabled}
+                        autoComplete="off"
                     />
                 </div>
                 <div className={styles.textInput}>
@@ -120,6 +121,7 @@ export class InfoView extends Component<Props, State> {
                         onChange={this.onDescriptionChange}
                         preserveLabelSpace
                         disabled={disabled}
+                        autoComplete="off"
                     />
                 </div>
                 {stream && stream.id &&


### PR DESCRIPTION
Remove autocomplete possibility from stream name and description fields as browsers were misinterpreting what the field was meant for. 

https://streamr.atlassian.net/browse/PLATFORM-515