### PR TITLE
Calculate Community product deployment estimate

### DIFF
--- a/app/src/marketplace/components/Modal/DeployingCommunityDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/DeployingCommunityDialog/index.jsx
@@ -13,6 +13,7 @@ import styles from './deployingCommunityDialog.pcss'
 
 export type Props = {
     product: Product,
+    estimate: number,
     onClose: () => void,
     onContinue: () => void,
 }
@@ -24,39 +25,35 @@ const formatSeconds = (seconds) => {
     return timeValue.substr(0, 2) === '00' ? timeValue.substr(3) : timeValue
 }
 
-const DeployingCommunityDialog = ({ product, onClose, onContinue }: Props) => {
-    const estimate = 205
-
-    return (
-        <Modal>
-            <Dialog
-                className={cx(styles.root, styles.DeployingCommunityDialog)}
-                title={I18n.t('modal.deployCommunity.deploying.title', {
-                    name: product.name,
-                })}
-                onClose={onClose}
-                contentClassName={styles.content}
-                actions={{
-                    continue: {
-                        title: I18n.t('modal.common.close'),
-                        outline: true,
-                        onClick: onContinue,
-                    },
-                }}
-            >
-                <div className={styles.spinner}>
-                    <DeploySpinner isRunning showCounter />
-                </div>
-                <div className={styles.description}>
-                    <Translate
-                        value="modal.deployCommunity.deploying.description"
-                        time={formatSeconds(estimate)}
-                        dangerousHTML
-                    />
-                </div>
-            </Dialog>
-        </Modal>
-    )
-}
+const DeployingCommunityDialog = ({ product, estimate, onClose, onContinue }: Props) => (
+    <Modal>
+        <Dialog
+            className={cx(styles.root, styles.DeployingCommunityDialog)}
+            title={I18n.t('modal.deployCommunity.deploying.title', {
+                name: product.name,
+            })}
+            onClose={onClose}
+            contentClassName={styles.content}
+            actions={{
+                continue: {
+                    title: I18n.t('modal.common.close'),
+                    outline: true,
+                    onClick: onContinue,
+                },
+            }}
+        >
+            <div className={styles.spinner}>
+                <DeploySpinner isRunning showCounter />
+            </div>
+            <div className={styles.description}>
+                <Translate
+                    value="modal.deployCommunity.deploying.description"
+                    time={formatSeconds(estimate)}
+                    dangerousHTML
+                />
+            </div>
+        </Dialog>
+    </Modal>
+)
 
 export default DeployingCommunityDialog

--- a/app/src/marketplace/containers/EditProductPage2/DeployCommunityModal.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/DeployCommunityModal.jsx
@@ -44,8 +44,8 @@ function setSkipGuide(value) {
     storage.setItem(SKIP_GUIDE_KEY, JSON.stringify(value))
 }
 
-// allow 60s for the API to start in CP server
-const API_READY_ESTIMATE = 60
+// allow 5s for the API to start in CP server
+const API_READY_ESTIMATE = 5
 
 export const DeployDialog = ({ product, api, updateAddress }: DeployDialogProps) => {
     const dontShowAgain = skipGuide()
@@ -72,9 +72,8 @@ export const DeployDialog = ({ product, api, updateAddress }: DeployDialogProps)
 
         // Set estimate
         const blockEstimate = await averageBlockTime(getWeb3())
-        setEstimate(blockEstimate + API_READY_ESTIMATE)
-
         if (!isMounted()) { return Promise.resolve() }
+        setEstimate(blockEstimate + API_READY_ESTIMATE)
 
         return new Promise((resolve) => (
             deployContract(joinPartStreamId, adminFee)

--- a/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx
+++ b/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx
@@ -3,19 +3,14 @@
 import React, { type Node } from 'react'
 import { connect } from 'react-redux'
 
-import getWeb3 from '$shared/web3/web3Provider'
 import { selectAccountId } from '$mp/modules/web3/selectors'
-import { selectDataPerUsd, selectIsWeb3Injected } from '$mp/modules/global/selectors'
+import { selectDataPerUsd } from '$mp/modules/global/selectors'
 import { receiveAccount, changeAccount, accountError, updateEthereumNetworkId } from '$mp/modules/web3/actions'
 import type { StoreState } from '$shared/flowtype/store-state'
 import type { Address, Hash, Receipt } from '$shared/flowtype/web3-types'
-import type { StreamrWeb3 as StreamrWeb3Type } from '$shared/web3/web3Provider'
 import type { ErrorInUi, TransactionType, NumberString } from '$shared/flowtype/common-types'
 import { getUserData } from '$shared/modules/user/actions'
-import {
-    getDataPerUsd as getDataPerUsdAction,
-    checkWeb3 as checkWeb3Action,
-} from '$mp/modules/global/actions'
+import { getDataPerUsd as getDataPerUsdAction } from '$mp/modules/global/actions'
 import { areAddressesEqual } from '$mp/utils/smartContract'
 import {
     addTransaction as addTransactionAction,
@@ -41,7 +36,6 @@ type DispatchProps = {
     getUserData: () => void,
     getDataPerUsd: () => void,
     updateEthereumNetworkId: (id: any) => void,
-    checkWeb3: (?boolean) => void,
     addTransaction: (Hash, TransactionType) => void,
     completeTransaction: (Hash, Receipt) => void,
     transactionError: (Hash, TransactionError) => void,
@@ -55,8 +49,6 @@ const PENDING_TX_WAIT = 1000 // 1s
 
 export class GlobalInfoWatcher extends React.Component<Props> {
     componentDidMount = () => {
-        this.initWeb3()
-
         // Start polling for info
         this.pollDataPerUsdRate()
         this.pollLogin()
@@ -81,12 +73,6 @@ export class GlobalInfoWatcher extends React.Component<Props> {
 
     loginPollTimeout: ?TimeoutID = null
     dataPerUsdRatePollTimeout: ?TimeoutID = null
-    web3: StreamrWeb3Type = getWeb3()
-
-    initWeb3 = () => {
-        this.web3 = getWeb3()
-        this.props.checkWeb3()
-    }
 
     pollLogin = () => {
         this.props.getUserData()
@@ -161,7 +147,6 @@ export class GlobalInfoWatcher extends React.Component<Props> {
 export const mapStateToProps = (state: StoreState): StateProps => ({
     account: selectAccountId(state),
     dataPerUsd: selectDataPerUsd(state),
-    isWeb3Injected: selectIsWeb3Injected(state),
 })
 
 export const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
@@ -171,7 +156,6 @@ export const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
     getUserData: () => dispatch(getUserData()),
     getDataPerUsd: () => dispatch(getDataPerUsdAction()),
     updateEthereumNetworkId: (id: any) => dispatch(updateEthereumNetworkId(id)),
-    checkWeb3: () => dispatch(checkWeb3Action()),
     addTransaction: (id: Hash, type: TransactionType) => dispatch(addTransactionAction(id, type)),
     completeTransaction: (id: Hash, receipt: Receipt) => dispatch(completeTransactionAction(id, receipt)),
     transactionError: (id: Hash, error: TransactionError) => dispatch(transactionErrorAction(id, error)),

--- a/app/src/marketplace/flowtype/store-state.js
+++ b/app/src/marketplace/flowtype/store-state.js
@@ -183,8 +183,6 @@ export type GlobalState = {
     fetchingDataPerUsdRate: boolean,
     dataPerUsdRateError: ?TransactionError,
     ethereumNetworkError: ?TransactionError,
-    metamaskPermission: ?boolean,
-    isWeb3Injected: ?boolean,
 }
 
 // transactions

--- a/app/src/marketplace/modules/global/actions.js
+++ b/app/src/marketplace/modules/global/actions.js
@@ -12,10 +12,8 @@ import {
     CHECK_ETHEREUM_NETWORK_REQUEST,
     CHECK_ETHEREUM_NETWORK_SUCCESS,
     CHECK_ETHEREUM_NETWORK_FAILURE,
-    UPDATE_METAMASK_PERMISSION,
-    CHECK_WEB3,
 } from './constants'
-import type { DataPerUsdActionCreator, GlobalEthereumErrorActionCreator, MetamaskPermissionActionCreator, IsWeb3InjectedActionCreator } from './types'
+import type { DataPerUsdActionCreator, GlobalEthereumErrorActionCreator } from './types'
 import * as services from './services'
 
 const getDataPerUsdRequest: ReduxActionCreator = createAction(GET_DATA_USD_RATE_REQUEST)
@@ -71,22 +69,4 @@ export const checkEthereumNetwork = () => (dispatch: Function) => {
                 }))
             },
         )
-}
-
-export const updateMetamaskPermission: MetamaskPermissionActionCreator = createAction(
-    UPDATE_METAMASK_PERMISSION,
-    (metamaskPermission: boolean) => ({
-        metamaskPermission,
-    }),
-)
-const checkWeb3Success: IsWeb3InjectedActionCreator = createAction(
-    CHECK_WEB3,
-    (isWeb3Injected: boolean) => ({
-        isWeb3Injected,
-    }),
-)
-
-export const checkWeb3 = (confirmedInjection: boolean = false) => (dispatch: Function) => {
-    const isWeb3Injected = confirmedInjection || services.isWeb3Injected()
-    dispatch(checkWeb3Success(isWeb3Injected))
 }

--- a/app/src/marketplace/modules/global/constants.js
+++ b/app/src/marketplace/modules/global/constants.js
@@ -7,6 +7,3 @@ export const GET_DATA_USD_RATE_FAILURE: string = 'marketplace/global/GET_DATA_US
 export const CHECK_ETHEREUM_NETWORK_REQUEST: string = 'marketplace/global/CHECK_ETHEREUM_NETWORK_REQUEST'
 export const CHECK_ETHEREUM_NETWORK_SUCCESS: string = 'marketplace/global/CHECK_ETHEREUM_NETWORK_SUCCESS'
 export const CHECK_ETHEREUM_NETWORK_FAILURE: string = 'marketplace/global/CHECK_ETHEREUM_NETWORK_FAILURE'
-
-export const UPDATE_METAMASK_PERMISSION: string = 'marketplace/global/UPDATE_METAMASK_PERMISSION'
-export const CHECK_WEB3: string = 'marketplace/global/CHECK_WEB3'

--- a/app/src/marketplace/modules/global/reducer.js
+++ b/app/src/marketplace/modules/global/reducer.js
@@ -11,10 +11,8 @@ import {
     CHECK_ETHEREUM_NETWORK_REQUEST,
     CHECK_ETHEREUM_NETWORK_SUCCESS,
     CHECK_ETHEREUM_NETWORK_FAILURE,
-    UPDATE_METAMASK_PERMISSION,
-    CHECK_WEB3,
 } from './constants'
-import type { DataPerUsdAction, GlobalEthereumErrorAction, MetamaskPermissionAction, IsWeb3InjectedAction } from './types'
+import type { DataPerUsdAction, GlobalEthereumErrorAction } from './types'
 
 export const initialState: GlobalState = {
     dataPerUsd: null,
@@ -23,8 +21,6 @@ export const initialState: GlobalState = {
     fetchingDataPerUsdRate: false,
     ethereumNetworkError: null,
     dataPerUsdRateError: null,
-    metamaskPermission: false,
-    isWeb3Injected: null,
 }
 
 const reducer: (GlobalState) => GlobalState = handleActions({
@@ -61,16 +57,6 @@ const reducer: (GlobalState) => GlobalState = handleActions({
         ethereumNetworkIsCorrect: false,
         ethereumNetworkError: action.payload.error,
         checkingNetwork: false,
-    }),
-
-    [UPDATE_METAMASK_PERMISSION]: (state: GlobalState, action: MetamaskPermissionAction) => ({
-        ...state,
-        metamaskPermission: action.payload.metamaskPermission,
-    }),
-
-    [CHECK_WEB3]: (state: GlobalState, action: IsWeb3InjectedAction) => ({
-        ...state,
-        isWeb3Injected: action.payload.isWeb3Injected,
     }),
 
 }, initialState)

--- a/app/src/marketplace/modules/global/selectors.js
+++ b/app/src/marketplace/modules/global/selectors.js
@@ -28,13 +28,3 @@ export const selectEthereumNetworkError: (StoreState) => ?TransactionError = cre
     selectGlobalState,
     (subState: GlobalState): ?TransactionError => subState.ethereumNetworkError,
 )
-
-export const selectMetamaskPermission: (StoreState) => boolean = createSelector(
-    selectGlobalState,
-    (subState: GlobalState): ?boolean => subState.metamaskPermission,
-)
-
-export const selectIsWeb3Injected: (StoreState) => boolean = createSelector(
-    selectGlobalState,
-    (subState: GlobalState): boolean => (subState.isWeb3Injected != null ? subState.isWeb3Injected : false),
-)

--- a/app/src/marketplace/modules/global/services.js
+++ b/app/src/marketplace/modules/global/services.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { getContract, call } from '$mp/utils/smartContract'
-import { isWeb3Injected as isWeb3InjectedUtil } from '$mp/utils/web3'
 import { checkEthereumNetworkIsCorrect as checkEthereumNetworkIsCorrectUtil } from '$shared/utils/web3'
 import getConfig from '$shared/web3/config'
 import getWeb3 from '$shared/web3/web3Provider'
@@ -15,5 +14,3 @@ export const getDataPerUsd = (): SmartContractCall<NumberString> => call(marketp
     .then((value) => fromAtto(value).toString())
 
 export const checkEthereumNetworkIsCorrect = (): Promise<void> => (checkEthereumNetworkIsCorrectUtil(getWeb3()))
-
-export const isWeb3Injected = (): boolean => isWeb3InjectedUtil(getWeb3())

--- a/app/src/marketplace/modules/global/types.js
+++ b/app/src/marketplace/modules/global/types.js
@@ -11,12 +11,3 @@ export type GlobalEthereumErrorAction = PayloadAction<{
     error: ErrorInUi,
 }>
 export type GlobalEthereumErrorActionCreator = (ErrorInUi) => GlobalEthereumErrorAction
-
-export type MetamaskPermissionAction = PayloadAction<{
-    metamaskPermission: boolean,
-}>
-export type MetamaskPermissionActionCreator = (boolean) => MetamaskPermissionAction
-export type IsWeb3InjectedAction = PayloadAction<{
-    isWeb3Injected: boolean,
-}>
-export type IsWeb3InjectedActionCreator = (boolean) => IsWeb3InjectedAction

--- a/app/src/marketplace/utils/web3.js
+++ b/app/src/marketplace/utils/web3.js
@@ -23,6 +23,3 @@ export const getDataTokenBalance = (web3Instance: StreamrWeb3): SmartContractCal
     .then((myAddress) => call(tokenContractMethods().balanceOf(myAddress)))
     .then(fromAtto).then((result) => result.toString())
 )
-
-export const isWeb3Injected = (web3Instance: StreamrWeb3): boolean =>
-    web3Instance && (web3Instance.currentProvider != null)

--- a/app/src/shared/utils/web3.js
+++ b/app/src/shared/utils/web3.js
@@ -28,3 +28,17 @@ export const hasTransactionCompleted = (txHash: Hash): Promise<boolean> => {
     return web3.eth.getTransaction(txHash)
         .then((trx) => !!(trx && trx.blockNumber))
 }
+
+export const averageBlockTime = async (web3Instance: StreamrWeb3, blocksAgo: number = 500) => {
+    // Get the current block number
+    const currentBlockNumber = await web3Instance.eth.getBlockNumber()
+
+    // Get the current block
+    const currentBlock = await web3Instance.eth.getBlock(currentBlockNumber)
+
+    // Get the block X blocks ago
+    const thenBlock = await web3Instance.eth.getBlock(currentBlockNumber - blocksAgo)
+
+    // Take the average of the then and now timestamps
+    return (currentBlock.timestamp - thenBlock.timestamp) / blocksAgo
+}

--- a/app/src/shared/utils/web3.js
+++ b/app/src/shared/utils/web3.js
@@ -29,6 +29,13 @@ export const hasTransactionCompleted = (txHash: Hash): Promise<boolean> => {
         .then((trx) => !!(trx && trx.blockNumber))
 }
 
+/**
+ * Estimates time it takes to mine one block on the blockchain by counting the average time
+ * between the current and the given amount of previous blocks.
+ *
+ * @param {*} web3Instance Web3 instance
+ * @param {*} blocksAgo How many previous blocks to include
+ */
 export const averageBlockTime = async (web3Instance: StreamrWeb3, blocksAgo: number = 500) => {
     // Get the current block number
     const currentBlockNumber = await web3Instance.eth.getBlockNumber()

--- a/app/src/shared/utils/web3.js
+++ b/app/src/shared/utils/web3.js
@@ -36,7 +36,7 @@ export const averageBlockTime = async (web3Instance: StreamrWeb3, blocksAgo: num
     // Get the current block
     const currentBlock = await web3Instance.eth.getBlock(currentBlockNumber)
 
-    // Get the block X blocks ago
+    // Get the block X number of blocks ago
     const thenBlock = await web3Instance.eth.getBlock(currentBlockNumber - blocksAgo)
 
     // Take the average of the then and now timestamps

--- a/app/test/unit/containers/GlobalInfoWatcher/GlobalInfoWatcher.test.jsx
+++ b/app/test/unit/containers/GlobalInfoWatcher/GlobalInfoWatcher.test.jsx
@@ -32,7 +32,6 @@ describe('GlobalInfoWatcher', () => {
             getUserData: sandbox.spy(),
             getDataPerUsd: sandbox.spy(),
             updateEthereumNetworkId: sandbox.spy(),
-            checkWeb3: sandbox.spy(),
             addTransaction: sandbox.spy(),
             completeTransaction: sandbox.spy(),
             transactionError: sandbox.spy(),
@@ -67,7 +66,6 @@ describe('GlobalInfoWatcher', () => {
         const expectedProps = {
             account,
             dataPerUsd,
-            isWeb3Injected: false,
         }
 
         assert.deepStrictEqual(mapStateToProps(state), expectedProps)
@@ -81,7 +79,6 @@ describe('GlobalInfoWatcher', () => {
         sandbox.stub(userActions, 'getUserData').callsFake(() => 'getUserData')
         sandbox.stub(globalActions, 'getDataPerUsd').callsFake(() => 'getDataPerUsd')
         const updateEthereumNetworkIdStub = sandbox.stub(web3Actions, 'updateEthereumNetworkId').callsFake(() => 'updateEthereumNetworkId')
-        sandbox.stub(globalActions, 'checkWeb3').callsFake(() => 'checkWeb3')
         const addTransactionStub = sandbox.stub(transactionActions, 'addTransaction').callsFake(() => 'addTransaction')
         const completeTransactionStub = sandbox.stub(transactionActions, 'completeTransaction').callsFake(() => 'completeTransaction')
         const transactionErrorStub = sandbox.stub(transactionActions, 'transactionError').callsFake(() => 'transactionError')
@@ -94,7 +91,6 @@ describe('GlobalInfoWatcher', () => {
             getUserData: actions.getUserData(),
             getDataPerUsd: actions.getDataPerUsd(),
             updateEthereumNetworkId: actions.updateEthereumNetworkId('1'),
-            checkWeb3: actions.checkWeb3(),
             addTransaction: actions.addTransaction('txHash', 'purchase'),
             completeTransaction: actions.completeTransaction('txHash', 'receipt'),
             transactionError: actions.transactionError('txHash', 'error'),
@@ -106,7 +102,6 @@ describe('GlobalInfoWatcher', () => {
             getUserData: 'getUserData',
             getDataPerUsd: 'getDataPerUsd',
             updateEthereumNetworkId: 'updateEthereumNetworkId',
-            checkWeb3: 'checkWeb3',
             addTransaction: 'addTransaction',
             completeTransaction: 'completeTransaction',
             transactionError: 'transactionError',

--- a/app/test/unit/containers/WithContractProduct/WithContractProduct.test.jsx
+++ b/app/test/unit/containers/WithContractProduct/WithContractProduct.test.jsx
@@ -60,7 +60,6 @@ describe('WithContractProduct', () => {
             },
             global: {
                 ethereumNetworkIsCorrect: true,
-                isWeb3Injected: true,
             },
         }
         props = {


### PR DESCRIPTION
Adds `averageBlockTime` method to estimate block mining time for community deployment (+ constant time to wait for API to start up).

To test, create a community product and deploy it.

Other changes:
- Show error message from exception in CP deploy dialog
- Removed `isWeb3Injected` and `metamaskPermission` from `global` reducer state, they didn't seem to be used for anything.