### PR TITLE
[PLATFORM-1134] Disable editor inputs while saving

### DIFF
--- a/app/src/editor/canvas/components/Resizable/resizeable.stories.jsx
+++ b/app/src/editor/canvas/components/Resizable/resizeable.stories.jsx
@@ -1,4 +1,4 @@
-// $flow
+// @flow
 
 import React from 'react'
 import { storiesOf } from '@storybook/react'

--- a/app/src/editor/shared/components/ModuleHeader/moduleHeader.stories.jsx
+++ b/app/src/editor/shared/components/ModuleHeader/moduleHeader.stories.jsx
@@ -1,4 +1,4 @@
-// $flow
+// @flow
 
 import React from 'react'
 import { storiesOf } from '@storybook/react'

--- a/app/src/marketplace/components/ProductPage/EditorNav/editorNav.stories.jsx
+++ b/app/src/marketplace/components/ProductPage/EditorNav/editorNav.stories.jsx
@@ -1,4 +1,4 @@
-// $flow
+// @flow
 
 import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
@@ -36,7 +36,7 @@ const sections = [{
 }]
 
 const EditNavController = () => {
-    const [activeSection, setActiveSection] = useState(null)
+    const [activeSection, setActiveSection] = useState('')
     const nameStatus = select('Name', statuses, statuses.EMPTY)
     const coverImageStatus = select('Cover Image', statuses, statuses.EMPTY)
     const descriptionStatus = select('Description', statuses, statuses.EMPTY)

--- a/app/src/marketplace/components/StreamSelector/index.jsx
+++ b/app/src/marketplace/components/StreamSelector/index.jsx
@@ -24,6 +24,7 @@ type Props = LastErrorProps & {
     availableStreams: StreamList,
     className?: string,
     onEdit: (StreamIdList) => void,
+    disabled?: boolean,
 }
 
 const SORT_BY_NAME = 'name'
@@ -37,6 +38,7 @@ export const StreamSelector = (props: Props) => {
         onEdit,
         availableStreams,
         fetchingStreams = false,
+        disabled,
         ...rest
     } = props
     const [sort, setSort] = useState(SORT_BY_NAME)
@@ -100,6 +102,7 @@ export const StreamSelector = (props: Props) => {
                 <div
                     className={classNames(styles.root, {
                         [styles.withError]: !!hasError,
+                        [styles.disabled]: !!disabled,
                     })}
                 >
                     {!!fetchingStreams && <Translate value="streamSelector.loading" />}
@@ -110,6 +113,7 @@ export const StreamSelector = (props: Props) => {
                             onChange={onSearchChange}
                             value={search}
                             placeholder={I18n.t('streamSelector.typeToSearch')}
+                            disabled={!!disabled}
                         />
                         <DropdownActions
                             className={classNames(styles.sortDropdown, styles.dropdown)}
@@ -120,6 +124,7 @@ export const StreamSelector = (props: Props) => {
                                     {sort}
                                 </span>
                             }
+                            disabled={!!disabled}
                         >
                             <DropdownActions.Item onClick={() => setSort(SORT_BY_NAME)}>
                                 <Translate value="streamSelector.sortByName" />
@@ -155,6 +160,7 @@ export const StreamSelector = (props: Props) => {
                                     onClick={() => {
                                         onToggle(stream.id)
                                     }}
+                                    disabled={!!disabled}
                                 >
                                     {stream.name}
                                 </button>
@@ -178,6 +184,7 @@ export const StreamSelector = (props: Props) => {
                                     onSelectAll(toSelect)
                                 }
                             }}
+                            disabled={!!disabled}
                         >
                             {!allVisibleStreamsSelected
                                 ? <Translate value="streamSelector.selectAll" />

--- a/app/src/marketplace/components/StreamSelector/streamSelector.pcss
+++ b/app/src/marketplace/components/StreamSelector/streamSelector.pcss
@@ -16,13 +16,18 @@
   border: 1px solid #FF5C00;
 }
 
+.disabled {
+  opacity: 0.5;
+}
+
 .input {
   border: none;
   background: none;
   width: auto;
   flex: 1;
 
-  &:focus {
+  &:focus,
+  &:disabled {
     background: none;
     outline: none;
     box-shadow: none;

--- a/app/src/marketplace/containers/EditProductPage2/CoverImage.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/CoverImage.jsx
@@ -9,6 +9,7 @@ import useValidation from '../ProductController/useValidation'
 import useProductActions from '../ProductController/useProductActions'
 import ImageUpload from '$shared/components/ImageUpload'
 import InputError from '$mp/components/InputError'
+import usePending from '$shared/hooks/usePending'
 
 import styles from './coverImage.pcss'
 
@@ -17,6 +18,7 @@ const CoverImage = () => {
     const { isTouched } = useContext(ValidationContext)
     const { updateImageFile } = useProductActions()
     const { isValid, message } = useValidation('imageUrl')
+    const { isPending } = usePending('product.SAVE')
 
     const hasError = isTouched('imageUrl') && !isValid
 
@@ -36,6 +38,7 @@ const CoverImage = () => {
                     dropzoneClassname={cx(styles.dropZone, {
                         [styles.dropZoneError]: !!hasError,
                     })}
+                    disabled={!!isPending}
                 />
                 <InputError
                     eligible={hasError}

--- a/app/src/marketplace/containers/EditProductPage2/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/PriceSelector.jsx
@@ -36,10 +36,12 @@ const PriceSelector = () => {
         updateBeneficiaryAddress,
     } = useProductActions()
     const dataPerUsd = useSelector(selectDataPerUsd)
-    const { isPending } = usePending('contractProduct.LOAD')
+    const { isPending: savePending } = usePending('product.SAVE')
+    const { isPending: contractProductLoadPending } = usePending('contractProduct.LOAD')
     const isPublic = isPublished(product)
     const contractProduct = useSelector(selectContractProduct)
-    const isPriceTypeDisabled = !!(isPending || isPublic || !!contractProduct)
+    const isLoadingOrSaving = !!(savePending || contractProductLoadPending)
+    const isPriceTypeDisabled = !!(isLoadingOrSaving || isPublic || !!contractProduct)
 
     const [currency, setCurrency] = useState(product.priceCurrency || DEFAULT_CURRENCY)
 
@@ -78,12 +80,12 @@ const PriceSelector = () => {
                     disabled={isPriceTypeDisabled}
                 />
                 <div className={cx(styles.inner, {
-                    [styles.disabled]: isFreeProduct,
+                    [styles.disabled]: isFreeProduct || isLoadingOrSaving,
                 })}
                 >
                     <SetPrice
                         className={styles.priceSelector}
-                        disabled={!!product.isFree}
+                        disabled={isFreeProduct || isLoadingOrSaving}
                         price={product.price}
                         onPriceChange={onPriceChange}
                         currency={currency}
@@ -98,7 +100,7 @@ const PriceSelector = () => {
                             className={styles.beneficiaryAddress}
                             address={product.beneficiaryAddress}
                             onChange={updateBeneficiaryAddress}
-                            disabled={isFreeProduct}
+                            disabled={isFreeProduct || isLoadingOrSaving}
                         />
                     )}
                     <div className={styles.fixPrice}>
@@ -110,7 +112,7 @@ const PriceSelector = () => {
                             className={styles.toggle}
                             value={fixInFiat}
                             onChange={onFixPriceChange}
-                            disabled={isFreeProduct}
+                            disabled={isFreeProduct || isLoadingOrSaving}
                         />
                     </div>
                 </div>

--- a/app/src/marketplace/containers/EditProductPage2/ProductDescription.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/ProductDescription.jsx
@@ -8,6 +8,7 @@ import useValidation from '../ProductController/useValidation'
 import useProductActions from '../ProductController/useProductActions'
 import MarkdownEditor from '$mp/components/MarkdownEditor'
 import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
+import usePending from '$shared/hooks/usePending'
 
 import styles from './productDescription.pcss'
 
@@ -16,6 +17,7 @@ const ProductDescription = () => {
     const { isTouched } = useContext(ValidationContext)
     const { isValid, message } = useValidation('description')
     const { updateDescription } = useProductActions()
+    const { isPending } = usePending('product.SAVE')
 
     return (
         <section id="description" className={cx(styles.root, styles.ProductDescription)}>
@@ -32,6 +34,7 @@ const ProductDescription = () => {
                     onCommit={updateDescription}
                     className={styles.productDescription}
                     error={isTouched('description') && !isValid ? message : undefined}
+                    disabled={!!isPending}
                 />
             </div>
         </section>

--- a/app/src/marketplace/containers/EditProductPage2/ProductDetails.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/ProductDetails.jsx
@@ -6,6 +6,7 @@ import cx from 'classnames'
 import useProduct from '../ProductController/useProduct'
 import useValidation from '../ProductController/useValidation'
 import useProductActions from '../ProductController/useProductActions'
+import { usePending } from '$shared/hooks/usePending'
 import SelectField from '$mp/components/SelectField'
 import { isCommunityProduct } from '$mp/utils/product'
 import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
@@ -27,6 +28,7 @@ const ProductDetails = () => {
     const { isValid: isCategoryValid, message: categoryMessage } = useValidation('category')
     const { isValid: isAdminFeeValid, message: adminFeeMessage } = useValidation('adminFee')
     const { updateCategory, updateAdminFee } = useProductActions()
+    const { isPending } = usePending('product.SAVE')
 
     const adminFee = product && product.adminFee
     const selectedAdminFee = useMemo(() => adminFeeOptions.find(({ value }) => value === adminFee), [adminFee])
@@ -53,6 +55,7 @@ const ProductDetails = () => {
                                         onChange={(option) => updateCategory(option.value)}
                                         isSearchable={false}
                                         error={isTouched('category') && !isCategoryValid ? categoryMessage : undefined}
+                                        disabled={!!isPending}
                                     />
                                 ) : null
                             }}
@@ -67,6 +70,7 @@ const ProductDetails = () => {
                                 onChange={(option) => updateAdminFee(option.value)}
                                 isSearchable={false}
                                 error={isTouched('adminFee') && !isAdminFeeValid ? adminFeeMessage : undefined}
+                                disabled={!!isPending}
                             />
                         </Details.Row>
                     )}

--- a/app/src/marketplace/containers/EditProductPage2/ProductName.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/ProductName.jsx
@@ -4,6 +4,7 @@ import React, { useContext } from 'react'
 import cx from 'classnames'
 import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
 
+import usePending from '$shared/hooks/usePending'
 import useProduct from '../ProductController/useProduct'
 import useValidation from '../ProductController/useValidation'
 import useProductActions from '../ProductController/useProductActions'
@@ -17,6 +18,7 @@ const ProductName = () => {
     const { isValid, message } = useValidation('name')
     const { updateName } = useProductActions()
     const { isTouched } = useContext(ValidationContext)
+    const { isPending } = usePending('product.SAVE')
 
     return (
         <section id="product-name" className={cx(styles.root, styles.ProductName)}>
@@ -27,6 +29,7 @@ const ProductName = () => {
                     onCommit={updateName}
                     placeholder="Product Name"
                     error={isTouched('name') && !isValid ? message : undefined}
+                    disabled={isPending}
                 />
             </div>
         </section>

--- a/app/src/marketplace/containers/EditProductPage2/ProductStreams.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/ProductStreams.jsx
@@ -8,6 +8,7 @@ import useProduct from '../ProductController/useProduct'
 import useValidation from '../ProductController/useValidation'
 import useProductActions from '../ProductController/useProductActions'
 import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
+import usePending from '$shared/hooks/usePending'
 
 import AvailableStreams from '../AvailableStreams'
 import styles from './productStreams.pcss'
@@ -17,6 +18,7 @@ const ProductStreams = () => {
     const { isValid, message } = useValidation('streams')
     const { updateStreams } = useProductActions()
     const { isTouched } = useContext(ValidationContext)
+    const { isPending } = usePending('product.SAVE')
 
     return (
         <section id="streams" className={cx(styles.root, styles.StreamSelector)}>
@@ -34,6 +36,7 @@ const ProductStreams = () => {
                             streams={product.streams}
                             className={styles.streams}
                             error={isTouched('streams') && !isValid ? message : undefined}
+                            disabled={!!isPending}
                         />
                     )}
                 </AvailableStreams>

--- a/app/src/marketplace/containers/EditProductPage2/index.jsx
+++ b/app/src/marketplace/containers/EditProductPage2/index.jsx
@@ -88,9 +88,9 @@ const EditProductPage = ({ product }: { product: Product }) => {
             title: (productState && I18n.t(`editProductPage.${titles[tmpState]}`)) || '',
             color: 'primary',
             onClick: publish,
-            disabled: !(productState === productStates.NOT_DEPLOYED || productState === productStates.DEPLOYED),
+            disabled: !(productState === productStates.NOT_DEPLOYED || productState === productStates.DEPLOYED) || isSaving,
         }
-    }, [isAnyChangePending, productState, publish])
+    }, [isAnyChangePending, productState, publish, isSaving])
 
     const deployButton = useMemo(() => {
         if (isCommunity && !isDeployed) {

--- a/app/src/shared/components/DropdownActions/dropdownActions.pcss
+++ b/app/src/shared/components/DropdownActions/dropdownActions.pcss
@@ -28,7 +28,11 @@
     cursor: pointer;
   }
 
-  &:--enter {
+  &[disabled] {
+    opacity: 0.5;
+  }
+
+  &:not([disabled]):--enter {
     color: var(--streamrBlue);
   }
 }

--- a/app/src/shared/components/DropdownActions/index.jsx
+++ b/app/src/shared/components/DropdownActions/index.jsx
@@ -19,6 +19,7 @@ type Props = {
     },
     onMenuToggle?: (boolean) => any,
     direction?: string,
+    disabled?: boolean,
 }
 
 type State = {
@@ -61,6 +62,7 @@ export default class DropdownActions extends Component<Props, State> {
             toggleProps: { className: toggleClassName, ...toggleProps },
             menuProps: { className: menuClassName, ...menuProps },
             direction,
+            disabled,
         } = this.props
 
         return (
@@ -76,6 +78,7 @@ export default class DropdownActions extends Component<Props, State> {
                     tag="div"
                     {...toggleProps}
                     className={cx(styles.textToggle, toggleClassName)}
+                    disabled={!!disabled}
                 >
                     {title}
                     {!noCaret && <span className={styles.caret}>&#9662;</span>}

--- a/app/src/shared/components/EditableText/editableText.stories.jsx
+++ b/app/src/shared/components/EditableText/editableText.stories.jsx
@@ -1,4 +1,4 @@
-// $flow
+// @flow
 
 import React from 'react'
 import { storiesOf } from '@storybook/react'

--- a/app/src/shared/components/ImageUpload/imageUpload.pcss
+++ b/app/src/shared/components/ImageUpload/imageUpload.pcss
@@ -64,28 +64,34 @@
   border-radius: 4px;
   border: 1px solid #EBEBEB;
 
-  &.dragEntered {
-    border: 1px solid #0324FF;
-    background-color: #EFEFEF;
-
-    .dropzoneAdvice {
-      display: block;
-    }
-
-    .previewImage {
-      display: none;
-    }
+  &[aria-disabled='true'] {
+    opacity: 0.5;
   }
 
-  &:hover {
-    cursor: pointer;
+  &:not([aria-disabled='true']) {
+    &.dragEntered {
+      border: 1px solid #0324FF;
+      background-color: #EFEFEF;
 
-    .dropzoneAdvice {
-      display: block;
+      .dropzoneAdvice {
+        display: block;
+      }
+
+      .previewImage {
+        display: none;
+      }
     }
 
-    .previewImage {
-      opacity: 0.05;
+    &:hover {
+      cursor: pointer;
+
+      .dropzoneAdvice {
+        display: block;
+      }
+
+      .previewImage {
+        opacity: 0.05;
+      }
     }
   }
 }

--- a/app/src/shared/components/ImageUpload/imageUpload.stories.jsx
+++ b/app/src/shared/components/ImageUpload/imageUpload.stories.jsx
@@ -1,0 +1,55 @@
+// @flow
+
+import React, { useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import styles from '@sambego/storybook-styles'
+
+import ImageUpload from '.'
+
+const stories = storiesOf('Shared/ImageUpload', module)
+    .addDecorator(styles({
+        color: '#323232',
+        padding: '5rem',
+        background: '#F8F8F8',
+    }))
+
+type Props = {
+    defaultImage?: string,
+    disabled?: boolean,
+}
+
+const ImageUploadContainer = ({ disabled, defaultImage }: Props) => {
+    const [image, setImage] = useState(defaultImage)
+
+    return (
+        <ImageUpload
+            // $FlowFixMe
+            setImageToUpload={setImage}
+            originalImage={image}
+            disabled={!!disabled}
+        />
+    )
+}
+
+// onUploadError={this.onUploadError}
+
+stories.add('default', () => (
+    <ImageUploadContainer />
+))
+
+stories.add('with default image', () => (
+    <ImageUploadContainer
+        defaultImage="https://miro.medium.com/fit/c/256/256/1*NfJkA-ChiQtYLRBOLryZxQ.jpeg"
+    />
+))
+
+stories.add('disabled', () => (
+    <ImageUploadContainer disabled />
+))
+
+stories.add('disabled with default image', () => (
+    <ImageUploadContainer
+        disabled
+        defaultImage="https://miro.medium.com/fit/c/256/256/1*NfJkA-ChiQtYLRBOLryZxQ.jpeg"
+    />
+))

--- a/app/src/shared/components/ImageUpload/index.jsx
+++ b/app/src/shared/components/ImageUpload/index.jsx
@@ -26,6 +26,7 @@ type Props = {
     originalImage?: ?string,
     dropzoneClassname?: string,
     className?: string,
+    disabled?: boolean,
 }
 
 type State = {
@@ -116,7 +117,7 @@ class ImageUpload extends Component<Props, State> {
     unmounted = false
 
     render() {
-        const { originalImage, dropzoneClassname, className } = this.props
+        const { originalImage, dropzoneClassname, className, disabled } = this.props
         const { imageUploading, imageUploaded, dragEntered } = this.state
         const srcImage = this.getPreviewImage() || originalImage
         return (
@@ -140,6 +141,7 @@ class ImageUpload extends Component<Props, State> {
                     onDropRejected={this.onDropRejected}
                     accept="image/jpeg, image/png"
                     maxSize={maxFileSizeForImageUpload}
+                    disabled={!!disabled}
                 >
                     <div className={styles.dropzoneAdvice}>
                         <PngIcon

--- a/app/src/shared/components/Meatball/index.jsx
+++ b/app/src/shared/components/Meatball/index.jsx
@@ -10,14 +10,22 @@ type Props = {
     blue?: boolean,
     gray?: boolean,
     white?: boolean,
+    disabled?: boolean,
 }
 
-const Meatball = ({ alt, blue, gray, white }: Props) => (
+const Meatball = ({
+    alt,
+    blue,
+    gray,
+    white,
+    disabled,
+}: Props) => (
     <div
         className={cx(styles.root, {
             [styles.blue]: !!blue,
             [styles.gray]: !!gray,
             [styles.white]: !!white,
+            [styles.disabled]: !!disabled,
         })}
     >
         <svg

--- a/app/src/shared/components/Meatball/meatball.pcss
+++ b/app/src/shared/components/Meatball/meatball.pcss
@@ -16,8 +16,10 @@
   fill: var(--greyDark);
 }
 
-.root:--enter,
-a:--enter .root {
+.disabled {}
+
+.root:not(.disabled):--enter,
+a:--enter .root:not(.disabled) {
   opacity: 1;
   transition-duration: 50ms;
 }

--- a/app/src/shared/components/Onboarding/onboarding.stories.jsx
+++ b/app/src/shared/components/Onboarding/onboarding.stories.jsx
@@ -1,4 +1,4 @@
-// $flow
+// @flow
 
 import React from 'react'
 import { storiesOf } from '@storybook/react'

--- a/app/src/shared/components/TextControl/textControl.stories.jsx
+++ b/app/src/shared/components/TextControl/textControl.stories.jsx
@@ -1,4 +1,4 @@
-// $flow
+// @flow
 
 import React from 'react'
 import { storiesOf } from '@storybook/react'

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -89,10 +89,30 @@ story('Popover actions')
             <DropdownActions.Item>Another option</DropdownActions.Item>
         </DropdownActions>
     ))
+    .addWithJSX('disabled', () => (
+        <DropdownActions title="Select" disabled>
+            <DropdownActions.Item onClick={action('clicked')}>
+                Click me
+            </DropdownActions.Item>
+            <DropdownActions.Item>Another option</DropdownActions.Item>
+        </DropdownActions>
+    ))
     .addWithJSX('meatball dropdown', () => (
         <DropdownActions
             title={<Meatball alt="Select" />}
             noCaret
+        >
+            <DropdownActions.Item onClick={action('clicked')}>
+                Click me
+            </DropdownActions.Item>
+            <DropdownActions.Item>Another option</DropdownActions.Item>
+        </DropdownActions>
+    ))
+    .addWithJSX('disabled meatball dropdown', () => (
+        <DropdownActions
+            title={<Meatball alt="Select" disabled />}
+            noCaret
+            disabled
         >
             <DropdownActions.Item onClick={action('clicked')}>
                 Click me

--- a/app/stories/userpages.stories.jsx
+++ b/app/stories/userpages.stories.jsx
@@ -1,4 +1,4 @@
-// $flow
+// @flow
 
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -56,6 +56,7 @@ story('Avatar')
         return (
             <Avatar
                 editable={boolean('Editable', false)}
+                // $FlowFixMe
                 user={user}
                 onImageChange={() => Promise.resolve()}
             />
@@ -69,10 +70,12 @@ story('KeyField')
             value={text('Value')}
             hideValue={boolean('Hide value')}
             allowEdit={boolean('Allow edit')}
+            // $FlowFixMe
             onSave={() => {
                 alert('Saved!') // eslint-disable-line no-alert
             }}
             allowDelete={boolean('Allow delete')}
+            // $FlowFixMe
             onDelete={() => {
                 alert('Deleted!') // eslint-disable-line no-alert
             }}


### PR DESCRIPTION
Disable editor inputs while saving is in progress. Added some `opacity: 0.5` to cover image and stream selector while disabled but inputs don't have any designed disabled state so I left it out for now.

To test, edit any product and hit save (try changing the network speed to slow to see). All inputs should be properly disabled.