### PR TITLE
[PLATFORM-1106] Remove self from list of users in share dialog.

### DIFF
--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogPermissionRow/ShareDialogPermission/index.jsx
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogPermissionRow/ShareDialogPermission/index.jsx
@@ -43,9 +43,12 @@ export class ShareDialogPermission extends Component<Props> {
     }
 
     render() {
+        const user = this.props.permissions[0] && this.props.permissions[0].user
+        const isSelf = user === this.props.username
+        if (isSelf) { return null } // hide self
+
         const errors = this.props.permissions.filter((p) => p.error).map((p) => p.error && p.error.message) || []
         const highestOperationIndex = Math.max(...(this.props.permissions.map((p) => operationsInOrder.indexOf(p.operation))))
-        const user = this.props.permissions[0] && this.props.permissions[0].user
         const options = operationsInOrder.map((o) => ({
             value: o,
             label: I18n.t(`modal.shareResource.permissions.${o}`),
@@ -55,10 +58,7 @@ export class ShareDialogPermission extends Component<Props> {
                 <div className={styles.permissionRow}>
                     <SvgIcon name="user" className={styles.avatarIcon} />
                     <div className={styles.user}>
-                        <div className={cx(styles.title, {
-                            [styles.meLabel]: user === this.props.username,
-                        })}
-                        >
+                        <div className={styles.title}>
                             <Translate value="modal.shareResource.user.defaultTitle" />
                         </div>
                         <div className={styles.username} title={user}>
@@ -71,13 +71,11 @@ export class ShareDialogPermission extends Component<Props> {
                         options={options}
                         value={options[highestOperationIndex]}
                         onChange={this.onSelect}
-                        isDisabled={user === this.props.username}
                     />
                     <button
                         type="button"
                         onClick={this.onRemove}
                         className={cx(styles.button, buttonStyles.btn, buttonStyles.btnOutline)}
-                        disabled={user === this.props.username}
                     >
                         <SvgIcon name="crossHeavy" />
                     </button>

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogPermissionRow/shareDialogPermissionRow.pcss
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogPermissionRow/shareDialogPermissionRow.pcss
@@ -1,6 +1,9 @@
-
 .container {
   margin-top: 2.5rem;
   padding-top: 2.5rem;
   border-top: 1px solid #F2F1F1;
+}
+
+.container:empty {
+  border-top: none;
 }


### PR DESCRIPTION
As per the ticket:

> In share dialogue, users are shown as being able to access the resource they are sharing. 
However, they cannot adjust the settings for their own user account nor remove themselves from the list, so the UI is pointless & should be removed.

Now ignores current user, only shows other users. In screenshot below, current user is tester1, canvas is shared with tester2

![image](https://user-images.githubusercontent.com/43438/67839121-d9f01200-fb2d-11e9-9b15-c2852ca58bb2.png)

