### PR TITLE
Remove withCredentials from requests

### DIFF
--- a/app/src/auth/utils/post.js
+++ b/app/src/auth/utils/post.js
@@ -14,7 +14,6 @@ export default (url: string, form: FormFields, successWithError: boolean, xhr?: 
                     'X-Requested-With': 'XMLHttpRequest',
                 } : {}),
             },
-            withCredentials: true,
         })
         .then(({ data }) => {
             if (successWithError && data.error) {

--- a/app/src/editor/shared/utils/api.js
+++ b/app/src/editor/shared/utils/api.js
@@ -10,6 +10,5 @@ export default () => (
             ...getAuthorizationHeader(),
             'Content-Type': 'application/json',
         },
-        withCredentials: true,
     }))
 )

--- a/app/src/shared/utils/request.js
+++ b/app/src/shared/utils/request.js
@@ -39,7 +39,6 @@ export default function request(url: string, method: RequestMethod = 'get', data
         url,
         method,
         data,
-        withCredentials: true,
     })
         .then((res) => (
             getData(res)

--- a/app/test/unit/components/AuthPage/utils/post.test.js
+++ b/app/test/unit/components/AuthPage/utils/post.test.js
@@ -49,14 +49,6 @@ describe('post', () => {
         expect(request.config.data).toEqual('param=value')
     })
 
-    it('posts with withCredentials flag set to true', async () => {
-        post('url', {}, false)
-        await moxios.promiseWait()
-        const request = moxios.requests.mostRecent()
-
-        expect(request.config.withCredentials).toBe(true)
-    })
-
     it('resolves on success with response body', async () => {
         moxios.stubRequest('url', {
             status: 200,


### PR DESCRIPTION
Removes `withCredentials: true` from `utils/request.js`. This should not be needed anymore for every request we make. I believe this was added when we used cookies for authentication. Now with token based authentication we don't need this.

Everything seemed to work fine with this line removed. Can you think of anything that could possibly break because of this?

The need for this occured because some new CP endpoints are sending a wildcard CORS header `Access-Control-Allow-Origin: *` which does not work if we use `withCredentials`.