### PR TITLE
[DOCS-100] Hash link scrolling

### DIFF
--- a/app/src/docs/components/CanvasModuleHelp/index.jsx
+++ b/app/src/docs/components/CanvasModuleHelp/index.jsx
@@ -64,6 +64,7 @@ export default function CanvasModuleHelp({ module: m, help, minifiedContent, cla
     return (
         <section
             key={m.id}
+            id={m.name.toLowerCase()}
             className={cx(
                 styles.root,
                 className, {

--- a/app/src/docs/content/canvases/modulesBasics.mdx
+++ b/app/src/docs/content/canvases/modulesBasics.mdx
@@ -1,6 +1,7 @@
 import cx from 'classnames'
 import { Link } from 'react-router-dom'
 import links from '$shared/../links'
+import routes from '$routes'
 
 import Modules from './images/module_basics_01_desktop.jpg'
 import Modules2x from './images/module_basics_01_desktop@2x.jpg'
@@ -76,7 +77,7 @@ Many modules have parameters which control their operation. Module parameters ca
     <figcaption>The basic elements of a canvas module</figcaption>
 </figure>
 
-As an example, the RoundToStep module has three inputs, two parameters, and one output. The first two inputs correspond to the module’s parameters, i.e. precision and mode. The last input is a numeric value which will be rounded with the specified precision in the direction specified by the mode. The module output is equal to the rounded input. Inputs, outputs, and parameters can be renamed by double clicking on them and typing new text. Renaming has no bearing on functionality.
+As an example, the <Link to={routes.docsModuleReferenceTimeSeries({}, 'roundtostep')}>RoundToStep</Link> module has three inputs, two parameters, and one output. The first two inputs correspond to the module’s parameters, i.e. precision and mode. The last input is a numeric value which will be rounded with the specified precision in the direction specified by the mode. The module output is equal to the rounded input. Inputs, outputs, and parameters can be renamed by double clicking on them and typing new text. Renaming has no bearing on functionality.
 
 <figure className={docsStyles.darkBg}>
     <picture>
@@ -147,7 +148,7 @@ Along with **inputs** and **outputs**, there are also **parameters**. **Paramete
     </picture>
 </figure>
 
-You can only connect endpoints with compatible data types. As you hold your mouse down, compatible connections will glow green and incompatible connections glow red. For instance, you cannot create a connection which feeds string events to an endpoint where numerical events are expected. There are conversion modules such as StringToNumber which can help when you get stuck with the wrong data type.
+You can only connect endpoints with compatible data types. As you hold your mouse down, compatible connections will glow green and incompatible connections glow red. For instance, you cannot create a connection which feeds string events to an endpoint where numerical events are expected. There are conversion modules such as <Link to={routes.docsModuleReferenceText({}, 'stringtonumber')}>StringToNumber</Link> which can help when you get stuck with the wrong data type.
 
 All connections are unidirectional, i.e. the data always flows from an output to one or more inputs in one direction only. The modules form a directed graph. Feedback loops are discouraged, but you can create them if you really want.
 

--- a/app/src/shared/components/AutoScroll/index.jsx
+++ b/app/src/shared/components/AutoScroll/index.jsx
@@ -6,16 +6,33 @@ import scrollIntoView from 'smooth-scroll-into-view-if-needed'
 import RouteWatcher from '$shared/containers/RouteWatcher'
 import ModalContext from '$shared/contexts/Modal'
 
+/**
+ * AutoScroll controls the page load scroll behaviour for the entire app,
+ * it is triggered when there's a change in page location.
+ * If the URL contains a hash, scroll to it.
+ * If the URL is really long, avoid nauseous smooth scroll up.
+ * Otherwisee, default action is to smooth scroll to top on page load/navigation.
+ */
+
 class AutoScroll extends React.Component<{}> {
     static contextType = ModalContext
 
-    scroll = () => {
+    scroll = (urlHash?: string) => {
         const root = document.getElementById('root')
         const { isModalOpen } = this.context
 
-        // Edge case for really long pages
-        // Snap straight to top
-        if (root && !isModalOpen && window.pageYOffset > 2000) {
+        if (urlHash) {
+            const elementId = urlHash.substr(1)
+            const hashReference = document.getElementById(elementId)
+
+            if (hashReference) {
+                scrollIntoView(hashReference, {
+                    behavior: 'smooth',
+                    block: 'start',
+                    inline: 'nearest',
+                })
+            }
+        } else if (root && !isModalOpen && window.pageYOffset > 2000) {
             window.scrollTo(0, 0)
         } else if (root && !isModalOpen) {
             scrollIntoView(root, {
@@ -28,7 +45,7 @@ class AutoScroll extends React.Component<{}> {
 
     render() {
         return (
-            <RouteWatcher onChange={this.scroll} />
+            <RouteWatcher onChange={(urlHash) => this.scroll(urlHash)} />
         )
     }
 }

--- a/app/src/shared/containers/RouteWatcher/index.js
+++ b/app/src/shared/containers/RouteWatcher/index.js
@@ -4,17 +4,26 @@ import React from 'react'
 import { withRouter } from 'react-router-dom'
 
 type Props = {
-    onChange: () => void,
+    onChange: (urlHash?: string) => void,
     location: {
         pathname: string,
+        hash: string,
     },
 }
 
 class RouteWatcher extends React.Component<Props> {
+    componentDidMount() {
+        this.checkIfPathChange('')
+    }
+
     componentDidUpdate({ location: { pathname: prevPathname } }: Props) {
-        const { location: { pathname }, onChange } = this.props
+        this.checkIfPathChange(prevPathname)
+    }
+
+    checkIfPathChange(prevPathname) {
+        const { location: { pathname, hash }, onChange } = this.props
         if (pathname !== prevPathname) {
-            onChange()
+            onChange(hash)
         }
     }
 


### PR DESCRIPTION
Added:
- IDs for individual modules, inside the module docs.
- A few inline links to these modules inside the docs.
- Smooth scroll to hash element ID when a hash fragment is present in the URL.

I noticed that hash linking wasn't working that well out of the box.. looked into it and it seems to compete with our Autoscroll measures, which ensure that page navigations render at the top of the new page.

To test, visit: http://localhost/docs/module-reference/time-series#roundtostep