### PR TITLE
Prevent crash on hitting back button in product editor

### DIFF
--- a/app/src/marketplace/containers/ProductPage2/CollapsedText.jsx
+++ b/app/src/marketplace/containers/ProductPage2/CollapsedText.jsx
@@ -13,7 +13,8 @@ type Props = {
     className?: string,
 }
 
-const CollapsedText = ({ text, className }: Props) => {
+const CollapsedText = ({ text: textProp, className }: Props) => {
+    const text = textProp || ''
     const maxLength = 4000
     const rootRef = useRef(null)
     const truncationRequired = text.length > maxLength


### PR DESCRIPTION
Fixes this:

![crash-on-back](https://user-images.githubusercontent.com/43438/67830972-b621d180-fb17-11e9-88c4-6627070c14e3.gif)
