### PR TITLE
[PLATFORM-1030] Disable share link for unsharable resources

### DIFF
--- a/app/src/shared/components/DropdownActions/index.jsx
+++ b/app/src/shared/components/DropdownActions/index.jsx
@@ -17,7 +17,7 @@ type Props = {
         className?: string,
         modifiers?: Object,
     },
-    onMenuToggle?: (boolean) => void,
+    onMenuToggle?: (boolean) => any,
     direction?: string,
 }
 

--- a/app/src/shared/components/Tile/index.jsx
+++ b/app/src/shared/components/Tile/index.jsx
@@ -17,7 +17,7 @@ type Props = {
     image?: ?Node,
     imageUrl?: string,
     dropdownActions?: Array<typeof DropdownActions.Item> | Node,
-    onMenuToggle?: (boolean) => void,
+    onMenuToggle?: (boolean) => any,
     className?: string,
     badges: subcomponents.BadgesType,
     labels: subcomponents.LabelsType,

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -161,7 +161,7 @@ class CanvasList extends Component<Props, State> {
                     <Translate value="userpages.canvases.menu.edit" />
                 </DropdownActions.Item>
                 <DropdownActions.Item
-                    disabled={!this.hasPermission(canvas.id, 'share')}
+                    disabled={!this.canBeSharedByCurrentUser(canvas.id)}
                     onClick={() => this.onOpenShareDialog(canvas)}
                 >
                     <Translate value="userpages.canvases.menu.share" />
@@ -225,14 +225,14 @@ class CanvasList extends Component<Props, State> {
         }
     }
 
-    hasPermission = (id: string, operation: string): boolean => {
+    canBeSharedByCurrentUser = (id: string): boolean => {
         const { fetchingPermissions, permissions, user } = this.props
 
         return (
             !fetchingPermissions &&
             !!user &&
             permissions[id] &&
-            permissions[id].find((p: Permission) => p.user === user.username && p.operation === operation) !== undefined
+            permissions[id].find((p: Permission) => p.user === user.username && p.operation === 'share') !== undefined
         )
     }
 

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -231,14 +231,14 @@ class StreamList extends Component<Props, State> {
         }
     }
 
-    hasPermission = (id: StreamId, operation: string): boolean => {
+    canBeSharedByCurrentUser = (id: StreamId): boolean => {
         const { fetchingPermissions, permissions, user } = this.props
 
         return (
             !fetchingPermissions &&
             !!user &&
             permissions[id] &&
-            permissions[id].find((p: Permission) => p.user === user.username && p.operation === operation) !== undefined
+            permissions[id].find((p: Permission) => p.user === user.username && p.operation === 'share') !== undefined
         )
     }
 
@@ -430,7 +430,7 @@ class StreamList extends Component<Props, State> {
                                                                 <Translate value="userpages.streams.actions.copySnippet" />
                                                             </DropdownActions.Item>
                                                             <DropdownActions.Item
-                                                                disabled={!this.hasPermission(stream.id, 'share')}
+                                                                disabled={!this.canBeSharedByCurrentUser(stream.id)}
                                                                 onClick={() => this.onOpenShareDialog(stream)}
                                                             >
                                                                 <Translate value="userpages.streams.actions.share" />

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -219,17 +219,6 @@ class StreamList extends Component<Props, State> {
         }
     }
 
-    hasWritePermission = (id: StreamId) => {
-        const { fetchingPermissions, permissions, user } = this.props
-
-        return (
-            !fetchingPermissions &&
-            !!user &&
-            permissions[id] &&
-            permissions[id].find((p: Permission) => p.user === user.username && p.operation === 'write') !== undefined
-        )
-    }
-
     onOpenShareDialog = (stream: Stream) => {
         this.setState({
             dialogTargetStream: stream,

--- a/app/src/userpages/modules/permission/actions.js
+++ b/app/src/userpages/modules/permission/actions.js
@@ -113,15 +113,17 @@ const saveRemovedResourcePermissionFailure = (resourceType: ResourceType, resour
     permission,
 })
 
-export const getResourcePermissions = (resourceType: ResourceType, resourceId: ResourceId) => async (dispatch: Function) => {
+export const getResourcePermissions = (resourceType: ResourceType, resourceId: ResourceId, notify: boolean = true) => async (dispatch: Function) => {
     dispatch(getResourcePermissionsRequest())
     const resourcePermissions = await api.get(`${getApiUrl(resourceType, resourceId)}/permissions`)
         .catch((error) => {
             dispatch(getResourcePermissionsFailure(error))
-            Notification.push({
-                title: error.message,
-                icon: NotificationIcon.ERROR,
-            })
+            if (notify) {
+                Notification.push({
+                    title: error.message,
+                    icon: NotificationIcon.ERROR,
+                })
+            }
             throw error
         })
     dispatch(getResourcePermissionsSuccess(resourceType, resourceId, resourcePermissions))


### PR DESCRIPTION
In this PR I disable the "Share" link when a user does not have permission to share a resource. Simple as that.

FYI, I didn't spend too much time on refactoring. First let's use hooks for both Stream and Canvas listing pages and then write some fancy reusable logic for utilizing permissions.

❗️ Requesting a merge into #749.