### PR TITLE
Test restarting canvas. WIP

### DIFF
--- a/app/src/editor/shared/tests/ModuleSubscription.test.jsx
+++ b/app/src/editor/shared/tests/ModuleSubscription.test.jsx
@@ -82,9 +82,51 @@ describe('Canvas Subscriptions', () => {
             await wait(10000)
             const receivedMessages = messages.slice() // copy before unmounting
             result.unmount()
-            // should have roughly 10 messages
-            expect(receivedMessages.length).toBeGreaterThanOrEqual(8)
-            expect(receivedMessages.length).toBeLessThanOrEqual(13)
+            await Services.stop(canvas)
+            const newRowMessages = receivedMessages.filter(({ nr }) => nr)
+            // should have roughly 10 new row messages
+            expect(newRowMessages.length).toBeTruthy()
+            expect(newRowMessages.length).toBeGreaterThanOrEqual(8)
+            expect(newRowMessages.length).toBeLessThanOrEqual(13)
+            done()
+        }, 15000)
+
+        it('should get canvas module subscription messages in restarted canvas', async (done) => {
+            let canvas = await Services.create()
+            canvas = State.addModule(canvas, await loadModuleDefinition('Clock'))
+            const clock = canvas.modules.find((m) => m.name === 'Clock')
+            canvas = State.addModule(canvas, await loadModuleDefinition('Table'))
+            const table = canvas.modules.find((m) => m.name === 'Table')
+            const clockDateOut = State.findModulePort(canvas, clock.hash, (p) => p.name === 'date')
+            const tableIn1 = State.findModulePort(canvas, table.hash, (p) => p.displayName === 'in1')
+            canvas = State.updateCanvas(State.connectPorts(canvas, clockDateOut.id, tableIn1.id))
+            canvas = State.updateCanvas(await Services.start(canvas))
+            const messages = []
+
+            const result = mount((
+                <ClientProviderComponent apiKey={apiKey}>
+                    <ModuleSubscription
+                        module={canvas.modules.find((m) => m.name === 'Table')}
+                        onMessage={(message) => {
+                            messages.push(message)
+                        }}
+                        isSubscriptionActive
+                    />
+                </ClientProviderComponent>
+            ))
+
+            canvas = State.updateCanvas(await Services.stop(canvas))
+            canvas = State.updateCanvas(await Services.start(canvas))
+
+            await wait(10000)
+            const receivedMessages = messages.slice() // copy before unmounting
+            result.unmount()
+            await Services.stop(canvas)
+            const newRowMessages = receivedMessages.filter(({ nr }) => nr)
+            // should have roughly 10 new row messages
+            expect(newRowMessages.length).toBeTruthy()
+            expect(newRowMessages.length).toBeGreaterThanOrEqual(8)
+            expect(newRowMessages.length).toBeLessThanOrEqual(13)
             done()
         }, 20000)
     })

--- a/app/src/editor/shared/tests/Subscription.test.jsx
+++ b/app/src/editor/shared/tests/Subscription.test.jsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { mount } from 'enzyme'
 import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
+import { act } from 'react-dom/test-utils'
 import uniqueId from 'lodash/uniqueId'
 
 import api from '../utils/api'
@@ -61,6 +62,30 @@ describe('Subscription', () => {
         afterEach(async () => {
             await teardown()
         })
+
+        it('unsubscribes on isActive false', async (done) => {
+            const Test = () => {
+                const [isActive, setIsActive] = useState(true)
+                return (
+                    <ClientProviderComponent apiKey={apiKey}>
+                        <Subscription
+                            uiChannel={stream}
+                            onSubscribed={() => {
+                                act(() => {
+                                    setIsActive(false)
+                                })
+                            }}
+                            onUnsubscribed={() => {
+                                done()
+                            }}
+                            isActive={isActive}
+                        />
+                    </ClientProviderComponent>
+                )
+            }
+
+            mount(<Test />)
+        }, 15000)
 
         it('can create subscription', async (done) => {
             const msg = { test: uniqueId() }

--- a/app/src/editor/shared/tests/Subscription.test.jsx
+++ b/app/src/editor/shared/tests/Subscription.test.jsx
@@ -215,7 +215,7 @@ describe('Subscription', () => {
                         resendLast={0}
                         onSubscribed={async () => {
                             await stream.publish(msg3)
-                            await wait(5000)
+                            await wait(15000)
                             expect(onResending).not.toHaveBeenCalled()
                             expect(messages).toEqual([msg3])
                             result.unmount()
@@ -230,6 +230,6 @@ describe('Subscription', () => {
                     />
                 </ClientProviderComponent>
             ))
-        }, 20000)
+        }, 30000)
     })
 })

--- a/app/src/editor/shared/tests/Subscription.test.jsx
+++ b/app/src/editor/shared/tests/Subscription.test.jsx
@@ -215,7 +215,7 @@ describe('Subscription', () => {
                         resendLast={0}
                         onSubscribed={async () => {
                             await stream.publish(msg3)
-                            await wait(500)
+                            await wait(5000)
                             expect(onResending).not.toHaveBeenCalled()
                             expect(messages).toEqual([msg3])
                             result.unmount()
@@ -230,6 +230,6 @@ describe('Subscription', () => {
                     />
                 </ClientProviderComponent>
             ))
-        }, 15000)
+        }, 20000)
     })
 })

--- a/app/src/shared/components/Subscription/index.jsx
+++ b/app/src/shared/components/Subscription/index.jsx
@@ -216,11 +216,13 @@ class Subscription extends Component<Props> {
             subscription.off('resent', this.onResent)
             subscription.off('no_resend', this.onNoResend)
             subscription.off('error', this.onError)
-            subscription.off('unsubscribed', this.onUnsubscribed)
-            client.unsubscribe(subscription)
         }
         this.subscription = undefined
         this.isSubscribed = false
+        subscription.once('unsubscribed', () => {
+            subscription.off('unsubscribed', this.onSubscribed)
+        })
+        client.unsubscribe(subscription)
     }
 
     handleKnownMessageTypes = (message, ...args) => {


### PR DESCRIPTION
Adds a test that checks module data is flowing on a canvas that has been restarted, based on this report by @fonty1: https://github.com/streamr-dev/streamr-platform/pull/735#issuecomment-547766988

Seems to fail currently. 

WIP