### PR TITLE
[PLATFORM-1109] Fix permission errors on public endpoints

### DIFF
--- a/app/src/auth/components/LogoutPage/index.jsx
+++ b/app/src/auth/components/LogoutPage/index.jsx
@@ -22,7 +22,9 @@ const LogoutPage = ({ logout }: Props) => {
     const isMounted = useIsMounted()
 
     useOnMount(() => {
-        post(routes.externalLogout())
+        post({
+            url: routes.externalLogout(),
+        })
             .then(
                 () => {
                     if (isMounted()) {

--- a/app/src/marketplace/modules/categories/services.js
+++ b/app/src/marketplace/modules/categories/services.js
@@ -5,6 +5,9 @@ import { formatApiUrl } from '$shared/utils/url'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import type { Category } from '../../flowtype/category-types'
 
-export const getCategories = (includeEmpty: boolean): ApiResult<Array<Category>> => get(formatApiUrl('categories', {
-    includeEmpty,
-}))
+export const getCategories = (includeEmpty: boolean): ApiResult<Array<Category>> => get({
+    url: formatApiUrl('categories', {
+        includeEmpty,
+    }),
+    useAuthorization: false,
+})

--- a/app/src/marketplace/modules/communityProduct/services.js
+++ b/app/src/marketplace/modules/communityProduct/services.js
@@ -26,11 +26,14 @@ export const getStreamrEngineAddresses = (): Array<string> => {
     return addresses
 }
 
-export const addPermission = (id: StreamId, permission: Permission): ApiResult<Array<Permission>> =>
-    post(formatApiUrl('streams', id, 'permissions'), permission)
+export const addPermission = (id: StreamId, permission: Permission): ApiResult<Array<Permission>> => post({
+    url: formatApiUrl('streams', id, 'permissions'),
+    data: permission,
+})
 
-export const deletePermission = (id: StreamId, permissionId: string): ApiResult<Array<Permission>> =>
-    del(formatApiUrl('streams', id, 'permissions', permissionId))
+export const deletePermission = (id: StreamId, permissionId: string): ApiResult<Array<Permission>> => del({
+    url: formatApiUrl('streams', id, 'permissions', permissionId),
+})
 
 export const createJoinPartStream = async (productId: ?ProductId = undefined): Promise<Stream> => {
     const newStream: NewStream = {
@@ -148,13 +151,15 @@ export const setAdminFee = (address: CommunityId, adminFee: number): SmartContra
 export const getJoinPartStreamId = (address: CommunityId, usePublicNode: boolean = false) =>
     call(getCommunityContract(address, usePublicNode).methods.joinPartStream())
 
-export const getCommunityStats = (id: CommunityId): ApiResult<Object> =>
-    get(formatApiUrl('communities', id, 'stats'))
+export const getCommunityStats = (id: CommunityId): ApiResult<Object> => get({
+    url: formatApiUrl('communities', id, 'stats'),
+})
 
-export const getStreamData = (id: CommunityId, fromTimestamp: number): ApiResult<Object> =>
-    get(formatApiUrl('streams', id, 'data', 'partitions', 0, 'from', {
+export const getStreamData = (id: CommunityId, fromTimestamp: number): ApiResult<Object> => get({
+    url: formatApiUrl('streams', id, 'data', 'partitions', 0, 'from', {
         fromTimestamp,
-    }))
+    }),
+})
 
 export const getCommunityData = async (id: CommunityId, usePublicNode: boolean = true): ApiResult<Object> => {
     const adminFee = await getAdminFee(id, usePublicNode)

--- a/app/src/marketplace/modules/deprecated/editProduct/services.js
+++ b/app/src/marketplace/modules/deprecated/editProduct/services.js
@@ -6,12 +6,16 @@ import { formatApiUrl } from '$shared/utils/url'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import type { EditProduct, Product, ProductId, ProductType } from '$mp/flowtype/product-types'
 
-export const putProduct = (data: EditProduct, id: ProductId): ApiResult<Product> => (
-    put(formatApiUrl('products', id), mapProductToPutApi(data))
-        .then(mapProductFromApi)
-)
+export const putProduct = (data: EditProduct, id: ProductId): ApiResult<Product> => put({
+    url: formatApiUrl('products', id),
+    data: mapProductToPutApi(data),
+})
+    .then(mapProductFromApi)
 
-export const postProduct = (product: Product): ApiResult<Product> => post(formatApiUrl('products'), mapProductToPostApi(product))
+export const postProduct = (product: Product): ApiResult<Product> => post({
+    url: formatApiUrl('products'),
+    data: mapProductToPostApi(product),
+})
     .then(mapProductFromApi)
 
 export const postEmptyProduct = (type: ProductType): ApiResult<Product> => {
@@ -19,7 +23,10 @@ export const postEmptyProduct = (type: ProductType): ApiResult<Product> => {
         type,
     }
 
-    return post(formatApiUrl('products'), product)
+    return post({
+        url: formatApiUrl('products'),
+        data: product,
+    })
         .then(mapProductFromApi)
 }
 
@@ -33,5 +40,9 @@ export const postImage = (id: ProductId, image: File): ApiResult<EditProduct> =>
     const data = new FormData()
     data.append('file', image, image.name)
 
-    return post(formatApiUrl('products', id, 'images'), data, options).then(mapProductFromApi)
+    return post({
+        url: formatApiUrl('products', id, 'images'),
+        data,
+        options,
+    }).then(mapProductFromApi)
 }

--- a/app/src/marketplace/modules/myProductList/services.js
+++ b/app/src/marketplace/modules/myProductList/services.js
@@ -7,7 +7,10 @@ import { mapAllProductsFromApi } from '../../utils/product'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import type { Product } from '../../flowtype/product-types'
 
-export const getMyProducts = (params: any): ApiResult<Array<Product>> => get(formatApiUrl('users/me/products'), {
-    params,
+export const getMyProducts = (params: any): ApiResult<Array<Product>> => get({
+    url: formatApiUrl('users/me/products'),
+    options: {
+        params,
+    },
 })
     .then(mapAllProductsFromApi)

--- a/app/src/marketplace/modules/myPurchaseList/services.js
+++ b/app/src/marketplace/modules/myPurchaseList/services.js
@@ -13,5 +13,7 @@ const mapProductSubscriptions = (subscriptions: Array<ProductSubscription>): Arr
         product: mapProductFromApi(subscription.product),
     }))
 
-export const getMyPurchases = (): ApiResult<Array<ProductSubscription>> => get(formatApiUrl('subscriptions'))
+export const getMyPurchases = (): ApiResult<Array<ProductSubscription>> => get({
+    url: formatApiUrl('subscriptions'),
+})
     .then(mapProductSubscriptions)

--- a/app/src/marketplace/modules/product/services.js
+++ b/app/src/marketplace/modules/product/services.js
@@ -13,12 +13,15 @@ import { getValidId, mapProductFromApi } from '$mp/utils/product'
 import { getProductFromContract } from '$mp/modules/contractProduct/services'
 import getWeb3 from '$shared/web3/web3Provider'
 
-export const getProductById = async (id: ProductId): ApiResult<Product> => get(formatApiUrl('products', getValidId(id, false)))
+export const getProductById = async (id: ProductId): ApiResult<Product> => get({
+    url: formatApiUrl('products', getValidId(id, false)),
+})
     .then(mapProductFromApi)
 
-export const getStreamsByProductId = async (id: ProductId): ApiResult<StreamList> => (
-    get(formatApiUrl('products', getValidId(id, false), 'streams'))
-)
+export const getStreamsByProductId = async (id: ProductId): ApiResult<StreamList> => get({
+    url: formatApiUrl('products', getValidId(id, false), 'streams'),
+    useAuthorization: false,
+})
 
 const contractMethods = () => getContract(getConfig().marketplace).methods
 
@@ -39,7 +42,9 @@ export const getMyProductSubscription = (id: ProductId): SmartContractCall<Subsc
     Otherwise it'd be a synchronous error.
   */
 export const getUserProductPermissions = async (id: ProductId): ApiResult<Object> => {
-    const result = await get(formatApiUrl('products', getValidId(id, false), 'permissions', 'me'))
+    const result = await get({
+        url: formatApiUrl('products', getValidId(id, false), 'permissions', 'me'),
+    })
 
     const p = result.reduce((permissions, permission) => {
         if (permission.anonymous) {

--- a/app/src/marketplace/modules/productList/services.js
+++ b/app/src/marketplace/modules/productList/services.js
@@ -8,13 +8,16 @@ import type { Filter, ProductListPageWrapper } from '../../flowtype/product-type
 import { mapProductFromApi } from '../../utils/product'
 
 export const getProducts = (filter: Filter, pageSize: number, offset: number): ApiResult<ProductListPageWrapper> => (
-    get(formatApiUrl('products', {
-        ...filter,
-        publicAccess: true,
-        grantedAccess: false,
-        max: pageSize + 1, // query 1 extra element to determine if we should show "load more" button
-        offset,
-    }))
+    get({
+        url: formatApiUrl('products', {
+            ...filter,
+            publicAccess: true,
+            grantedAccess: false,
+            max: pageSize + 1, // query 1 extra element to determine if we should show "load more" button
+            offset,
+        }),
+        useAuthorization: false,
+    })
         .then((products) => ({
             products: products.splice(0, pageSize).map(mapProductFromApi),
             hasMoreProducts: products.length > 0,

--- a/app/src/marketplace/modules/publish/services.js
+++ b/app/src/marketplace/modules/publish/services.js
@@ -9,12 +9,17 @@ import type { ProductId, Product } from '$mp/flowtype/product-types'
 import type { SmartContractTransaction, Hash } from '$shared/flowtype/web3-types'
 import { getValidId, mapProductFromApi } from '$mp/utils/product'
 
-export const postDeployFree = async (id: ProductId): ApiResult<Product> => post(formatApiUrl('products', getValidId(id, false), 'deployFree'))
+export const postDeployFree = async (id: ProductId): ApiResult<Product> => post({
+    url: formatApiUrl('products', getValidId(id, false), 'deployFree'),
+})
     .then(mapProductFromApi)
 
 export const postSetDeploying = async (id: ProductId, txHash: Hash): ApiResult<Product> => (
-    post(formatApiUrl('products', getValidId(id, false), 'setDeploying'), {
-        transactionHash: txHash,
+    post({
+        url: formatApiUrl('products', getValidId(id, false), 'setDeploying'),
+        data: {
+            transactionHash: txHash,
+        },
     }).then(mapProductFromApi)
 )
 

--- a/app/src/marketplace/modules/purchase/services.js
+++ b/app/src/marketplace/modules/purchase/services.js
@@ -11,9 +11,12 @@ import type { SmartContractTransaction } from '$shared/flowtype/web3-types'
 import { gasLimits } from '$shared/utils/constants'
 import { getValidId } from '$mp/utils/product'
 
-export const addFreeProduct = async (id: ProductId, endsAt: number): ApiResult<null> => post(formatApiUrl('subscriptions'), {
-    product: getValidId(id, false),
-    endsAt,
+export const addFreeProduct = async (id: ProductId, endsAt: number): ApiResult<null> => post({
+    url: formatApiUrl('subscriptions'),
+    data: {
+        product: getValidId(id, false),
+        endsAt,
+    },
 })
 
 const contractMethods = () => getContract(getConfig().marketplace).methods

--- a/app/src/marketplace/modules/relatedProducts/services.js
+++ b/app/src/marketplace/modules/relatedProducts/services.js
@@ -7,5 +7,8 @@ import { mapAllProductsFromApi } from '../../utils/product'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import type { Product, ProductId } from '../../flowtype/product-types'
 
-export const getRelatedProducts = (id: ProductId): ApiResult<Array<Product>> => get(formatApiUrl('products', id, 'related'))
+export const getRelatedProducts = (id: ProductId): ApiResult<Array<Product>> => get({
+    url: formatApiUrl('products', id, 'related'),
+    useAuthorization: false,
+})
     .then(mapAllProductsFromApi)

--- a/app/src/marketplace/modules/streams/services.js
+++ b/app/src/marketplace/modules/streams/services.js
@@ -5,7 +5,9 @@ import { formatApiUrl } from '$shared/utils/url'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import type { StreamList } from '$shared/flowtype/stream-types'
 
-export const getStreams = (): ApiResult<StreamList> => get(formatApiUrl('streams', {
-    uiChannel: false,
-    operation: 'SHARE',
-}))
+export const getStreams = (): ApiResult<StreamList> => get({
+    url: formatApiUrl('streams', {
+        uiChannel: false,
+        operation: 'SHARE',
+    }),
+})

--- a/app/src/marketplace/modules/unpublish/services.js
+++ b/app/src/marketplace/modules/unpublish/services.js
@@ -10,14 +10,17 @@ import type { SmartContractTransaction, Hash } from '$shared/flowtype/web3-types
 import { gasLimits } from '$shared/utils/constants'
 import { getValidId, mapProductFromApi } from '$mp/utils/product'
 
-export const postUndeployFree = async (id: ProductId): ApiResult<Product> => post(formatApiUrl('products', getValidId(id, false), 'undeployFree'))
+export const postUndeployFree = async (id: ProductId): ApiResult<Product> => post({
+    url: formatApiUrl('products', getValidId(id, false), 'undeployFree'),
+})
     .then(mapProductFromApi)
 
-export const postSetUndeploying = async (id: ProductId, txHash: Hash): ApiResult<Product> => (
-    post(formatApiUrl('products', getValidId(id, false), 'setUndeploying'), {
+export const postSetUndeploying = async (id: ProductId, txHash: Hash): ApiResult<Product> => post({
+    url: formatApiUrl('products', getValidId(id, false), 'setUndeploying'),
+    data: {
         transactionHash: txHash,
-    }).then(mapProductFromApi)
-)
+    },
+}).then(mapProductFromApi)
 
 const contractMethods = () => getContract(getConfig().marketplace).methods
 

--- a/app/src/shared/modules/integrationKey/services.js
+++ b/app/src/shared/modules/integrationKey/services.js
@@ -14,35 +14,48 @@ import {
     IdentityExistsError,
 } from '$shared/errors/Web3'
 
-export const getIntegrationKeys = (): ApiResult<Array<IntegrationKey>> => get(formatApiUrl('integration_keys'))
+export const getIntegrationKeys = (): ApiResult<Array<IntegrationKey>> => get({
+    url: formatApiUrl('integration_keys'),
+})
 
 export const createPrivateKey = (name: string, privateKey: Address): ApiResult<IntegrationKey> =>
-    post(formatApiUrl('integration_keys'), {
-        name,
-        service: integrationKeyServices.PRIVATE_KEY,
-        json: {
-            privateKey,
+    post({
+        url: formatApiUrl('integration_keys'),
+        data: {
+            name,
+            service: integrationKeyServices.PRIVATE_KEY,
+            json: {
+                privateKey,
+            },
         },
     })
 
 export const editIntegrationKey = (keyId: IntegrationKeyId, name: string): ApiResult<IntegrationKey> =>
-    put(formatApiUrl('integration_keys', keyId), {
-        name,
+    put({
+        url: formatApiUrl('integration_keys', keyId),
+        data: {
+            name,
+        },
     })
 
-export const createChallenge = (account: Address): ApiResult<Challenge> => post(formatApiUrl('login', 'challenge', account))
+export const createChallenge = (account: Address): ApiResult<Challenge> => post({
+    url: formatApiUrl('login', 'challenge', account),
+})
 
 export const createEthereumIdentity = (
     name: string,
     address: Address,
     challenge: Challenge,
     signature: Hash,
-): ApiResult<IntegrationKey> => post(formatApiUrl('integration_keys'), {
-    name,
-    service: integrationKeyServices.ETHEREREUM_IDENTITY,
-    challenge,
-    signature,
-    address,
+): ApiResult<IntegrationKey> => post({
+    url: formatApiUrl('integration_keys'),
+    data: {
+        name,
+        service: integrationKeyServices.ETHEREREUM_IDENTITY,
+        challenge,
+        signature,
+        address,
+    },
 })
 
 export const createIdentity = async (name: string): ApiResult<IntegrationKey> => {
@@ -83,4 +96,6 @@ export const createIdentity = async (name: string): ApiResult<IntegrationKey> =>
     }
 }
 
-export const deleteIntegrationKey = (id: IntegrationKeyId): ApiResult<null> => del(formatApiUrl('integration_keys', id))
+export const deleteIntegrationKey = (id: IntegrationKeyId): ApiResult<null> => del({
+    url: formatApiUrl('integration_keys', id),
+})

--- a/app/src/shared/modules/resourceKey/services.js
+++ b/app/src/shared/modules/resourceKey/services.js
@@ -6,37 +6,52 @@ import type { ApiResult } from '$shared/flowtype/common-types'
 import type { ResourceKeyList, ResourceKey, ResourceKeyId, ResourcePermission } from '$shared/flowtype/resource-key-types'
 import type { StreamId } from '$shared/flowtype/stream-types'
 
-export const getMyResourceKeys = (): ApiResult<ResourceKeyList> =>
-    get(formatApiUrl('users', 'me', 'keys'))
+export const getMyResourceKeys = (): ApiResult<ResourceKeyList> => get({
+    url: formatApiUrl('users', 'me', 'keys'),
+})
 
-export const getStreamResourceKeys = (streamId: StreamId): ApiResult<ResourceKeyList> =>
-    get(formatApiUrl('streams', streamId, 'keys'))
+export const getStreamResourceKeys = (streamId: StreamId): ApiResult<ResourceKeyList> => get({
+    url: formatApiUrl('streams', streamId, 'keys'),
+})
 
-export const addMyResourceKey = (keyName: string): ApiResult<ResourceKey> =>
-    post(formatApiUrl('users', 'me', 'keys'), {
+export const addMyResourceKey = (keyName: string): ApiResult<ResourceKey> => post({
+    url: formatApiUrl('users', 'me', 'keys'),
+    data: {
         name: keyName,
-    })
+    },
+})
 
 export const addStreamResourceKey = (streamId: StreamId, name: string, permission: ResourcePermission): ApiResult<ResourceKey> =>
-    post(formatApiUrl('streams', streamId, 'keys'), {
-        name,
-        permission,
+    post({
+        url: formatApiUrl('streams', streamId, 'keys'),
+        data: {
+            name,
+            permission,
+        },
     })
 
 export const editStreamResourceKey =
     (streamId: StreamId, keyId: ResourceKeyId, keyName: string, keyPermission: ResourcePermission): ApiResult<ResourceKey> =>
-        put(formatApiUrl('streams', streamId, 'keys', keyId), {
-            name: keyName,
-            permission: keyPermission,
+        put({
+            url: formatApiUrl('streams', streamId, 'keys', keyId),
+            data: {
+                name: keyName,
+                permission: keyPermission,
+            },
         })
 
 export const editMyResourceKey = (keyId: ResourceKeyId, name: string): ApiResult<ResourceKey> =>
-    put(formatApiUrl('users', 'me', 'keys', keyId), {
-        name,
+    put({
+        url: formatApiUrl('users', 'me', 'keys', keyId),
+        data: {
+            name,
+        },
     })
 
-export const removeMyResourceKey = (id: ResourceKeyId): ApiResult<null> =>
-    del(formatApiUrl('users', 'me', 'keys', id))
+export const removeMyResourceKey = (id: ResourceKeyId): ApiResult<null> => del({
+    url: formatApiUrl('users', 'me', 'keys', id),
+})
 
-export const removeStreamResourceKey = (streamId: StreamId, id: ResourceKeyId): ApiResult<null> =>
-    del(formatApiUrl('streams', streamId, 'keys', id))
+export const removeStreamResourceKey = (streamId: StreamId, id: ResourceKeyId): ApiResult<null> => del({
+    url: formatApiUrl('streams', streamId, 'keys', id),
+})

--- a/app/src/shared/modules/user/services.js
+++ b/app/src/shared/modules/user/services.js
@@ -5,15 +5,20 @@ import { formatApiUrl } from '$shared/utils/url'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import type { User, PasswordUpdate } from '$shared/flowtype/user-types'
 
-export const getUserData = (): ApiResult<User> => get(formatApiUrl('users', 'me', {
-    noCache: Date.now(),
-}))
+export const getUserData = (): ApiResult<User> => get({
+    url: formatApiUrl('users', 'me', {
+        noCache: Date.now(),
+    }),
+})
 
-export const putUser = (user: User): ApiResult<User> => put(formatApiUrl('users', 'me'), {
-    headers: {
-        'Content-Type': 'application/json',
+export const putUser = (user: User): ApiResult<User> => put({
+    url: formatApiUrl('users', 'me'),
+    data: {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        ...user,
     },
-    ...user,
 })
 
 export const postPasswordUpdate = (passwordUpdate: PasswordUpdate, userInputs?: Array<string> = []): ApiResult<null> => {
@@ -23,10 +28,14 @@ export const postPasswordUpdate = (passwordUpdate: PasswordUpdate, userInputs?: 
     form.append('password', passwordUpdate.newPassword)
     form.append('password2', passwordUpdate.confirmNewPassword)
 
-    return post(formatApiUrl('users', 'me', 'changePassword'), form, {
-        headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'X-Requested-With': 'XMLHttpRequest',
+    return post({
+        url: formatApiUrl('users', 'me', 'changePassword'),
+        data: form,
+        options: {
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-Requested-With': 'XMLHttpRequest',
+            },
         },
     })
 }
@@ -41,7 +50,13 @@ export const uploadProfileAvatar = (image: File): Promise<void> => {
     const data = new FormData()
     data.append('file', image, image.name)
 
-    return post(formatApiUrl('users', 'me', 'image'), data, options)
+    return post({
+        url: formatApiUrl('users', 'me', 'image'),
+        data,
+        options,
+    })
 }
 
-export const deleteUserAccount = (): ApiResult<null> => del(formatApiUrl('users/me'))
+export const deleteUserAccount = (): ApiResult<null> => del({
+    url: formatApiUrl('users/me'),
+})

--- a/app/src/shared/modules/user/services.js
+++ b/app/src/shared/modules/user/services.js
@@ -13,12 +13,7 @@ export const getUserData = (): ApiResult<User> => get({
 
 export const putUser = (user: User): ApiResult<User> => put({
     url: formatApiUrl('users', 'me'),
-    data: {
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        ...user,
-    },
+    data: user,
 })
 
 export const postPasswordUpdate = (passwordUpdate: PasswordUpdate, userInputs?: Array<string> = []): ApiResult<null> => {

--- a/app/src/shared/utils/api.js
+++ b/app/src/shared/utils/api.js
@@ -1,12 +1,24 @@
 // @flow
 
 import type { ApiResult } from '$shared/flowtype/common-types'
-import request from '$shared/utils/request'
+import request, { type RequestParams } from '$shared/utils/request'
 
-export const get = (endpoint: string, options?: Object): ApiResult<*> => request(endpoint, 'get', null, options)
+export const get = (args: RequestParams): ApiResult<*> => request({
+    ...args,
+    method: 'get',
+})
 
-export const post = (endpoint: string, data: any, options?: Object): ApiResult<*> => request(endpoint, 'post', data, options)
+export const post = (args: RequestParams): ApiResult<*> => request({
+    ...args,
+    method: 'post',
+})
 
-export const put = (endpoint: string, data: any, options?: Object): ApiResult<*> => request(endpoint, 'put', data, options)
+export const put = (args: RequestParams): ApiResult<*> => request({
+    ...args,
+    method: 'put',
+})
 
-export const del = (endpoint: string, data: any, options?: Object): ApiResult<*> => request(endpoint, 'delete', data, options)
+export const del = (args: RequestParams): ApiResult<*> => request({
+    ...args,
+    method: 'delete',
+})

--- a/app/src/shared/utils/request.js
+++ b/app/src/shared/utils/request.js
@@ -17,10 +17,24 @@ export const getError = (res: any): ErrorInUi => ({
     statusCode: res && res.response && res.response.status,
 })
 
-export default function request(url: string, method: RequestMethod = 'get', data?: any = null, options?: Object): ApiResult<*> {
+export type RequestParams = {
+    url: string,
+    method?: RequestMethod,
+    data?: any,
+    options?: Object,
+    useAuthorization?: boolean,
+}
+
+export default function request({
+    url,
+    options,
+    method = 'get',
+    data = null,
+    useAuthorization = true,
+}: RequestParams): ApiResult<*> {
     const defaultOptions = {
         headers: {
-            ...getAuthorizationHeader(),
+            ...(useAuthorization ? getAuthorizationHeader() : {}),
         },
     }
 

--- a/app/src/userpages/components/StreamPage/Show/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/index.jsx
@@ -13,7 +13,6 @@ import type { Stream, StreamId } from '$shared/flowtype/stream-types'
 import type { Operation } from '$userpages/flowtype/permission-types'
 import type { StoreState } from '$shared/flowtype/store-state'
 import type { User } from '$shared/flowtype/user-types'
-import type { ResourceKeyId } from '$shared/flowtype/resource-key-types'
 import {
     getMyStreamPermissions,
     getStream,

--- a/app/src/userpages/components/WebComponents/StreamrWidget/index.jsx
+++ b/app/src/userpages/components/WebComponents/StreamrWidget/index.jsx
@@ -144,9 +144,13 @@ export default class StreamrWidget extends Component<Props> {
     stream: ?StreamId
 
     sendRequest = (msg: {}): Promise<any> => (
-        api.post(`${this.props.url}/request`, msg, {
-            headers: {
-                ...this.getHeaders(),
+        api.post({
+            url: `${this.props.url}/request`,
+            data: msg,
+            options: {
+                headers: {
+                    ...this.getHeaders(),
+                },
             },
         })
     )

--- a/app/src/userpages/modules/canvas/actions.js
+++ b/app/src/userpages/modules/canvas/actions.js
@@ -91,7 +91,10 @@ export const getCanvases = () => (dispatch: Function, getState: () => StoreState
         sortBy: 'lastUpdated',
     })
 
-    return api.get(apiUrl, { params })
+    return api.get({
+        url: apiUrl,
+        options: { params },
+    })
         .then((data) => (
             // filter out adhoc canvases which should be filtered by server
             data.filter(({ adhoc }) => !adhoc)
@@ -108,7 +111,9 @@ export const getCanvases = () => (dispatch: Function, getState: () => StoreState
 
 export const getCanvas = (id: CanvasId) => (dispatch: Function) => {
     dispatch(getCanvasRequest(id))
-    return api.get(`${apiUrl}/${id}`)
+    return api.get({
+        url: `${apiUrl}/${id}`,
+    })
         .then(handleEntities(canvasSchema, dispatch))
         .then((data) => dispatch(getCanvasSuccess(data)))
         .catch((e) => {
@@ -124,7 +129,9 @@ export const getCanvas = (id: CanvasId) => (dispatch: Function) => {
 export const deleteCanvas = (id: CanvasId) => async (dispatch: Function): Promise<void> => {
     dispatch(deleteCanvasRequest(id))
     try {
-        const deleteCanvas = await api.del(`${apiUrl}/${id}`)
+        const deleteCanvas = await api.del({
+            url: `${apiUrl}/${id}`,
+        })
         dispatch(deleteCanvasSuccess(id))
         Notification.push({
             title: I18n.t('userpages.canvases.deleteCanvas'),

--- a/app/src/userpages/modules/dashboard/services.js
+++ b/app/src/userpages/modules/dashboard/services.js
@@ -6,21 +6,35 @@ import type { ApiResult } from '$shared/flowtype/common-types'
 import type { DashboardId, Dashboard, DashboardList } from '$userpages/flowtype/dashboard-types'
 import type { Permission } from '$userpages/flowtype/permission-types'
 
-export const getDashboards = (params: any): ApiResult<DashboardList> => get(formatApiUrl('dashboards'), { params })
-
-export const getDashboard = (id: DashboardId): ApiResult<Dashboard> => get(formatApiUrl('dashboards', id))
-
-export const deleteDashboard = (id: DashboardId): ApiResult<null> => del(formatApiUrl('dashboards', id))
-
-export const getMyDashboardPermissions = (id: DashboardId): ApiResult<Array<Permission>> =>
-    get(formatApiUrl('dashboards', id, 'permissions', 'me'))
-
-export const postDashboard = (dashboard: Dashboard): ApiResult<Dashboard> => post(formatApiUrl('dashboards'), {
-    ...dashboard,
-    layout: JSON.stringify(dashboard.layout),
+export const getDashboards = (params: any): ApiResult<DashboardList> => get({
+    url: formatApiUrl('dashboards'),
+    options: { params },
 })
 
-export const putDashboard = (id: DashboardId, dashboard: Dashboard): ApiResult<Dashboard> => put(formatApiUrl('dashboards', id), {
-    ...dashboard,
-    layout: JSON.stringify(dashboard.layout),
+export const getDashboard = (id: DashboardId): ApiResult<Dashboard> => get({
+    url: formatApiUrl('dashboards', id),
+})
+
+export const deleteDashboard = (id: DashboardId): ApiResult<null> => del({
+    url: formatApiUrl('dashboards', id),
+})
+
+export const getMyDashboardPermissions = (id: DashboardId): ApiResult<Array<Permission>> => get({
+    url: formatApiUrl('dashboards', id, 'permissions', 'me'),
+})
+
+export const postDashboard = (dashboard: Dashboard): ApiResult<Dashboard> => post({
+    url: formatApiUrl('dashboards'),
+    data: {
+        ...dashboard,
+        layout: JSON.stringify(dashboard.layout),
+    },
+})
+
+export const putDashboard = (id: DashboardId, dashboard: Dashboard): ApiResult<Dashboard> => put({
+    url: formatApiUrl('dashboards', id),
+    data: {
+        ...dashboard,
+        layout: JSON.stringify(dashboard.layout),
+    },
 })

--- a/app/src/userpages/modules/permission/actions.js
+++ b/app/src/userpages/modules/permission/actions.js
@@ -115,7 +115,9 @@ const saveRemovedResourcePermissionFailure = (resourceType: ResourceType, resour
 
 export const getResourcePermissions = (resourceType: ResourceType, resourceId: ResourceId, notify: boolean = true) => async (dispatch: Function) => {
     dispatch(getResourcePermissionsRequest())
-    const resourcePermissions = await api.get(`${getApiUrl(resourceType, resourceId)}/permissions`)
+    const resourcePermissions = await api.get({
+        url: `${getApiUrl(resourceType, resourceId)}/permissions`,
+    })
         .catch((error) => {
             dispatch(getResourcePermissionsFailure(error))
             if (notify) {
@@ -188,7 +190,10 @@ export const saveUpdatedResourcePermissions = (
     const addPermissions = new Promise((resolve) => {
         settle(addedPermissions.map((permission) => {
             dispatch(saveAddedResourcePermissionRequest(resourceType, resourceId, permission))
-            return api.post(`${getApiUrl(resourceType, resourceId)}/permissions`, permission)
+            return api.post({
+                url: `${getApiUrl(resourceType, resourceId)}/permissions`,
+                data: permission,
+            })
         }))
             .then((results) => {
                 results.forEach((res, i) => {
@@ -213,7 +218,10 @@ export const saveUpdatedResourcePermissions = (
     const removePermissions = new Promise((resolve) => {
         settle(removedPermissions.map((permission) => {
             dispatch(saveRemovedResourcePermissionRequest(resourceType, resourceId, permission))
-            return api.del(`${getApiUrl(resourceType, resourceId)}/permissions/${permission.id}`, permission)
+            return api.del({
+                url: `${getApiUrl(resourceType, resourceId)}/permissions/${permission.id}`,
+                data: permission,
+            })
         }))
             .then((results) => {
                 results.forEach((res, i) => {

--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -437,7 +437,9 @@ export const updateStream = (stream: Stream) => (dispatch: Function) => {
 export const deleteStream = (id: StreamId) => async (dispatch: Function): Promise<void> => {
     dispatch(deleteStreamRequest())
     try {
-        const deleteStream = await api.del(formatApiUrl('streams', id))
+        const deleteStream = await api.del({
+            url: formatApiUrl('streams', id),
+        })
         dispatch(deleteStreamSuccess(id))
         Notification.push({
             title: I18n.t('userpages.streams.actions.deleteStreamSuccess'),
@@ -455,7 +457,10 @@ export const deleteStream = (id: StreamId) => async (dispatch: Function): Promis
 
 export const saveFields = (id: StreamId, fields: StreamFieldList) => (dispatch: Function) => {
     dispatch(saveFieldsRequest())
-    return api.post(`${process.env.STREAMR_API_URL}/streams/${id}/fields`, fields)
+    return api.post({
+        url: `${process.env.STREAMR_API_URL}/streams/${id}/fields`,
+        data: fields,
+    })
         .then((data) => ({
             id,
             config: {

--- a/app/src/userpages/modules/userPageStreams/services.js
+++ b/app/src/userpages/modules/userPageStreams/services.js
@@ -16,34 +16,48 @@ import type {
 } from '$shared/flowtype/stream-types'
 import type { Permission } from '$userpages/flowtype/permission-types'
 
-export const getStream = (id: StreamId): ApiResult<Stream> => get(formatApiUrl('streams', id))
+export const getStream = (id: StreamId): ApiResult<Stream> => get({
+    url: formatApiUrl('streams', id),
+})
 
-export const postStream = (stream: NewStream): ApiResult<Stream> => post(formatApiUrl('streams'), stream)
+export const postStream = (stream: NewStream): ApiResult<Stream> => post({
+    url: formatApiUrl('streams'),
+    data: stream,
+})
 
-export const putStream = (id: StreamId, stream: Stream): ApiResult<null> => put(formatApiUrl('streams', id), stream)
+export const putStream = (id: StreamId, stream: Stream): ApiResult<null> => put({
+    url: formatApiUrl('streams', id),
+    data: stream,
+})
 
-export const deleteStream = (id: StreamId): ApiResult<null> => del(formatApiUrl('streams', id))
+export const deleteStream = (id: StreamId): ApiResult<null> => del({
+    url: formatApiUrl('streams', id),
+})
 
 export type StreamListWrapper = {
     streams: StreamList,
     hasMoreResults: boolean,
 }
 
-export const getStreams = (params: any, pageSize: number, offset: number): ApiResult<StreamListWrapper> =>
-    get(formatApiUrl('streams', {
+export const getStreams = (params: any, pageSize: number, offset: number): ApiResult<StreamListWrapper> => get({
+    url: formatApiUrl('streams', {
         ...params,
         max: pageSize + 1, // query 1 extra element to determine if we should show "load more" button
         offset,
+    }),
+})
+    .then((streams) => ({
+        streams: streams.splice(0, pageSize),
+        hasMoreResults: streams.length > 0,
     }))
-        .then((streams) => ({
-            streams: streams.splice(0, pageSize),
-            hasMoreResults: streams.length > 0,
-        }))
 
-export const getMyStreamPermissions = (id: StreamId): ApiResult<Array<Permission>> =>
-    get(formatApiUrl('streams', id, 'permissions', 'me'))
+export const getMyStreamPermissions = (id: StreamId): ApiResult<Array<Permission>> => get({
+    url: formatApiUrl('streams', id, 'permissions', 'me'),
+})
 
-export const getStreamStatus = (id: StreamId): ApiResult<StreamStatus> => get(formatApiUrl('streams', id, 'status'))
+export const getStreamStatus = (id: StreamId): ApiResult<StreamStatus> => get({
+    url: formatApiUrl('streams', id, 'status'),
+})
 
 export const uploadCsvFile = (id: StreamId, file: File): Promise<CsvUploadResult> => {
     const options = {
@@ -55,7 +69,11 @@ export const uploadCsvFile = (id: StreamId, file: File): Promise<CsvUploadResult
     const formData = new FormData()
     formData.append('file', file)
 
-    return post(formatApiUrl('streams', id, 'uploadCsvFile'), formData, options)
+    return post({
+        url: formatApiUrl('streams', id, 'uploadCsvFile'),
+        data: formData,
+        options,
+    })
 }
 
 export const confirmCsvFileUpload = (
@@ -63,21 +81,27 @@ export const confirmCsvFileUpload = (
     fileId: string,
     dateFormat: string,
     timestampColumnIndex: number,
-): ApiResult<any> => (
-    post(formatApiUrl('streams', id, 'confirmCsvFileUpload'), {
+): ApiResult<any> => post({
+    url: formatApiUrl('streams', id, 'confirmCsvFileUpload'),
+    data: {
         fileId,
         dateFormat,
         timestampColumnIndex,
-    })
-)
+    },
+})
 
-export const getRange = (id: StreamId): ApiResult<Range> => get(formatApiUrl('streams', id, 'range'))
+export const getRange = (id: StreamId): ApiResult<Range> => get({
+    url: formatApiUrl('streams', id, 'range'),
+})
 
-export const deleteDataUpTo = (id: StreamId, date: Date): ApiResult<any> => (
-    del(formatApiUrl('streams', id, 'deleteDataUpTo'), {
+export const deleteDataUpTo = (id: StreamId, date: Date): ApiResult<any> => del({
+    url: formatApiUrl('streams', id, 'deleteDataUpTo'),
+    data: {
         id,
         date: moment(date).valueOf(),
-    })
-)
+    },
+})
 
-export const autodetectStreamfields = (id: StreamId): ApiResult<Stream> => get(formatApiUrl('streams', id, 'detectFields'))
+export const autodetectStreamfields = (id: StreamId): ApiResult<Stream> => get({
+    url: formatApiUrl('streams', id, 'detectFields'),
+})

--- a/app/test/unit/utils/api.test.js
+++ b/app/test/unit/utils/api.test.js
@@ -34,7 +34,9 @@ describe('api utils', () => {
                 assert.equal(request.config.url, '/test-endpoint')
             })
 
-            const result = await all.get('/test-endpoint')
+            const result = await all.get({
+                url: '/test-endpoint',
+            })
             assert.equal(result, data)
         })
 
@@ -48,7 +50,9 @@ describe('api utils', () => {
             })
 
             try {
-                await all.get('/test-endpoint')
+                await all.get({
+                    url: '/test-endpoint',
+                })
             } catch (e) {
                 assert.equal(e.statusCode, 500)
                 assert.equal(e.code, error.code)
@@ -72,7 +76,10 @@ describe('api utils', () => {
                 assert.equal(request.config.data, JSON.stringify(data))
             })
 
-            const result = await all.post('/test-endpoint', data)
+            const result = await all.post({
+                url: '/test-endpoint',
+                data,
+            })
             assert.equal(result, data)
         })
     })
@@ -92,7 +99,10 @@ describe('api utils', () => {
                 assert.equal(request.config.data, JSON.stringify(data))
             })
 
-            const result = await all.put('/test-endpoint', data)
+            const result = await all.put({
+                url: '/test-endpoint',
+                data,
+            })
             assert.equal(result, data)
         })
     })


### PR DESCRIPTION
Added option to omit the authorization header from requests.

These endpoints now don't send authorization header:
- `/categories` (product list & product page)
- `/products/${id}/streams` (product page)
- `/products/` (product list)
- `/products/${id}/related` (product page)