### PR TITLE
[PLATFORM-1127] Use platform-specific chord to trigger zoom shortcuts.

### DIFF
--- a/app/src/editor/canvas/components/Camera/index.jsx
+++ b/app/src/editor/canvas/components/Camera/index.jsx
@@ -341,6 +341,7 @@ function useKeyboardPanControls({ panAmount = 25 } = {}) {
         if (event.key === 'ArrowRight' || event.key.toLowerCase() === 'd') {
             event.preventDefault()
             event.stopPropagation()
+            event.stopImmediatePropagation()
             pan({ x: -panAmount })
         }
         if ((!event.shiftKey && event.key === 'ArrowUp') || event.key.toLowerCase() === 'w') {

--- a/app/src/editor/canvas/components/KeyboardShortcutsSidebar.jsx
+++ b/app/src/editor/canvas/components/KeyboardShortcutsSidebar.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { KeyboardShortcutsSidebar, ComboList } from '$editor/shared/components/KeyboardShortcutsSidebar'
+import { chord } from '$editor/shared/utils/shortcuts'
 
 const generalCombos = [
     {
@@ -79,11 +80,11 @@ const generalCombos = [
         title: 'Zoom In',
     },
     {
-        keys: [['meta', '0']],
+        keys: [[...chord, '0']],
         title: 'Full Size',
     },
     {
-        keys: [['meta', '1']],
+        keys: [[...chord, '1']],
         title: 'Fit to Screen',
     },
     {

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -18,7 +18,6 @@ import dateFormatter from '$utils/dateFormatter'
 import EditableText from '$shared/components/EditableText'
 import UseState from '$shared/components/UseState'
 import confirmDialog from '$shared/utils/confirm'
-import { getKeyLabel } from '$editor/shared/components/KeyboardShortcutsSidebar'
 
 import Toolbar from '$editor/shared/components/Toolbar'
 import useCanvasCamera from '../hooks/useCanvasCamera'
@@ -33,7 +32,6 @@ import styles from './Toolbar.pcss'
 function ZoomControls({ className, canvas }) {
     const camera = useCameraContext()
     const canvasCamera = useCanvasCamera({ canvas })
-    const metaKeyLabel = getKeyLabel('meta')
     return (
         <div className={cx(className, styles.ZoomControls)}>
             <DropdownActions
@@ -65,16 +63,16 @@ function ZoomControls({ className, canvas }) {
                 }
             >
                 <DropdownActions.Item onClick={() => camera.setScale(1)}>
-                    Full Size <span className={styles.menuShortcut}>{metaKeyLabel}0</span>
+                    Full size
                 </DropdownActions.Item>
                 <DropdownActions.Item onClick={() => canvasCamera.fitCanvas()}>
-                    Fit Screen <span className={styles.menuShortcut}>{metaKeyLabel}1</span>
+                    Fit screen
                 </DropdownActions.Item>
                 <DropdownActions.Item onClick={() => camera.zoomIn()}>
-                    Zoom In <span className={styles.menuShortcut}>{metaKeyLabel}=</span>
+                    Zoom In
                 </DropdownActions.Item>
                 <DropdownActions.Item onClick={() => camera.zoomOut()}>
-                    Zoom Out <span className={styles.menuShortcut}>{metaKeyLabel}-</span>
+                    Zoom Out
                 </DropdownActions.Item>
                 <DropdownActions.Item divider />
                 <DropdownActions.Item onClick={() => camera.setScale(0.5)}>50%</DropdownActions.Item>

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -497,8 +497,3 @@ body .RealtimeRunButtonMenu {
     }
   }
 }
-
-.menuShortcut {
-  margin-left: 1um;
-  text-align: right;
-}

--- a/app/src/editor/canvas/hooks/useCanvasCamera.js
+++ b/app/src/editor/canvas/hooks/useCanvasCamera.js
@@ -1,6 +1,7 @@
 import { useMemo, useCallback, useEffect, useState, useRef, useContext } from 'react'
 import { getCanvasBounds, getModuleBounds } from '$editor/shared/utils/bounds'
 import { useThrottled } from '$shared/hooks/wrapCallback'
+import { isChordEvent } from '$editor/shared/utils/shortcuts'
 
 import { useCameraContext } from '../components/Camera'
 import { DragDropContext } from '../components/DragDropContext'
@@ -155,16 +156,16 @@ function useKeyboardZoomControls() {
 
     const onKeyDown = useCallback((event) => {
         if (shouldIgnoreEvent(event)) { return }
-        const meta = (event.metaKey || event.ctrlKey)
+        const chordEvent = isChordEvent(event)
 
-        if (event.key === '0' && meta) {
+        if (event.code === 'Digit0' && chordEvent) {
             event.preventDefault()
             event.stopPropagation()
             event.stopImmediatePropagation()
             setScale(1)
         }
 
-        if (event.key === '1' && meta) {
+        if (event.code === 'Digit1' && chordEvent) {
             event.preventDefault()
             event.stopPropagation()
             event.stopImmediatePropagation()

--- a/app/src/editor/shared/components/KeyboardShortcutsSidebar/index.jsx
+++ b/app/src/editor/shared/components/KeyboardShortcutsSidebar/index.jsx
@@ -1,19 +1,21 @@
 import React, { useEffect, useCallback, useState } from 'react'
 import cx from 'classnames'
 
-import { isWindows as getIsWindows } from '$shared/utils/platform'
+import { isWindows as getIsWindows, isMac as getIsMac } from '$shared/utils/platform'
 import { Header, Content, Section } from '$editor/shared/components/Sidebar'
 import isEditableElement from '$editor/shared/utils/isEditableElement'
 
 import styles from './KeyboardShortcutsSidebar.pcss'
 
 const isWindows = getIsWindows()
+const isMac = getIsMac()
 
 const keyLabels = {
     escape: 'esc',
     meta: isWindows ? 'win' : '⌘',
-    control: '⌃',
-    shift: '⇧',
+    control: 'ctrl',
+    alt: isMac ? 'opt' : 'alt',
+    shift: 'shift',
 }
 
 function getPlatformKey(key) {
@@ -40,10 +42,12 @@ const getEventKey = (event) => {
         finalKey = key
     } else if (code === 'Space') {
         finalKey = code
-    } else if (code.substring(0, 3) === 'Key') {
-        finalKey = code.substring(3)
+    } else if (code.startsWith('Key')) {
+        finalKey = code.slice('Key'.length)
+    } else if (code.startsWith('Digit')) {
+        finalKey = code.slice('Digit'.length)
     } else {
-        finalKey = key
+        finalKey = code
     }
 
     return finalKey.toLowerCase()
@@ -155,15 +159,15 @@ function usePressedKeys(initialState = INITIAL_PRESSED_KEYS_STATE) {
     }, [resetState, isInitialState, setState])
 
     useEffect(() => {
-        window.addEventListener('keydown', onKeyDown)
-        window.addEventListener('keyup', onKeyUp)
-        window.addEventListener('blur', resetState)
-        window.addEventListener('focus', resetState)
+        window.addEventListener('keydown', onKeyDown, true)
+        window.addEventListener('keyup', onKeyUp, true)
+        window.addEventListener('blur', resetState, true)
+        window.addEventListener('focus', resetState, true)
         return () => {
-            window.removeEventListener('keydown', onKeyDown)
-            window.removeEventListener('keyup', onKeyUp)
-            window.removeEventListener('blur', resetState)
-            window.removeEventListener('focus', resetState)
+            window.removeEventListener('keydown', onKeyDown, true)
+            window.removeEventListener('keyup', onKeyUp, true)
+            window.removeEventListener('blur', resetState, true)
+            window.removeEventListener('focus', resetState, true)
         }
     }, [onKeyDown, onKeyUp, resetState])
     return state

--- a/app/src/editor/shared/tests/shortcuts.test.js
+++ b/app/src/editor/shared/tests/shortcuts.test.js
@@ -1,0 +1,17 @@
+import UserAgents from '$shared/../../test/unit/utils/useragents'
+import { getShortcutChord, SHORTCUT_CHORDS } from '$editor/shared/utils/shortcuts'
+
+describe('getShortcutChord', () => {
+    test('mac desktop chrome', () => {
+        expect(getShortcutChord(UserAgents.MacDesktopChrome)).toEqual(SHORTCUT_CHORDS.Chrome.mac)
+    })
+    test('win desktop chrome', () => {
+        expect(getShortcutChord(UserAgents.WindowsDesktopChrome)).toEqual(SHORTCUT_CHORDS.Chrome.default)
+    })
+    test('linux desktop firefox', () => {
+        expect(getShortcutChord(UserAgents.LinuxDesktopFirefox)).toEqual(SHORTCUT_CHORDS.Firefox.default)
+    })
+    test('win desktop IE11', () => {
+        expect(getShortcutChord(UserAgents.WindowsDesktopIE11)).toEqual(SHORTCUT_CHORDS.IE.default)
+    })
+})

--- a/app/src/editor/shared/utils/shortcuts.js
+++ b/app/src/editor/shared/utils/shortcuts.js
@@ -1,0 +1,39 @@
+import platform, { isMac } from '$shared/utils/platform'
+
+export const SHORTCUT_CHORDS = {
+    Firefox: {
+        default: ['alt', 'shift'],
+        mac: ['control', 'alt'],
+    },
+    'Microsoft Edge': {
+        default: ['alt'],
+    },
+    IE: {
+        default: ['alt'],
+    },
+    Chrome: {
+        default: ['alt', 'shift'],
+        mac: ['control', 'alt'],
+    },
+    default: {
+        default: ['alt'],
+        mac: ['control', 'alt'],
+    },
+}
+
+export function getShortcutChord(userAgent = navigator.userAgent) {
+    const info = platform.parse(userAgent)
+    const name = (info.name && info.name) || ''
+    const browserShortcuts = SHORTCUT_CHORDS[name] || SHORTCUT_CHORDS.default
+    const os = isMac(userAgent) ? 'mac' : 'default'
+    return (browserShortcuts[os] || browserShortcuts.default)
+}
+
+export const chord = getShortcutChord()
+
+export function isChordEvent(event) {
+    const chord = getShortcutChord()
+    return chord.every((key) => (
+        event[`${key === 'control' ? 'ctrl' : key}Key`]
+    ))
+}

--- a/app/src/shared/utils/platform.js
+++ b/app/src/shared/utils/platform.js
@@ -22,3 +22,12 @@ export const isWindows = (userAgent: string = navigator.userAgent): boolean => {
 
     return !!osFamily.match(/windows/)
 }
+
+export const isMac = (userAgent: string = navigator.userAgent): boolean => {
+    const info = platform.parse(userAgent)
+    const osFamily = (info.os && info.os.family && info.os.family.toLowerCase()) || ''
+
+    return !!osFamily.match(/os x/)
+}
+
+export default platform

--- a/app/test/unit/utils/platform.test.js
+++ b/app/test/unit/utils/platform.test.js
@@ -1,28 +1,30 @@
 import * as all from '$shared/utils/platform'
+import startCase from 'lodash/startCase'
 
-/* eslint-disable max-len */
-const UserAgents = {
-    // Desktop
-    MacDesktopChrome: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36',
-    MacDesktopFirefox: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0',
-    MacDesktopOpera: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.87 Safari/537.36 OPR/37.0.2178.31',
-    MacDesktopBrave: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.84 Safari/537.36',
-    WindowsDesktopIE11: 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko',
-    WindowsDesktopChrome: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36',
-    WindowsDesktopFirefox: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
-    WindowsDesktopEdge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134',
-    WindowsDesktopOpera: 'Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.18',
-
-    // Mobile
-    iPhoneMobileChrome: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) CriOS/67.0.3396.99 Mobile/13B143 Safari/601.1.46',
-    iPhoneMobileFirefox: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
-    iPhoneMobileOpera: 'Opera/9.80 (iPhone; Opera Mini/8.0.0/34.2336; U; en) Presto/2.8.119 Version/11.10',
-    AndroidMobileBrowser: 'Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; Galaxy Nexus Build/ICL53F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
-    WPMobileIE: 'Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 635) like Gecko',
-}
-/* eslint-enable max-len */
+import UserAgents from './useragents'
 
 describe('platform utils', () => {
+    describe.each(Object.keys(UserAgents))('isMac/isWindows detection', (key) => {
+        if (key.startsWith('Mac')) {
+            test(`${startCase(key)} is Mac`, () => {
+                expect(all.isMac(UserAgents[key])).toEqual(true)
+            })
+        } else {
+            test(`${startCase(key)} is not Mac`, () => {
+                expect(all.isMac(UserAgents[key])).toEqual(false)
+            })
+        }
+        if (key.startsWith('Windows') || key.startsWith('WP')) {
+            test(`${startCase(key)} is windows`, () => {
+                expect(all.isWindows(UserAgents[key])).toEqual(true)
+            })
+        } else {
+            test(`${startCase(key)} is not windows`, () => {
+                expect(all.isWindows(UserAgents[key])).toEqual(false)
+            })
+        }
+    })
+
     describe('Desktop', () => {
         it('detects Chrome on Mac', () => {
             expect(all.isMobile(UserAgents.MacDesktopChrome)).toEqual(false)
@@ -47,19 +49,6 @@ describe('platform utils', () => {
         it('detects IE11 on Windows', () => {
             expect(all.isMobile(UserAgents.WindowsDesktopIE11)).toEqual(false)
             expect(all.isMetamaskSupported(UserAgents.WindowsDesktopIE11)).toEqual(false)
-        })
-
-        it('detects Windows operating system', () => {
-            expect(all.isWindows(UserAgents.MacDesktopChrome)).toEqual(false)
-            expect(all.isWindows(UserAgents.MacDesktopFirefox)).toEqual(false)
-            expect(all.isWindows(UserAgents.MacDesktopOpera)).toEqual(false)
-            expect(all.isWindows(UserAgents.MacDesktopBrave)).toEqual(false)
-            expect(all.isWindows(UserAgents.WindowsDesktopIE11)).toEqual(true)
-            expect(all.isWindows(UserAgents.WindowsDesktopChrome)).toEqual(true)
-            expect(all.isWindows(UserAgents.WindowsDesktopFirefox)).toEqual(true)
-            expect(all.isWindows(UserAgents.WindowsDesktopEdge)).toEqual(true)
-            expect(all.isWindows(UserAgents.WindowsDesktopOpera)).toEqual(true)
-            expect(all.isWindows(UserAgents.WPMobileIE)).toEqual(true)
         })
     })
 

--- a/app/test/unit/utils/useragents.js
+++ b/app/test/unit/utils/useragents.js
@@ -1,0 +1,22 @@
+/* eslint-disable max-len */
+export default {
+    // Desktop
+    MacDesktopChrome: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36',
+    MacDesktopFirefox: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0',
+    MacDesktopOpera: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.87 Safari/537.36 OPR/37.0.2178.31',
+    MacDesktopBrave: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.84 Safari/537.36',
+    WindowsDesktopIE11: 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko',
+    WindowsDesktopChrome: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36',
+    WindowsDesktopFirefox: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
+    WindowsDesktopEdge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134',
+    WindowsDesktopOpera: 'Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.18',
+    LinuxDesktopFirefox: 'Mozilla/5.0 (X11; Linux i686; rv:64.0) Gecko/20100101 Firefox/64.0',
+
+    // Mobile
+    iPhoneMobileChrome: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) CriOS/67.0.3396.99 Mobile/13B143 Safari/601.1.46',
+    iPhoneMobileFirefox: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
+    iPhoneMobileOpera: 'Opera/9.80 (iPhone; Opera Mini/8.0.0/34.2336; U; en) Presto/2.8.119 Version/11.10',
+    AndroidMobileBrowser: 'Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; Galaxy Nexus Build/ICL53F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    WPMobileIE: 'Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 635) like Gecko',
+}
+/* eslint-enable max-len */


### PR DESCRIPTION
Going forward we should probably use this type of thing for any shortcuts which aren't replacing built-in behaviour e.g. not for cut/copy/paste/undo

* Fixes issue with the zoom shortcuts e.g. cmd+1 not working in Safari by using a "safe" meta key combo.
* Fixes issue with undo shortcut in Safari restoring last closed tab (event wasn't being cancelled properly).
* As discussed with @mattatgit have removed the keyboard shortcuts from the dropdown menu, they only appear in the sidebar now.

Uses this table for changing the appropriate chord depending on browser/os: https://en.wikipedia.org/wiki/Access_key#Access_in_different_browsers