### PR TITLE
Fix infinite retry load create canvas

### DIFF
--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -92,7 +92,7 @@ export async function handleLoadError(err) {
         await notFoundRedirect()
     }
 
-    if (err.response.status === 403) {
+    if (err.response.status === 403 || err.response.status === 401) {
         // if already logged in and no access, do not redirect to login
         if (isLoggedInError(err)) {
             await notFoundRedirect() // redirect to not found

--- a/app/src/auth/utils/loginInterceptor.js
+++ b/app/src/auth/utils/loginInterceptor.js
@@ -81,6 +81,14 @@ function isLoggedInError(err) {
     return err.response.data.user && err.response.data.user !== '<not authenticated>'
 }
 
+export function canHandleLoadError(err) {
+    if (!err.response) { return false }
+    if (err.response.status === 404) { return true }
+    if (err.response.status === 403) { return true }
+    if (err.response.status === 401) { return true }
+    return false
+}
+
 export async function handleLoadError(err) {
     if (!err.response) { throw err } // unexpected error
     // server issues

--- a/app/src/editor/canvas/components/CanvasController/index.jsx
+++ b/app/src/editor/canvas/components/CanvasController/index.jsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet'
 
 import * as RouterContext from '$shared/components/RouterContextProvider'
 import { usePending } from '$shared/hooks/usePending'
+import { handleLoadError, canHandleLoadError } from '$auth/utils/loginInterceptor'
 
 import * as CanvasState from '../../state'
 import useCanvas from './useCanvas'
@@ -80,6 +81,10 @@ function useError() {
         setError(undefined)
     }, [match.path])
     if (error) {
+        if (canHandleLoadError(error)) {
+            handleLoadError(error)
+            return
+        }
         // propagate error to error boundary
         throw error
     }

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -146,7 +146,7 @@ function ModuleError(props) {
         ...restProps
     } = props
 
-    const errorObj = (error && error.error) ? error.error : error
+    const errorObj = error
     const moduleLayout = layout || module.layout
     const errorMessage = (errorObj.stack || errorObj.message || '').trim()
 

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -1,17 +1,19 @@
 import React, { PureComponent, useContext } from 'react'
-import { withRouter } from 'react-router-dom'
+import { Link, withRouter } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
 import { connect } from 'react-redux'
+import { Translate } from 'react-redux-i18n'
 import { selectAuthState } from '$shared/modules/user/selectors'
 import SessionContext from '$auth/contexts/Session'
 import cx from 'classnames'
 
 import Layout from '$shared/components/Layout'
 import withErrorBoundary from '$shared/utils/withErrorBoundary'
-import ErrorComponentView from '$shared/components/ErrorComponentView'
+import { ErrorPageContent } from '$mp/components/ErrorPageView'
 import copyToClipboard from 'copy-to-clipboard'
 
 import links from '../../links'
+import routes from '$routes'
 
 import isEditableElement from '$editor/shared/utils/isEditableElement'
 import UndoControls from '$editor/shared/components/UndoControls'
@@ -548,7 +550,25 @@ const CanvasEditWrap = () => {
     )
 }
 
-const CanvasContainer = withRouter(withErrorBoundary(ErrorComponentView)((props) => (
+const CanvasErrorPage = () => (
+    <ErrorPageContent>
+        <Link
+            to=""
+            onClick={window.location.reload}
+            className="btn btn-special"
+        >
+            <Translate value="editor.error.refresh" />
+        </Link>
+        <Link
+            to={routes.canvases()}
+            className="btn btn-special d-none d-md-inline-block"
+        >
+            <Translate value="editor.general.backToCanvases" />
+        </Link>
+    </ErrorPageContent>
+)
+
+const CanvasContainer = withRouter(withErrorBoundary(CanvasErrorPage)((props) => (
     <UndoContext.Provider key={props.match.params.id} enableBreadcrumbs>
         <PendingProvider name="canvas">
             <PendingLoadingIndicator />
@@ -569,7 +589,7 @@ export default connect(selectAuthState)(({ embed, isAuthenticated }) => {
     // don't drop into embed mode unless no token
     embed = embed || (!isAuthenticated && !token)
     return (
-        <Layout className={styles.layout} footer={false} nav={!embed}>
+        <Layout className={styles.layout} footer={false} nav={!embed} navshadow>
             <BodyClass className="editor" />
             <CanvasContainer embed={embed} />
         </Layout>

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -554,7 +554,10 @@ const CanvasErrorPage = () => (
     <ErrorPageContent>
         <Link
             to=""
-            onClick={window.location.reload}
+            onClick={(event) => {
+                event.preventDefault()
+                window.location.reload()
+            }}
             className="btn btn-special"
         >
             <Translate value="editor.error.refresh" />

--- a/app/src/editor/i18n/en.po
+++ b/app/src/editor/i18n/en.po
@@ -8,6 +8,12 @@ msgstr ""
 "POT-Creation-Date: 2018-09-26T12:51:00.805Z\n"
 "PO-Revision-Date: 2018-09-26T12:51:00.805Z\n"
 
+msgid "editor##error##refresh"
+msgstr "Refresh"
+
+msgid "editor##general##backToCanvases"
+msgstr "Back to Canvases"
+
 msgid "editor##module##portOption##drivingInput##name"
 msgstr "Driving Input"
 

--- a/app/src/marketplace/components/ErrorPageView/index.jsx
+++ b/app/src/marketplace/components/ErrorPageView/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react'
+import React, { type Node } from 'react'
 import { Link } from 'react-router-dom'
 import { Container } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
@@ -14,40 +14,46 @@ import appCrashedImage2x from '$shared/assets/images/app_crashed@2x.png'
 
 import styles from './errorPageView.pcss'
 
+type Props = {
+    children?: Node,
+}
+
+export const ErrorPageContent = ({ children }: Props) => (
+    <Container>
+        <EmptyState
+            image={(
+                <img
+                    className={styles.image}
+                    src={appCrashedImage}
+                    srcSet={`${appCrashedImage2x} 2x`}
+                    alt={I18n.t('errorPageView.imageCaption')}
+                />
+            )}
+            link={children}
+            linkOnMobile
+        >
+            <Translate value="errorPageView.message" dangerousHTML />
+        </EmptyState>
+    </Container>
+)
+
 const ErrorPageView = () => (
     <Layout className={styles.errorPageView}>
         <BodyClass className={PAGE_SECONDARY} />
-        <Container>
-            <EmptyState
-                image={(
-                    <img
-                        className={styles.image}
-                        src={appCrashedImage}
-                        srcSet={`${appCrashedImage2x} 2x`}
-                        alt={I18n.t('errorPageView.imageCaption')}
-                    />
-                )}
-                link={(
-                    <React.Fragment>
-                        <Link
-                            to={links.marketplace.main}
-                            className="btn btn-special"
-                        >
-                            <Translate value="errorPageView.top" />
-                        </Link>
-                        <Link
-                            to={links.userpages.products}
-                            className="btn btn-special d-none d-md-inline-block"
-                        >
-                            <Translate value="general.products" />
-                        </Link>
-                    </React.Fragment>
-                )}
-                linkOnMobile
+        <ErrorPageContent>
+            <Link
+                to={links.marketplace.main}
+                className="btn btn-special"
             >
-                <Translate value="errorPageView.message" dangerousHTML />
-            </EmptyState>
-        </Container>
+                <Translate value="errorPageView.top" />
+            </Link>
+            <Link
+                to={links.userpages.products}
+                className="btn btn-special d-none d-md-inline-block"
+            >
+                <Translate value="general.products" />
+            </Link>
+        </ErrorPageContent>
     </Layout>
 )
 

--- a/app/src/shared/utils/withErrorBoundary.jsx
+++ b/app/src/shared/utils/withErrorBoundary.jsx
@@ -16,31 +16,35 @@ const withErrorBoundary = (ErrorComponent: ComponentType<any>) => (
     (OriginalComponent: ComponentType<any>) => (
         class ErrorBoundary extends Component<Props, State> {
             state = {
-                error: null,
+                error: undefined,
             }
 
-            componentWillReceiveProps(nextProps: Props) {
+            static getDerivedStateFromError(error: Error, extra: any) {
+                console.error({
+                    error,
+                })
+                analytics.reportError(error, extra)
                 // Reset error state if route changes, otherwise error is always shown.
-                if (this.props.path !== nextProps.path) {
-                    this.setState({
-                        error: null,
-                    })
+                return {
+                    error,
                 }
             }
 
-            componentDidCatch(error: Error, extra: any) {
-                console.error(error)
-                analytics.reportError(error, extra)
-                this.setState({
-                    error,
-                })
+            componentDidUpdate(prevProps: Props) {
+                // Reset error state if route changes, otherwise error is always shown.
+                if (this.props.path !== prevProps.path) {
+                    // eslint-disable-next-line react/no-did-update-set-state
+                    this.setState({
+                        error: undefined,
+                    })
+                }
             }
 
             render() {
                 const { error } = this.state
                 const { children, ...props } = this.props
                 return error ? (
-                    <ErrorComponent {...props} error={this.state} />
+                    <ErrorComponent {...props} error={this.state.error} />
                 ) : (
                     <OriginalComponent {...props}>
                         {children}


### PR DESCRIPTION
Should show error page if there's an error loading or creating a canvas, unless error is 401/403 in which case it'll redirect to login.

### To Test

1. Open a canvas
2. `streamr-docker-dev stop engine-and-editor`
3. Refresh canvas
4. Should show error page
5. Go to the "create" url http://localhost/canvas/editor/
6. Should show error page
7. `streamr-docker-dev start engine-and-editor`
8. Refresh, log out and go back to canvas.
9. Should redirect you to login with a redirect back to canvas
10. Go to the "create" url http://localhost/canvas/editor/ while logged out
11. Should redirect you to login with a redirect back to create canvas page