### PR TITLE
[PLATFORM-1123] Prevent search text being cut off at top/bottom

### DIFF
--- a/app/src/marketplace/components/ActionBar/SearchInput/searchInput.pcss
+++ b/app/src/marketplace/components/ActionBar/SearchInput/searchInput.pcss
@@ -22,7 +22,7 @@
     height: 100%;
     text-align: center;
     font-style: normal;
-    line-height: 16px;
+    line-height: normal;
     cursor: initial;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
As above.

## After

#### Chrome

![image](https://user-images.githubusercontent.com/43438/67827924-773a4e80-fb0c-11e9-8bf9-4e66324a9611.png)

![image](https://user-images.githubusercontent.com/43438/67827849-2b87a500-fb0c-11e9-895f-e30682c2c558.png)

#### Safari

![image](https://user-images.githubusercontent.com/43438/67827890-507c1800-fb0c-11e9-887a-ef3912e28937.png)

![image](https://user-images.githubusercontent.com/43438/67827849-2b87a500-fb0c-11e9-895f-e30682c2c558.png)

## Before

#### Chrome

![image](https://user-images.githubusercontent.com/43438/67827881-42c69280-fb0c-11e9-8318-206e0b4eca7a.png)

#### Safari

![image](https://user-images.githubusercontent.com/43438/67827868-3b9f8480-fb0c-11e9-82a9-66254dc79146.png)
