### PR TITLE
[PLATFORM-1149] Markdown formatting styles

### DIFF
--- a/app/src/marketplace/components/MarkdownEditor/index.jsx
+++ b/app/src/marketplace/components/MarkdownEditor/index.jsx
@@ -68,8 +68,6 @@ const MarkdownEditor = ({
                         <span className={styles.italic}>*italics*</span>
                         <span className={styles.code}>`code`</span>
                         <span>&gt;quote</span>
-                        <span>#Headline 1</span>
-                        <span>##Headline 2</span>
                         <span>* bullet point</span>
                     </div>
                     <div className={styles.wordCount}>

--- a/app/src/marketplace/components/MarkdownEditor/index.jsx
+++ b/app/src/marketplace/components/MarkdownEditor/index.jsx
@@ -64,8 +64,8 @@ const MarkdownEditor = ({
                 />
                 <div className={styles.footer}>
                     <div>
-                        <span className={styles.bold}>*bold*</span>
-                        <span className={styles.italic}>_italics_</span>
+                        <span className={styles.bold}>**bold**</span>
+                        <span className={styles.italic}>*italics*</span>
                         <span className={styles.code}>`code`</span>
                         <span>&gt;quote</span>
                         <span>#Headline 1</span>

--- a/app/src/marketplace/components/MarkdownEditor/markdownEditor.pcss
+++ b/app/src/marketplace/components/MarkdownEditor/markdownEditor.pcss
@@ -33,7 +33,7 @@
 
 .footer {
   display: grid;
-  grid-template-columns: auto 200px;
+  grid-template-columns: 1fr auto;
   padding: 1.5em;
   border-top: #EBEBEB 1px solid;
   color: #A3A3A3;

--- a/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.pcss
+++ b/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.pcss
@@ -1,7 +1,7 @@
 .root {
   color: var(--greyDark2);
-  line-height: 24px;
-  font-size: 16px;
+  line-height: 30px;
+  font-size: 18px;
   letter-spacing: 0;
 }
 
@@ -40,18 +40,31 @@
   letter-spacing: 0;
   line-height: 1.875rem;
 
+  p {
+    margin-bottom: 2rem;
+  }
+
+  strong {
+    font-weight: var(--medium);
+  }
+
+  em {
+    font-weight: 400;
+    font-style: italic;
+  }
+
   h1 {
     font-size: 1.25rem;
     font-weight: var(--semiBold);
     margin: 0;
-    margin-bottom: 1rem;
+    margin-bottom: 2rem;
   }
 
   h2 {
     font-size: 1rem;
     font-weight: var(--semiBold);
     margin: 0;
-    margin-bottom: 1rem;
+    margin-bottom: 2rem;
   }
 
   h3,
@@ -60,21 +73,75 @@
     font-size: 1rem;
     font-weight: var(--medium);
     margin: 0;
-    margin-bottom: 1rem;
+    margin-bottom: 2rem;
   }
 
   blockquote {
-    font-size: 0.875rem;
-    border-left: 4px solid var(--grey4);
-    padding: 0 1rem;
+    border-left: 4px solid var(--grey2);
+    padding-left: calc(1.875rem - 4px);
+  }
+
+  ul,
+  ol,
+  dl {
+    padding: 0;
+    margin-bottom: 2rem;
+  }
+
+  ul {
+    list-style-type: none;
+
+    li {
+      position: relative;
+      margin-left: 1.875rem;
+    }
+
+    li::before {
+      content: '•';
+      position: absolute;
+      left: -1.875rem;
+      color: var(--grey2);
+    }
+  }
+
+  ol {
+    counter-reset: list-counter;
+    list-style-type: none;
+
+    li {
+      position: relative;
+      margin-left: 1.875rem;
+      counter-increment: list-counter;
+    }
+
+    li::before {
+      content: counter(list-counter) '.';
+      position: absolute;
+      left: -1.875rem;
+      color: var(--grey2);
+    }
   }
 
   code {
     font-family: var(--mono);
-    color: #E83E8C;
-    font-size: 0.875rem;
+    color: inherit;
+    font-size: 14px;
     letter-spacing: 1px;
-    line-height: 1rem;
+    line-height: 30px;
+    background: #E7E7E7;
+    padding: 0.2rem 0.2rem 0.2rem 0.4rem;
+    border-radius: 1px;
+    margin-left: 0.2rem;
+    margin-right: 0.2rem;
+  }
+
+  pre {
+    overflow: scroll;
+    white-space: nowrap;
+  }
+
+  pre > code {
+    margin: 0;
   }
 
   *:last-child {

--- a/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.pcss
+++ b/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.pcss
@@ -11,6 +11,7 @@
   position: relative;
   overflow: hidden;
   max-height: 240px;
+  padding-left: 1.5rem;
 }
 
 .truncated {
@@ -78,7 +79,7 @@
 
   blockquote {
     border-left: 4px solid var(--grey2);
-    padding-left: calc(1.875rem - 4px);
+    padding-left: calc(1.5rem - 4px);
   }
 
   ul,
@@ -86,6 +87,7 @@
   dl {
     padding: 0;
     margin-bottom: 2rem;
+    margin-left: -1.5rem;
   }
 
   ul {
@@ -94,12 +96,13 @@
     li {
       position: relative;
       margin-left: 1.875rem;
+      margin-left: 3rem;
     }
 
     li::before {
       content: '•';
       position: absolute;
-      left: -1.875rem;
+      left: -1.5rem;
       color: var(--grey2);
     }
   }
@@ -110,15 +113,18 @@
 
     li {
       position: relative;
-      margin-left: 1.875rem;
       counter-increment: list-counter;
+      margin-left: 3rem;
     }
 
     li::before {
-      content: counter(list-counter) '.';
-      position: absolute;
-      left: -1.875rem;
+      content: counter(list-counter, decimal) '.';
       color: var(--grey2);
+      width: 2rem;
+      display: inline-block;
+      text-align: right;
+      position: absolute;
+      left: -3rem;
     }
   }
 
@@ -159,6 +165,7 @@
   outline: none;
   cursor: pointer;
   text-decoration: underline;
+  margin-left: 1.5rem;
 
   &:focus {
     outline: none;

--- a/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.pcss
+++ b/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.pcss
@@ -78,7 +78,7 @@
   }
 
   blockquote {
-    border-left: 4px solid var(--grey2);
+    border-left: 4px solid var(--greyDark2);
     padding-left: calc(1.5rem - 4px);
   }
 
@@ -103,7 +103,6 @@
       content: '•';
       position: absolute;
       left: -1.5rem;
-      color: var(--grey2);
     }
   }
 
@@ -119,7 +118,6 @@
 
     li::before {
       content: counter(list-counter, decimal) '.';
-      color: var(--grey2);
       width: 2rem;
       display: inline-block;
       text-align: right;

--- a/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.pcss
+++ b/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.pcss
@@ -36,8 +36,48 @@
 
 .inner {
   position: relative;
+  font-size: 1.125rem;
+  letter-spacing: 0;
+  line-height: 1.875rem;
 
-  p:last-child {
+  h1 {
+    font-size: 1.25rem;
+    font-weight: var(--semiBold);
+    margin: 0;
+    margin-bottom: 1rem;
+  }
+
+  h2 {
+    font-size: 1rem;
+    font-weight: var(--semiBold);
+    margin: 0;
+    margin-bottom: 1rem;
+  }
+
+  h3,
+  h4,
+  h6 {
+    font-size: 1rem;
+    font-weight: var(--medium);
+    margin: 0;
+    margin-bottom: 1rem;
+  }
+
+  blockquote {
+    font-size: 0.875rem;
+    border-left: 4px solid var(--grey4);
+    padding: 0 1rem;
+  }
+
+  code {
+    font-family: var(--mono);
+    color: #E83E8C;
+    font-size: 0.875rem;
+    letter-spacing: 1px;
+    line-height: 1rem;
+  }
+
+  *:last-child {
     margin-bottom: 0;
   }
 }

--- a/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.stories.jsx
+++ b/app/src/marketplace/components/ProductPage/CollapsedText/collapsedText.stories.jsx
@@ -184,6 +184,31 @@ This paragraph has some \`code\` in it.
 ![Alt Text](http://placehold.it/200x50 "Image Title")
 
     ![Alt Text](http://placehold.it/200x50 "Image Title")`
+
+// $FlowFixMe
+const markdownWithNumberedList = String.raw`Normal & numbered list:
+
+* List item 1
+* List item 2
+* List item 3
+
+1. Item 1
+2. Item 2
+3. Item 3
+4. Item 4
+5. Item 5
+6. Item 6
+7. Item 7
+8. Item 8
+9. Item 9
+10. Item 10
+11. Item 11
+12. Item 12
+
+> Quote at the end
+
+Bullets should align with dots, same text left align.
+`
 /* eslint-enable max-len */
 
 stories.add('short', () => (
@@ -200,4 +225,8 @@ stories.add('long', () => (
 
 stories.add('markdown', () => (
     <CollapsedText text={markdown} />
+))
+
+stories.add('numbered list', () => (
+    <CollapsedText text={markdownWithNumberedList} />
 ))

--- a/app/src/marketplace/components/deprecated/ProductPageEditor/index.jsx
+++ b/app/src/marketplace/components/deprecated/ProductPageEditor/index.jsx
@@ -13,7 +13,6 @@ import type { PropertySetter } from '$shared/flowtype/common-types'
 import type { CategoryList, Category } from '$mp/flowtype/category-types'
 import type { User } from '$shared/flowtype/user-types'
 
-import productPageStyles from '$mp/components/ProductPage/productPage.pcss'
 import StreamSelector from './StreamSelector'
 import ProductDetailsEditor from './ProductDetailsEditor'
 import styles from './productPageEditor.pcss'
@@ -79,7 +78,7 @@ export default class ProductPage extends Component<Props> {
                     onEdit={onEdit}
                     availableStreams={availableStreams}
                     fetchingStreams={fetchingStreams}
-                    className={productPageStyles.section}
+                    className={styles.section}
                 />
             </div>
         )

--- a/app/src/marketplace/components/deprecated/ProductPageEditor/productPageEditor.pcss
+++ b/app/src/marketplace/components/deprecated/ProductPageEditor/productPageEditor.pcss
@@ -15,3 +15,7 @@
     margin: 0;
   }
 }
+
+.section {
+  margin-top: 3em;
+}

--- a/app/src/marketplace/containers/ProductPage/description.pcss
+++ b/app/src/marketplace/containers/ProductPage/description.pcss
@@ -15,6 +15,7 @@
   display: grid;
   grid-template-columns: auto 17em;
   grid-column-gap: 9.875em;
+  margin-left: -1.5rem;
 }
 
 .description {

--- a/app/src/marketplace/containers/ProductPage/page.pcss
+++ b/app/src/marketplace/containers/ProductPage/page.pcss
@@ -5,11 +5,6 @@
   :global(.container) {
     max-width: 1110px;
   }
-
-  h1,
-  h2 {
-    margin: 0;
-  }
 }
 
 .loadingIndicator {


### PR DESCRIPTION
Styling of the generated markdown text. Note that these are not finished, just added some default styles as example:

<img width="708" alt="Screen Shot 2019-11-19 at 14 28 22" src="https://user-images.githubusercontent.com/1064982/69126664-4762e300-0adb-11ea-84f8-1b456595f2eb.png">

<img width="577" alt="Screen Shot 2019-11-19 at 14 34 22" src="https://user-images.githubusercontent.com/1064982/69126646-40d46b80-0adb-11ea-8189-3a2b1b6a5845.png">

@mattatgit Can you do a pass on these text stylings?