### PR TITLE
Use moment from moment-timezone (Fix CI)

### DIFF
--- a/app/src/editor/shared/components/modules/Table.jsx
+++ b/app/src/editor/shared/components/modules/Table.jsx
@@ -3,7 +3,7 @@ import uuid from 'uuid'
 import cx from 'classnames'
 import throttle from 'lodash/throttle'
 import { formatDateTime } from '$mp/utils/time'
-import moment from 'moment'
+import moment from 'moment-timezone'
 
 import UiSizeConstraint from '../UiSizeConstraint'
 import ModuleSubscription from '../ModuleSubscription'

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -3,7 +3,7 @@
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
-import moment from 'moment'
+import moment from 'moment-timezone'
 import copy from 'copy-to-clipboard'
 import { Translate, I18n } from 'react-redux-i18n'
 import Helmet from 'react-helmet'


### PR DESCRIPTION
Storybook seems broken because `Table` editor module used `moment.tz` and the imported lib was `'moment'` instead of `'moment-timezone'`. For some reason it works elsewhere 🤷‍♂ 

I changed also stream listing to use this lib, as that was another place where `moment.tz` is used.