### PR TITLE
Fix button styles to match new design

### DIFF
--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -115,7 +115,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
             message: I18n.t('userpages.canvases.delete.confirmMessage'),
             acceptButton: {
                 title: I18n.t('userpages.canvases.delete.confirmButton'),
-                type: 'destructive',
+                kind: 'destructive',
             },
             centerButtons: true,
             dontShowAgain: false,

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -115,7 +115,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
             message: I18n.t('userpages.canvases.delete.confirmMessage'),
             acceptButton: {
                 title: I18n.t('userpages.canvases.delete.confirmButton'),
-                color: 'danger',
+                type: 'destructive',
             },
             centerButtons: true,
             dontShowAgain: false,

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -554,7 +554,7 @@ const CanvasEditWrap = () => {
 const CanvasErrorPage = () => (
     <ErrorPageContent>
         <Button
-            type="special"
+            kind="special"
             tag={Link}
             to=""
             onClick={(event) => {
@@ -565,7 +565,7 @@ const CanvasErrorPage = () => (
             <Translate value="editor.error.refresh" />
         </Button>
         <Button
-            type="special"
+            kind="special"
             tag={Link}
             to={routes.canvases()}
             className="d-none d-md-inline-block"

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -17,6 +17,7 @@ import routes from '$routes'
 
 import isEditableElement from '$editor/shared/utils/isEditableElement'
 import UndoControls from '$editor/shared/components/UndoControls'
+import Button from '$shared/components/Button'
 import * as UndoContext from '$shared/components/UndoContextProvider'
 import { Provider as PendingProvider } from '$shared/components/PendingContextProvider'
 import Subscription from '$editor/shared/components/Subscription'
@@ -552,22 +553,25 @@ const CanvasEditWrap = () => {
 
 const CanvasErrorPage = () => (
     <ErrorPageContent>
-        <Link
+        <Button
+            type="special"
+            tag={Link}
             to=""
             onClick={(event) => {
                 event.preventDefault()
                 window.location.reload()
             }}
-            className="btn btn-special"
         >
             <Translate value="editor.error.refresh" />
-        </Link>
-        <Link
+        </Button>
+        <Button
+            type="special"
+            tag={Link}
             to={routes.canvases()}
-            className="btn btn-special d-none d-md-inline-block"
+            className="d-none d-md-inline-block"
         >
             <Translate value="editor.general.backToCanvases" />
-        </Link>
+        </Button>
     </ErrorPageContent>
 )
 

--- a/app/src/marketplace/components/ActionBar/actionBar.pcss
+++ b/app/src/marketplace/components/ActionBar/actionBar.pcss
@@ -14,19 +14,6 @@
       padding: 0 5em;
     }
   }
-
-  .createProductButton {
-    text-transform: initial;
-    font-family: 'IBM Plex Sans', sans-serif;
-    font-size: 16px;
-    padding-top: 0;
-    padding-bottom: 0;
-    line-height: 24px;
-    letter-spacing: 0;
-    font-weight: var(--regular);
-    color: var(--greyDark);
-    border-color: var(--greyDark);
-  }
 }
 
 .searchFilter {

--- a/app/src/marketplace/components/ActionBar/index.jsx
+++ b/app/src/marketplace/components/ActionBar/index.jsx
@@ -4,13 +4,14 @@ import React, { Component } from 'react'
 import BN from 'bignumber.js'
 import { Link } from 'react-router-dom'
 import classNames from 'classnames'
-import { Container, Button } from 'reactstrap'
+import { Container } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 
 import links from '../../../links'
 import type { Filter, SearchFilter, CategoryFilter, SortByFilter } from '../../flowtype/product-types'
 import type { Category } from '../../flowtype/category-types'
 import { isValidSearchQuery } from '../../utils/validate'
+import Button from '$shared/components/Button'
 
 import SearchInput from './SearchInput'
 import FilterSelector from './FilterSelector'
@@ -133,11 +134,9 @@ class ActionBar extends Component<Props> {
                                 </FilterSelector>
                             </li>
                             <li className={classNames('d-none d-md-block', styles.createProduct)}>
-                                <Link to={links.marketplace.createProduct}>
-                                    <Button className={styles.createProductButton} color="secondary" outline>
-                                        <Translate value="actionBar.create" />
-                                    </Button>
-                                </Link>
+                                <Button type="secondary" tag={Link} to={links.marketplace.createProduct}>
+                                    <Translate value="actionBar.create" />
+                                </Button>
                             </li>
                         </ul>
                     </Container>

--- a/app/src/marketplace/components/ActionBar/index.jsx
+++ b/app/src/marketplace/components/ActionBar/index.jsx
@@ -134,7 +134,7 @@ class ActionBar extends Component<Props> {
                                 </FilterSelector>
                             </li>
                             <li className={classNames('d-none d-md-block', styles.createProduct)}>
-                                <Button type="secondary" tag={Link} to={links.marketplace.createProduct}>
+                                <Button kind="secondary" tag={Link} to={links.marketplace.createProduct}>
                                     <Translate value="actionBar.create" />
                                 </Button>
                             </li>

--- a/app/src/marketplace/components/ErrorPageView/index.jsx
+++ b/app/src/marketplace/components/ErrorPageView/index.jsx
@@ -43,14 +43,14 @@ const ErrorPageView = () => (
         <BodyClass className={PAGE_SECONDARY} />
         <ErrorPageContent>
             <Button
-                type="special"
+                kind="special"
                 tag={Link}
                 to={links.marketplace.main}
             >
                 <Translate value="errorPageView.top" />
             </Button>
             <Button
-                type="special"
+                kind="special"
                 tag={Link}
                 to={links.userpages.products}
                 className="d-none d-md-inline-block"

--- a/app/src/marketplace/components/ErrorPageView/index.jsx
+++ b/app/src/marketplace/components/ErrorPageView/index.jsx
@@ -11,6 +11,7 @@ import Layout from '$shared/components/Layout'
 import links from '../../../links'
 import appCrashedImage from '$shared/assets/images/app_crashed.png'
 import appCrashedImage2x from '$shared/assets/images/app_crashed@2x.png'
+import Button from '$shared/components/Button'
 
 import styles from './errorPageView.pcss'
 
@@ -41,18 +42,21 @@ const ErrorPageView = () => (
     <Layout className={styles.errorPageView}>
         <BodyClass className={PAGE_SECONDARY} />
         <ErrorPageContent>
-            <Link
+            <Button
+                type="special"
+                tag={Link}
                 to={links.marketplace.main}
-                className="btn btn-special"
             >
                 <Translate value="errorPageView.top" />
-            </Link>
-            <Link
+            </Button>
+            <Button
+                type="special"
+                tag={Link}
                 to={links.userpages.products}
-                className="btn btn-special d-none d-md-inline-block"
+                className="d-none d-md-inline-block"
             >
                 <Translate value="general.products" />
-            </Link>
+            </Button>
         </ErrorPageContent>
     </Layout>
 )

--- a/app/src/marketplace/components/LoadMore/index.jsx
+++ b/app/src/marketplace/components/LoadMore/index.jsx
@@ -22,7 +22,7 @@ const LoadMore = ({ onClick, hasMoreSearchResults }: Props) => {
         <Container className={styles.container}>
             <Row className="justify-content-center">
                 <Col xs="auto">
-                    <Button type="special" variant="dark" onClick={onClick}>
+                    <Button kind="special" variant="dark" onClick={onClick}>
                         <Translate value="productList.viewMore" />
                     </Button>
                 </Col>

--- a/app/src/marketplace/components/LoadMore/index.jsx
+++ b/app/src/marketplace/components/LoadMore/index.jsx
@@ -2,7 +2,9 @@
 
 import React from 'react'
 import { Translate } from 'react-redux-i18n'
-import { Row, Container, Col, Button } from 'reactstrap'
+import { Row, Container, Col } from 'reactstrap'
+
+import Button from '$shared/components/Button'
 
 import styles from './loadMore.pcss'
 
@@ -20,7 +22,7 @@ const LoadMore = ({ onClick, hasMoreSearchResults }: Props) => {
         <Container className={styles.container}>
             <Row className="justify-content-center">
                 <Col xs="auto">
-                    <Button color="special" onClick={onClick}>
+                    <Button type="special" variant="dark" onClick={onClick}>
                         <Translate value="productList.viewMore" />
                     </Button>
                 </Col>

--- a/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/index.jsx
@@ -70,11 +70,11 @@ export const ChooseAccessPeriodDialog = ({
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
                     onClick: onCancel,
-                    color: 'link',
+                    type: 'link',
                 },
                 next: {
                     title: I18n.t('modal.common.next'),
-                    color: 'primary',
+                    type: 'primary',
                     outline: true,
                     onClick: () => onNext(time, timeUnit),
                     disabled: BN(time).isNaN() || BN(time).isLessThanOrEqualTo(0) || waiting,

--- a/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/index.jsx
@@ -70,11 +70,11 @@ export const ChooseAccessPeriodDialog = ({
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
                     onClick: onCancel,
-                    type: 'link',
+                    kind: 'link',
                 },
                 next: {
                     title: I18n.t('modal.common.next'),
-                    type: 'primary',
+                    kind: 'primary',
                     outline: true,
                     onClick: () => onNext(time, timeUnit),
                     disabled: BN(time).isNaN() || BN(time).isLessThanOrEqualTo(0) || waiting,

--- a/app/src/marketplace/components/Modal/CompleteContractProductPublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompleteContractProductPublishDialog/index.jsx
@@ -28,11 +28,11 @@ const CompleteContractProductPublishDialog = ({ onCancel, publishState }: Props)
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             onClick: onCancel,
-                            type: 'link',
+                            kind: 'link',
                         },
                         publish: {
                             title: I18n.t('modal.common.waiting'),
-                            type: 'primary',
+                            kind: 'primary',
                             disabled: true,
                             spinner: true,
                         },

--- a/app/src/marketplace/components/Modal/CompleteContractProductPublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompleteContractProductPublishDialog/index.jsx
@@ -28,11 +28,11 @@ const CompleteContractProductPublishDialog = ({ onCancel, publishState }: Props)
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             onClick: onCancel,
-                            color: 'link',
+                            type: 'link',
                         },
                         publish: {
                             title: I18n.t('modal.common.waiting'),
-                            color: 'primary',
+                            type: 'primary',
                             disabled: true,
                             spinner: true,
                         },

--- a/app/src/marketplace/components/Modal/CompleteContractProductUnpublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompleteContractProductUnpublishDialog/index.jsx
@@ -28,11 +28,11 @@ const CompleteContractProductUnpublishDialog = ({ onCancel, publishState }: Prop
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             onClick: onCancel,
-                            type: 'link',
+                            kind: 'link',
                         },
                         publish: {
                             title: I18n.t('modal.common.waiting'),
-                            type: 'primary',
+                            kind: 'primary',
                             disabled: true,
                             spinner: true,
                         },

--- a/app/src/marketplace/components/Modal/CompleteContractProductUnpublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/CompleteContractProductUnpublishDialog/index.jsx
@@ -28,11 +28,11 @@ const CompleteContractProductUnpublishDialog = ({ onCancel, publishState }: Prop
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             onClick: onCancel,
-                            color: 'link',
+                            type: 'link',
                         },
                         publish: {
                             title: I18n.t('modal.common.waiting'),
-                            color: 'primary',
+                            type: 'primary',
                             disabled: true,
                             spinner: true,
                         },

--- a/app/src/marketplace/components/Modal/CompletePublishTransaction/index.jsx
+++ b/app/src/marketplace/components/Modal/CompletePublishTransaction/index.jsx
@@ -40,11 +40,11 @@ const CompletePublishTransaction = ({ isUnpublish, onCancel, status }: Props) =>
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
                     onClick: onCancel,
-                    color: 'link',
+                    type: 'link',
                 },
                 close: {
                     title: somePending ? I18n.t('modal.common.waiting') : I18n.t('modal.common.close'),
-                    color: 'primary',
+                    type: 'primary',
                     disabled: somePending,
                     spinner: somePending,
                     onClick: onCancel,

--- a/app/src/marketplace/components/Modal/CompletePublishTransaction/index.jsx
+++ b/app/src/marketplace/components/Modal/CompletePublishTransaction/index.jsx
@@ -40,11 +40,11 @@ const CompletePublishTransaction = ({ isUnpublish, onCancel, status }: Props) =>
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
                     onClick: onCancel,
-                    type: 'link',
+                    kind: 'link',
                 },
                 close: {
                     title: somePending ? I18n.t('modal.common.waiting') : I18n.t('modal.common.close'),
-                    type: 'primary',
+                    kind: 'primary',
                     disabled: somePending,
                     spinner: somePending,
                     onClick: onCancel,

--- a/app/src/marketplace/components/Modal/ConfirmDeployCommunityDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ConfirmDeployCommunityDialog/index.jsx
@@ -53,12 +53,12 @@ const ConfirmDeployCommunityDialog = ({ product, onClose, onContinue: onContinue
                                 cancel: {
                                     title: I18n.t('modal.common.cancel'),
                                     onClick: onClose,
-                                    type: 'link',
+                                    kind: 'link',
                                     disabled: waitingOnContinue,
                                 },
                                 continue: {
                                     title: I18n.t('modal.common.deploy'),
-                                    type: 'primary',
+                                    kind: 'primary',
                                     onClick: onContinue,
                                     spinner: waitingOnContinue,
                                     disabled: waitingOnContinue,

--- a/app/src/marketplace/components/Modal/ConfirmDeployCommunityDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ConfirmDeployCommunityDialog/index.jsx
@@ -53,12 +53,12 @@ const ConfirmDeployCommunityDialog = ({ product, onClose, onContinue: onContinue
                                 cancel: {
                                     title: I18n.t('modal.common.cancel'),
                                     onClick: onClose,
-                                    color: 'link',
+                                    type: 'link',
                                     disabled: waitingOnContinue,
                                 },
                                 continue: {
                                     title: I18n.t('modal.common.deploy'),
-                                    color: 'primary',
+                                    type: 'primary',
                                     onClick: onContinue,
                                     spinner: waitingOnContinue,
                                     disabled: waitingOnContinue,

--- a/app/src/marketplace/components/Modal/ConfirmPublishTransaction/index.jsx
+++ b/app/src/marketplace/components/Modal/ConfirmPublishTransaction/index.jsx
@@ -44,11 +44,11 @@ const ConfirmPublishTransaction = ({
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             onClick: onCancel,
-                            type: 'link',
+                            kind: 'link',
                         },
                         publish: {
                             title: I18n.t('modal.common.waiting'),
-                            type: 'primary',
+                            kind: 'primary',
                             disabled: true,
                             spinner: true,
                         },

--- a/app/src/marketplace/components/Modal/ConfirmPublishTransaction/index.jsx
+++ b/app/src/marketplace/components/Modal/ConfirmPublishTransaction/index.jsx
@@ -44,11 +44,11 @@ const ConfirmPublishTransaction = ({
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             onClick: onCancel,
-                            color: 'link',
+                            type: 'link',
                         },
                         publish: {
                             title: I18n.t('modal.common.waiting'),
-                            color: 'primary',
+                            type: 'primary',
                             disabled: true,
                             spinner: true,
                         },

--- a/app/src/marketplace/components/Modal/ConfirmSaveDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ConfirmSaveDialog/index.jsx
@@ -28,7 +28,7 @@ const ConfirmSaveDialog = ({ onSave, onClose, onContinue }: Props) => (
                 <div className={styles.footer}>
                     <div className={styles.footerText}>
                         <Button
-                            type="primary"
+                            kind="primary"
                             onClick={onContinue}
                             outline
                         >
@@ -40,11 +40,11 @@ const ConfirmSaveDialog = ({ onSave, onClose, onContinue }: Props) => (
                             cancel: {
                                 title: I18n.t('modal.common.cancel'),
                                 onClick: onClose,
-                                type: 'link',
+                                kind: 'link',
                             },
                             continue: {
                                 title: I18n.t('modal.common.save'),
-                                type: 'primary',
+                                kind: 'primary',
                                 onClick: onSave,
                             },
                         }}

--- a/app/src/marketplace/components/Modal/ConfirmSaveDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ConfirmSaveDialog/index.jsx
@@ -2,12 +2,12 @@
 
 import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
-import { Button } from 'reactstrap'
 
 import Modal from '$shared/components/Modal'
 import Dialog from '$shared/components/Dialog'
 import DiscardChangesPng from '$mp/assets/discard-changes.png'
 import DiscardChangesPng2x from '$mp/assets/discard-changes@2x.png'
+import Button from '$shared/components/Button'
 import Buttons from '$shared/components/Buttons'
 
 import styles from './confirmSave.pcss'
@@ -28,6 +28,7 @@ const ConfirmSaveDialog = ({ onSave, onClose, onContinue }: Props) => (
                 <div className={styles.footer}>
                     <div className={styles.footerText}>
                         <Button
+                            type="primary"
                             onClick={onContinue}
                             outline
                         >
@@ -39,11 +40,11 @@ const ConfirmSaveDialog = ({ onSave, onClose, onContinue }: Props) => (
                             cancel: {
                                 title: I18n.t('modal.common.cancel'),
                                 onClick: onClose,
-                                color: 'link',
+                                type: 'link',
                             },
                             continue: {
                                 title: I18n.t('modal.common.save'),
-                                color: 'primary',
+                                type: 'primary',
                                 onClick: onSave,
                             },
                         }}

--- a/app/src/marketplace/components/Modal/ErrorDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ErrorDialog/index.jsx
@@ -20,7 +20,7 @@ const ErrorDialog = ({ title, message, waiting, onClose }: Props) => (
         actions={{
             dismiss: {
                 title: I18n.t('modal.common.ok'),
-                color: 'primary',
+                kind: 'primary',
                 onClick: onClose,
             },
         }}

--- a/app/src/marketplace/components/Modal/GuidedDeployCommunityDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/GuidedDeployCommunityDialog/index.jsx
@@ -175,12 +175,12 @@ const GuidedDeployCommunityDialog = ({ product, onClose, onContinue: onContinueP
                                 cancel: {
                                     title: I18n.t('modal.common.cancel'),
                                     onClick: onClose,
-                                    color: 'link',
+                                    type: 'link',
                                     disabled: waitingOnContinue,
                                 },
                                 continue: isLastStep ? {
                                     title: I18n.t('modal.common.deploy'),
-                                    color: 'primary',
+                                    type: 'primary',
                                     onClick: onContinue,
                                     spinner: waitingOnContinue,
                                     disabled: waitingOnContinue,

--- a/app/src/marketplace/components/Modal/GuidedDeployCommunityDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/GuidedDeployCommunityDialog/index.jsx
@@ -175,12 +175,12 @@ const GuidedDeployCommunityDialog = ({ product, onClose, onContinue: onContinueP
                                 cancel: {
                                     title: I18n.t('modal.common.cancel'),
                                     onClick: onClose,
-                                    type: 'link',
+                                    kind: 'link',
                                     disabled: waitingOnContinue,
                                 },
                                 continue: isLastStep ? {
                                     title: I18n.t('modal.common.deploy'),
-                                    type: 'primary',
+                                    kind: 'primary',
                                     onClick: onContinue,
                                     spinner: waitingOnContinue,
                                     disabled: waitingOnContinue,

--- a/app/src/marketplace/components/Modal/PurchaseSummaryDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/PurchaseSummaryDialog/index.jsx
@@ -37,11 +37,11 @@ export const PurchaseSummaryDialog = ({
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        color: 'link',
+                        type: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.common.waiting'),
-                        color: 'primary',
+                        type: 'primary',
                         disabled: true,
                         spinner: true,
                     },
@@ -61,12 +61,12 @@ export const PurchaseSummaryDialog = ({
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    color: 'link',
+                    type: 'link',
                     onClick: onCancel,
                 },
                 next: {
                     title: I18n.t('modal.purchaseSummary.pay'),
-                    color: 'primary',
+                    type: 'primary',
                     onClick: () => onPay(),
                 },
             }}

--- a/app/src/marketplace/components/Modal/PurchaseSummaryDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/PurchaseSummaryDialog/index.jsx
@@ -37,11 +37,11 @@ export const PurchaseSummaryDialog = ({
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        type: 'link',
+                        kind: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.common.waiting'),
-                        type: 'primary',
+                        kind: 'primary',
                         disabled: true,
                         spinner: true,
                     },
@@ -61,12 +61,12 @@ export const PurchaseSummaryDialog = ({
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    type: 'link',
+                    kind: 'link',
                     onClick: onCancel,
                 },
                 next: {
                     title: I18n.t('modal.purchaseSummary.pay'),
-                    type: 'primary',
+                    kind: 'primary',
                     onClick: () => onPay(),
                 },
             }}

--- a/app/src/marketplace/components/Modal/ReadyToPublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReadyToPublishDialog/index.jsx
@@ -37,11 +37,11 @@ class ReadyToPublishDialog extends Component<Props, State> {
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        type: 'link',
+                        kind: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.readyToPublish.publish'),
-                        type: 'primary',
+                        kind: 'primary',
                         onClick: onContinue,
                         disabled: !this.state.termsAccepted,
                     },

--- a/app/src/marketplace/components/Modal/ReadyToPublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReadyToPublishDialog/index.jsx
@@ -37,11 +37,11 @@ class ReadyToPublishDialog extends Component<Props, State> {
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        color: 'link',
+                        type: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.readyToPublish.publish'),
-                        color: 'primary',
+                        type: 'primary',
                         onClick: onContinue,
                         disabled: !this.state.termsAccepted,
                     },

--- a/app/src/marketplace/components/Modal/ReadyToUnpublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReadyToUnpublishDialog/index.jsx
@@ -18,11 +18,11 @@ const ReadyToUnpublishDialog = ({ onCancel, onContinue }: Props) => (
             cancel: {
                 title: I18n.t('modal.common.cancel'),
                 onClick: onCancel,
-                color: 'link',
+                type: 'link',
             },
             unpublish: {
                 title: I18n.t('modal.readyToUnpublish.unpublish'),
-                color: 'primary',
+                type: 'primary',
                 onClick: onContinue,
             },
         }}

--- a/app/src/marketplace/components/Modal/ReadyToUnpublishDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReadyToUnpublishDialog/index.jsx
@@ -18,11 +18,11 @@ const ReadyToUnpublishDialog = ({ onCancel, onContinue }: Props) => (
             cancel: {
                 title: I18n.t('modal.common.cancel'),
                 onClick: onCancel,
-                type: 'link',
+                kind: 'link',
             },
             unpublish: {
                 title: I18n.t('modal.readyToUnpublish.unpublish'),
-                type: 'primary',
+                kind: 'primary',
                 onClick: onContinue,
             },
         }}

--- a/app/src/marketplace/components/Modal/ReplaceAllowanceDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReplaceAllowanceDialog/index.jsx
@@ -31,11 +31,11 @@ const ReplaceAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, 
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        type: 'link',
+                        kind: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.common.waiting'),
-                        type: 'primary',
+                        kind: 'primary',
                         disabled: true,
                         spinner: true,
                     },
@@ -57,12 +57,12 @@ const ReplaceAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, 
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    type: 'link',
+                    kind: 'link',
                     onClick: onCancel,
                 },
                 next: {
                     title: I18n.t('modal.common.next'),
-                    type: 'primary',
+                    kind: 'primary',
                     outline: true,
                     onClick: () => onSet(),
                 },

--- a/app/src/marketplace/components/Modal/ReplaceAllowanceDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ReplaceAllowanceDialog/index.jsx
@@ -31,11 +31,11 @@ const ReplaceAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, 
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        color: 'link',
+                        type: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.common.waiting'),
-                        color: 'primary',
+                        type: 'primary',
                         disabled: true,
                         spinner: true,
                     },
@@ -57,12 +57,12 @@ const ReplaceAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, 
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    color: 'link',
+                    type: 'link',
                     onClick: onCancel,
                 },
                 next: {
                     title: I18n.t('modal.common.next'),
-                    color: 'primary',
+                    type: 'primary',
                     outline: true,
                     onClick: () => onSet(),
                 },

--- a/app/src/marketplace/components/Modal/SaveContractProductDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/SaveContractProductDialog/index.jsx
@@ -28,13 +28,13 @@ const SaveContractProductDialog = ({ transactionState, onClose }: Props) => {
                     actions={{
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
-                            type: 'link',
+                            kind: 'link',
                             onClick: onClose,
                             outline: true,
                         },
                         publish: {
                             title: I18n.t('modal.common.waiting'),
-                            type: 'primary',
+                            kind: 'primary',
                             disabled: true,
                             spinner: true,
                         },

--- a/app/src/marketplace/components/Modal/SaveContractProductDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/SaveContractProductDialog/index.jsx
@@ -28,12 +28,13 @@ const SaveContractProductDialog = ({ transactionState, onClose }: Props) => {
                     actions={{
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
+                            type: 'link',
                             onClick: onClose,
                             outline: true,
                         },
                         publish: {
                             title: I18n.t('modal.common.waiting'),
-                            color: 'primary',
+                            type: 'primary',
                             disabled: true,
                             spinner: true,
                         },

--- a/app/src/marketplace/components/Modal/SetAllowanceDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/SetAllowanceDialog/index.jsx
@@ -31,11 +31,11 @@ const SetAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, onSe
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        color: 'link',
+                        type: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.common.waiting'),
-                        color: 'primary',
+                        type: 'primary',
                         disabled: true,
                         spinner: true,
                     },
@@ -57,12 +57,12 @@ const SetAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, onSe
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    color: 'link',
+                    type: 'link',
                     onClick: onCancel,
                 },
                 next: {
                     title: I18n.t('modal.common.next'),
-                    color: 'primary',
+                    type: 'primary',
                     outline: true,
                     onClick: () => onSet(),
                 },

--- a/app/src/marketplace/components/Modal/SetAllowanceDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/SetAllowanceDialog/index.jsx
@@ -31,11 +31,11 @@ const SetAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, onSe
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        type: 'link',
+                        kind: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.common.waiting'),
-                        type: 'primary',
+                        kind: 'primary',
                         disabled: true,
                         spinner: true,
                     },
@@ -57,12 +57,12 @@ const SetAllowanceDialog = ({ gettingAllowance, settingAllowance, onCancel, onSe
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    type: 'link',
+                    kind: 'link',
                     onClick: onCancel,
                 },
                 next: {
                     title: I18n.t('modal.common.next'),
-                    type: 'primary',
+                    kind: 'primary',
                     outline: true,
                     onClick: () => onSet(),
                 },

--- a/app/src/marketplace/components/NotFoundPage/index.jsx
+++ b/app/src/marketplace/components/NotFoundPage/index.jsx
@@ -11,6 +11,8 @@ import Layout from '$shared/components/Layout'
 import links from '../../../links'
 import pageNotFoundPic from '$shared/assets/images/404_blocks.png'
 import pageNotFoundPic2x from '$shared/assets/images/404_blocks@2x.png'
+import Button from '$shared/components/Button'
+
 import styles from './notFoundPage.pcss'
 
 const NotFoundPage = () => (
@@ -27,24 +29,27 @@ const NotFoundPage = () => (
                 )}
                 link={(
                     <React.Fragment>
-                        <Link
+                        <Button
+                            type="special"
+                            tag={Link}
                             to={links.userpages.main}
-                            className="btn btn-special"
                         >
                             <Translate value="notFoundPage.coreApp" />
-                        </Link>
-                        <Link
+                        </Button>
+                        <Button
+                            type="special"
+                            tag={Link}
                             to={links.marketplace.main}
-                            className="btn btn-special"
                         >
                             <Translate value="notFoundPage.top" />
-                        </Link>
-                        <Link
+                        </Button>
+                        <Button
+                            type="special"
+                            tag={Link}
                             to={links.root}
-                            className="btn btn-special"
                         >
                             <Translate value="notFoundPage.publicSite" />
-                        </Link>
+                        </Button>
                     </React.Fragment>
                 )}
                 linkOnMobile

--- a/app/src/marketplace/components/NotFoundPage/index.jsx
+++ b/app/src/marketplace/components/NotFoundPage/index.jsx
@@ -30,21 +30,21 @@ const NotFoundPage = () => (
                 link={(
                     <React.Fragment>
                         <Button
-                            type="special"
+                            kind="special"
                             tag={Link}
                             to={links.userpages.main}
                         >
                             <Translate value="notFoundPage.coreApp" />
                         </Button>
                         <Button
-                            type="special"
+                            kind="special"
                             tag={Link}
                             to={links.marketplace.main}
                         >
                             <Translate value="notFoundPage.top" />
                         </Button>
                         <Button
-                            type="special"
+                            kind="special"
                             tag={Link}
                             to={links.root}
                         >

--- a/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
@@ -2,10 +2,10 @@
 
 import React, { useRef, useState, useCallback } from 'react'
 import cx from 'classnames'
-import { Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import scrollIntoView from 'smooth-scroll-into-view-if-needed'
 
+import Button from '$shared/components/Button'
 import Link from '$shared/components/Link'
 import { isPaidProduct } from '$mp/utils/product'
 import type { Product } from '$mp/flowtype/product-types'
@@ -34,7 +34,6 @@ const buttonTitle = (product: Product, isValidSubscription: boolean) => {
 
 const ProductDetails = ({ product, isValidSubscription, onPurchase }: Props) => {
     const productDetailsRef = useRef(null)
-    console.log(product.description.length)
     const truncationRequired = !((product.description || '').length < 400)
     const [truncated, setTruncatedState] = useState(truncationRequired)
 
@@ -80,7 +79,7 @@ const ProductDetails = ({ product, isValidSubscription, onPurchase }: Props) => 
             <div className={styles.buttonWrapper}>
                 <Button
                     className={styles.button}
-                    color="primary"
+                    type="primary"
                     disabled={(!isPaidProduct(product) && isValidSubscription) || product.state !== productStates.DEPLOYED}
                     onClick={onPurchase}
                 >

--- a/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
@@ -34,7 +34,7 @@ const buttonTitle = (product: Product, isValidSubscription: boolean) => {
 
 const ProductDetails = ({ product, isValidSubscription, onPurchase }: Props) => {
     const productDetailsRef = useRef(null)
-
+    console.log(product.description.length)
     const truncationRequired = !((product.description || '').length < 400)
     const [truncated, setTruncatedState] = useState(truncationRequired)
 

--- a/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
+++ b/app/src/marketplace/components/ProductPage/ProductDetails/index.jsx
@@ -79,7 +79,7 @@ const ProductDetails = ({ product, isValidSubscription, onPurchase }: Props) => 
             <div className={styles.buttonWrapper}>
                 <Button
                     className={styles.button}
-                    type="primary"
+                    kind="primary"
                     disabled={(!isPaidProduct(product) && isValidSubscription) || product.state !== productStates.DEPLOYED}
                     onClick={onPurchase}
                 >

--- a/app/src/marketplace/components/ProductPage/ProductDetails/productDetails.pcss
+++ b/app/src/marketplace/components/ProductPage/ProductDetails/productDetails.pcss
@@ -54,10 +54,6 @@
 }
 
 .button {
-  font-size: 1em;
-  height: auto;
-  line-height: 1em;
-  padding: 1em 0;
   width: 100%;
 }
 

--- a/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
+++ b/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
@@ -61,7 +61,7 @@ const HoverComponent = ({
     <div className={styles.hoverContainer}>
         {(isLoggedIn && (isProductFree || isProductSubscriptionValid)) && (
             <Button
-                type="secondary"
+                kind="secondary"
                 size="mini"
                 outline
                 tag={Link}
@@ -76,7 +76,7 @@ const HoverComponent = ({
         {/* No need to show the preview button on editProduct page */}
         {(isProductFree || (isLoggedIn && isProductSubscriptionValid)) && productId && (
             <Button
-                type="secondary"
+                kind="secondary"
                 size="mini"
                 outline
                 tag={Link}

--- a/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
+++ b/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React from 'react'
-import { Button } from 'reactstrap'
 import classNames from 'classnames'
 import MediaQuery from 'react-responsive'
 import { Translate } from 'react-redux-i18n'
@@ -14,6 +13,7 @@ import { formatExternalUrl } from '$shared/utils/url'
 import type { Product, ProductId } from '../../../flowtype/product-types'
 import links from '../../../../links'
 import Link from '$shared/components/Link'
+import Button from '$shared/components/Button'
 
 import styles from './streamListing.pcss'
 
@@ -61,9 +61,11 @@ const HoverComponent = ({
     <div className={styles.hoverContainer}>
         {(isLoggedIn && (isProductFree || isProductSubscriptionValid)) && (
             <Button
-                color="secondary"
-                size="sm"
-                className="d-none d-md-inline-block"
+                type="secondary"
+                size="mini"
+                outline
+                tag={Link}
+                className={styles.button}
                 href={formatExternalUrl(links.editor.canvasEditor, {
                     addStream: streamId,
                 })}
@@ -74,9 +76,10 @@ const HoverComponent = ({
         {/* No need to show the preview button on editProduct page */}
         {(isProductFree || (isLoggedIn && isProductSubscriptionValid)) && productId && (
             <Button
+                type="secondary"
+                size="mini"
+                outline
                 tag={Link}
-                color="secondary"
-                size="sm"
                 to={routes.streamPreview({
                     id: productId,
                     streamId,

--- a/app/src/marketplace/components/ProductPage/StreamListing/streamListing.pcss
+++ b/app/src/marketplace/components/ProductPage/StreamListing/streamListing.pcss
@@ -20,6 +20,10 @@
   }
 }
 
+.button {
+  margin-right: 1rem;
+}
+
 .tableBody {
   max-height: calc(5 * var(--rowHeight));
   overflow: auto;

--- a/app/src/marketplace/components/ProductTypeChooser/index.jsx
+++ b/app/src/marketplace/components/ProductTypeChooser/index.jsx
@@ -38,7 +38,7 @@ const ProductTypeChooser = ({ onSelect }: Props) => (
                         <Translate value="productTypeChooser.standard.description" />
                     </div>
                     <Button
-                        type="special"
+                        kind="special"
                         className={styles.button}
                         onClick={() => onSelect('NORMAL')}
                     >
@@ -62,7 +62,7 @@ const ProductTypeChooser = ({ onSelect }: Props) => (
                         <Translate value="productTypeChooser.community.description" />
                     </div>
                     <Button
-                        type="special"
+                        kind="special"
                         className={styles.button}
                         onClick={() => onSelect('COMMUNITY')}
                     >

--- a/app/src/marketplace/components/ProductTypeChooser/index.jsx
+++ b/app/src/marketplace/components/ProductTypeChooser/index.jsx
@@ -1,9 +1,9 @@
 // @flow
 
 import * as React from 'react'
-import cx from 'classnames'
 import { Translate, I18n } from 'react-redux-i18n'
 
+import Button from '$shared/components/Button'
 import standardProductImage from '$mp/assets/product_standard.png'
 import standardProductImage2x from '$mp/assets/product_standard@2x.png'
 import communityProductImage from '$mp/assets/product_community.png'
@@ -37,13 +37,13 @@ const ProductTypeChooser = ({ onSelect }: Props) => (
                     <div className={styles.description}>
                         <Translate value="productTypeChooser.standard.description" />
                     </div>
-                    <button
-                        type="button"
-                        className={cx('btn', 'btn-special', styles.button)}
+                    <Button
+                        type="special"
+                        className={styles.button}
                         onClick={() => onSelect('NORMAL')}
                     >
                         <Translate value="productTypeChooser.standard.linkTitle" />
-                    </button>
+                    </Button>
                 </div>
             </div>
             <div className={styles.padding} />
@@ -61,13 +61,13 @@ const ProductTypeChooser = ({ onSelect }: Props) => (
                     <div className={styles.description}>
                         <Translate value="productTypeChooser.community.description" />
                     </div>
-                    <button
-                        type="button"
-                        className={cx('btn', 'btn-special', styles.button)}
+                    <Button
+                        type="special"
+                        className={styles.button}
                         onClick={() => onSelect('COMMUNITY')}
                     >
                         <Translate value="productTypeChooser.community.linkTitle" />
-                    </button>
+                    </Button>
                 </div>
             </div>
             <div className={styles.padding} />

--- a/app/src/marketplace/components/Products/NoMyProductsView/index.jsx
+++ b/app/src/marketplace/components/Products/NoMyProductsView/index.jsx
@@ -19,7 +19,7 @@ const NoProductsView = () => (
             />
         )}
         link={(
-            <Button tag="a" href={editor.canvasEditor} type="special">
+            <Button tag="a" href={editor.canvasEditor} kind="special">
                 <Translate value="noMyProductsView.goToEditor" />
             </Button>
         )}

--- a/app/src/marketplace/components/Products/NoMyProductsView/index.jsx
+++ b/app/src/marketplace/components/Products/NoMyProductsView/index.jsx
@@ -7,6 +7,7 @@ import { editor } from '$shared/../links'
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
+import Button from '$shared/components/Button'
 
 const NoProductsView = () => (
     <EmptyState
@@ -18,9 +19,9 @@ const NoProductsView = () => (
             />
         )}
         link={(
-            <a href={editor.canvasEditor} className="btn btn-special">
+            <Button tag="a" href={editor.canvasEditor} type="special">
                 <Translate value="noMyProductsView.goToEditor" />
-            </a>
+            </Button>
         )}
     >
         <Translate value="noMyProductsView.message" />

--- a/app/src/marketplace/components/Products/NoMyPurchasesView/index.jsx
+++ b/app/src/marketplace/components/Products/NoMyPurchasesView/index.jsx
@@ -19,7 +19,7 @@ const NoProductsView = () => (
             />
         )}
         link={(
-            <Button tag="a" href={marketplace.main} type="special">
+            <Button tag="a" href={marketplace.main} kind="special">
                 <Translate value="noMyPurchasesView.goToMarketplace" />
             </Button>
         )}

--- a/app/src/marketplace/components/Products/NoMyPurchasesView/index.jsx
+++ b/app/src/marketplace/components/Products/NoMyPurchasesView/index.jsx
@@ -7,6 +7,7 @@ import EmptyState from '$shared/components/EmptyState'
 import { marketplace } from '$shared/../links'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
+import Button from '$shared/components/Button'
 
 const NoProductsView = () => (
     <EmptyState
@@ -18,9 +19,9 @@ const NoProductsView = () => (
             />
         )}
         link={(
-            <a href={marketplace.main} className="btn btn-special">
+            <Button tag="a" href={marketplace.main} type="special">
                 <Translate value="noMyPurchasesView.goToMarketplace" />
-            </a>
+            </Button>
         )}
     >
         <Translate value="noMyPurchasesView.message" />

--- a/app/src/marketplace/components/Steps/index.jsx
+++ b/app/src/marketplace/components/Steps/index.jsx
@@ -95,13 +95,13 @@ class Steps extends Component<Props, State> {
                 actions={{
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
-                        type: 'link',
+                        kind: 'link',
                         onClick: this.props.onCancel,
                     },
                     next: {
                         title: this.nextButtonLabel(),
                         outline: this.nextButtonOutline(),
-                        type: 'primary',
+                        kind: 'primary',
                         onClick: this.onNext,
                         disabled: this.props.isDisabled,
                     },

--- a/app/src/marketplace/components/Steps/index.jsx
+++ b/app/src/marketplace/components/Steps/index.jsx
@@ -95,13 +95,13 @@ class Steps extends Component<Props, State> {
                 actions={{
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
-                        color: 'link',
+                        type: 'link',
                         onClick: this.props.onCancel,
                     },
                     next: {
                         title: this.nextButtonLabel(),
                         outline: this.nextButtonOutline(),
-                        color: 'primary',
+                        type: 'primary',
                         onClick: this.onNext,
                         disabled: this.props.isDisabled,
                     },

--- a/app/src/marketplace/components/StreamPreviewPage/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/index.jsx
@@ -6,11 +6,11 @@ import { Link } from 'react-router-dom'
 import findIndex from 'lodash/findIndex'
 import { Translate, I18n } from 'react-redux-i18n'
 
-import { Button } from 'reactstrap'
 import type { StreamId, StreamList } from '$shared/flowtype/stream-types'
 import type { User } from '$shared/flowtype/user-types'
 import type { ResourceKeyId } from '$shared/flowtype/resource-key-types'
 import type { ProductId } from '../../flowtype/product-types'
+import Button from '$shared/components/Button'
 import routes from '$routes'
 
 import StreamLivePreviewTable, { type DataPoint } from './StreamLivePreview'
@@ -206,20 +206,18 @@ class StreamPreviewPage extends React.Component<Props, State> {
                         {productId &&
                             <div className={styles.footer}>
                                 <Button
-                                    outline
-                                    color="secondary"
+                                    type="secondary"
                                     disabled={!prevStreamId}
-                                    className={classnames(styles.button, styles.prevbutton)}
+                                    className={styles.button}
                                     to={prevStreamUrl}
                                     tag={Link}
                                 >
                                     <Translate value="modal.streamLiveData.previous" />
                                 </Button>
                                 <Button
-                                    outline
-                                    color="secondary"
+                                    type="secondary"
                                     disabled={!nextStreamId}
-                                    className={classnames(styles.button, styles.nextButton)}
+                                    className={styles.button}
                                     to={nextStreamUrl}
                                     tag={Link}
                                 >

--- a/app/src/marketplace/components/StreamPreviewPage/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/index.jsx
@@ -206,7 +206,7 @@ class StreamPreviewPage extends React.Component<Props, State> {
                         {productId &&
                             <div className={styles.footer}>
                                 <Button
-                                    type="secondary"
+                                    kind="secondary"
                                     disabled={!prevStreamId}
                                     className={styles.button}
                                     to={prevStreamUrl}
@@ -215,7 +215,7 @@ class StreamPreviewPage extends React.Component<Props, State> {
                                     <Translate value="modal.streamLiveData.previous" />
                                 </Button>
                                 <Button
-                                    type="secondary"
+                                    kind="secondary"
                                     disabled={!nextStreamId}
                                     className={styles.button}
                                     to={nextStreamUrl}

--- a/app/src/marketplace/components/StreamPreviewPage/streamPreviewPage.pcss
+++ b/app/src/marketplace/components/StreamPreviewPage/streamPreviewPage.pcss
@@ -96,9 +96,6 @@
 
   > .button {
     width: 140px;
-    border-color: var(--greyDark2);
-    color: var(--greyDark2);
-    font-weight: 600;
 
     &:not(:first-child) {
       margin-left: 15px;

--- a/app/src/marketplace/components/StreamSelector/index.jsx
+++ b/app/src/marketplace/components/StreamSelector/index.jsx
@@ -5,9 +5,10 @@ import React, { useState, useMemo, useCallback } from 'react'
 import classNames from 'classnames'
 import uniq from 'lodash/uniq'
 import sortBy from 'lodash/sortBy'
-import { Input, Button } from 'reactstrap'
+import { Input } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 
+import Button from '$shared/components/Button'
 import DropdownActions from '$shared/components/DropdownActions'
 import SvgIcon from '$shared/components/SvgIcon'
 import InputError from '$mp/components/InputError'
@@ -175,6 +176,7 @@ export const StreamSelector = (props: Props) => {
                             }
                         </div>
                         <Button
+                            type="secondary"
                             onClick={() => {
                                 const toSelect = matchingStreams.map((s) => s.id)
 

--- a/app/src/marketplace/components/StreamSelector/index.jsx
+++ b/app/src/marketplace/components/StreamSelector/index.jsx
@@ -176,7 +176,7 @@ export const StreamSelector = (props: Props) => {
                             }
                         </div>
                         <Button
-                            type="secondary"
+                            kind="secondary"
                             onClick={() => {
                                 const toSelect = matchingStreams.map((s) => s.id)
 

--- a/app/src/marketplace/components/deprecated/ChooseAccessPeriodDialog/index.jsx
+++ b/app/src/marketplace/components/deprecated/ChooseAccessPeriodDialog/index.jsx
@@ -71,11 +71,11 @@ export class ChooseAccessPeriodDialog extends React.Component<Props, State> {
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        color: 'link',
+                        kind: 'link',
                     },
                     next: {
                         title: I18n.t('modal.common.next'),
-                        color: 'primary',
+                        kind: 'primary',
                         outline: true,
                         onClick: () => onNext(time, timeUnit),
                         disabled: BN(time).isNaN() || BN(time).isLessThanOrEqualTo(0),

--- a/app/src/marketplace/components/deprecated/ConfirmNoCoverImageDialog/index.jsx
+++ b/app/src/marketplace/components/deprecated/ConfirmNoCoverImageDialog/index.jsx
@@ -26,11 +26,11 @@ const ConfirmNoCoverImageDialog = ({ closeOnContinue, onClose, onContinue }: Pro
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
                     onClick: onClose,
-                    type: 'link',
+                    kind: 'link',
                 },
                 continue: {
                     title: I18n.t('modal.common.continue'),
-                    type: 'primary',
+                    kind: 'primary',
                     onClick: () => {
                         onContinue()
 

--- a/app/src/marketplace/components/deprecated/ConfirmNoCoverImageDialog/index.jsx
+++ b/app/src/marketplace/components/deprecated/ConfirmNoCoverImageDialog/index.jsx
@@ -26,11 +26,11 @@ const ConfirmNoCoverImageDialog = ({ closeOnContinue, onClose, onContinue }: Pro
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
                     onClick: onClose,
-                    color: 'link',
+                    type: 'link',
                 },
                 continue: {
                     title: I18n.t('modal.common.continue'),
-                    color: 'primary',
+                    type: 'primary',
                     onClick: () => {
                         onContinue()
 

--- a/app/src/marketplace/components/deprecated/NoStreamsWarningDialog/index.jsx
+++ b/app/src/marketplace/components/deprecated/NoStreamsWarningDialog/index.jsx
@@ -25,11 +25,11 @@ const NoStreamsWarningDialog = ({ onClose, onContinue, waiting }: Props) => (
             cancel: {
                 title: I18n.t('modal.common.cancel'),
                 onClick: onClose,
-                type: 'link',
+                kind: 'link',
             },
             continue: {
                 title: I18n.t('editProductPage.edit'),
-                type: 'primary',
+                kind: 'primary',
                 onClick: onContinue,
             },
         }}

--- a/app/src/marketplace/components/deprecated/NoStreamsWarningDialog/index.jsx
+++ b/app/src/marketplace/components/deprecated/NoStreamsWarningDialog/index.jsx
@@ -25,11 +25,11 @@ const NoStreamsWarningDialog = ({ onClose, onContinue, waiting }: Props) => (
             cancel: {
                 title: I18n.t('modal.common.cancel'),
                 onClick: onClose,
-                color: 'link',
+                type: 'link',
             },
             continue: {
                 title: I18n.t('editProductPage.edit'),
-                color: 'primary',
+                type: 'primary',
                 onClick: onContinue,
             },
         }}

--- a/app/src/marketplace/components/deprecated/ProductPageEditor/StreamSelector/index.jsx
+++ b/app/src/marketplace/components/deprecated/ProductPageEditor/StreamSelector/index.jsx
@@ -4,10 +4,11 @@ import React from 'react'
 import classNames from 'classnames'
 import uniq from 'lodash/uniq'
 import sortBy from 'lodash/sortBy'
-import { Input, Button } from 'reactstrap'
+import { Input } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 
 import StreamListing from '$mp/components/ProductPage/StreamListing'
+import Button from '$shared/components/Button'
 import DropdownActions from '$shared/components/DropdownActions'
 import SvgIcon from '$shared/components/SvgIcon'
 import ProductContainer from '$shared/components/Container/Product'
@@ -297,7 +298,7 @@ export class StreamSelector extends React.Component<Props, State> {
                                 <Translate value="streamSelector.selectedStream" streamCount={selectedStreams.size} />
                             }
                         </div>
-                        <Button color="link" onClick={() => this.onCancel()}>
+                        <Button type="link" onClick={() => this.onCancel()}>
                             <Translate value="modal.common.cancel" />
                         </Button>
                         <Button

--- a/app/src/marketplace/components/deprecated/PurchaseSummaryDialog/index.jsx
+++ b/app/src/marketplace/components/deprecated/PurchaseSummaryDialog/index.jsx
@@ -35,11 +35,11 @@ export const PurchaseSummaryDialog = ({
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         onClick: onCancel,
-                        color: 'link',
+                        kind: 'link',
                     },
                     publish: {
                         title: I18n.t('modal.common.waiting'),
-                        color: 'primary',
+                        kind: 'primary',
                         disabled: true,
                         spinner: true,
                     },
@@ -61,12 +61,12 @@ export const PurchaseSummaryDialog = ({
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    color: 'link',
+                    kind: 'link',
                     onClick: onCancel,
                 },
                 next: {
                     title: I18n.t('modal.purchaseSummary.pay'),
-                    color: 'primary',
+                    kind: 'primary',
                     onClick: () => onPay(),
                 },
             }}

--- a/app/src/marketplace/containers/EditProductPage/index.jsx
+++ b/app/src/marketplace/containers/EditProductPage/index.jsx
@@ -87,7 +87,7 @@ const EditProductPage = ({ product }: { product: Product }) => {
 
         return {
             title: (productState && I18n.t(`editProductPage.${titles[tmpState]}`)) || '',
-            color: 'primary',
+            type: 'primary',
             onClick: publish,
             disabled: !(productState === productStates.NOT_DEPLOYED || productState === productStates.DEPLOYED) || isSaving,
         }
@@ -97,7 +97,7 @@ const EditProductPage = ({ product }: { product: Product }) => {
         if (isCommunity && !isDeployed) {
             return {
                 title: 'Continue',
-                color: 'primary',
+                type: 'primary',
                 onClick: deployCommunity,
                 disabled: isSaving,
             }

--- a/app/src/marketplace/containers/EditProductPage/index.jsx
+++ b/app/src/marketplace/containers/EditProductPage/index.jsx
@@ -87,7 +87,7 @@ const EditProductPage = ({ product }: { product: Product }) => {
 
         return {
             title: (productState && I18n.t(`editProductPage.${titles[tmpState]}`)) || '',
-            type: 'primary',
+            kind: 'primary',
             onClick: publish,
             disabled: !(productState === productStates.NOT_DEPLOYED || productState === productStates.DEPLOYED) || isSaving,
         }
@@ -97,7 +97,7 @@ const EditProductPage = ({ product }: { product: Product }) => {
         if (isCommunity && !isDeployed) {
             return {
                 title: 'Continue',
-                type: 'primary',
+                kind: 'primary',
                 onClick: deployCommunity,
                 disabled: isSaving,
             }

--- a/app/src/marketplace/containers/ProductPage/ProductDetails.jsx
+++ b/app/src/marketplace/containers/ProductPage/ProductDetails.jsx
@@ -2,9 +2,9 @@
 
 import React from 'react'
 import cx from 'classnames'
-import { Button } from 'reactstrap'
 import { I18n } from 'react-redux-i18n'
 
+import Button from '$shared/components/Button'
 import { isPaidProduct } from '$mp/utils/product'
 import type { Product, Subscription } from '$mp/flowtype/product-types'
 import PaymentRate from '$mp/components/PaymentRate'
@@ -67,7 +67,8 @@ const ProductDetails = ({ product, isValidSubscription, productSubscription, onP
         <div className={styles.buttonWrapper}>
             <Button
                 className={styles.button}
-                color="primary"
+                type="primary"
+                size="big"
                 disabled={(!isPaidProduct(product) && isValidSubscription) || product.state !== productStates.DEPLOYED}
                 onClick={onPurchase}
             >

--- a/app/src/marketplace/containers/ProductPage/ProductDetails.jsx
+++ b/app/src/marketplace/containers/ProductPage/ProductDetails.jsx
@@ -67,7 +67,7 @@ const ProductDetails = ({ product, isValidSubscription, productSubscription, onP
         <div className={styles.buttonWrapper}>
             <Button
                 className={styles.button}
-                type="primary"
+                kind="primary"
                 size="big"
                 disabled={(!isPaidProduct(product) && isValidSubscription) || product.state !== productStates.DEPLOYED}
                 onClick={onPurchase}

--- a/app/src/marketplace/containers/ProductPage/productDetails2.pcss
+++ b/app/src/marketplace/containers/ProductPage/productDetails2.pcss
@@ -33,10 +33,6 @@
 }
 
 .button {
-  font-size: 1em;
-  height: auto;
-  line-height: 1em;
-  padding: 1em 0;
   width: 100%;
 }
 

--- a/app/src/marketplace/containers/deprecated/EditProductPage/index.jsx
+++ b/app/src/marketplace/containers/deprecated/EditProductPage/index.jsx
@@ -172,6 +172,7 @@ export class EditProductPage extends Component<Props, State> {
                 toolbarActions.saveAndExit = {
                     title: this.getUpdateButtonTitle(editProduct),
                     disabled: this.isUpdateButtonDisabled(editProduct),
+                    kind: 'primary',
                     onClick: () => this.validateProductBeforeSaving(() => redirect(links.userpages.products)),
                 }
             }
@@ -180,7 +181,7 @@ export class EditProductPage extends Component<Props, State> {
                 toolbarActions.publish = {
                     title: this.getPublishButtonTitle(editProduct),
                     disabled: this.isPublishButtonDisabled(editProduct),
-                    color: 'primary',
+                    kind: 'primary',
                     onClick: () => this.validateProductBeforeSaving((id) => noHistoryRedirect(links.marketplace.products, id, 'publish')),
                     className: 'd-none d-sm-inline-block',
                 }
@@ -193,11 +194,12 @@ export class EditProductPage extends Component<Props, State> {
         return {
             saveAndExit: {
                 title: I18n.t('editProductPage.save'),
+                kind: 'primary',
                 onClick: () => this.validateProductBeforeSaving(onSaveAndExit),
             },
             publish: {
                 title: I18n.t('editProductPage.publish'),
-                color: 'primary',
+                kind: 'primary',
                 onClick: () => this.validateProductBeforeSaving(onPublish),
                 className: 'd-none d-sm-block',
             },

--- a/app/src/marketplace/containers/deprecated/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/deprecated/ProductPage/index.jsx
@@ -199,7 +199,7 @@ export class ProductPage extends Component<Props> {
             toolbarActions.publish = {
                 title: this.getPublishButtonTitle(product),
                 disabled: this.getPublishButtonDisabled(product),
-                color: 'primary',
+                kind: 'primary',
                 onClick: () => noHistoryRedirect(links.marketplace.products, product.id || '', 'publish'),
                 className: 'd-none d-sm-inline-block',
             }

--- a/app/src/shared/components/Button/index.jsx
+++ b/app/src/shared/components/Button/index.jsx
@@ -1,0 +1,79 @@
+// @flow
+
+import React, { type Node, type ElementType } from 'react'
+import cx from 'classnames'
+
+import Spinner from '$shared/components/Spinner'
+
+import styles from './newButton.pcss'
+
+type Size = 'mini' | 'normal' | 'big'
+type Type = 'primary' | 'secondary' | 'destructive' | 'link' | 'special'
+type Variant = 'dark'
+
+type Props = {
+    className?: string,
+    tag: ElementType,
+    size: Size,
+    type: Type,
+    variant?: Variant,
+    outline: boolean,
+    disabled: boolean,
+    waiting: boolean,
+    onClick?: () => void,
+    children?: Node,
+}
+
+const Button = ({
+    className,
+    tag: Tag,
+    size,
+    type,
+    variant,
+    outline,
+    disabled,
+    waiting,
+    onClick,
+    children,
+    ...args
+}: Props) => {
+    console.log(type, size, outline, disabled, args)
+    return (
+        <Tag
+            className={
+                cx(styles.root, {
+                    [styles.primary]: type === 'primary',
+                    [styles.secondary]: type === 'secondary',
+                    [styles.destructive]: type === 'destructive',
+                    [styles.link]: type === 'link',
+                    [styles.special]: type === 'special',
+                    [styles.mini]: size === 'mini',
+                    [styles.normal]: size === 'normal',
+                    [styles.big]: size === 'big',
+                    [styles.dark]: variant === 'dark',
+                    [styles.outline]: outline,
+                    [styles.waiting]: waiting,
+                }, className)
+            }
+            onClick={onClick}
+            disabled={disabled}
+            {...args}
+        >
+            {children}
+            {waiting && (
+                <Spinner color="white" />
+            )}
+        </Tag>
+    )
+}
+
+Button.defaultProps = {
+    tag: 'button',
+    type: 'primary',
+    size: 'normal',
+    outline: false,
+    disabled: false,
+    waiting: false,
+}
+
+export default Button

--- a/app/src/shared/components/Button/index.jsx
+++ b/app/src/shared/components/Button/index.jsx
@@ -8,14 +8,14 @@ import Spinner from '$shared/components/Spinner'
 import styles from './newButton.pcss'
 
 export type Size = 'mini' | 'normal' | 'big'
-export type Type = 'primary' | 'secondary' | 'destructive' | 'link' | 'special'
+export type Kind = 'primary' | 'secondary' | 'destructive' | 'link' | 'special'
 export type Variant = 'dark'
 
 type Props = {
     className?: string,
     tag: ElementType,
     size?: Size,
-    type?: Type,
+    kind?: Kind,
     variant?: Variant,
     outline?: boolean,
     disabled?: boolean,
@@ -28,7 +28,7 @@ const Button = ({
     className,
     tag: Tag,
     size,
-    type,
+    kind,
     variant,
     outline,
     disabled,
@@ -40,11 +40,11 @@ const Button = ({
     <Tag
         className={
             cx(styles.root, {
-                [styles.primary]: type === 'primary',
-                [styles.secondary]: type === 'secondary',
-                [styles.destructive]: type === 'destructive',
-                [styles.link]: type === 'link',
-                [styles.special]: type === 'special',
+                [styles.primary]: kind === 'primary',
+                [styles.secondary]: kind === 'secondary',
+                [styles.destructive]: kind === 'destructive',
+                [styles.link]: kind === 'link',
+                [styles.special]: kind === 'special',
                 [styles.mini]: size === 'mini',
                 [styles.normal]: size === 'normal',
                 [styles.big]: size === 'big',
@@ -69,7 +69,7 @@ const Button = ({
 
 Button.defaultProps = {
     tag: 'button',
-    type: 'primary',
+    kind: 'primary',
     size: 'normal',
     outline: false,
     disabled: false,

--- a/app/src/shared/components/Button/index.jsx
+++ b/app/src/shared/components/Button/index.jsx
@@ -14,12 +14,12 @@ export type Variant = 'dark'
 type Props = {
     className?: string,
     tag: ElementType,
-    size: Size,
-    type: Type,
+    size?: Size,
+    type?: Type,
     variant?: Variant,
-    outline: boolean,
-    disabled: boolean,
-    waiting: boolean,
+    outline?: boolean,
+    disabled?: boolean,
+    waiting?: boolean,
     onClick?: (e: SyntheticInputEvent<EventTarget>) => void | Promise<void>,
     children?: Node,
 }
@@ -55,6 +55,7 @@ const Button = ({
         onClick={onClick}
         disabled={disabled || waiting}
         {...args}
+        tabIndex={disabled ? -1 : 0}
     >
         {children}
         {waiting && (

--- a/app/src/shared/components/Button/index.jsx
+++ b/app/src/shared/components/Button/index.jsx
@@ -7,9 +7,9 @@ import Spinner from '$shared/components/Spinner'
 
 import styles from './newButton.pcss'
 
-type Size = 'mini' | 'normal' | 'big'
-type Type = 'primary' | 'secondary' | 'destructive' | 'link' | 'special'
-type Variant = 'dark'
+export type Size = 'mini' | 'normal' | 'big'
+export type Type = 'primary' | 'secondary' | 'destructive' | 'link' | 'special'
+export type Variant = 'dark'
 
 type Props = {
     className?: string,
@@ -20,7 +20,7 @@ type Props = {
     outline: boolean,
     disabled: boolean,
     waiting: boolean,
-    onClick?: () => void,
+    onClick?: (e: SyntheticInputEvent<EventTarget>) => void | Promise<void>,
     children?: Node,
 }
 

--- a/app/src/shared/components/Button/index.jsx
+++ b/app/src/shared/components/Button/index.jsx
@@ -36,36 +36,35 @@ const Button = ({
     onClick,
     children,
     ...args
-}: Props) => {
-    console.log(type, size, outline, disabled, args)
-    return (
-        <Tag
-            className={
-                cx(styles.root, {
-                    [styles.primary]: type === 'primary',
-                    [styles.secondary]: type === 'secondary',
-                    [styles.destructive]: type === 'destructive',
-                    [styles.link]: type === 'link',
-                    [styles.special]: type === 'special',
-                    [styles.mini]: size === 'mini',
-                    [styles.normal]: size === 'normal',
-                    [styles.big]: size === 'big',
-                    [styles.dark]: variant === 'dark',
-                    [styles.outline]: outline,
-                    [styles.waiting]: waiting,
-                }, className)
-            }
-            onClick={onClick}
-            disabled={disabled}
-            {...args}
-        >
-            {children}
-            {waiting && (
+}: Props) => (
+    <Tag
+        className={
+            cx(styles.root, {
+                [styles.primary]: type === 'primary',
+                [styles.secondary]: type === 'secondary',
+                [styles.destructive]: type === 'destructive',
+                [styles.link]: type === 'link',
+                [styles.special]: type === 'special',
+                [styles.mini]: size === 'mini',
+                [styles.normal]: size === 'normal',
+                [styles.big]: size === 'big',
+                [styles.dark]: variant === 'dark',
+                [styles.outline]: outline,
+            }, className)
+        }
+        onClick={onClick}
+        disabled={disabled || waiting}
+        {...args}
+    >
+        {children}
+        {waiting && (
+            <React.Fragment>
+                &nbsp;
                 <Spinner color="white" />
-            )}
-        </Tag>
-    )
-}
+            </React.Fragment>
+        )}
+    </Tag>
+)
 
 Button.defaultProps = {
     tag: 'button',

--- a/app/src/shared/components/Button/newButton.pcss
+++ b/app/src/shared/components/Button/newButton.pcss
@@ -1,0 +1,250 @@
+.root {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  background-color: transparent;
+  border: 1px solid;
+  border-radius: 4px;
+  font: var(--sans);
+  font-weight: var(--medium);
+  letter-spacing: 0;
+  text-align: center;
+  transition: 200ms ease-in-out;
+  transition-property: border-color, background-color, color;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+
+  &,
+  &:--idle,
+  &:--enter {
+    text-decoration: none;
+    outline: none;
+  }
+
+  &:--enter {
+    transition-duration: 5ms;
+    transform: scale(1.05);
+  }
+
+  &:active {
+    transform: scale(0.95);
+    outline: none;
+  }
+
+  &[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &.waiting {
+    opacity: 0.5;
+  }
+}
+
+/*
+  Types
+*/
+.primary {
+  color: rgba(255, 255, 255, 1);
+  background-color: #0324FF;
+  border-color: #0324FF;
+
+  &:--enter {
+    background-color: #0D009A;
+    border-color: #0D009A;
+  }
+
+  &:active {
+    background-color: #09006D;
+    border-color: #09006D;
+  }
+
+  &[disabled] {
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  &.outline {
+    color: rgb(3, 36, 255, 1);
+    background-color: #FFFFFF;
+    border-color: #0324FF;
+
+    &:--enter {
+      color: #0D009A;
+      border-color: #0D009A;
+    }
+
+    &:active {
+      color: #09006D;
+      border-color: #09006D;
+    }
+
+    &[disabled] {
+      color: rgb(3, 36, 255, 0.5);
+    }
+  }
+}
+
+.secondary {
+  color: rgba(50, 50, 50, 1);
+  background-color: #EFEFEF;
+  border-color: #EFEFEF;
+
+  &:--enter {
+    background-color: #E7E7E7;
+    border-color: #E7E7E7;
+  }
+
+  &:active {
+    background-color: #D8D8D8;
+    border-color: #D8D8D8;
+  }
+
+  &[disabled] {
+    color: rgba(50, 50, 50, 0.5);
+  }
+
+  &.outline {
+    border-color: #525252;
+    background-color: #FFFFFF;
+
+    &:--enter {
+      border-color: #323232;
+    }
+
+    &:active {
+      border-color: #525252;
+    }
+  }
+}
+
+.destructive {
+  color: rgba(255, 255, 255, 1);
+  background-color: #FF0F2D;
+  border-color: #FF0F2D;
+
+  &:--enter {
+    background-color: #EA112C;
+    border-color: #EA112C;
+  }
+
+  &:active {
+    background-color: #D50F28;
+    border-color: #D50F28;
+  }
+
+  &[disabled] {
+    color: rgba(255, 255, 255, 0.5);
+  }
+}
+
+.link {
+  color: rgba(171, 171, 171, 1);
+  background-color: transparent;
+  border-color: transparent;
+
+  &:--enter {
+    color: #323232;
+    transform: scale(1);
+  }
+
+  &:active {
+    color: rgba(171, 171, 171, 0.8);
+    transform: scale(1);
+  }
+
+  &[disabled] {
+    color: rgba(171, 171, 171, 0.5);
+  }
+
+  &.dark {
+    color: rgba(3, 36, 255, 1);
+    background-color: transparent;
+    border-color: transparent;
+
+    &:--enter {
+      color: #0D009A;
+    }
+
+    &:active {
+      color: #13013D;
+    }
+
+    &[disabled] {
+      color: rgba(3, 36, 255, 0.5);
+    }
+  }
+}
+
+.special {
+  color: rgba(50, 50, 50, 1);
+  background-color: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.9);
+  border-radius: 20px;
+  font: var(--sans);
+  font-weight: var(--medium);
+  font-size: 12px !important;
+  line-height: 12px !important;
+  padding: 0 1.5rem !important;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  height: 40px !important;
+
+  &:--enter {
+    background-color: rgba(255, 255, 255, 1);
+    border-color: rgba(255, 255, 255, 1);
+  }
+
+  &:active {
+    background-color: rgba(255, 255, 255, 0.8);
+    border-color: rgba(255, 255, 255, 0.8);
+  }
+
+  &[disabled] {
+    color: rgba(50, 50, 50, 0.5);
+  }
+
+  &.dark {
+    color: rgba(50, 50, 50, 1);
+    background-color: rgba(239, 239, 239, 0.9);
+    border-color: rgba(239, 239, 239, 0.9);
+
+    &:--enter {
+      background-color: #E7E7E7;
+      border-color: #E7E7E7;
+    }
+
+    &:active {
+      background-color: #D8D8D8;
+      border-color: #D8D8D8;
+    }
+
+    &[disabled] {
+      color: rgba(50, 50, 50, 0.5);
+    }
+  }
+}
+
+/*
+  Sizes
+*/
+.mini {
+  height: 2rem;
+  padding: 0 0.5rem;
+  font-size: 14px;
+  line-height: 16px;
+}
+
+.normal {
+  height: 2.5rem;
+  padding: 0 1rem;
+  font-size: 14px;
+  line-height: 22px;
+}
+
+.big {
+  height: 3rem;
+  padding: 0 2rem;
+  font-size: 16px;
+  line-height: 24px;
+}

--- a/app/src/shared/components/Button/newButton.pcss
+++ b/app/src/shared/components/Button/newButton.pcss
@@ -1,4 +1,5 @@
 .root {
+  position: relative;
   display: inline-flex;
   align-items: center;
   padding: 0;
@@ -10,7 +11,7 @@
   letter-spacing: 0;
   text-align: center;
   transition: 200ms ease-in-out;
-  transition-property: border-color, background-color, color;
+  transition-property: border-color, background-color, color, transform;
   white-space: nowrap;
   cursor: pointer;
   user-select: none;
@@ -39,6 +40,10 @@
 
   &.waiting {
     opacity: 0.5;
+  }
+
+  & * {
+    width: 100%;
   }
 }
 
@@ -70,6 +75,7 @@
     border-color: #0324FF;
 
     &:--enter {
+      color: inherit;
       color: #0D009A;
       border-color: #0D009A;
     }
@@ -91,6 +97,7 @@
   border-color: #EFEFEF;
 
   &:--enter {
+    color: inherit;
     background-color: #E7E7E7;
     border-color: #E7E7E7;
   }
@@ -139,9 +146,11 @@
 }
 
 .link {
-  color: rgba(171, 171, 171, 1);
+  color: rgba(82, 82, 82, 1);
   background-color: transparent;
   border-color: transparent;
+  font-weight: var(--regular);
+  padding: 0 0.5rem !important; /* ignore "size" classes */
 
   &:--enter {
     color: #323232;
@@ -149,12 +158,12 @@
   }
 
   &:active {
-    color: rgba(171, 171, 171, 0.8);
+    color: rgba(82, 82, 82, 0.8);
     transform: scale(1);
   }
 
   &[disabled] {
-    color: rgba(171, 171, 171, 0.5);
+    color: rgba(82, 82, 82, 0.5);
   }
 
   &.dark {
@@ -183,14 +192,15 @@
   border-radius: 20px;
   font: var(--sans);
   font-weight: var(--medium);
-  font-size: 12px !important;
-  line-height: 12px !important;
-  padding: 0 1.5rem !important;
+  font-size: 12px !important; /* ignore "size" classes */
+  line-height: 12px !important; /* ignore "size" classes */
+  padding: 0 1.5rem !important; /* ignore "size" classes */
   text-transform: uppercase;
   letter-spacing: 1px;
-  height: 40px !important;
+  height: 40px !important; /* ignore "size" classes */
 
   &:--enter {
+    color: inherit;
     background-color: rgba(255, 255, 255, 1);
     border-color: rgba(255, 255, 255, 1);
   }

--- a/app/src/shared/components/Button/newButton.pcss
+++ b/app/src/shared/components/Button/newButton.pcss
@@ -73,7 +73,6 @@
     border-color: #0324FF;
 
     &:--enter {
-      color: inherit;
       color: #0D009A;
       border-color: #0D009A;
     }

--- a/app/src/shared/components/Button/newButton.pcss
+++ b/app/src/shared/components/Button/newButton.pcss
@@ -12,7 +12,7 @@
   text-align: center;
   transition: 200ms ease-in-out;
   transition-property: border-color, background-color, color, transform;
-  transform: transale3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
   white-space: nowrap;
   cursor: pointer;
   user-select: none;
@@ -28,18 +28,18 @@
 
   &:--enter {
     transition-duration: 5ms;
-    transform: scale(1.05);
+    transform: scale(1.05) translate3d(0, 0, 0);
   }
 
   &:active {
-    transform: scale(0.95);
+    transform: scale(0.95) translate3d(0, 0, 0);
     outline: none;
   }
 
   &[disabled] {
     opacity: 0.5;
     cursor: not-allowed;
-    transform: scale(1);
+    transform: scale(1) translate3d(0, 0, 0);
   }
 
   & * {
@@ -153,12 +153,12 @@
 
   &:--enter {
     color: #323232;
-    transform: scale(1);
+    transform: scale(1) translate3d(0, 0, 0);
   }
 
   &:active {
     color: rgba(82, 82, 82, 0.8);
-    transform: scale(1);
+    transform: scale(1) translate3d(0, 0, 0);
   }
 
   &[disabled] {
@@ -238,21 +238,21 @@
   Sizes
 */
 .mini {
-  height: 2rem;
+  height: calc(2 * var(--um));
   padding: 0 0.5rem;
   font-size: 14px;
   line-height: 16px;
 }
 
 .normal {
-  height: 2.5rem;
+  height: calc(2.5 * var(--um));
   padding: 0 1rem;
   font-size: 14px;
   line-height: 22px;
 }
 
 .big {
-  height: 3rem;
+  height: calc(3 * var(--um));
   padding: 0 2rem;
   font-size: 16px;
   line-height: 24px;

--- a/app/src/shared/components/Button/newButton.pcss
+++ b/app/src/shared/components/Button/newButton.pcss
@@ -12,6 +12,7 @@
   text-align: center;
   transition: 200ms ease-in-out;
   transition-property: border-color, background-color, color, transform;
+  will-change: transform;
   white-space: nowrap;
   cursor: pointer;
   user-select: none;
@@ -36,6 +37,7 @@
   &[disabled] {
     opacity: 0.5;
     cursor: not-allowed;
+    transform: scale(1);
   }
 
   & * {

--- a/app/src/shared/components/Button/newButton.pcss
+++ b/app/src/shared/components/Button/newButton.pcss
@@ -38,10 +38,6 @@
     cursor: not-allowed;
   }
 
-  &.waiting {
-    opacity: 0.5;
-  }
-
   & * {
     width: 100%;
   }

--- a/app/src/shared/components/Button/newButton.pcss
+++ b/app/src/shared/components/Button/newButton.pcss
@@ -12,10 +12,12 @@
   text-align: center;
   transition: 200ms ease-in-out;
   transition-property: border-color, background-color, color, transform;
-  will-change: transform;
+  transform: transale3d(0, 0, 0);
   white-space: nowrap;
   cursor: pointer;
   user-select: none;
+  backface-visibility: hidden;
+  -webkit-font-smoothing: subpixel-antialiased;
 
   &,
   &:--idle,

--- a/app/src/shared/components/Buttons/buttons.pcss
+++ b/app/src/shared/components/Buttons/buttons.pcss
@@ -10,13 +10,11 @@
   display: none;
 }
 
-.buttons > :global(.btn) {
-  font-size: 14px;
-  min-width: 96px;
+.buttons > * {
   padding-right: 15px;
   padding-left: 15px;
 }
 
-.buttons > :global(.btn) + :global(.btn) {
+.buttons > * + * {
   margin-left: 1rem;
 }

--- a/app/src/shared/components/Buttons/index.jsx
+++ b/app/src/shared/components/Buttons/index.jsx
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Fragment } from 'react'
-import { Button } from 'reactstrap'
 import { Link } from 'react-router-dom'
 import classNames from 'classnames'
 
+import Button, { type Type } from '$shared/components/Button'
 import Spinner from '$shared/components/Spinner'
 import styles from './buttons.pcss'
 
@@ -12,7 +12,7 @@ export type ButtonAction = {
     title: string,
     onClick?: () => void | Promise<void>,
     linkTo?: string,
-    color?: string,
+    type?: Type,
     disabled?: boolean,
     visible?: boolean,
     outline?: boolean,
@@ -36,18 +36,18 @@ export const Buttons = ({ actions, className }: Props) => (
                 title,
                 onClick,
                 linkTo,
-                color,
+                type,
                 disabled,
                 outline,
                 spinner,
                 className: cn,
             } = (actions && actions[key]) || {}
             return linkTo ? (
-                <Button key={key} tag={Link} to={linkTo} onClick={onClick} disabled={disabled} color={color} outline={outline} className={cn}>
+                <Button key={key} tag={Link} to={linkTo} onClick={onClick} disabled={disabled} type={type} outline={outline} className={cn}>
                     {title}
                 </Button>
             ) : (
-                <Button key={key} disabled={disabled} onClick={onClick} color={color} outline={outline} className={cn}>
+                <Button key={key} disabled={disabled} onClick={onClick} type={type} outline={outline} className={cn}>
                     {title}
                     {spinner &&
                         <Fragment>

--- a/app/src/shared/components/Buttons/index.jsx
+++ b/app/src/shared/components/Buttons/index.jsx
@@ -1,18 +1,17 @@
 // @flow
 
-import React, { Fragment } from 'react'
+import React from 'react'
 import { Link } from 'react-router-dom'
 import classNames from 'classnames'
 
-import Button, { type Type } from '$shared/components/Button'
-import Spinner from '$shared/components/Spinner'
+import Button, { type Kind } from '$shared/components/Button'
 import styles from './buttons.pcss'
 
 export type ButtonAction = {
     title: string,
     onClick?: () => void | Promise<void>,
     linkTo?: string,
-    type?: Type,
+    kind?: Kind,
     disabled?: boolean,
     visible?: boolean,
     outline?: boolean,
@@ -36,25 +35,25 @@ export const Buttons = ({ actions, className }: Props) => (
                 title,
                 onClick,
                 linkTo,
-                type,
+                kind,
                 disabled,
                 outline,
                 spinner,
                 className: cn,
             } = (actions && actions[key]) || {}
-            return linkTo ? (
-                <Button key={key} tag={Link} to={linkTo} onClick={onClick} disabled={disabled} type={type} outline={outline} className={cn}>
+            return (
+                <Button
+                    key={key}
+                    tag={linkTo != null ? Link : 'button'}
+                    to={linkTo}
+                    onClick={onClick}
+                    disabled={disabled}
+                    kind={kind}
+                    outline={outline}
+                    waiting={spinner}
+                    className={cn}
+                >
                     {title}
-                </Button>
-            ) : (
-                <Button key={key} disabled={disabled} onClick={onClick} type={type} outline={outline} className={cn}>
-                    {title}
-                    {spinner &&
-                        <Fragment>
-                            <span>&nbsp;</span>
-                            <Spinner size="small" color="white" />
-                        </Fragment>
-                    }
                 </Button>
             )
         })}

--- a/app/src/shared/components/ConfirmDialog/index.jsx
+++ b/app/src/shared/components/ConfirmDialog/index.jsx
@@ -5,6 +5,8 @@ import { I18n, Translate } from 'react-redux-i18n'
 import cx from 'classnames'
 import { Label, FormGroup } from 'reactstrap'
 
+import type { Kind } from '$shared/components/Button'
+
 import Dialog from '$shared/components/Dialog'
 import Modal from '$shared/components/Modal'
 import Buttons from '$shared/components/Buttons'
@@ -14,7 +16,7 @@ import styles from './confirmDialog.pcss'
 
 type Button = string | {
     title: string,
-    color?: 'outline' | 'primary' | 'danger',
+    kind?: Kind,
     disabled?: boolean,
     spinner?: boolean,
 }
@@ -68,14 +70,14 @@ const ConfirmDialog = (props: Props) => {
         cancel: {
             title: I18n.t('modal.common.cancel'),
             onClick: onReject,
-            type: 'link',
+            kind: 'link',
             outline: true,
             ...cancelButtonProps,
         },
         save: {
             title: I18n.t('modal.common.ok'),
             onClick: (event) => onAccept(event, checked),
-            type: 'primary',
+            kind: 'primary',
             ...acceptButtonProps,
         },
     }

--- a/app/src/shared/components/ConfirmDialog/index.jsx
+++ b/app/src/shared/components/ConfirmDialog/index.jsx
@@ -68,14 +68,14 @@ const ConfirmDialog = (props: Props) => {
         cancel: {
             title: I18n.t('modal.common.cancel'),
             onClick: onReject,
-            color: 'link',
+            type: 'link',
             outline: true,
             ...cancelButtonProps,
         },
         save: {
             title: I18n.t('modal.common.ok'),
             onClick: (event) => onAccept(event, checked),
-            color: 'primary',
+            type: 'primary',
             ...acceptButtonProps,
         },
     }

--- a/app/src/shared/components/Spinner/index.jsx
+++ b/app/src/shared/components/Spinner/index.jsx
@@ -16,9 +16,10 @@ type Props = {
 }
 
 const Spinner = ({ size, color, className }: Props) => (
-    <span className={classNames(className, styles[size], styles.spinner, styles[color])}>
-        <Translate value="spinner.screenReaderText" />
-    </span>
+    <div className={styles.container}>
+        <span className={classNames(className, styles[size], styles.spinner, styles[color])} />
+        <Translate className={styles.screenReaderText} value="spinner.screenReaderText" />
+    </div>
 )
 
 Spinner.defaultProps = {

--- a/app/src/shared/components/Spinner/spinner.pcss
+++ b/app/src/shared/components/Spinner/spinner.pcss
@@ -1,7 +1,11 @@
+.container {
+  display: inline-flex;
+  align-self: center;
+}
+
 .spinner {
   display: inline-block;
   position: relative;
-  text-indent: -9999em;
   transform: translateZ(0);
   animation: spin 1.1s infinite linear;
 
@@ -12,6 +16,17 @@
     min-height: 16px;
     line-height: 1;
   }
+}
+
+.screenReaderText {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
 }
 
 .small {

--- a/app/src/userpages/components/Avatar/AvatarUpload/avatarUpload.pcss
+++ b/app/src/userpages/components/Avatar/AvatarUpload/avatarUpload.pcss
@@ -9,17 +9,3 @@
 .uploadHelpText {
   margin-top: 1rem;
 }
-
-.updateButton {
-  font-weight: var(--regular);
-  font-family: 'IBM Plex Sans', sans-serif;
-  text-transform: capitalize;
-  width: 80px;
-  height: 32px;
-  border: 1px solid #525252;
-  border-radius: 4px;
-  color: #525252;
-  font-size: 14px;
-  letter-spacing: 0;
-  line-height: 20px;
-}

--- a/app/src/userpages/components/Avatar/AvatarUpload/index.jsx
+++ b/app/src/userpages/components/Avatar/AvatarUpload/index.jsx
@@ -42,7 +42,7 @@ class AvatarUpload extends React.Component<Props, State> {
         return (
             <div className={styles.upload}>
                 <Button
-                    type="secondary"
+                    kind="secondary"
                     disabled={modalOpen}
                     onClick={this.onShowModal}
                 >

--- a/app/src/userpages/components/Avatar/AvatarUpload/index.jsx
+++ b/app/src/userpages/components/Avatar/AvatarUpload/index.jsx
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react'
-import { Button } from 'reactstrap'
 import { Translate } from 'react-redux-i18n'
 
 import EditAvatarDialog from '../EditAvatarDialog'
+import Button from '$shared/components/Button'
 
 import styles from './avatarUpload.pcss'
 
@@ -42,10 +42,7 @@ class AvatarUpload extends React.Component<Props, State> {
         return (
             <div className={styles.upload}>
                 <Button
-                    color="userpages"
-                    type="button"
-                    outline
-                    className={styles.updateButton}
+                    type="secondary"
                     disabled={modalOpen}
                     onClick={this.onShowModal}
                 >

--- a/app/src/userpages/components/Avatar/AvatarUploadDialog/index.jsx
+++ b/app/src/userpages/components/Avatar/AvatarUploadDialog/index.jsx
@@ -62,12 +62,12 @@ class AvatarUploadDialog extends React.Component<Props, State> {
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             outline: true,
-                            type: 'link',
+                            kind: 'link',
                             onClick: onClose,
                         },
                         save: {
                             title: I18n.t('modal.common.apply'),
-                            type: 'primary',
+                            kind: 'primary',
                             onClick: this.onSave,
                             disabled: (!originalImage && !this.state.image),
                         },

--- a/app/src/userpages/components/Avatar/AvatarUploadDialog/index.jsx
+++ b/app/src/userpages/components/Avatar/AvatarUploadDialog/index.jsx
@@ -62,12 +62,12 @@ class AvatarUploadDialog extends React.Component<Props, State> {
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             outline: true,
-                            color: 'link',
+                            type: 'link',
                             onClick: onClose,
                         },
                         save: {
                             title: I18n.t('modal.common.apply'),
-                            color: 'primary',
+                            type: 'primary',
                             onClick: this.onSave,
                             disabled: (!originalImage && !this.state.image),
                         },

--- a/app/src/userpages/components/Avatar/CropAvatarDialog/index.jsx
+++ b/app/src/userpages/components/Avatar/CropAvatarDialog/index.jsx
@@ -77,12 +77,12 @@ class CropAvatarDialog extends React.Component<Props, State> {
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         outline: true,
-                        color: 'link',
+                        type: 'link',
                         onClick: onClose,
                     },
                     save: {
                         title: I18n.t('modal.avatar.saveAndApplyAvatar'),
-                        color: 'primary',
+                        type: 'primary',
                         onClick: this.onSave,
                         disabled: saving,
                         spinner: saving,

--- a/app/src/userpages/components/Avatar/CropAvatarDialog/index.jsx
+++ b/app/src/userpages/components/Avatar/CropAvatarDialog/index.jsx
@@ -77,12 +77,12 @@ class CropAvatarDialog extends React.Component<Props, State> {
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
                         outline: true,
-                        type: 'link',
+                        kind: 'link',
                         onClick: onClose,
                     },
                     save: {
                         title: I18n.t('modal.avatar.saveAndApplyAvatar'),
-                        type: 'primary',
+                        kind: 'primary',
                         onClick: this.onSave,
                         disabled: saving,
                         spinner: saving,

--- a/app/src/userpages/components/CanvasPage/List/NoCanvases/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/NoCanvases/index.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
 import MediaQuery from 'react-responsive'
 
+import Button from '$shared/components/Button'
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
@@ -50,13 +51,12 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
             />
         )}
         link={(
-            <button
-                type="button"
-                className="btn btn-special"
+            <Button
+                type="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.canvases.noCanvasesResult.clearFilters" />
-            </button>
+            </Button>
         )}
     >
         <Translate value="userpages.canvases.noCanvasesResult.title" />

--- a/app/src/userpages/components/CanvasPage/List/NoCanvases/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/NoCanvases/index.jsx
@@ -52,7 +52,7 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
         )}
         link={(
             <Button
-                type="special"
+                kind="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.canvases.noCanvasesResult.clearFilters" />

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -2,8 +2,8 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Button } from 'reactstrap'
 import { capital } from 'case'
+import { Link as RouterLink } from 'react-router-dom'
 import Link from '$shared/components/Link'
 import { push } from 'connected-react-router'
 import copy from 'copy-to-clipboard'
@@ -41,6 +41,7 @@ import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
 import ListContainer from '$shared/components/Container/List'
 import TileGrid from '$shared/components/TileGrid'
+import Button from '$shared/components/Button'
 
 import styles from './canvasList.pcss'
 
@@ -72,9 +73,8 @@ type State = {
 
 const CreateCanvasButton = () => (
     <Button
-        color="primary"
         className={styles.createCanvasButton}
-        tag={Link}
+        tag={RouterLink}
         to={links.editor.canvasEditor}
     >
         <Translate value="userpages.canvases.createCanvas" />

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -115,7 +115,7 @@ class CanvasList extends Component<Props, State> {
             message: I18n.t('userpages.canvases.delete.confirmMessage'),
             acceptButton: {
                 title: I18n.t('userpages.canvases.delete.confirmButton'),
-                color: 'danger',
+                type: 'destructive',
             },
             centerButtons: true,
             dontShowAgain: false,

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -115,7 +115,7 @@ class CanvasList extends Component<Props, State> {
             message: I18n.t('userpages.canvases.delete.confirmMessage'),
             acceptButton: {
                 title: I18n.t('userpages.canvases.delete.confirmButton'),
-                type: 'destructive',
+                kind: 'destructive',
             },
             centerButtons: true,
             dontShowAgain: false,

--- a/app/src/userpages/components/DashboardPage/List/NoDashboards/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/NoDashboards/index.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
 import MediaQuery from 'react-responsive'
 
+import Button from '$shared/components/Button'
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
@@ -50,13 +51,12 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
             />
         )}
         link={(
-            <button
-                type="button"
-                className="btn btn-special"
+            <Button
+                type="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.dashboards.noDashboardsResult.clearFilters" />
-            </button>
+            </Button>
         )}
     >
         <Translate value="userpages.dashboards.noDashboardsResult.title" />

--- a/app/src/userpages/components/DashboardPage/List/NoDashboards/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/NoDashboards/index.jsx
@@ -52,7 +52,7 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
         )}
         link={(
             <Button
-                type="special"
+                kind="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.dashboards.noDashboardsResult.clearFilters" />

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import Helmet from 'react-helmet'
 import { Link } from 'react-router-dom'
@@ -25,6 +24,7 @@ import DashboardPreview from '$editor/dashboard/components/Preview'
 import styles from './dashboardList.pcss'
 import ListContainer from '$shared/components/Container/List'
 import TileGrid from '$shared/components/TileGrid'
+import Button from '$shared/components/Button'
 
 import NoDashboardsView from './NoDashboards'
 
@@ -43,7 +43,6 @@ type Props = StateProps & DispatchProps
 
 const CreateDashboardButton = () => (
     <Button
-        color="primary"
         className={styles.createDashboardButton}
         tag={Link}
         to={links.editor.dashboardEditor}

--- a/app/src/userpages/components/KeyField/AddKeyField/addKeyField.pcss
+++ b/app/src/userpages/components/KeyField/AddKeyField/addKeyField.pcss
@@ -1,8 +1,0 @@
-.button {
-  width: 176px;
-  font-size: 16px;
-  font-weight: var(--regular);
-  font-family: 'IBM Plex Sans', sans-serif;
-  text-transform: inherit;
-  letter-spacing: 0;
-}

--- a/app/src/userpages/components/KeyField/AddKeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/AddKeyField/index.jsx
@@ -77,7 +77,7 @@ class AddKeyField extends React.Component<Props, State> {
         const { label, createWithValue, showPermissionType, addKeyFieldAllowed } = this.props
         return !editing ? (
             <Button
-                type="secondary"
+                kind="secondary"
                 onClick={this.onEdit}
                 disabled={!addKeyFieldAllowed}
             >

--- a/app/src/userpages/components/KeyField/AddKeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/AddKeyField/index.jsx
@@ -1,12 +1,10 @@
 // @flow
 
 import React from 'react'
-import { Button } from 'reactstrap'
 
+import Button from '$shared/components/Button'
 import type { ResourcePermission } from '$shared/flowtype/resource-key-types'
 import KeyFieldEditor from '../KeyFieldEditor'
-
-import styles from './addKeyField.pcss'
 
 type Props = {
     label: string,
@@ -79,11 +77,8 @@ class AddKeyField extends React.Component<Props, State> {
         const { label, createWithValue, showPermissionType, addKeyFieldAllowed } = this.props
         return !editing ? (
             <Button
-                type="button"
-                color="userpages"
-                className={styles.button}
+                type="secondary"
                 onClick={this.onEdit}
-                outline
                 disabled={!addKeyFieldAllowed}
             >
                 {label}

--- a/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
+++ b/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
@@ -138,14 +138,13 @@ class KeyFieldEditor extends React.Component<Props, State> {
                     actions={{
                         save: {
                             title: I18n.t(`userpages.keyFieldEditor.${createNew ? 'add' : 'save'}`),
-                            color: 'primary',
-                            outline: true,
+                            type: 'secondary',
                             onClick: this.onSave,
                             disabled: !filled || waiting,
                             spinner: waiting,
                         },
                         cancel: {
-                            color: 'link',
+                            type: 'link',
                             className: 'grey-container',
                             title: I18n.t('userpages.keyFieldEditor.cancel'),
                             outline: true,

--- a/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
+++ b/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
@@ -138,13 +138,13 @@ class KeyFieldEditor extends React.Component<Props, State> {
                     actions={{
                         save: {
                             title: I18n.t(`userpages.keyFieldEditor.${createNew ? 'add' : 'save'}`),
-                            type: 'secondary',
+                            kind: 'secondary',
                             onClick: this.onSave,
                             disabled: !filled || waiting,
                             spinner: waiting,
                         },
                         cancel: {
-                            type: 'link',
+                            kind: 'link',
                             className: 'grey-container',
                             title: I18n.t('userpages.keyFieldEditor.cancel'),
                             outline: true,

--- a/app/src/userpages/components/ProductsPage/NoProducts/index.jsx
+++ b/app/src/userpages/components/ProductsPage/NoProducts/index.jsx
@@ -52,7 +52,7 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
         )}
         link={(
             <Button
-                type="special"
+                kind="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.products.noProductsResult.clearFilters" />

--- a/app/src/userpages/components/ProductsPage/NoProducts/index.jsx
+++ b/app/src/userpages/components/ProductsPage/NoProducts/index.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
 import MediaQuery from 'react-responsive'
 
+import Button from '$shared/components/Button'
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
@@ -50,13 +51,12 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
             />
         )}
         link={(
-            <button
-                type="button"
-                className="btn btn-special"
+            <Button
+                type="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.products.noProductsResult.clearFilters" />
-            </button>
+            </Button>
         )}
     >
         <Translate value="userpages.products.noProductsResult.title" />

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -2,7 +2,6 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
 import { push } from 'connected-react-router'
@@ -26,6 +25,7 @@ import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import ListContainer from '$shared/components/Container/List'
 import TileGrid from '$shared/components/TileGrid'
 import { isCommunityProduct } from '$mp/utils/product'
+import Button from '$shared/components/Button'
 
 import type { ProductList, ProductId, Product } from '$mp/flowtype/product-types'
 import type { Filter, SortOption } from '$userpages/flowtype/common-types'
@@ -50,7 +50,6 @@ type Props = StateProps & DispatchProps
 
 const CreateProductButton = () => (
     <Button
-        color="primary"
         className={styles.createProductButton}
         tag={Link}
         to={links.marketplace.createProduct}

--- a/app/src/userpages/components/ProfilePage/ChangePassword/changePassword.pcss
+++ b/app/src/userpages/components/ProfilePage/ChangePassword/changePassword.pcss
@@ -47,15 +47,6 @@
   z-index: 100;
 }
 
-.changePassword {
-  width: 176px;
-  font-size: 16px;
-  font-weight: var(--regular);
-  font-family: 'IBM Plex Sans', sans-serif;
-  text-transform: capitalize;
-  letter-spacing: 0;
-}
-
 .dialogContainerOverride {
   top: 40%;
 }

--- a/app/src/userpages/components/ProfilePage/ChangePassword/index.jsx
+++ b/app/src/userpages/components/ProfilePage/ChangePassword/index.jsx
@@ -96,12 +96,12 @@ class ChangePasswordDialog extends Component<Props, State> {
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             outline: true,
-                            type: 'link',
+                            kind: 'link',
                             onClick: this.props.onToggle,
                         },
                         save: {
                             title: I18n.t('modal.common.save'),
-                            type: 'primary',
+                            kind: 'primary',
                             onClick: this.onSubmit,
                             disabled: !allPasswordsGiven || !passWordsMatch || !strongEnoughPassword || updating,
                             spinner: updating,
@@ -202,7 +202,7 @@ class ChangePasswordButton extends React.Component<TriggerProps, TriggerState> {
         return (
             <React.Fragment>
                 <Button
-                    type="secondary"
+                    kind="secondary"
                     className={styles.changePassword}
                     onClick={this.onToggle}
                     aria-label="Change Password"

--- a/app/src/userpages/components/ProfilePage/ChangePassword/index.jsx
+++ b/app/src/userpages/components/ProfilePage/ChangePassword/index.jsx
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Button } from 'reactstrap'
 import { I18n, Translate } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
 
@@ -11,6 +10,7 @@ import Modal from '$shared/components/Modal'
 import Dialog from '$shared/components/Dialog'
 import TextInput from '$shared/components/TextInput'
 import routes from '$routes'
+import Button from '$shared/components/Button'
 
 import type { PasswordUpdate } from '$shared/flowtype/user-types'
 import styles from './changePassword.pcss'
@@ -96,12 +96,12 @@ class ChangePasswordDialog extends Component<Props, State> {
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             outline: true,
-                            color: 'link',
+                            type: 'link',
                             onClick: this.props.onToggle,
                         },
                         save: {
                             title: I18n.t('modal.common.save'),
-                            color: 'primary',
+                            type: 'primary',
                             onClick: this.onSubmit,
                             disabled: !allPasswordsGiven || !passWordsMatch || !strongEnoughPassword || updating,
                             spinner: updating,
@@ -202,9 +202,7 @@ class ChangePasswordButton extends React.Component<TriggerProps, TriggerState> {
         return (
             <React.Fragment>
                 <Button
-                    outline
-                    type="button"
-                    color="userpages"
+                    type="secondary"
                     className={styles.changePassword}
                     onClick={this.onToggle}
                     aria-label="Change Password"

--- a/app/src/userpages/components/ProfilePage/DeleteAccount/DeleteAccountDialog/index.jsx
+++ b/app/src/userpages/components/ProfilePage/DeleteAccount/DeleteAccountDialog/index.jsx
@@ -21,7 +21,7 @@ const DeleteAccountDialog = ({ waiting, onClose, onSave }: Props) => (
         message={<Translate value="modal.deleteAccount.content" tag="p" className={styles.deleteWarning} />}
         acceptButton={{
             title: I18n.t('modal.deleteAccount.save'),
-            color: 'danger',
+            type: 'destructive',
             disabled: waiting,
             spinner: waiting,
         }}

--- a/app/src/userpages/components/ProfilePage/DeleteAccount/DeleteAccountDialog/index.jsx
+++ b/app/src/userpages/components/ProfilePage/DeleteAccount/DeleteAccountDialog/index.jsx
@@ -21,7 +21,7 @@ const DeleteAccountDialog = ({ waiting, onClose, onSave }: Props) => (
         message={<Translate value="modal.deleteAccount.content" tag="p" className={styles.deleteWarning} />}
         acceptButton={{
             title: I18n.t('modal.deleteAccount.save'),
-            type: 'destructive',
+            kind: 'destructive',
             disabled: waiting,
             spinner: waiting,
         }}

--- a/app/src/userpages/components/ProfilePage/DeleteAccount/deleteAccount.pcss
+++ b/app/src/userpages/components/ProfilePage/DeleteAccount/deleteAccount.pcss
@@ -1,9 +1,0 @@
-.button {
-  margin-top: 1.5rem;
-  width: 176px;
-  font-size: 16px;
-  font-weight: var(--regular);
-  font-family: 'IBM Plex Sans', sans-serif;
-  text-transform: inherit;
-  letter-spacing: 0;
-}

--- a/app/src/userpages/components/ProfilePage/DeleteAccount/index.jsx
+++ b/app/src/userpages/components/ProfilePage/DeleteAccount/index.jsx
@@ -3,15 +3,14 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { Translate, I18n } from 'react-redux-i18n'
-import { Button } from 'reactstrap'
 
 import profileStyles from '../profilePage.pcss'
-import styles from './deleteAccount.pcss'
 
 import DeleteAccountDialog from './DeleteAccountDialog'
 import { deleteUserAccount } from '$shared/modules/user/actions'
 import { selectDeletingUserAccount } from '$shared/modules/user/selectors'
 import type { StoreState } from '$shared/flowtype/store-state'
+import Button from '$shared/components/Button'
 
 type State = {
     modalOpen: boolean,
@@ -62,12 +61,9 @@ class DeleteAccount extends React.Component<Props, State> {
         return (
             <div>
                 <Translate value="userpages.profilePage.deleteAccount.description" tag="p" className={profileStyles.longText} />
-                <div className={styles.button}>
+                <div>
                     <Button
-                        outline
-                        type="button"
-                        color="userpages"
-                        className={styles.button}
+                        type="destructive"
                         onClick={this.openModal}
                         disabled={modalOpen}
                         aria-label={I18n.t('userpages.profilePage.deleteAccount.button')}

--- a/app/src/userpages/components/ProfilePage/DeleteAccount/index.jsx
+++ b/app/src/userpages/components/ProfilePage/DeleteAccount/index.jsx
@@ -63,7 +63,7 @@ class DeleteAccount extends React.Component<Props, State> {
                 <Translate value="userpages.profilePage.deleteAccount.description" tag="p" className={profileStyles.longText} />
                 <div>
                     <Button
-                        type="destructive"
+                        kind="destructive"
                         onClick={this.openModal}
                         disabled={modalOpen}
                         aria-label={I18n.t('userpages.profilePage.deleteAccount.button')}

--- a/app/src/userpages/components/ProfilePage/IdentityHandler/AddIdentityButton/addIdentityButton.pcss
+++ b/app/src/userpages/components/ProfilePage/IdentityHandler/AddIdentityButton/addIdentityButton.pcss
@@ -1,8 +1,0 @@
-.button {
-  width: 176px;
-  font-size: 16px;
-  font-weight: var(--regular);
-  font-family: 'IBM Plex Sans', sans-serif;
-  text-transform: inherit;
-  letter-spacing: 0;
-}

--- a/app/src/userpages/components/ProfilePage/IdentityHandler/AddIdentityButton/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IdentityHandler/AddIdentityButton/index.jsx
@@ -35,7 +35,7 @@ class AddIdentityButton extends React.Component<Props, State> {
         return (
             <Fragment>
                 <Button
-                    type="secondary"
+                    kind="secondary"
                     disabled={modalOpen}
                     onClick={this.onShowModal}
                 >

--- a/app/src/userpages/components/ProfilePage/IdentityHandler/AddIdentityButton/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IdentityHandler/AddIdentityButton/index.jsx
@@ -1,13 +1,11 @@
 // @flow
 
 import React, { Fragment } from 'react'
-import { Button } from 'reactstrap'
 import { Translate } from 'react-redux-i18n'
 
+import Button from '$shared/components/Button'
 import Modal from '$shared/components/Modal'
 import AddIdentityDialog from '$userpages/components/ProfilePage/IdentityHandler/AddIdentityDialog'
-
-import styles from './addIdentityButton.pcss'
 
 type Props = {}
 
@@ -37,10 +35,7 @@ class AddIdentityButton extends React.Component<Props, State> {
         return (
             <Fragment>
                 <Button
-                    className={styles.button}
-                    color="userpages"
-                    type="button"
-                    outline
+                    type="secondary"
                     disabled={modalOpen}
                     onClick={this.onShowModal}
                 >

--- a/app/src/userpages/components/ProfilePage/IdentityHandler/IdentityNameDialog/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IdentityHandler/IdentityNameDialog/index.jsx
@@ -42,13 +42,13 @@ class IdentityNameDialog extends React.Component<Props, State> {
                 actions={{
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
-                        color: 'link',
+                        type: 'link',
                         outline: true,
                         onClick: onClose,
                     },
                     save: {
                         title: I18n.t('modal.common.next'),
-                        color: 'primary',
+                        type: 'primary',
                         onClick: this.onSave,
                         disabled: !name,
                     },

--- a/app/src/userpages/components/ProfilePage/IdentityHandler/IdentityNameDialog/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IdentityHandler/IdentityNameDialog/index.jsx
@@ -42,13 +42,13 @@ class IdentityNameDialog extends React.Component<Props, State> {
                 actions={{
                     cancel: {
                         title: I18n.t('modal.common.cancel'),
-                        type: 'link',
+                        kind: 'link',
                         outline: true,
                         onClick: onClose,
                     },
                     save: {
                         title: I18n.t('modal.common.next'),
-                        type: 'primary',
+                        kind: 'primary',
                         onClick: this.onSave,
                         disabled: !name,
                     },

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -85,12 +85,12 @@ export class ProfilePage extends Component<Props, State> {
                         actions={{
                             cancel: {
                                 title: I18n.t('userpages.profilePage.toolbar.cancel'),
-                                type: 'link',
+                                kind: 'link',
                                 linkTo: links.userpages.main,
                             },
                             saveChanges: {
                                 title: I18n.t('userpages.profilePage.toolbar.saveAndExit'),
-                                type: 'primary',
+                                kind: 'primary',
                                 onClick: this.onSave,
                                 disabled: saving,
                                 spinner: saving,

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -85,12 +85,12 @@ export class ProfilePage extends Component<Props, State> {
                         actions={{
                             cancel: {
                                 title: I18n.t('userpages.profilePage.toolbar.cancel'),
-                                color: 'link',
+                                type: 'link',
                                 linkTo: links.userpages.main,
                             },
                             saveChanges: {
                                 title: I18n.t('userpages.profilePage.toolbar.saveAndExit'),
-                                color: 'primary',
+                                type: 'primary',
                                 onClick: this.onSave,
                                 disabled: saving,
                                 spinner: saving,

--- a/app/src/userpages/components/PurchasesPage/NoPurchases/index.jsx
+++ b/app/src/userpages/components/PurchasesPage/NoPurchases/index.jsx
@@ -31,7 +31,7 @@ const NoAddedPurchasesView = () => (
             />
         )}
         link={(
-            <Button type="special" tag={Link} to={routes.marketplace()}>
+            <Button kind="special" tag={Link} to={routes.marketplace()}>
                 <Translate value="userpages.purchases.noAddedPurchases.hint" />
             </Button>
         )}
@@ -52,7 +52,7 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
         )}
         link={(
             <Button
-                type="special"
+                kind="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.purchases.noPurchasesResult.clearFilters" />

--- a/app/src/userpages/components/PurchasesPage/NoPurchases/index.jsx
+++ b/app/src/userpages/components/PurchasesPage/NoPurchases/index.jsx
@@ -5,6 +5,7 @@ import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
 
 import routes from '$routes'
+import Button from '$shared/components/Button'
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
@@ -30,9 +31,9 @@ const NoAddedPurchasesView = () => (
             />
         )}
         link={(
-            <Link to={routes.marketplace()} className="btn btn-special">
+            <Button type="special" tag={Link} to={routes.marketplace()}>
                 <Translate value="userpages.purchases.noAddedPurchases.hint" />
-            </Link>
+            </Button>
         )}
     >
         <Translate value="userpages.purchases.noAddedPurchases.title" />
@@ -50,13 +51,12 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
             />
         )}
         link={(
-            <button
-                type="button"
-                className="btn btn-special"
+            <Button
+                type="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.purchases.noPurchasesResult.clearFilters" />
-            </button>
+            </Button>
         )}
     >
         <Translate value="userpages.purchases.noPurchasesResult.title" />

--- a/app/src/userpages/components/ShareDialog/EmbedDialogContent/index.jsx
+++ b/app/src/userpages/components/ShareDialog/EmbedDialogContent/index.jsx
@@ -42,12 +42,12 @@ const EmbedDialogContent = (props: Props) => {
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    type: 'link',
+                    kind: 'link',
                     onClick: onClose,
                 },
                 copy: {
                     title: buttonText,
-                    type: 'primary',
+                    kind: 'primary',
                     onClick: onCopy,
                 },
             }}

--- a/app/src/userpages/components/ShareDialog/EmbedDialogContent/index.jsx
+++ b/app/src/userpages/components/ShareDialog/EmbedDialogContent/index.jsx
@@ -42,12 +42,12 @@ const EmbedDialogContent = (props: Props) => {
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    outline: true,
+                    type: 'link',
                     onClick: onClose,
                 },
                 copy: {
                     title: buttonText,
-                    color: 'primary',
+                    type: 'primary',
                     onClick: onCopy,
                 },
             }}

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/index.jsx
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/index.jsx
@@ -1,13 +1,12 @@
 // @flow
 
 import React, { Component } from 'react'
-import cx from 'classnames'
 import { I18n } from 'react-redux-i18n'
 
+import Button from '$shared/components/Button'
 import SvgIcon from '$shared/components/SvgIcon'
 
 import styles from './shareDialogInputRow.pcss'
-import buttonStyles from '$shared/components/Button/button.pcss'
 
 type Props = {
     onAdd: (email: string) => void,
@@ -49,14 +48,14 @@ export class ShareDialogInputRow extends Component<Props, State> {
                     value={email}
                     onChange={this.onChange}
                 />
-                <button
-                    type="button"
-                    className={cx(styles.button, buttonStyles.btn, buttonStyles.btnOutline)}
+                <Button
+                    type="secondary"
                     onClick={this.onAdd}
                     disabled={!email}
+                    className={styles.button}
                 >
                     <SvgIcon name="plus" className={styles.plusIcon} />
-                </button>
+                </Button>
             </div>
         )
     }

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/index.jsx
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/index.jsx
@@ -49,7 +49,7 @@ export class ShareDialogInputRow extends Component<Props, State> {
                     onChange={this.onChange}
                 />
                 <Button
-                    type="secondary"
+                    kind="secondary"
                     onClick={this.onAdd}
                     disabled={!email}
                     className={styles.button}

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/shareDialogInputRow.pcss
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogInputRow/shareDialogInputRow.pcss
@@ -23,10 +23,7 @@
 .button {
   width: 32px;
   height: 32px;
-  border-radius: 4px;
-  position: relative;
   margin-top: 0.625rem;
-  cursor: pointer;
 }
 
 .plusIcon {

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogPermissionRow/ShareDialogPermission/index.jsx
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogPermissionRow/ShareDialogPermission/index.jsx
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import cx from 'classnames'
 import { I18n, Translate } from 'react-redux-i18n'
 
 import { setResourceHighestOperationForUser, removeAllResourcePermissionsByUser } from '../../../../../modules/permission/actions'
@@ -11,9 +10,9 @@ import type { Permission, ResourceType, ResourceId } from '../../../../../flowty
 import { selectUserData } from '$shared/modules/user/selectors'
 import SvgIcon from '$shared/components/SvgIcon'
 import SelectInput from '$shared/components/SelectInput'
+import Button from '$shared/components/Button'
 
 import styles from './shareDialogPermission.pcss'
-import buttonStyles from '$shared/components/Button/button.pcss'
 
 type StateProps = {}
 
@@ -72,13 +71,13 @@ export class ShareDialogPermission extends Component<Props> {
                         value={options[highestOperationIndex]}
                         onChange={this.onSelect}
                     />
-                    <button
-                        type="button"
+                    <Button
+                        type="secondary"
                         onClick={this.onRemove}
-                        className={cx(styles.button, buttonStyles.btn, buttonStyles.btnOutline)}
+                        className={styles.button}
                     >
                         <SvgIcon name="crossHeavy" />
-                    </button>
+                    </Button>
                 </div>
                 {errors.length > 0 && (
                     <div className={styles.errorContainer}>

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogPermissionRow/ShareDialogPermission/index.jsx
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/ShareDialogPermissionRow/ShareDialogPermission/index.jsx
@@ -72,7 +72,7 @@ export class ShareDialogPermission extends Component<Props> {
                         onChange={this.onSelect}
                     />
                     <Button
-                        type="secondary"
+                        kind="secondary"
                         onClick={this.onRemove}
                         className={styles.button}
                     >

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/index.jsx
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/index.jsx
@@ -104,12 +104,12 @@ export const ShareDialogContent = (props: Props) => {
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    type: 'link',
+                    kind: 'link',
                     onClick: onClose,
                 },
                 save: {
                     title: I18n.t('modal.shareResource.save'),
-                    type: 'primary',
+                    kind: 'primary',
                     onClick: saveDialog,
                     disabled: saving,
                     spinner: saving,

--- a/app/src/userpages/components/ShareDialog/ShareDialogContent/index.jsx
+++ b/app/src/userpages/components/ShareDialog/ShareDialogContent/index.jsx
@@ -104,12 +104,12 @@ export const ShareDialogContent = (props: Props) => {
             actions={{
                 cancel: {
                     title: I18n.t('modal.common.cancel'),
-                    outline: true,
+                    type: 'link',
                     onClick: onClose,
                 },
                 save: {
                     title: I18n.t('modal.shareResource.save'),
-                    color: 'primary',
+                    type: 'primary',
                     onClick: saveDialog,
                     disabled: saving,
                     spinner: saving,

--- a/app/src/userpages/components/StreamPage/ConfirmCsvImportDialog/index.jsx
+++ b/app/src/userpages/components/StreamPage/ConfirmCsvImportDialog/index.jsx
@@ -163,13 +163,12 @@ export class ConfirmCsvImportView extends Component<Props, State> {
                     actions={{
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
-                            outline: true,
                             onClick: onClose,
-                            color: 'link',
+                            type: 'link',
                         },
                         confirm: {
                             title: I18n.t('modal.common.confirm'),
-                            color: 'primary',
+                            type: 'primary',
                             onClick: this.onConfirm,
                             spinner: fetching,
                         },

--- a/app/src/userpages/components/StreamPage/ConfirmCsvImportDialog/index.jsx
+++ b/app/src/userpages/components/StreamPage/ConfirmCsvImportDialog/index.jsx
@@ -164,11 +164,11 @@ export class ConfirmCsvImportView extends Component<Props, State> {
                         cancel: {
                             title: I18n.t('modal.common.cancel'),
                             onClick: onClose,
-                            type: 'link',
+                            kind: 'link',
                         },
                         confirm: {
                             title: I18n.t('modal.common.confirm'),
-                            type: 'primary',
+                            kind: 'primary',
                             onClick: this.onConfirm,
                             spinner: fetching,
                         },

--- a/app/src/userpages/components/StreamPage/List/NoStreams/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/NoStreams/index.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
 import MediaQuery from 'react-responsive'
 
+import Button from '$shared/components/Button'
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
@@ -50,13 +51,12 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
             />
         )}
         link={(
-            <button
-                type="button"
-                className="btn btn-special"
+            <Button
+                type="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.streams.noStreamsResult.clearFilters" />
-            </button>
+            </Button>
         )}
     >
         <Translate value="userpages.streams.noStreamsResult.title" />

--- a/app/src/userpages/components/StreamPage/List/NoStreams/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/NoStreams/index.jsx
@@ -52,7 +52,7 @@ const NoResultsView = ({ onResetFilter }: NoResultsViewProps) => (
         )}
         link={(
             <Button
-                type="special"
+                kind="special"
                 onClick={onResetFilter}
             >
                 <Translate value="userpages.streams.noStreamsResult.clearFilters" />

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -207,7 +207,7 @@ class StreamList extends Component<Props, State> {
             message: I18n.t('userpages.streams.delete.confirmMessage'),
             acceptButton: {
                 title: I18n.t('userpages.streams.delete.confirmButton'),
-                type: 'destructive',
+                kind: 'destructive',
             },
             centerButtons: true,
             dontShowAgain: false,

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -207,7 +207,7 @@ class StreamList extends Component<Props, State> {
             message: I18n.t('userpages.streams.delete.confirmMessage'),
             acceptButton: {
                 title: I18n.t('userpages.streams.delete.confirmButton'),
-                color: 'danger',
+                type: 'destructive',
             },
             centerButtons: true,
             dontShowAgain: false,

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -7,7 +7,6 @@ import moment from 'moment-timezone'
 import copy from 'copy-to-clipboard'
 import { Translate, I18n } from 'react-redux-i18n'
 import Helmet from 'react-helmet'
-import { Button } from 'reactstrap'
 import MediaQuery from 'react-responsive'
 import cx from 'classnames'
 import { Link } from 'react-router-dom'
@@ -54,6 +53,7 @@ import breakpoints from '$app/scripts/breakpoints'
 import Notification from '$shared/utils/Notification'
 import LoadMore from '$mp/components/LoadMore'
 import ListContainer from '$shared/components/Container/List'
+import Button from '$shared/components/Button'
 
 import styles from './streamsList.pcss'
 
@@ -61,7 +61,6 @@ const { lg } = breakpoints
 
 export const CreateStreamButton = () => (
     <Button
-        color="primary"
         className={styles.createStreamButton}
         tag={Link}
         to={links.userpages.streamCreate}

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
@@ -1,9 +1,9 @@
 // @flow
 
 import React, { Component } from 'react'
-import { Button } from 'reactstrap'
 import { I18n, Translate } from 'react-redux-i18n'
 
+import Button from '$shared/components/Button'
 import Dropdown from '$shared/components/Dropdown'
 import TextInput from '$shared/components/TextInput'
 import type { StreamField } from '$shared/flowtype/stream-types'
@@ -113,6 +113,7 @@ export class NewFieldEditor extends Component<Props, State> {
                     </Dropdown>
                 </SplitControl>
                 <Button
+                    type="secondary"
                     disabled={nameError !== null}
                     className={styles.addButton}
                     onClick={this.onConfirm}
@@ -120,9 +121,9 @@ export class NewFieldEditor extends Component<Props, State> {
                     <Translate value="userpages.streams.edit.configure.newFieldEditor.add" />
                 </Button>
                 <Button
+                    type="link"
                     className={styles.cancelButton}
                     onClick={onCancel}
-                    color="link"
                 >
                     <Translate value="userpages.streams.edit.configure.newFieldEditor.cancel" />
                 </Button>

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/index.jsx
@@ -113,7 +113,7 @@ export class NewFieldEditor extends Component<Props, State> {
                     </Dropdown>
                 </SplitControl>
                 <Button
-                    type="secondary"
+                    kind="secondary"
                     disabled={nameError !== null}
                     className={styles.addButton}
                     onClick={this.onConfirm}
@@ -121,7 +121,7 @@ export class NewFieldEditor extends Component<Props, State> {
                     <Translate value="userpages.streams.edit.configure.newFieldEditor.add" />
                 </Button>
                 <Button
-                    type="link"
+                    kind="link"
                     className={styles.cancelButton}
                     onClick={onCancel}
                 >

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
@@ -22,22 +22,6 @@
   right: -105px;
   top: 6px;
   margin: 0;
-  font-weight: var(--regular);
-  font-family: 'IBM Plex Sans', sans-serif;
-  text-transform: capitalize;
-  width: 80px;
-  height: 32px;
-  border: 1px solid #525252;
-  border-radius: 4px;
-  color: #525252;
-  font-size: 14px;
-  letter-spacing: 0;
-  line-height: 20px;
-}
-
-.autodetect {
-  height: 32px;
-  width: 128px;
 }
 
 @media (--lg-down) {
@@ -64,12 +48,7 @@
 
 .addFieldButton {
   margin-top: 2em;
-  width: 144px;
-  font-size: 16px;
-  font-weight: 400;
-  font-family: 'IBM Plex Sans', sans-serif;
-  text-transform: inherit;
-  letter-spacing: 0;
+  margin-right: 1em;
 }
 
 .settings {

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
@@ -2,12 +2,12 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Button } from 'reactstrap'
 import copy from 'copy-to-clipboard'
 import { arrayMove } from 'react-sortable-hoc'
 import { Translate } from 'react-redux-i18n'
 import uuid from 'uuid'
 
+import Button from '$shared/components/Button'
 import Spinner from '$shared/components/Spinner'
 import type { Stream, StreamId } from '$shared/flowtype/stream-types'
 import type { StoreState } from '$shared/flowtype/store-state'
@@ -160,6 +160,7 @@ export class ConfigureView extends Component<Props, State> {
 
     autodetectFields = () => {
         if (this.props.stream && this.props.stream.id) {
+            // $FlowFixMe: "streamFieldsAutodetect is missing in OwnProps or StateProps"
             return this.props.streamFieldsAutodetect(this.props.stream.id)
         }
     }
@@ -170,26 +171,7 @@ export class ConfigureView extends Component<Props, State> {
 
         return (
             <div>
-                <SplitControl className={styles.helpText}>
-                    <Translate value="userpages.streams.edit.configure.help" tag="p" className={styles.longText} />
-                    <Button
-                        color="userpages"
-                        className={styles.autodetect}
-                        outline
-                        onClick={this.autodetectFields}
-                        disabled={this.props.fieldsAutodetectFetching || disabled}
-                    >
-                        {!this.props.fieldsAutodetectFetching && (
-                            <Translate value="userpages.streams.edit.configure.autodetect" />
-                        )}
-                        {this.props.fieldsAutodetectFetching && (
-                            <Fragment>
-                                <Translate value="userpages.streams.edit.configure.waiting" />
-                                <Spinner size="small" className={styles.spinner} color="white" />
-                            </Fragment>
-                        )}
-                    </Button>
-                </SplitControl>
+                <Translate value="userpages.streams.edit.configure.help" tag="p" className={styles.longText} />
                 {stream && stream.config && stream.config.fields && !!stream.config.fields.length &&
                     <Fragment>
                         <SplitControl className={styles.fieldHeaderRow}>
@@ -225,8 +207,9 @@ export class ConfigureView extends Component<Props, State> {
                                                     ))}
                                                 </Dropdown>
                                                 <Button
+                                                    type="secondary"
+                                                    size="mini"
                                                     outline
-                                                    color="userpages"
                                                     className={styles.deleteFieldButton}
                                                     onClick={() => this.deleteField(field.name)}
                                                     disabled={disabled}
@@ -241,15 +224,32 @@ export class ConfigureView extends Component<Props, State> {
                         </FieldList>
                     </Fragment>}
                 {!isAddingField &&
-                    <Button
-                        color="userpages"
-                        className={styles.addFieldButton}
-                        outline
-                        onClick={this.addNewField}
-                        disabled={disabled}
-                    >
-                        <Translate value="userpages.streams.edit.configure.addField" />
-                    </Button>
+                    <React.Fragment>
+                        <Button
+                            type="secondary"
+                            className={styles.addFieldButton}
+                            onClick={this.addNewField}
+                            disabled={disabled}
+                        >
+                            <Translate value="userpages.streams.edit.configure.addField" />
+                        </Button>
+                        <Button
+                            type="secondary"
+                            outline
+                            onClick={this.autodetectFields}
+                            disabled={this.props.fieldsAutodetectFetching || disabled}
+                        >
+                            {!this.props.fieldsAutodetectFetching && (
+                                <Translate value="userpages.streams.edit.configure.autodetect" />
+                            )}
+                            {this.props.fieldsAutodetectFetching && (
+                                <Fragment>
+                                    <Translate value="userpages.streams.edit.configure.waiting" />
+                                    <Spinner size="small" className={styles.spinner} color="white" />
+                                </Fragment>
+                            )}
+                        </Button>
+                    </React.Fragment>
                 }
                 {isAddingField &&
                     <NewFieldEditor

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
@@ -207,7 +207,7 @@ export class ConfigureView extends Component<Props, State> {
                                                     ))}
                                                 </Dropdown>
                                                 <Button
-                                                    type="secondary"
+                                                    kind="secondary"
                                                     size="mini"
                                                     outline
                                                     className={styles.deleteFieldButton}
@@ -226,7 +226,7 @@ export class ConfigureView extends Component<Props, State> {
                 {!isAddingField &&
                     <React.Fragment>
                         <Button
-                            type="secondary"
+                            kind="secondary"
                             className={styles.addFieldButton}
                             onClick={this.addNewField}
                             disabled={disabled}
@@ -234,7 +234,7 @@ export class ConfigureView extends Component<Props, State> {
                             <Translate value="userpages.streams.edit.configure.addField" />
                         </Button>
                         <Button
-                            type="secondary"
+                            kind="secondary"
                             outline
                             onClick={this.autodetectFields}
                             disabled={this.props.fieldsAutodetectFetching || disabled}

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/historyView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/historyView.pcss
@@ -22,7 +22,6 @@
 
 .deleteButton,
 .browseFiles {
-  height: 32px;
   min-width: 128px;
   margin-left: 0;
   margin-top: 18px;

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
@@ -272,7 +272,6 @@ class HistoryView extends Component<Props, State> {
                             />
                             <Button
                                 type="secondary"
-                                size="mini"
                                 className={styles.browseFiles}
                                 onClick={() => this.handleBrowseFilesClick()}
                                 disabled={disabled}
@@ -304,7 +303,6 @@ class HistoryView extends Component<Props, State> {
                         </div>
                         <Button
                             type="secondary"
-                            size="mini"
                             className={styles.deleteButton}
                             onClick={() => this.deleteDataUpTo(streamId, deleteDate)}
                             disabled={deleteDate == null || disabled}

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
@@ -271,7 +271,7 @@ class HistoryView extends Component<Props, State> {
                                 disabled={disabled}
                             />
                             <Button
-                                type="secondary"
+                                kind="secondary"
                                 className={styles.browseFiles}
                                 onClick={() => this.handleBrowseFilesClick()}
                                 disabled={disabled}
@@ -302,7 +302,7 @@ class HistoryView extends Component<Props, State> {
                             />
                         </div>
                         <Button
-                            type="secondary"
+                            kind="secondary"
                             className={styles.deleteButton}
                             onClick={() => this.deleteDataUpTo(streamId, deleteDate)}
                             disabled={deleteDate == null || disabled}

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
@@ -2,7 +2,6 @@
 
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import cx from 'classnames'
 
@@ -12,6 +11,7 @@ import type { StoreState } from '$userpages/flowtype/states/store-state'
 import type { CsvUploadState } from '$userpages/flowtype/states/stream-state'
 import { getRange, deleteDataUpTo, uploadCsvFile, confirmCsvFileUpload, updateEditStream } from '$userpages/modules/userPageStreams/actions'
 import { selectDeleteDataError, selectUploadCsvState, selectEditedStream } from '$userpages/modules/userPageStreams/selectors'
+import Button from '$shared/components/Button'
 import TextInput from '$shared/components/TextInput'
 import FileUpload from '$shared/components/FileUpload'
 import DatePicker from '$shared/components/DatePicker'
@@ -271,8 +271,9 @@ class HistoryView extends Component<Props, State> {
                                 disabled={disabled}
                             />
                             <Button
+                                type="secondary"
+                                size="mini"
                                 className={styles.browseFiles}
-                                color="userpages"
                                 onClick={() => this.handleBrowseFilesClick()}
                                 disabled={disabled}
                             >
@@ -302,8 +303,9 @@ class HistoryView extends Component<Props, State> {
                             />
                         </div>
                         <Button
+                            type="secondary"
+                            size="mini"
                             className={styles.deleteButton}
-                            color="userpages"
                             onClick={() => this.deleteDataUpTo(streamId, deleteDate)}
                             disabled={deleteDate == null || disabled}
                         >

--- a/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
@@ -140,7 +140,7 @@ export class InfoView extends Component<Props, State> {
                                 />
                             </div>
                             <Button
-                                type="secondary"
+                                kind="secondary"
                                 size="mini"
                                 outline
                                 className={styles.copyStreamIdButton}

--- a/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Button } from 'reactstrap'
 import copy from 'copy-to-clipboard'
 import { I18n, Translate } from 'react-redux-i18n'
 
+import Button from '$shared/components/Button'
 import Notification from '$shared/utils/Notification'
 import type { Stream } from '$shared/flowtype/stream-types'
 import type { StoreState } from '$shared/flowtype/store-state'
@@ -140,7 +140,9 @@ export class InfoView extends Component<Props, State> {
                                 />
                             </div>
                             <Button
-                                color="userpages"
+                                type="secondary"
+                                size="mini"
+                                outline
                                 className={styles.copyStreamIdButton}
                                 onClick={() => this.copyStreamTap(stream.id)}
                             >

--- a/app/src/userpages/components/StreamPage/Show/InfoView/infoView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/infoView.pcss
@@ -8,7 +8,6 @@
 
 .copyStreamIdButton {
   width: 128px;
-  height: 32px;
   margin-top: 24px;
 }
 

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component, Fragment } from 'react'
-import { Button } from 'reactstrap'
 import { Link } from 'react-router-dom'
 import { Translate } from 'react-redux-i18n'
 import cx from 'classnames'
@@ -9,6 +8,7 @@ import cx from 'classnames'
 import type { Stream } from '$shared/flowtype/stream-types'
 import type { User } from '$shared/flowtype/user-types'
 import type { ResourceKeyId } from '$shared/flowtype/resource-key-types'
+import Button from '$shared/components/Button'
 import StreamLivePreview from '$mp/components/StreamPreviewPage/StreamLivePreview'
 import SvgIcon from '$shared/components/SvgIcon'
 import routes from '$routes'
@@ -74,7 +74,12 @@ export class PreviewView extends Component<Props, State> {
                         })}
                     >
                         <div className={styles.previewControls}>
-                            <Button color="userpages" className={styles.playPauseButton} onClick={this.onToggleRun}>
+                            <Button
+                                type="secondary"
+                                outline
+                                className={styles.playPauseButton}
+                                onClick={this.onToggleRun}
+                            >
                                 {!isRunning ?
                                     <SvgIcon name="play" className={styles.icon} /> :
                                     <SvgIcon name="pause" className={styles.icon} />
@@ -82,8 +87,9 @@ export class PreviewView extends Component<Props, State> {
                             </Button>
                             {stream && stream.id && (
                                 <Button
+                                    type="secondary"
+                                    outline
                                     className={styles.inspectButton}
-                                    color="userpages"
                                     tag={Link}
                                     to={routes.userPageStreamPreview({
                                         streamId: stream.id,

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
@@ -75,7 +75,7 @@ export class PreviewView extends Component<Props, State> {
                     >
                         <div className={styles.previewControls}>
                             <Button
-                                type="secondary"
+                                kind="secondary"
                                 outline
                                 className={styles.playPauseButton}
                                 onClick={this.onToggleRun}
@@ -87,7 +87,7 @@ export class PreviewView extends Component<Props, State> {
                             </Button>
                             {stream && stream.id && (
                                 <Button
-                                    type="secondary"
+                                    kind="secondary"
                                     outline
                                     className={styles.inspectButton}
                                     tag={Link}

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/previewView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/previewView.pcss
@@ -6,10 +6,11 @@
 }
 
 .previewControls {
+  display: flex;
   position: absolute;
   height: 32px;
   right: 0;
-  top: 8px;
+  top: 16px;
 }
 
 @media (--md-down) {

--- a/app/src/userpages/components/StreamPage/Show/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/index.jsx
@@ -170,7 +170,7 @@ export class StreamShowView extends Component<Props, State> {
                                 actions={{
                                     cancel: {
                                         title: I18n.t('userpages.profilePage.toolbar.cancel'),
-                                        type: 'link',
+                                        kind: 'link',
                                         onClick: () => {
                                             cancel()
                                         },
@@ -179,7 +179,7 @@ export class StreamShowView extends Component<Props, State> {
                                         title: isDesktop ?
                                             I18n.t('userpages.profilePage.toolbar.saveAndExit') :
                                             I18n.t('userpages.profilePage.toolbar.done'),
-                                        type: 'primary',
+                                        kind: 'primary',
                                         spinner: this.state.saving,
                                         onClick: () => {
                                             if (editedStream) {

--- a/app/src/userpages/components/StreamPage/Show/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/index.jsx
@@ -170,8 +170,7 @@ export class StreamShowView extends Component<Props, State> {
                                 actions={{
                                     cancel: {
                                         title: I18n.t('userpages.profilePage.toolbar.cancel'),
-                                        color: 'link',
-                                        outline: true,
+                                        type: 'link',
                                         onClick: () => {
                                             cancel()
                                         },
@@ -180,7 +179,7 @@ export class StreamShowView extends Component<Props, State> {
                                         title: isDesktop ?
                                             I18n.t('userpages.profilePage.toolbar.saveAndExit') :
                                             I18n.t('userpages.profilePage.toolbar.done'),
-                                        color: 'primary',
+                                        type: 'primary',
                                         spinner: this.state.saving,
                                         onClick: () => {
                                             if (editedStream) {

--- a/app/src/userpages/components/TransactionPage/List/NoTransactions/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/NoTransactions/index.jsx
@@ -27,7 +27,7 @@ const NoTransactionsView = ({ accountsExist, accountLinked }: Props) => (
         )}
         link={(!accountsExist || !accountLinked) && (
             <Button
-                type="special"
+                kind="special"
                 tag={Link}
                 to={routes.editProfile({}, 'ethereum-accounts')}
             >

--- a/app/src/userpages/components/TransactionPage/List/NoTransactions/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/NoTransactions/index.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
 
+import Button from '$shared/components/Button'
 import EmptyState from '$shared/components/EmptyState'
 import emptyStateIcon from '$shared/assets/images/empty_state_icon.png'
 import emptyStateIcon2x from '$shared/assets/images/empty_state_icon@2x.png'
@@ -25,12 +26,13 @@ const NoTransactionsView = ({ accountsExist, accountLinked }: Props) => (
             />
         )}
         link={(!accountsExist || !accountLinked) && (
-            <Link
-                className="btn btn-special"
+            <Button
+                type="special"
+                tag={Link}
                 to={routes.editProfile({}, 'ethereum-accounts')}
             >
                 <Translate value="userpages.transactions.noAccountsLinked.linkAccount" />
-            </Link>
+            </Button>
         )}
     >
         {(() => {

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -324,7 +324,7 @@ msgid "userpages##streams##edit##configure##delete"
 msgstr "Delete"
 
 msgid "userpages##streams##edit##configure##addField"
-msgstr "+ Add field"
+msgstr "Add field"
 
 msgid "userpages##streams##edit##configure##help"
 msgstr "You can configure your stream’s fields and data types here. This affects how this stream appears on canvases. You can choose to have Streamr try to autoconfigure fields, or you can edit them yourself."
@@ -631,7 +631,7 @@ msgstr ""
 "As they give the holder complete power over your account, please be cautious when sharing these keys."
 
 msgid "userpages##profilePage##apiCredentials##addAPIKey"
-msgstr "+ Add new key"
+msgstr "Add new key"
 
 msgid "userpages##profilePage##ethereumAddress##title"
 msgstr "Ethereum Address"
@@ -645,10 +645,10 @@ msgstr ""
 "You might use them for the Ethereum one-click login feature or for buying and selling products on the Marketplace."
 
 msgid "userpages##profilePage##ethereumAddress##addAddress"
-msgstr "+ Add address"
+msgstr "Add address"
 
 msgid "userpages##profilePage##ethereumAddress##addNewAddress"
-msgstr "+ Add new address"
+msgstr "Add new address"
 
 msgid "userpages##profilePage##ethereumAddress##notMetamaskEnabledBrowser"
 msgstr ""

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -46,6 +46,7 @@ import DeploySpinner from '$shared/components/DeploySpinner'
 import Label from '$shared/components/Label'
 import Tile from '$shared/components/Tile'
 import DonutChart from '$shared/components/DonutChart'
+import Button from '$shared/components/Button'
 
 import sharedStyles from './shared.pcss'
 
@@ -905,4 +906,43 @@ story('DonutChart')
                 },
             ]}
         />
+    ))
+
+story('Button')
+    .addWithJSX('all', () => (
+        <div>
+            <Button type="primary" size="mini" onClick={action('Clicked')}>Primary mini</Button>
+            <br />
+            <Button type="primary" size="normal" onClick={action('Clicked')}>Primary normal</Button>
+            <br />
+            <Button type="primary" size="big" onClick={action('Clicked')}>Primary big</Button>
+            <br />
+            <Button type="primary" size="normal" disabled onClick={action('Clicked')}>Primary normal disabled</Button>
+            <br />
+            <Button type="primary" size="normal" outline onClick={action('Clicked')}>Primary normal outline</Button>
+            <br />
+            <Button type="secondary" size="mini" onClick={action('Clicked')}>Secondary mini</Button>
+            <br />
+            <Button type="secondary" size="normal" onClick={action('Clicked')}>Secondary normal</Button>
+            <br />
+            <Button type="secondary" size="big" onClick={action('Clicked')}>Secondary big</Button>
+            <br />
+            <Button type="secondary" size="normal" disabled onClick={action('Clicked')}>Secondary normal disabled</Button>
+            <br />
+            <Button type="secondary" size="normal" outline onClick={action('Clicked')}>Secondary normal outline</Button>
+            <br />
+            <Button type="destructive" onClick={action('Clicked')}>Destructive</Button>
+            <br />
+            <Button type="destructive" disabled onClick={action('Clicked')}>Destructive disabled</Button>
+            <br />
+            <Button type="link" variant="dark" onClick={action('Clicked')}>Link (dark)</Button>
+            <br />
+            <Button type="link" variant="light" onClick={action('Clicked')}>Link (light)</Button>
+            <br />
+            <Button type="special" variant="dark" onClick={action('Clicked')}>Special (dark)</Button>
+            <br />
+            <Button type="special" variant="light" onClick={action('Clicked')}>Special (light)</Button>
+            <br />
+            <Button tag="a" href="#" onClick={action('Clicked')}>With link tag</Button>
+        </div>
     ))

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -734,12 +734,12 @@ story('RadioButtonGroup')
 const toolbarActions = {
     cancel: {
         title: 'Cancel',
-        color: 'link',
+        type: 'link',
         onClick: action('cancel'),
     },
     ok: {
         title: 'Ok',
-        color: 'primary',
+        type: 'primary',
         onClick: action('ok'),
         disabled: boolean('disabled'),
         spinner: boolean('spinner'),

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -447,7 +447,7 @@ story('Dialog')
         if (boolean('hasCancel', true)) {
             actions.cancel = {
                 title: 'Cancel',
-                outline: true,
+                kind: 'link',
                 onClick: action('onDismiss'),
             }
         }
@@ -456,7 +456,7 @@ story('Dialog')
             const waitingForSave = boolean('waitingForSave', false)
             actions.ok = {
                 title: waitingForSave ? 'Saving....' : 'Save',
-                color: 'primary',
+                kind: 'primary',
                 onClick: action('onSave'),
                 disabled: waitingForSave,
                 spinner: waitingForSave,
@@ -735,12 +735,12 @@ story('RadioButtonGroup')
 const toolbarActions = {
     cancel: {
         title: 'Cancel',
-        type: 'link',
+        kind: 'link',
         onClick: action('cancel'),
     },
     ok: {
         title: 'Ok',
-        type: 'primary',
+        kind: 'primary',
         onClick: action('ok'),
         disabled: boolean('disabled'),
         spinner: boolean('spinner'),
@@ -918,42 +918,42 @@ story('Spinner')
 story('Button')
     .addWithJSX('all', () => (
         <div>
-            <Button type="primary" size="mini" onClick={action('Clicked')}>Primary mini</Button>
+            <Button kind="primary" size="mini" onClick={action('Clicked')}>Primary mini</Button>
             <br />
-            <Button type="primary" size="normal" onClick={action('Clicked')}>Primary normal</Button>
+            <Button kind="primary" size="normal" onClick={action('Clicked')}>Primary normal</Button>
             <br />
-            <Button type="primary" size="big" onClick={action('Clicked')}>Primary big</Button>
+            <Button kind="primary" size="big" onClick={action('Clicked')}>Primary big</Button>
             <br />
-            <Button type="primary" size="normal" disabled onClick={action('Clicked')}>Primary normal disabled</Button>
+            <Button kind="primary" size="normal" disabled onClick={action('Clicked')}>Primary normal disabled</Button>
             <br />
-            <Button type="primary" size="normal" outline onClick={action('Clicked')}>Primary normal outline</Button>
+            <Button kind="primary" size="normal" outline onClick={action('Clicked')}>Primary normal outline</Button>
             <br />
-            <Button type="secondary" size="mini" onClick={action('Clicked')}>Secondary mini</Button>
+            <Button kind="secondary" size="mini" onClick={action('Clicked')}>Secondary mini</Button>
             <br />
-            <Button type="secondary" size="normal" onClick={action('Clicked')}>Secondary normal</Button>
+            <Button kind="secondary" size="normal" onClick={action('Clicked')}>Secondary normal</Button>
             <br />
-            <Button type="secondary" size="big" onClick={action('Clicked')}>Secondary big</Button>
+            <Button kind="secondary" size="big" onClick={action('Clicked')}>Secondary big</Button>
             <br />
-            <Button type="secondary" size="normal" disabled onClick={action('Clicked')}>Secondary normal disabled</Button>
+            <Button kind="secondary" size="normal" disabled onClick={action('Clicked')}>Secondary normal disabled</Button>
             <br />
-            <Button type="secondary" size="normal" outline onClick={action('Clicked')}>Secondary normal outline</Button>
+            <Button kind="secondary" size="normal" outline onClick={action('Clicked')}>Secondary normal outline</Button>
             <br />
-            <Button type="destructive" onClick={action('Clicked')}>Destructive</Button>
+            <Button kind="destructive" onClick={action('Clicked')}>Destructive</Button>
             <br />
-            <Button type="destructive" disabled onClick={action('Clicked')}>Destructive disabled</Button>
+            <Button kind="destructive" disabled onClick={action('Clicked')}>Destructive disabled</Button>
             <br />
-            <Button type="link" variant="dark" onClick={action('Clicked')}>Link (dark)</Button>
+            <Button kind="link" variant="dark" onClick={action('Clicked')}>Link (dark)</Button>
             <br />
-            <Button type="link" variant="light" onClick={action('Clicked')}>Link (light)</Button>
+            <Button kind="link" variant="light" onClick={action('Clicked')}>Link (light)</Button>
             <br />
-            <Button type="special" variant="dark" onClick={action('Clicked')}>Special (dark)</Button>
+            <Button kind="special" variant="dark" onClick={action('Clicked')}>Special (dark)</Button>
             <br />
-            <Button type="special" variant="light" onClick={action('Clicked')}>Special (light)</Button>
+            <Button kind="special" variant="light" onClick={action('Clicked')}>Special (light)</Button>
             <br />
             <Button tag="a" href="#" onClick={action('Clicked')}>With link tag</Button>
             <br />
-            <Button type="primary" waiting onClick={action('Clicked')}>Waiting primary</Button>
+            <Button kind="primary" waiting onClick={action('Clicked')}>Waiting primary</Button>
             <br />
-            <Button type="secondary" waiting onClick={action('Clicked')}>Waiting secondary</Button>
+            <Button kind="secondary" waiting onClick={action('Clicked')}>Waiting secondary</Button>
         </div>
     ))

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -42,6 +42,7 @@ import ContextMenu from '$shared/components/ContextMenu'
 import { NotificationIcon } from '$shared/utils/constants'
 import RadioButtonGroup from '$shared/components/RadioButtonGroup'
 import Toolbar from '$shared/components/Toolbar'
+import Spinner from '$shared/components/Spinner'
 import DeploySpinner from '$shared/components/DeploySpinner'
 import Label from '$shared/components/Label'
 import Tile from '$shared/components/Tile'
@@ -908,6 +909,12 @@ story('DonutChart')
         />
     ))
 
+story('Spinner')
+    .addWithJSX('Small', () => (<Spinner size="small" />))
+    .addWithJSX('Large', () => (<Spinner size="large" />))
+    .addWithJSX('Green', () => (<Spinner color="green" />))
+    .addWithJSX('White', () => (<Spinner color="white" />))
+
 story('Button')
     .addWithJSX('all', () => (
         <div>
@@ -944,5 +951,9 @@ story('Button')
             <Button type="special" variant="light" onClick={action('Clicked')}>Special (light)</Button>
             <br />
             <Button tag="a" href="#" onClick={action('Clicked')}>With link tag</Button>
+            <br />
+            <Button type="primary" waiting onClick={action('Clicked')}>Waiting primary</Button>
+            <br />
+            <Button type="secondary" waiting onClick={action('Clicked')}>Waiting secondary</Button>
         </div>
     ))


### PR DESCRIPTION
Adds a new shared `Button` component with 5 different types (`primary`, `secondary`, `destructive`, `link` & `special`). They all have 3 sizes (`mini`, `normal` & `big`). Some also have different variants (only `dark` for now).

Check out the storybook to see them in action.

I replaced (almost) all `reactstrap` buttons with this new component so there's quite a lot of changes.