### PR TITLE
chore: Add building process into docker

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,2 +1,22 @@
-FROM nginx:alpine
-COPY dist /usr/share/nginx/html
+FROM node:8.16.0-stretch-slim
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq python git make g++ bash autoconf automake nginx
+
+RUN npm i -g npm@^6.9.0
+
+WORKDIR /streamr-platform/app
+
+# Helps to cache modules
+COPY ./app/package-lock.json /streamr-platform/app
+COPY ./app/package.json /streamr-platform/app
+# Install libs
+RUN npm ci
+COPY ./app /streamr-platform/app
+COPY ./.git /streamr-platform/.git/
+RUN npm run build
+# A plugin needs the git information but this should be removed from the image once its not needed
+RUN rm -rf /streamr-platform/.git
+COPY default /etc/nginx/sites-enabled/
+RUN cat /etc/nginx/sites-enabled/*
+EXPOSE 8180
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
I had commented on the PR that created the Docker file that it didn't solve the problem of having the streamr-platform contained in a docker image.

This file has the work I had been doing, I leave it up to @timoxley or @harbu to decide if you want to use it or not and continue the rest of the process.