### PR TITLE
[PLATFORM-1064] Consistency pass on Toolbar menus

### DIFF
--- a/app/src/editor/canvas/components/Camera/state.js
+++ b/app/src/editor/canvas/components/Camera/state.js
@@ -345,6 +345,8 @@ export function shouldIgnoreEvent(state, event) {
     if (event.target.classList.contains(styles.noCameraControl)) { return true }
     // always ignore if target is editable
     if (isEditableElement(event.target)) { return true }
+    if (event.target.tagName === 'BUTTON') { return true }
+    if (event.target.tagName === 'A') { return true }
 
     // do not ignore if is within parent with cameraControl class
     const cameraControlEl = getParentMatching(event.target, `.${styles.cameraControl}`)

--- a/app/src/editor/canvas/components/CanvasSearch.jsx
+++ b/app/src/editor/canvas/components/CanvasSearch.jsx
@@ -29,6 +29,7 @@ export default connect((state) => ({
     }
 
     render() {
+        const { className } = this.props
         const search = this.state.search.trim().toLowerCase()
         const otherCanvases = this.props.canvases.filter(({ id }) => id !== this.props.canvas.id)
 
@@ -38,7 +39,7 @@ export default connect((state) => ({
         return (
             <SearchPanel
                 placeholder="Search or select a canvas"
-                className={styles.CanvasSearch}
+                className={cx(className, styles.CanvasSearch)}
                 onChange={this.onChange}
                 isOpen={this.props.isOpen}
                 open={this.props.open}

--- a/app/src/editor/canvas/components/CanvasSearch.pcss
+++ b/app/src/editor/canvas/components/CanvasSearch.pcss
@@ -1,5 +1,5 @@
 body .CanvasSearch {
-  top: -8px;
+  top: -12px;
   left: 0;
   bottom: initial;
   transform: translateY(-100%);
@@ -20,11 +20,16 @@ body .CanvasSearch {
   background: #2AC437;
 }
 
-.CanvasSearchRow {
+.CanvasSearch input {
+  height: 40px;
+}
+
+.CanvasSearch .CanvasSearchRow {
   padding: 0 16px;
   border-bottom: none;
   display: flex;
   align-items: center;
+  height: 32px;
 }
 
 .CanvasSearch a {

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -63,10 +63,6 @@ function ZoomButtons({ canvas }) {
                 </div>
             }
         >
-            <DropdownActions.Item onClick={() => camera.setScale(0.25)}>25%</DropdownActions.Item>
-            <DropdownActions.Item onClick={() => camera.setScale(0.5)}>50%</DropdownActions.Item>
-            <DropdownActions.Item onClick={() => camera.setScale(1)}>100%</DropdownActions.Item>
-            <DropdownActions.Item divider />
             <DropdownActions.Item onClick={() => camera.zoomIn()}>
                 Zoom In <span className={styles.menuShortcut}>{metaKeyLabel}=</span>
             </DropdownActions.Item>
@@ -79,6 +75,10 @@ function ZoomButtons({ canvas }) {
             <DropdownActions.Item onClick={() => canvasCamera.fitCanvas()}>
                 Fit Screen <span className={styles.menuShortcut}>{metaKeyLabel}1</span>
             </DropdownActions.Item>
+            <DropdownActions.Item divider />
+            <DropdownActions.Item onClick={() => camera.setScale(0.5)}>50%</DropdownActions.Item>
+            <DropdownActions.Item onClick={() => camera.setScale(1)}>100%</DropdownActions.Item>
+            <DropdownActions.Item onClick={() => camera.setScale(2)}>200%</DropdownActions.Item>
         </DropdownActions>
     )
 }

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -35,51 +35,51 @@ function ZoomButtons({ canvas }) {
     const canvasCamera = useCanvasCamera({ canvas })
     const metaKeyLabel = getKeyLabel('meta')
     return (
-        <div className={styles.ZoomButtons}>
-            <button
-                className={cx(styles.ToolbarButton, styles.ZoomButton)}
-                type="button"
-                onClick={() => camera.zoomOut()}
-            >
-                <SvgIcon name="minusSmall" className={styles.icon} />
-            </button>
-            <DropdownActions
-                title={
+        <DropdownActions
+            className={cx(styles.ZoomMenu, styles.DropdownMenu)}
+            noCaret
+            menuProps={{
+                className: styles.DropdownMenuMenu,
+            }}
+            title={
+                <div className={styles.ZoomButtons}>
+                    <button
+                        className={cx(styles.ToolbarButton, styles.ZoomButton)}
+                        type="button"
+                        onClick={(event) => { event.stopPropagation(); camera.zoomOut() }}
+                    >
+                        <SvgIcon name="minusSmall" className={styles.icon} />
+                    </button>
                     <button className={cx(styles.ZoomMenuTrigger)} type="button">
                         {Math.round(camera.scale * 100)}%
                     </button>
-                }
-                noCaret
-                className={cx(styles.ZoomMenu, styles.DropdownMenu)}
-                menuProps={{
-                    className: styles.DropdownMenuMenu,
-                }}
-            >
-                <DropdownActions.Item onClick={() => camera.setScale(0.25)}>25%</DropdownActions.Item>
-                <DropdownActions.Item onClick={() => camera.setScale(0.5)}>50%</DropdownActions.Item>
-                <DropdownActions.Item onClick={() => camera.setScale(1)}>100%</DropdownActions.Item>
-                <DropdownActions.Item divider />
-                <DropdownActions.Item onClick={() => camera.zoomIn()}>
-                    Zoom In <span className={styles.menuShortcut}>{metaKeyLabel}=</span>
-                </DropdownActions.Item>
-                <DropdownActions.Item onClick={() => camera.zoomOut()}>
-                    Zoom Out <span className={styles.menuShortcut}>{metaKeyLabel}-</span>
-                </DropdownActions.Item>
-                <DropdownActions.Item onClick={() => camera.setScale(1)}>
-                    Full Size <span className={styles.menuShortcut}>{metaKeyLabel}0</span>
-                </DropdownActions.Item>
-                <DropdownActions.Item onClick={() => canvasCamera.fitCanvas()}>
-                    Fit Screen <span className={styles.menuShortcut}>{metaKeyLabel}1</span>
-                </DropdownActions.Item>
-            </DropdownActions>
-            <button
-                className={cx(styles.ToolbarButton, styles.ZoomButton)}
-                type="button"
-                onClick={() => camera.zoomIn()}
-            >
-                <SvgIcon name="plusSmall" className={styles.icon} />
-            </button>
-        </div>
+                    <button
+                        className={cx(styles.ToolbarButton, styles.ZoomButton)}
+                        type="button"
+                        onClick={(event) => { event.stopPropagation(); camera.zoomIn() }}
+                    >
+                        <SvgIcon name="plusSmall" className={styles.icon} />
+                    </button>
+                </div>
+            }
+        >
+            <DropdownActions.Item onClick={() => camera.setScale(0.25)}>25%</DropdownActions.Item>
+            <DropdownActions.Item onClick={() => camera.setScale(0.5)}>50%</DropdownActions.Item>
+            <DropdownActions.Item onClick={() => camera.setScale(1)}>100%</DropdownActions.Item>
+            <DropdownActions.Item divider />
+            <DropdownActions.Item onClick={() => camera.zoomIn()}>
+                Zoom In <span className={styles.menuShortcut}>{metaKeyLabel}=</span>
+            </DropdownActions.Item>
+            <DropdownActions.Item onClick={() => camera.zoomOut()}>
+                Zoom Out <span className={styles.menuShortcut}>{metaKeyLabel}-</span>
+            </DropdownActions.Item>
+            <DropdownActions.Item onClick={() => camera.setScale(1)}>
+                Full Size <span className={styles.menuShortcut}>{metaKeyLabel}0</span>
+            </DropdownActions.Item>
+            <DropdownActions.Item onClick={() => canvasCamera.fitCanvas()}>
+                Fit Screen <span className={styles.menuShortcut}>{metaKeyLabel}1</span>
+            </DropdownActions.Item>
+        </DropdownActions>
     )
 }
 
@@ -233,6 +233,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         Open
                                     </R.Button>
                                     <CanvasSearch
+                                        className={styles.CanvasSearch}
                                         canvas={canvas}
                                         isOpen={canvasSearchIsOpen}
                                         open={this.canvasSearchOpen}

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -64,17 +64,17 @@ function ZoomControls({ className, canvas }) {
                     </div>
                 }
             >
-                <DropdownActions.Item onClick={() => camera.zoomIn()}>
-                    Zoom In <span className={styles.menuShortcut}>{metaKeyLabel}=</span>
-                </DropdownActions.Item>
-                <DropdownActions.Item onClick={() => camera.zoomOut()}>
-                    Zoom Out <span className={styles.menuShortcut}>{metaKeyLabel}-</span>
-                </DropdownActions.Item>
                 <DropdownActions.Item onClick={() => camera.setScale(1)}>
                     Full Size <span className={styles.menuShortcut}>{metaKeyLabel}0</span>
                 </DropdownActions.Item>
                 <DropdownActions.Item onClick={() => canvasCamera.fitCanvas()}>
                     Fit Screen <span className={styles.menuShortcut}>{metaKeyLabel}1</span>
+                </DropdownActions.Item>
+                <DropdownActions.Item onClick={() => camera.zoomIn()}>
+                    Zoom In <span className={styles.menuShortcut}>{metaKeyLabel}=</span>
+                </DropdownActions.Item>
+                <DropdownActions.Item onClick={() => camera.zoomOut()}>
+                    Zoom Out <span className={styles.menuShortcut}>{metaKeyLabel}-</span>
                 </DropdownActions.Item>
                 <DropdownActions.Item divider />
                 <DropdownActions.Item onClick={() => camera.setScale(0.5)}>50%</DropdownActions.Item>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -30,56 +30,58 @@ import * as RunController from './CanvasController/Run'
 import { useCameraContext } from './Camera'
 import styles from './Toolbar.pcss'
 
-function ZoomButtons({ canvas }) {
+function ZoomControls({ className, canvas }) {
     const camera = useCameraContext()
     const canvasCamera = useCanvasCamera({ canvas })
     const metaKeyLabel = getKeyLabel('meta')
     return (
-        <DropdownActions
-            className={cx(styles.ZoomMenu, styles.DropdownMenu)}
-            noCaret
-            menuProps={{
-                className: styles.DropdownMenuMenu,
-            }}
-            title={
-                <div className={styles.ZoomButtons}>
-                    <button
-                        className={cx(styles.ToolbarButton, styles.ZoomButton)}
-                        type="button"
-                        onClick={(event) => { event.stopPropagation(); camera.zoomOut() }}
-                    >
-                        <SvgIcon name="minusSmall" className={styles.icon} />
-                    </button>
-                    <button className={cx(styles.ZoomMenuTrigger)} type="button">
-                        {Math.round(camera.scale * 100)}%
-                    </button>
-                    <button
-                        className={cx(styles.ToolbarButton, styles.ZoomButton)}
-                        type="button"
-                        onClick={(event) => { event.stopPropagation(); camera.zoomIn() }}
-                    >
-                        <SvgIcon name="plusSmall" className={styles.icon} />
-                    </button>
-                </div>
-            }
-        >
-            <DropdownActions.Item onClick={() => camera.zoomIn()}>
-                Zoom In <span className={styles.menuShortcut}>{metaKeyLabel}=</span>
-            </DropdownActions.Item>
-            <DropdownActions.Item onClick={() => camera.zoomOut()}>
-                Zoom Out <span className={styles.menuShortcut}>{metaKeyLabel}-</span>
-            </DropdownActions.Item>
-            <DropdownActions.Item onClick={() => camera.setScale(1)}>
-                Full Size <span className={styles.menuShortcut}>{metaKeyLabel}0</span>
-            </DropdownActions.Item>
-            <DropdownActions.Item onClick={() => canvasCamera.fitCanvas()}>
-                Fit Screen <span className={styles.menuShortcut}>{metaKeyLabel}1</span>
-            </DropdownActions.Item>
-            <DropdownActions.Item divider />
-            <DropdownActions.Item onClick={() => camera.setScale(0.5)}>50%</DropdownActions.Item>
-            <DropdownActions.Item onClick={() => camera.setScale(1)}>100%</DropdownActions.Item>
-            <DropdownActions.Item onClick={() => camera.setScale(2)}>200%</DropdownActions.Item>
-        </DropdownActions>
+        <div className={cx(className, styles.ZoomControls)}>
+            <DropdownActions
+                className={cx(styles.ZoomMenu, styles.DropdownMenu)}
+                noCaret
+                menuProps={{
+                    className: styles.DropdownMenuMenu,
+                }}
+                title={
+                    <div className={styles.ZoomButtons}>
+                        <button
+                            className={cx(styles.ToolbarButton, styles.ZoomButton)}
+                            type="button"
+                            onClick={(event) => { event.stopPropagation(); camera.zoomOut() }}
+                        >
+                            <SvgIcon name="minusSmall" className={styles.icon} />
+                        </button>
+                        <button className={cx(styles.ZoomMenuTrigger)} type="button">
+                            {Math.round(camera.scale * 100)}%
+                        </button>
+                        <button
+                            className={cx(styles.ToolbarButton, styles.ZoomButton)}
+                            type="button"
+                            onClick={(event) => { event.stopPropagation(); camera.zoomIn() }}
+                        >
+                            <SvgIcon name="plusSmall" className={styles.icon} />
+                        </button>
+                    </div>
+                }
+            >
+                <DropdownActions.Item onClick={() => camera.zoomIn()}>
+                    Zoom In <span className={styles.menuShortcut}>{metaKeyLabel}=</span>
+                </DropdownActions.Item>
+                <DropdownActions.Item onClick={() => camera.zoomOut()}>
+                    Zoom Out <span className={styles.menuShortcut}>{metaKeyLabel}-</span>
+                </DropdownActions.Item>
+                <DropdownActions.Item onClick={() => camera.setScale(1)}>
+                    Full Size <span className={styles.menuShortcut}>{metaKeyLabel}0</span>
+                </DropdownActions.Item>
+                <DropdownActions.Item onClick={() => canvasCamera.fitCanvas()}>
+                    Fit Screen <span className={styles.menuShortcut}>{metaKeyLabel}1</span>
+                </DropdownActions.Item>
+                <DropdownActions.Item divider />
+                <DropdownActions.Item onClick={() => camera.setScale(0.5)}>50%</DropdownActions.Item>
+                <DropdownActions.Item onClick={() => camera.setScale(1)}>100%</DropdownActions.Item>
+                <DropdownActions.Item onClick={() => camera.setScale(2)}>200%</DropdownActions.Item>
+            </DropdownActions>
+        </div>
     )
 }
 
@@ -258,9 +260,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     </Tooltip>
                                 </div>
                             </div>
-                            <div className={styles.ToolbarZoomButtons}>
-                                <ZoomButtons canvas={canvas} />
-                            </div>
+                            <ZoomControls className={styles.ToolbarZoomControls} canvas={canvas} />
                             <div>
                                 <R.ButtonGroup
                                     className={cx(styles.RunButtonGroup, {

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -40,6 +40,18 @@
   margin: 0 1um;
 }
 
+.CanvasToolbar .CanvasSearch {
+  margin-bottom: 18px;
+}
+
+.CanvasToolbar :global(.btn) {
+  font-family: var(--sans);
+}
+
+.CanvasToolbar :global(.dropdown-item) {
+  line-height: 28px;
+}
+
 .ToolbarButton {
   &:global(.btn) {
     /* Reset button styles for toolbar */
@@ -48,7 +60,6 @@
     border: none;
     background: transparent;
     box-shadow: transparent;
-    font-family: inherit;
     text-transform: initial;
     padding: 12px;
   }
@@ -101,6 +112,17 @@
   }
 }
 
+.CanvasToolbar .DropdownMenu .DropdownMenuMenu {
+  padding-top: 4px;
+  padding-bottom: 4px;
+  margin-bottom: 10px;
+  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
+
+  & .show {
+    display: grid;
+  }
+}
+
 .CanvasNameContainer .DropdownMenu {
   margin-left: 8px;
 }
@@ -109,11 +131,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-}
-
-.CanvasNameContainer .DropdownMenu .DropdownMenuMenu {
-  margin-bottom: 10px;
-  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
 }
 
 .CanvasNameContainer .DropdownMenu svg {
@@ -148,12 +165,11 @@
 .RunButtonGroup :global(.btn) {
   border: none;
   box-shadow: transparent;
-  font-family: inherit;
+  font-family: var(--sans);
   color: #FFFFFF !important;
-  font-size: 14px !important;
+  font-size: 14px;
   font-weight: 500;
   text-align: center;
-  letter-spacing: 2px;
   text-transform: uppercase !important;
   line-height: 18px;
   border-radius: 4px;
@@ -175,7 +191,7 @@
 
 .RunButtonMenu {
   font-size: 12px;
-  padding: 8px;
+  padding: 0.5um 0;
   min-width: 152px !important;
   margin-bottom: 10px;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
@@ -183,10 +199,6 @@
   overflow: hidden;
 
   & :global(.dropdown-item) {
-    font-weight: 500;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    line-height: 1.2;
     transition: color 0.1s;
 
     &:not(:disabled) {
@@ -207,7 +219,6 @@ body .RealtimeRunButtonMenu {
   & :global(.dropdown-item):not(:disabled) {
     background: none;
     text-align: center;
-    color: #A3A3A3;
     padding-left: 0;
     padding-right: 0;
   }
@@ -215,8 +226,7 @@ body .RealtimeRunButtonMenu {
   & :global(.dropdown-item):active,
   & :global(.dropdown-item):hover,
   & :global(.dropdown-item):focus {
-    background: none;
-    color: #525252;
+    background-color: #F8F8F8;
   }
 }
 
@@ -228,9 +238,9 @@ body .RealtimeRunButtonMenu {
   & :global(.dropdown-item):active,
   & :global(.dropdown-item):hover,
   & :global(.dropdown-item):global(.active) {
-    background: url('../../../shared/assets/images/tick.svg') no-repeat 0 50%;
+    background: url('../../../shared/assets/images/tick.svg') no-repeat calc(100% - 14px) 50%;
+    background-color: #F8F8F8;
     outline: none;
-    background-color: transparent;
   }
 }
 
@@ -419,23 +429,26 @@ body .RealtimeRunButtonMenu {
   margin: 0 1um;
 }
 
-.ZoomButtons {
+body .ZoomButtons {
   display: flex;
   background: #FFFFFF;
-  border-radius: 4px;
-  color: #CDCDCD;
   align-items: center;
-  padding: 0 0.5um;
   line-height: 40px;
+  border-radius: 4px;
+  padding: 0 0.5um;
 }
 
-.ZoomButtons .ZoomMenuTrigger {
+.ZoomMenu {
+}
+
+.ToolbarZoomButtons .ZoomMenuTrigger {
   appearance: none;
+  transition: color 0.1s 0.2s;
   color: #CDCDCD;
   background: transparent;
   outline: none;
   border: none;
-  border-radius: inherit;
+  border-radius: 4px;
   margin: auto 0.5um;
   cursor: pointer;
   min-width: 48px; /* prevent jump when going from 2 to 3 digits e.g. 99% to 100% */
@@ -462,7 +475,7 @@ body .RealtimeRunButtonMenu {
   height: 1.5um;
   width: 1.5um;
   appearance: none;
-  border-radius: inherit;
+  border-radius: 4px;
   background: #F8F8F8;
   color: #A3A3A3;
   outline: none;

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -471,6 +471,7 @@ body .RealtimeRunButtonMenu {
 
   .ZoomMenu {
     .ZoomMenuTrigger {
+      display: inline-block;
       appearance: none;
       transition: color 0.1s;
       color: #CDCDCD;

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -425,69 +425,75 @@ body .RealtimeRunButtonMenu {
   color: #323232 !important;
 }
 
-.ToolbarZoomButtons {
+/**
+ * Zoom Controls
+ */
+
+.ToolbarZoomControls {
   margin: 0 1um;
 }
 
-body .ZoomButtons {
-  display: flex;
-  background: #FFFFFF;
-  align-items: center;
-  line-height: 40px;
-  border-radius: 4px;
-  padding: 0 0.5um;
-}
+.ZoomControls {
+  .ZoomButtons {
+    display: flex;
+    background: #FFFFFF;
+    align-items: center;
+    line-height: 40px;
+    border-radius: 4px;
+    padding: 0 0.5um;
 
-.ZoomMenu {
-}
+    .ZoomButton .icon {
+      height: 0.5um;
+      width: 0.5um;
+    }
 
-.ToolbarZoomButtons .ZoomMenuTrigger {
-  appearance: none;
-  transition: color 0.1s 0.2s;
-  color: #CDCDCD;
-  background: transparent;
-  outline: none;
-  border: none;
-  border-radius: 4px;
-  margin: auto 0.5um;
-  cursor: pointer;
-  min-width: 48px; /* prevent jump when going from 2 to 3 digits e.g. 99% to 100% */
-  text-align: center;
-}
+    .ZoomButton {
+      cursor: pointer;
+      height: 1.5um;
+      width: 1.5um;
+      appearance: none;
+      border-radius: 4px;
+      background: #F8F8F8;
+      color: #A3A3A3;
+      outline: none;
+      border: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
 
-.ZoomMenu:--enter .ZoomMenuTrigger {
-  outline: none;
-  color: #323232;
-}
+      &:--enter {
+        outline: none;
+        color: #323232;
+        background: #EFEFEF;
+      }
+    }
+  }
 
-.ZoomMenu button {
-  display: inline-flex;
-  justify-content: space-between;
-}
+  .ZoomMenu {
+    .ZoomMenuTrigger {
+      appearance: none;
+      transition: color 0.1s;
+      color: #CDCDCD;
+      background: transparent;
+      outline: none;
+      border: none;
+      border-radius: 4px;
+      margin: auto 0.5um;
+      cursor: pointer;
+      min-width: 48px; /* prevent jump when going from 2 to 3 digits e.g. 99% to 100% */
+      text-align: center;
+    }
 
-.ZoomButtons .ZoomButton .icon {
-  height: 0.5um;
-  width: 0.5um;
-}
+    &:global(.show) .ZoomMenuTrigger,
+    &:--enter .ZoomMenuTrigger {
+      outline: none;
+      color: #323232;
+    }
 
-.ZoomButtons .ZoomButton {
-  cursor: pointer;
-  height: 1.5um;
-  width: 1.5um;
-  appearance: none;
-  border-radius: 4px;
-  background: #F8F8F8;
-  color: #A3A3A3;
-  outline: none;
-  border: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  &:--enter {
-    outline: none;
-    color: #323232;
-    background: #EFEFEF;
+    button {
+      display: inline-flex;
+      justify-content: space-between;
+    }
   }
 }
 


### PR DESCRIPTION
* Changes vertical spacing in toolbar dropdowns to 28px.
* Reduces vertical spacing in canvas search to 32px.
* Aligns bottom of menus to same position (mostly)
* Uses sans font for all buttons and dropdown items
* Flips checkmark in historical speed menu from left to right side

Also resolves `PLATFORM-1126`:

* Changes order and content of zoom menu to match design
* Makes zoom menu same offset and width as the zoom controls area

Also:

* Prevents camera moving when using arrow keys in toolbar dropdown menu

#### Demo

![toolbar-menus-2](https://user-images.githubusercontent.com/43438/68103649-b7d20780-ff12-11e9-8b89-24e8cf310750.gif)

#### Mock

![image](https://user-images.githubusercontent.com/43438/68101767-455d2980-ff0a-11e9-84df-6a088b193675.png)