### PR TITLE
[PLATFORM-1109] Fix permission errors on public endpoints (part 2)

### DIFF
--- a/app/src/marketplace/containers/ProductController/index.jsx
+++ b/app/src/marketplace/containers/ProductController/index.jsx
@@ -17,6 +17,7 @@ import useContractProductSubscriptionLoadCallback from './useContractProductSubs
 import useLoadCategoriesCallback from './useLoadCategoriesCallback'
 import useLoadProductStreamsCallback from './useLoadProductStreamsCallback'
 import useCommunityProductLoadCallback from './useCommunityProductLoadCallback'
+import useRelatedProductsLoadCallback from './useRelatedProductsLoadCallback'
 
 type ContextProps = {
     loadProduct: Function,
@@ -25,6 +26,7 @@ type ContextProps = {
     loadCategories: Function,
     loadProductStreams: Function,
     loadCommunityProduct: Function,
+    loadRelatedProducts: Function,
 }
 
 const ProductControllerContext: Context<ContextProps> = React.createContext({})
@@ -70,6 +72,7 @@ function useProductController() {
     const loadCategories = useLoadCategoriesCallback()
     const loadProductStreams = useLoadProductStreamsCallback()
     const loadCommunityProduct = useCommunityProductLoadCallback()
+    const loadRelatedProducts = useRelatedProductsLoadCallback()
 
     return useMemo(() => ({
         loadProduct,
@@ -78,6 +81,7 @@ function useProductController() {
         loadCategories,
         loadProductStreams,
         loadCommunityProduct,
+        loadRelatedProducts,
     }), [
         loadProduct,
         loadContractProduct,
@@ -85,6 +89,7 @@ function useProductController() {
         loadCategories,
         loadProductStreams,
         loadCommunityProduct,
+        loadRelatedProducts,
     ])
 }
 

--- a/app/src/marketplace/containers/ProductController/useRelatedProductsLoadCallback.js
+++ b/app/src/marketplace/containers/ProductController/useRelatedProductsLoadCallback.js
@@ -6,15 +6,15 @@ import { useDispatch } from 'react-redux'
 import usePending from '$shared/hooks/usePending'
 
 import type { ProductId } from '$mp/flowtype/product-types'
-import { getStreamsByProductId } from '$mp/modules/product/actions'
+import { getRelatedProducts } from '../../modules/relatedProducts/actions'
 
-export default function useLoadProductStreamsCallback() {
+export default function useRelatedProductsLoadCallback() {
     const dispatch = useDispatch()
-    const { wrap } = usePending('product.LOAD_STREAMS')
+    const { wrap } = usePending('product.LOAD_RELATED_PRODUCTS')
 
     return useCallback(async (productId: ProductId, useAuthorization: boolean = true) => (
         wrap(async () => {
-            await dispatch(getStreamsByProductId(productId, useAuthorization))
+            await dispatch(getRelatedProducts(productId, useAuthorization))
         })
     ), [wrap, dispatch])
 }

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -16,7 +16,6 @@ import { getProductSubscription } from '$mp/modules/product/actions'
 import LoadingIndicator from '$userpages/components/LoadingIndicator'
 import { Provider as ModalProvider } from '$shared/contexts/ModalApi'
 
-import { getRelatedProducts } from '../../modules/relatedProducts/actions'
 import PurchaseModal from './PurchaseModal'
 import useProduct from '$mp/containers/ProductController/useProduct'
 import { selectUserData } from '$shared/modules/user/selectors'
@@ -26,7 +25,13 @@ import styles from './page.pcss'
 
 const ProductPage = () => {
     const dispatch = useDispatch()
-    const { loadContractProductSubscription, loadCategories, loadProductStreams, loadCommunityProduct } = useController()
+    const {
+        loadContractProductSubscription,
+        loadCategories,
+        loadProductStreams,
+        loadCommunityProduct,
+        loadRelatedProducts,
+    } = useController()
     const product = useProduct()
     const userData = useSelector(selectUserData)
     const isLoggedIn = userData !== null
@@ -34,14 +39,21 @@ const ProductPage = () => {
     const { match } = useContext(RouterContext.Context)
 
     const loadProduct = useCallback(async (id: ProductId) => {
-        dispatch(getRelatedProducts(id))
         loadContractProductSubscription(id)
         loadCategories()
-        loadProductStreams(id)
+        loadProductStreams(id, isLoggedIn)
+        loadRelatedProducts(id, isLoggedIn)
         if (isLoggedIn) {
             dispatch(getProductSubscription(id))
         }
-    }, [dispatch, isLoggedIn, loadContractProductSubscription, loadCategories, loadProductStreams])
+    }, [
+        dispatch,
+        isLoggedIn,
+        loadContractProductSubscription,
+        loadCategories,
+        loadProductStreams,
+        loadRelatedProducts,
+    ])
 
     const loadCommunity = useCallback(async (id: CommunityId) => {
         loadCommunityProduct(id)

--- a/app/src/marketplace/modules/product/actions.js
+++ b/app/src/marketplace/modules/product/actions.js
@@ -14,6 +14,7 @@ import type { StreamIdList } from '$shared/flowtype/stream-types'
 import type { ProductId, Subscription } from '../../flowtype/product-types'
 import type { ReduxActionCreator, ErrorInUi } from '$shared/flowtype/common-types'
 import type { StoreState } from '../../flowtype/store-state'
+import { productStates } from '$shared/utils/constants'
 
 import { selectProduct } from './selectors'
 import {
@@ -133,10 +134,10 @@ const getUserProductPermissionsFailure: ProductErrorActionCreator = createAction
 
 export const resetProduct: ReduxActionCreator = createAction(RESET_PRODUCT)
 
-export const getStreamsByProductId = (id: ProductId) => (dispatch: Function) => {
+export const getStreamsByProductId = (id: ProductId, useAuthorization: boolean = true) => (dispatch: Function) => {
     dispatch(getStreamsByProductIdRequest(id))
     return services
-        .getStreamsByProductId(id)
+        .getStreamsByProductId(id, useAuthorization)
         .then(handleEntities(streamsSchema, dispatch))
         .then(
             (result) => dispatch(getStreamsByProductIdSuccess(id, result)),
@@ -147,7 +148,7 @@ export const getStreamsByProductId = (id: ProductId) => (dispatch: Function) => 
 const fetchProductStreams = (id: ProductId, getState: () => StoreState, dispatch: Function) => () => {
     const product = selectProduct(getState())
     if (product && product.streams) {
-        dispatch(getStreamsByProductId(id))
+        dispatch(getStreamsByProductId(id, product.state !== productStates.DEPLOYED))
     }
 }
 

--- a/app/src/marketplace/modules/product/services.js
+++ b/app/src/marketplace/modules/product/services.js
@@ -18,9 +18,9 @@ export const getProductById = async (id: ProductId): ApiResult<Product> => get({
 })
     .then(mapProductFromApi)
 
-export const getStreamsByProductId = async (id: ProductId): ApiResult<StreamList> => get({
+export const getStreamsByProductId = async (id: ProductId, useAuthorization: boolean = true): ApiResult<StreamList> => get({
     url: formatApiUrl('products', getValidId(id, false), 'streams'),
-    useAuthorization: false,
+    useAuthorization,
 })
 
 const contractMethods = () => getContract(getConfig().marketplace).methods

--- a/app/src/marketplace/modules/relatedProducts/actions.js
+++ b/app/src/marketplace/modules/relatedProducts/actions.js
@@ -28,9 +28,9 @@ export const getRelatedProductsFailure: RelatedProductsErrorActionCreator = crea
     error,
 }))
 
-export const getRelatedProducts = (id: ProductId) => (dispatch: Function) => {
+export const getRelatedProducts = (id: ProductId, useAuthorization: boolean = true) => (dispatch: Function) => {
     dispatch(getRelatedProductsRequest())
-    return api.getRelatedProducts(id)
+    return api.getRelatedProducts(id, useAuthorization)
         .then((data) => {
             const { result, entities } = normalize(data, productsSchema)
             dispatch(updateEntities(entities))

--- a/app/src/marketplace/modules/relatedProducts/services.js
+++ b/app/src/marketplace/modules/relatedProducts/services.js
@@ -7,8 +7,8 @@ import { mapAllProductsFromApi } from '../../utils/product'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import type { Product, ProductId } from '../../flowtype/product-types'
 
-export const getRelatedProducts = (id: ProductId): ApiResult<Array<Product>> => get({
+export const getRelatedProducts = (id: ProductId, useAuthorization: boolean = true): ApiResult<Array<Product>> => get({
     url: formatApiUrl('products', id, 'related'),
-    useAuthorization: false,
+    useAuthorization,
 })
     .then(mapAllProductsFromApi)


### PR DESCRIPTION
Picking up from #788, this changes related products and product streams to send auth when logged in or if the product is not deployed.