### PR TITLE
Extend streamr.info()

### DIFF
--- a/app/src/shared/utils/diagnostics.js
+++ b/app/src/shared/utils/diagnostics.js
@@ -1,18 +1,17 @@
 // You should init the Sentry browser SDK as soon as possible during your application load up, before initializing React
 // https://docs.sentry.io/platforms/javascript/react/
 import '../../analytics'
-import packageJson from '$app/package'
+import { dependencies } from '$app/package-lock'
 
-/* Attach global diagnostic object */
 const navigator = global.navigator || {}
+const streamrClientVersion = dependencies['streamr-client'].version
 
 global.streamr = Object.assign(global.streamr || {}, {
     info() {
         const info = {
             userAgent: navigator.userAgent,
             environment: process.env.NODE_ENV,
-            packages: packageJson.dependencies,
-            streamrClientVersion: packageJson.dependencies['streamr-client'],
+            streamrClientVersion,
         }
 
         if (process.env.TRAVIS_TAG) {

--- a/app/src/shared/utils/diagnostics.js
+++ b/app/src/shared/utils/diagnostics.js
@@ -1,6 +1,7 @@
 // You should init the Sentry browser SDK as soon as possible during your application load up, before initializing React
 // https://docs.sentry.io/platforms/javascript/react/
 import '../../analytics'
+import packageJson from '$app/package'
 
 /* Attach global diagnostic object */
 const navigator = global.navigator || {}
@@ -10,6 +11,8 @@ global.streamr = Object.assign(global.streamr || {}, {
         const info = {
             userAgent: navigator.userAgent,
             environment: process.env.NODE_ENV,
+            packages: packageJson.dependencies,
+            streamrClientVersion: packageJson.dependencies['streamr-client'],
         }
 
         if (process.env.TRAVIS_TAG) {


### PR DESCRIPTION
Adds the version for `streamr-client` and all other package version info to `streamr.info()`. Handy for staging/production debugging.

<img width="917" alt="Screenshot 2019-11-14 at 11 45 41" src="https://user-images.githubusercontent.com/1593398/68851788-d5ebf480-06d6-11ea-8d85-89cf5288871b.png">
