### PR TITLE
[PLATFORM-1152] Fix comment module

### DIFF
--- a/app/src/editor/shared/components/modules/Comment.jsx
+++ b/app/src/editor/shared/components/modules/Comment.jsx
@@ -48,6 +48,7 @@ export default class CommentModule extends React.PureComponent {
                         disabled={!isEditable}
                         commitEmpty
                         flushHistoryOnBlur
+                        immediateCommit={false}
                         onCommit={this.onChange}
                         placeholder="Enter comment here…"
                         tag="textarea"

--- a/app/src/editor/shared/components/modules/TextField.jsx
+++ b/app/src/editor/shared/components/modules/TextField.jsx
@@ -75,6 +75,7 @@ export default class TextFieldModule extends React.Component {
                         flushHistoryOnBlur
                         onCommit={this.onChange}
                         placeholder="Enter your text here"
+                        immediateCommit={false}
                         tag="textarea"
                         value={value}
                         disabled={!hasWritePermission}

--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -116,6 +116,7 @@ const EditableText = ({
                 {editing && !disabled ? (
                     <Fragment>
                         <TextControl
+                            immediateCommit={false}
                             {...props}
                             autoComplete="off"
                             autoFocus

--- a/app/src/shared/components/TextControl/index.jsx
+++ b/app/src/shared/components/TextControl/index.jsx
@@ -21,8 +21,12 @@ type Props = {
     value?: string | number,
 }
 
+const sanitise = (value) => (
+    value == null ? '' : value
+)
+
 const normalize = (value: any): string => (
-    typeof value === 'string' ? value.trim() : String(value)
+    typeof value === 'string' ? value.trim() : String(sanitise(value))
 )
 
 const TextControl = ({
@@ -45,19 +49,17 @@ const TextControl = ({
     const el = useRef(null)
     const ref = innerRef || el
     const reverted: Ref<boolean> = useRef(false)
-    const sanitizedValue = valueProp == null ? '' : valueProp
-    const [value, setValue] = useState(sanitizedValue)
+    const normalizedValueProp = normalize(valueProp)
+    const [value, setValue] = useState(normalizedValueProp)
+    const [hasFocus, setFocus] = useState(false)
+
     const [blurCount, setBlurCount] = useState(0)
-    const normalizedValue = normalize(value)
     const commit = useCallback(() => {
-        if (onCommit && normalizedValue !== normalize(valueProp) && (normalizedValue || commitEmpty)) {
+        const normalizedValue = normalize(value)
+        if (onCommit && normalizedValue !== normalizedValueProp && (normalizedValue || commitEmpty)) {
             onCommit(normalizedValue)
         }
-    }, [normalizedValue, valueProp, onCommit, commitEmpty])
-
-    useEffect(() => {
-        setValue(valueProp)
-    }, [valueProp])
+    }, [normalizedValueProp, value, onCommit, commitEmpty])
 
     const onBlur = useCallback((e: SyntheticInputEvent<EventTarget>) => {
         if (flushHistoryOnBlur) {
@@ -70,24 +72,24 @@ const TextControl = ({
             commit()
         }
 
-        if (!commitEmpty && !normalizedValue) {
-            setValue(sanitizedValue)
-        }
-
+        setFocus(false)
         if (onBlurProp) {
             onBlurProp(e)
         }
-    }, [onBlurProp, flushHistoryOnBlur, commit, sanitizedValue, commitEmpty, normalizedValue, immediateCommit])
+    }, [onBlurProp, flushHistoryOnBlur, commit, immediateCommit])
 
     const onFocus = useCallback((e: SyntheticInputEvent<EventTarget>) => {
+        setValue(normalizedValueProp)
         if (selectAllOnFocus) {
             e.target.select()
         }
 
+        setFocus(true)
+
         if (onFocusProp) {
             onFocusProp(e)
         }
-    }, [onFocusProp, selectAllOnFocus])
+    }, [onFocusProp, selectAllOnFocus, normalizedValueProp])
 
     const onChange = useCallback((e: SyntheticInputEvent<EventTarget>) => {
         const { value: newValue } = e.target
@@ -111,15 +113,17 @@ const TextControl = ({
                     break
                 case 'Escape':
                     if (revertOnEsc) {
-                        if (value === sanitizedValue) {
+                        if (value === normalizedValueProp) {
                             // No change. Re-render won't happen. We can blur right away!
                             input.blur()
                         } else {
                             // If the value changed then we have to wait with the `blur`
                             // for another render. `onBlur` has to know current `value`.
-                            setValue(sanitizedValue)
+                            setValue(normalizedValueProp)
                             reverted.current = true
                         }
+                    } else {
+                        input.blur()
                     }
                     break
                 default:
@@ -130,7 +134,7 @@ const TextControl = ({
         if (onKeyDownProp) {
             onKeyDownProp(e)
         }
-    }, [onKeyDownProp, revertOnEsc, immediateCommit, sanitizedValue, tag, ref, value])
+    }, [onKeyDownProp, revertOnEsc, immediateCommit, normalizedValueProp, tag, ref, value])
 
     useEffect(() => {
         const { current: input } = ref
@@ -147,6 +151,8 @@ const TextControl = ({
         }
     }, [immediateCommit, commit])
 
+    const displayedValue = hasFocus ? value : normalizedValueProp
+
     return (
         <Tag
             {...props}
@@ -156,7 +162,7 @@ const TextControl = ({
             onFocus={onFocus}
             onKeyDown={onKeyDown}
             ref={ref}
-            value={value}
+            value={displayedValue}
         />
     )
 }

--- a/app/src/shared/components/TextControl/index.jsx
+++ b/app/src/shared/components/TextControl/index.jsx
@@ -145,11 +145,18 @@ const TextControl = ({
         }
     })
 
+    // captured refs for next effect
+    const commitRef = useRef(commit)
+    commitRef.current = commit
+    const immediateCommitRef = useRef()
+    immediateCommitRef.current = immediateCommit
+    // when value changes do immediate commit if needed
+    const normalizedCurrentValue = normalize(value)
     useEffect(() => {
-        if (immediateCommit) {
-            commit()
+        if (immediateCommitRef.current) {
+            commitRef.current()
         }
-    }, [immediateCommit, commit])
+    }, [normalizedCurrentValue])
 
     const displayedValue = hasFocus ? value : normalizedValueProp
 

--- a/app/src/shared/components/TextControl/textControl.stories.jsx
+++ b/app/src/shared/components/TextControl/textControl.stories.jsx
@@ -2,8 +2,8 @@
 
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
 import styles from '@sambego/storybook-styles'
+import UseState from '$shared/components/UseState'
 import TextControl from '.'
 
 const stories =
@@ -13,52 +13,103 @@ const stories =
         }))
 
 stories.add('enhanced', () => (
-    <TextControl
-        flushHistoryOnBlur
-        immediateCommit={false}
-        onCommit={action('Commit')}
-        commitEmpty={false}
-        revertOnEsc
-        selectAllOnFocus
-        value="Lorem ipsum."
-    />
+    <UseState initialValue="Lorem ipsum.">
+        {(value, setValue) => (
+            <TextControl
+                flushHistoryOnBlur
+                immediateCommit={false}
+                commitEmpty={false}
+                revertOnEsc
+                selectAllOnFocus
+                onCommit={setValue}
+                value={value}
+            />
+        )}
+    </UseState>
 ))
 
 stories.add('revert on Escape', () => (
-    <TextControl
-        onCommit={action('Commit')}
-        revertOnEsc
-        value="Lorem ipsum."
-    />
+    <UseState initialValue="Lorem ipsum.">
+        {(value, setValue) => (
+            <TextControl
+                revertOnEsc
+                onCommit={setValue}
+                value={value}
+            />
+        )}
+    </UseState>
 ))
 
 stories.add('require value', () => (
-    <TextControl
-        onCommit={action('Commit')}
-        commitEmpty={false}
-        value="Lorem ipsum."
-    />
+    <UseState initialValue="Lorem ipsum.">
+        {(value, setValue) => (
+            <TextControl
+                commitEmpty={false}
+                onCommit={setValue}
+                value={value}
+            />
+        )}
+    </UseState>
 ))
 
 stories.add('commit on Enter', () => (
-    <TextControl
-        immediateCommit={false}
-        onCommit={action('Commit')}
-        value="Lorem ipsum."
-    />
+    <UseState initialValue="Lorem ipsum.">
+        {(value, setValue) => (
+            <TextControl
+                immediateCommit={false}
+                onCommit={setValue}
+                value={value}
+            />
+        )}
+    </UseState>
 ))
 
 stories.add('select all on focus', () => (
-    <TextControl
-        onCommit={action('Commit')}
-        selectAllOnFocus
-        value="Lorem ipsum."
-    />
+    <UseState initialValue="Lorem ipsum.">
+        {(value, setValue) => (
+            <TextControl
+                selectAllOnFocus
+                onCommit={setValue}
+                value={value}
+            />
+        )}
+    </UseState>
 ))
 
 stories.add('prevent undo after blur', () => (
-    <TextControl
-        flushHistoryOnBlur
-        value="Lorem ipsum."
-    />
+    <UseState initialValue="Lorem ipsum.">
+        {(value, setValue) => (
+            <TextControl
+                flushHistoryOnBlur
+                onCommit={setValue}
+                value={value}
+            />
+        )}
+    </UseState>
+))
+
+stories.add('update prop on commit', () => (
+    <UseState initialValue="0">
+        {(value, setValue) => (
+            <TextControl
+                immediateCommit={false}
+                onCommit={(v) => {
+                    setValue(Number(v) + 1)
+                }}
+                value={value}
+            />
+        )}
+    </UseState>
+))
+
+stories.add('textarea', () => (
+    <UseState initialValue="Lorem ipsum.">
+        {(value, setValue) => (
+            <TextControl
+                tag="textarea"
+                value={value}
+                onCommit={setValue}
+            />
+        )}
+    </UseState>
 ))


### PR DESCRIPTION
The effect to update local state with prop was running recursively, causing comment module to die.

Fixed so the TextControl always uses the passed-in prop while not editing, and always uses local state when editing, copies prop to local state on focus, only fires commit when value changes.