### PR TITLE
[DOCS-101] Module Ref Fixes

### DIFF
--- a/app/src/docs/components/CanvasModuleHelp/canvasModuleHelp.pcss
+++ b/app/src/docs/components/CanvasModuleHelp/canvasModuleHelp.pcss
@@ -52,6 +52,7 @@ section.root {
 
 .nameAndDescription {
   margin-bottom: 1.8rem;
+  word-break: break-word;
 
   p {
     font-size: 18px;

--- a/app/src/docs/components/CanvasModuleHelp/index.jsx
+++ b/app/src/docs/components/CanvasModuleHelp/index.jsx
@@ -17,16 +17,35 @@ type PortHelpProps = {
 // doesn't play well with inline elements.
 const capitalizeText = (text: string): string => text.charAt(0).toUpperCase() + text.slice(1)
 
+const hasTrailingFullStop = (text: string): string => {
+    if (text.slice(-1) === '.') {
+        return true
+    }
+    return false
+}
+
 function PortHelp({ help, port }: PortHelpProps) {
+    const portName = capitalizeText(port.displayName || port.name)
+
     return (
         <div className={styles.portHelp}>
-            <span className={styles.portName} title={port.name}>{port.displayName || port.name}</span>
-            {port.type.split(/\s+/).map((type) => (
-                <span className={styles.portType} key={type}> {type}.</span>
-            ))}
-            {!help ? null : (<span className={styles.portText}> <ReactMarkdown source={capitalizeText(help) || ''} />.</span>)}
+            <span className={styles.portName} title={port.name}>{portName}</span>
+            {port.type.split(/\s+/).map((type) => {
+                const portType = capitalizeText(type)
+                return (
+                    <span className={styles.portType} key={type}>
+                        {portType === portName && help ? '.' : ` ${type}${hasTrailingFullStop(portType) ? null : '.'}`}
+                    </span>
+                )
+            })}
+            {!help ? null
+                : (
+                    <span className={styles.portText}> <ReactMarkdown source={capitalizeText(help) || ''} />
+                        {hasTrailingFullStop(help) ? null : '.'}
+                    </span>
+                )}
             {isEmpty(port.defaultValue) ? null : (
-                <span className={styles.defaultValue}> Default Value ${port.defaultValue}</span>
+                <span className={styles.defaultValue}> Default Value ${port.defaultValue}{hasTrailingFullStop(port.defaultValue) ? null : '.'}</span>
             )}
         </div>
     )

--- a/app/src/docs/content/moduleReference/CountByKey-221.jsx
+++ b/app/src/docs/content/moduleReference/CountByKey-221.jsx
@@ -22,7 +22,7 @@ export default {
         ],
         outputs: {
             map: 'Key-count pairs',
-            valueOfCurrentKey: 'The occurrence count of the last key received. ',
+            valueOfCurrentKey: 'The occurrence count of the last key received.',
         },
         outputNames: [
             'map',

--- a/app/src/docs/content/moduleReference/Map_geo-214.md
+++ b/app/src/docs/content/moduleReference/Map_geo-214.md
@@ -1,5 +1,5 @@
 
 [comment]: # (VisualizationsCanvasModule)
-This module displays a world map. Markers can be drawn on the map at WGS84 coordinates given to the inputs **latitude** and **longitude** as decimal numbers (degrees). Markers also have an **id**. To draw multiple markers, connect the **id** input. Coordinates for the same id will move the marker, and coordinates for a new id will create a new marker.  
+This module displays a world map. Markers can be drawn on the map at WGS84 coordinates given to the inputs **latitude** and **longitude** as decimal numbers (degrees). Markers also have an **id**. To draw multiple markers, connect the **id** input. Coordinates for the same id will move the marker, and coordinates for a new id will create a new marker.  
 
 In module options, you can enable directional markers to expose an additional **heading** input, which controls marker heading (e.g. vehicles on the street or ships at sea). Other options include marker coloring, autozoom behavior etc.

--- a/app/src/docs/content/moduleReference/Split-203.md
+++ b/app/src/docs/content/moduleReference/Split-203.md
@@ -1,16 +1,10 @@
 
 [comment]: # (TextCanvasModule)
-Splits the text by a given separator and outputs a list with the results  
+Splits the text by a given separator and outputs a list with the results.
 
+**Example**  
+Separator: `" "` (empty space)
 
+Text: `"Two Words"`
 
-Examples:  
-
-
-
-
-
-	- Separator: " "(empty space),Text: "Two Words"
-	
-
-		   - Output: Two, Words
+Output: `Two, Words`

--- a/app/src/docs/content/moduleReference/SumByKey-222.jsx
+++ b/app/src/docs/content/moduleReference/SumByKey-222.jsx
@@ -26,7 +26,7 @@ export default {
         ],
         outputs: {
             map: 'Key-sum pairs',
-            valueOfCurrentKey: 'The aggregated sum of the last key received. ',
+            valueOfCurrentKey: 'The aggregated sum of the last key received.',
         },
         outputNames: [
             'map',


### PR DESCRIPTION
Fixes:

**Map Geo**
- remove unnecessary linebreak after "WGS84 coordinates given to the" and before  "inputs latitude and longitude" in the .md file
- line 21 in the .jsx file - remove unnecessary period at end of line (shows as double periods in docs)

**Sum by Key**
- all entries in Input sections have 2 periods at end of line. ie remove the ones in the JSX file as looks like yr adding periods programatically.

**Split Help**
- code examples have very weird spacing - maybe an unnecessary line break in between them ?
- Outputs shows "List List" ie remove the unnecessary "list"

**Expression**
- link in .md file somehow breaks out of text box

Also adds some code that defends against double full stops and doubling of name and type when they are identical (Split Help issue).