### PR TITLE
[PLATFORM-1142] Meatball menus for stream editor

### DIFF
--- a/app/src/shared/components/Meatball/index.jsx
+++ b/app/src/shared/components/Meatball/index.jsx
@@ -33,6 +33,7 @@ const Meatball = ({
     >
         <svg
             xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 4"
             width="20"
             height="4"
             alt={alt}

--- a/app/src/shared/components/SortableList/SortableItem/sortableItem.pcss
+++ b/app/src/shared/components/SortableList/SortableItem/sortableItem.pcss
@@ -1,4 +1,4 @@
 .root {
   color: var(--greyDark);
-  z-index: 2;
+  position: relative;
 }

--- a/app/src/shared/components/SortableList/index.jsx
+++ b/app/src/shared/components/SortableList/index.jsx
@@ -16,15 +16,24 @@ type Props = {
     children: Node,
 }
 
-const SortableList = ({ children, ...props }: Props) => (
-    <div {...props}>
-        {React.Children.map(children, (child, index) => (
-            <SortableItem index={index}>
-                {child}
-            </SortableItem>
-        ))}
-    </div>
-)
+const SortableList = ({ children, ...props }: Props) => {
+    const len = React.Children.count(children)
+
+    return (
+        <div {...props}>
+            {React.Children.map(children, (child, index) => (
+                <SortableItem
+                    index={index}
+                    style={{
+                        zIndex: len - index,
+                    }}
+                >
+                    {child}
+                </SortableItem>
+            ))}
+        </div>
+    )
+}
 
 const Sortable = SortableContainer(SortableList)
 

--- a/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
+++ b/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
-import React from 'react'
+import React, { useState } from 'react'
+import cx from 'classnames'
 
 import Meatball from '$shared/components/Meatball'
 import DropdownActions from '$shared/components/DropdownActions'
@@ -13,28 +14,37 @@ type Props = {
     actions: Array<any>,
 }
 
-const TextFieldWithActions = ({ className, disabled, actions, ...props }: Props) => (
-    <React.Fragment>
-        <input
-            className={className}
-            disabled={disabled}
-            {...props}
-        />
-        {actions != null && actions.length > 0 && (
-            <div className={styles.actionContainer}>
-                <DropdownActions
-                    title={<Meatball alt="Actions" gray />}
-                    disabled={disabled}
-                    menuProps={{
-                        right: true,
-                    }}
-                    noCaret
+const TextFieldWithActions = ({ className, disabled, actions, ...props }: Props) => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    return (
+        <React.Fragment>
+            <input
+                className={className}
+                disabled={disabled}
+                {...props}
+            />
+            {actions != null && actions.length > 0 && (
+                <div
+                    className={cx(styles.actionContainer, {
+                        [styles.isOpen]: isOpen,
+                    })}
                 >
-                    {actions}
-                </DropdownActions>
-            </div>
-        )}
-    </React.Fragment>
-)
+                    <DropdownActions
+                        title={<Meatball alt="Actions" gray />}
+                        disabled={disabled}
+                        menuProps={{
+                            right: true,
+                        }}
+                        onMenuToggle={(open) => setIsOpen(open)}
+                        noCaret
+                    >
+                        {actions}
+                    </DropdownActions>
+                </div>
+            )}
+        </React.Fragment>
+    )
+}
 
 export default TextFieldWithActions

--- a/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
+++ b/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
@@ -25,6 +25,9 @@ const TextFieldWithActions = ({ className, disabled, actions, ...props }: Props)
                 <DropdownActions
                     title={<Meatball alt="Actions" gray />}
                     disabled={disabled}
+                    menuProps={{
+                        right: true,
+                    }}
                     noCaret
                 >
                     {actions}

--- a/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
+++ b/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
@@ -1,0 +1,34 @@
+// @flow
+
+import React from 'react'
+
+import Meatball from '$shared/components/Meatball'
+import DropdownActions from '$shared/components/DropdownActions'
+
+import styles from '../textField.pcss'
+
+type Props = {
+    className?: string,
+    actions: Array<any>,
+}
+
+const TextFieldWithActions = ({ className, actions, ...props }: Props) => (
+    <React.Fragment>
+        <input
+            className={className}
+            {...props}
+        />
+        {actions != null && actions.length > 0 && (
+            <div className={styles.actionContainer}>
+                <DropdownActions
+                    title={<Meatball gray />}
+                    noCaret
+                >
+                    {actions}
+                </DropdownActions>
+            </div>
+        )}
+    </React.Fragment>
+)
+
+export default TextFieldWithActions

--- a/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
+++ b/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
@@ -9,19 +9,22 @@ import styles from '../textField.pcss'
 
 type Props = {
     className?: string,
+    disabled?: boolean,
     actions: Array<any>,
 }
 
-const TextFieldWithActions = ({ className, actions, ...props }: Props) => (
+const TextFieldWithActions = ({ className, disabled, actions, ...props }: Props) => (
     <React.Fragment>
         <input
             className={className}
+            disabled={disabled}
             {...props}
         />
         {actions != null && actions.length > 0 && (
             <div className={styles.actionContainer}>
                 <DropdownActions
                     title={<Meatball alt="Actions" gray />}
+                    disabled={disabled}
                     noCaret
                 >
                     {actions}

--- a/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
+++ b/app/src/shared/components/TextField/TextFieldWithActions/index.jsx
@@ -21,7 +21,7 @@ const TextFieldWithActions = ({ className, actions, ...props }: Props) => (
         {actions != null && actions.length > 0 && (
             <div className={styles.actionContainer}>
                 <DropdownActions
-                    title={<Meatball gray />}
+                    title={<Meatball alt="Actions" gray />}
                     noCaret
                 >
                     {actions}

--- a/app/src/shared/components/TextField/index.jsx
+++ b/app/src/shared/components/TextField/index.jsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react'
 import cx from 'classnames'
 
 import NumberField from './NumberField'
+import TextFieldWithActions from './TextFieldWithActions'
 import styles from './textField.pcss'
 
 type Props = {
@@ -19,7 +20,12 @@ const TextField = ({ className, onAutoComplete, ...props }: Props) => {
         }
     }, [onAutoComplete])
 
-    const Tag = props.type === 'number' ? NumberField : 'input'
+    let Tag = 'input'
+    if (props.type === 'number') {
+        Tag = NumberField
+    } else if (props.actions != null && props.actions.length > 0) {
+        Tag = TextFieldWithActions
+    }
 
     return (
         <Tag

--- a/app/src/shared/components/TextField/index.jsx
+++ b/app/src/shared/components/TextField/index.jsx
@@ -11,6 +11,7 @@ type Props = {
     className?: string,
     onAutoComplete?: (boolean) => void,
     type?: string,
+    actions?: Array<any>,
 }
 
 const TextField = ({ className, onAutoComplete, ...props }: Props) => {

--- a/app/src/shared/components/TextField/textField.pcss
+++ b/app/src/shared/components/TextField/textField.pcss
@@ -106,3 +106,12 @@
 .numberButton:first-child {
   border-bottom: 1px solid #EFEFEF !important;
 }
+
+.actionContainer {
+  display: inline-block;
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translate(0, -50%);
+  z-index: 1;
+}

--- a/app/src/shared/components/TextField/textField.pcss
+++ b/app/src/shared/components/TextField/textField.pcss
@@ -113,5 +113,8 @@
   right: 0.5rem;
   top: 50%;
   transform: translate(0, -50%);
+}
+
+.actionContainer.isOpen {
   z-index: 1;
 }

--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -36,6 +36,8 @@ type State = {
     permission: ?ResourcePermission,
 }
 
+const useIf = (condition: boolean, elements: Array<any>) => (condition ? elements : [])
+
 class KeyField extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
@@ -144,8 +146,6 @@ class KeyField extends React.Component<Props, State> {
         }
     }
 
-    insertIf = (condition: boolean, ...elements: Array<any>) => (condition ? elements : [])
-
     renderInput = () => {
         const {
             hideValue,
@@ -159,21 +159,21 @@ class KeyField extends React.Component<Props, State> {
         const { hidden, menuOpen } = this.state
 
         const actions = [
-            ...this.insertIf(!!hideValue, [
-                <DropdownActions.Item onClick={this.toggleHidden}>
+            ...useIf(!!hideValue, [
+                <DropdownActions.Item key="reveal" onClick={this.toggleHidden}>
                     <Translate value={`userpages.keyField.${hidden ? 'reveal' : 'conceal'}`} />
                 </DropdownActions.Item>,
             ]),
-            <DropdownActions.Item onClick={this.onCopy}>
+            <DropdownActions.Item key="copy" onClick={this.onCopy}>
                 <Translate value="userpages.keyField.copy" />
             </DropdownActions.Item>,
-            ...this.insertIf(!!allowEdit, [
-                <DropdownActions.Item onClick={this.onEdit}>
+            ...useIf(!!allowEdit, [
+                <DropdownActions.Item key="edit" onClick={this.onEdit}>
                     <Translate value="userpages.keyField.edit" />
                 </DropdownActions.Item>,
             ]),
-            ...this.insertIf(!!allowDelete, [
-                <DropdownActions.Item onClick={this.onDelete} disabled={disableDelete}>
+            ...useIf(!!allowDelete, [
+                <DropdownActions.Item key="delete" onClick={this.onDelete} disabled={disableDelete}>
                     <Translate value="userpages.keyField.delete" />
                 </DropdownActions.Item>,
             ]),

--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -144,7 +144,7 @@ class KeyField extends React.Component<Props, State> {
         }
     }
 
-    insertIf = (condition, ...elements) => (condition ? elements : [])
+    insertIf = (condition: boolean, ...elements: Array<any>) => (condition ? elements : [])
 
     renderInput = () => {
         const {

--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -3,11 +3,10 @@
 import React from 'react'
 import copy from 'copy-to-clipboard'
 import cx from 'classnames'
-import { I18n, Translate } from 'react-redux-i18n'
+import { Translate } from 'react-redux-i18n'
 
 import type { ResourcePermission } from '$shared/flowtype/resource-key-types'
 import TextInput from '$shared/components/TextInput'
-import Meatball from '$shared/components/Meatball'
 import DropdownActions from '$shared/components/DropdownActions'
 import SelectInput from '$shared/components/SelectInput'
 import SplitControl from '$userpages/components/SplitControl'
@@ -145,6 +144,8 @@ class KeyField extends React.Component<Props, State> {
         }
     }
 
+    insertIf = (condition, ...elements) => (condition ? elements : [])
+
     renderInput = () => {
         const {
             hideValue,
@@ -157,39 +158,34 @@ class KeyField extends React.Component<Props, State> {
         } = this.props
         const { hidden, menuOpen } = this.state
 
+        const actions = [
+            ...this.insertIf(!!hideValue, [
+                <DropdownActions.Item onClick={this.toggleHidden}>
+                    <Translate value={`userpages.keyField.${hidden ? 'reveal' : 'conceal'}`} />
+                </DropdownActions.Item>,
+            ]),
+            <DropdownActions.Item onClick={this.onCopy}>
+                <Translate value="userpages.keyField.copy" />
+            </DropdownActions.Item>,
+            ...this.insertIf(!!allowEdit, [
+                <DropdownActions.Item onClick={this.onEdit}>
+                    <Translate value="userpages.keyField.edit" />
+                </DropdownActions.Item>,
+            ]),
+            ...this.insertIf(!!allowDelete, [
+                <DropdownActions.Item onClick={this.onDelete} disabled={disableDelete}>
+                    <Translate value="userpages.keyField.delete" />
+                </DropdownActions.Item>,
+            ]),
+        ]
+
         return (
             <div
                 className={cx(styles.container, className, {
                     [styles.withMenu]: menuOpen,
                 })}
             >
-                <TextInput label={keyName} value={value} readOnly type={hidden ? 'password' : 'text'} />
-                <div className={styles.actions}>
-                    <DropdownActions
-                        onMenuToggle={this.onMenuToggle}
-                        title={<Meatball alt={I18n.t('userpages.keyField.options')} gray />}
-                        noCaret
-                    >
-                        {!!hideValue && (
-                            <DropdownActions.Item onClick={this.toggleHidden}>
-                                <Translate value={`userpages.keyField.${hidden ? 'reveal' : 'conceal'}`} />
-                            </DropdownActions.Item>
-                        )}
-                        <DropdownActions.Item onClick={this.onCopy}>
-                            <Translate value="userpages.keyField.copy" />
-                        </DropdownActions.Item>
-                        {!!allowEdit && (
-                            <DropdownActions.Item onClick={this.onEdit}>
-                                <Translate value="userpages.keyField.edit" />
-                            </DropdownActions.Item>
-                        )}
-                        {!!allowDelete && (
-                            <DropdownActions.Item onClick={this.onDelete} disabled={disableDelete}>
-                                <Translate value="userpages.keyField.delete" />
-                            </DropdownActions.Item>
-                        )}
-                    </DropdownActions>
-                </div>
+                <TextInput label={keyName} actions={actions} value={value} readOnly type={hidden ? 'password' : 'text'} />
             </div>
         )
     }

--- a/app/src/userpages/components/KeyField/keyField.pcss
+++ b/app/src/userpages/components/KeyField/keyField.pcss
@@ -3,15 +3,6 @@
   max-width: 488px;
 }
 
-.actions {
-  display: inline-block;
-  position: absolute;
-  right: 0.5rem;
-  top: 50%;
-  transform: translate(0, -50%);
-  z-index: 1;
-}
-
 .withMenu {
   z-index: 2;
 }

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
@@ -16,14 +16,6 @@
   margin-left: 4px;
 }
 
-.deleteFieldButton {
-  display: none;
-  position: absolute;
-  right: -105px;
-  top: 6px;
-  margin: 0;
-}
-
 @media (--lg-down) {
   .autodetect {
     margin-left: 0;
@@ -37,13 +29,6 @@
 
 .hoverContainer {
   margin-right: -120px;
-
-  &:hover,
-  &:focus {
-    .deleteFieldButton {
-      display: flex;
-    }
-  }
 }
 
 .addFieldButton {

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
@@ -196,7 +196,7 @@ export class ConfigureView extends Component<Props, State> {
                                                     onChange={(e) => this.onFieldNameChange(field.name, e.target.value)}
                                                     disabled={disabled}
                                                     actions={[
-                                                        <DropdownActions.Item onClick={() => this.deleteField(field.name)}>
+                                                        <DropdownActions.Item key="delete" onClick={() => this.deleteField(field.name)}>
                                                             <Translate value="userpages.streams.edit.configure.delete" />
                                                         </DropdownActions.Item>,
                                                     ]}

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/index.jsx
@@ -19,6 +19,7 @@ import { selectEditedStream, selectFieldsAutodetectFetching, fieldTypes } from '
 import TextInput from '$shared/components/TextInput'
 import Toggle from '$shared/components/Toggle'
 import SplitControl from '$userpages/components/SplitControl'
+import DropdownActions from '$shared/components/DropdownActions'
 
 import styles from './configureView.pcss'
 import NewFieldEditor from './NewFieldEditor'
@@ -194,6 +195,11 @@ export class ConfigureView extends Component<Props, State> {
                                                     value={field.name}
                                                     onChange={(e) => this.onFieldNameChange(field.name, e.target.value)}
                                                     disabled={disabled}
+                                                    actions={[
+                                                        <DropdownActions.Item onClick={() => this.deleteField(field.name)}>
+                                                            <Translate value="userpages.streams.edit.configure.delete" />
+                                                        </DropdownActions.Item>,
+                                                    ]}
                                                 />
                                                 <SelectInput
                                                     label=""
@@ -203,16 +209,6 @@ export class ConfigureView extends Component<Props, State> {
                                                     onChange={(o) => this.onFieldTypeChange(field.name, o.value)}
                                                     preserveLabelSpace={false}
                                                 />
-                                                <Button
-                                                    kind="secondary"
-                                                    size="mini"
-                                                    outline
-                                                    className={styles.deleteFieldButton}
-                                                    onClick={() => this.deleteField(field.name)}
-                                                    disabled={disabled}
-                                                >
-                                                    <Translate value="userpages.streams.edit.configure.delete" />
-                                                </Button>
                                             </SplitControl>
                                         </FieldItem>
                                     </div>

--- a/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
@@ -23,8 +23,7 @@ type Props = {
 export const InfoView = ({ disabled }: Props) => {
     const stream = useSelector(selectEditedStream)
     const dispatch = useDispatch()
-    /* eslint-disable-next-line no-unused-vars */
-    const { isCopied, copy } = useCopy()
+    const { copy } = useCopy()
     const contentChangedRef = useRef(false)
     const streamRef = useRef()
     streamRef.current = stream

--- a/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
@@ -4,13 +4,12 @@ import React, { useEffect, useRef, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { I18n, Translate } from 'react-redux-i18n'
 
-import Button from '$shared/components/Button'
 import Notification from '$shared/utils/Notification'
 import TextInput from '$shared/components/TextInput'
+import DropdownActions from '$shared/components/DropdownActions'
 import { updateEditStreamField } from '$userpages/modules/userPageStreams/actions'
 import { selectEditedStream } from '$userpages/modules/userPageStreams/selectors'
 import { NotificationIcon } from '$shared/utils/constants'
-import SplitControl from '$userpages/components/SplitControl'
 import useCopy from '$shared/hooks/useCopy'
 import PartitionsView from '../PartitionsView'
 import type { StreamId } from '$shared/flowtype/stream-types'
@@ -24,6 +23,7 @@ type Props = {
 export const InfoView = ({ disabled }: Props) => {
     const stream = useSelector(selectEditedStream)
     const dispatch = useDispatch()
+    /* eslint-disable-next-line no-unused-vars */
     const { isCopied, copy } = useCopy()
     const contentChangedRef = useRef(false)
     const streamRef = useRef()
@@ -100,31 +100,22 @@ export const InfoView = ({ disabled }: Props) => {
             </div>
             {stream && stream.id &&
                 <React.Fragment>
-                    <SplitControl>
-                        <div className={styles.textInput}>
-                            <TextInput
-                                label={I18n.t('userpages.streams.edit.details.streamId')}
-                                type="text"
-                                name="id"
-                                value={(stream && stream.id) || ''}
-                                preserveLabelSpace
-                                readOnly
-                                disabled={disabled}
-                            />
-                        </div>
-                        <Button
-                            kind="secondary"
-                            size="mini"
-                            outline
-                            className={styles.copyStreamIdButton}
-                            onClick={() => onCopy(stream.id)}
-                        >
-                            {isCopied ?
-                                <Translate value="userpages.streams.edit.details.copied" /> :
-                                <Translate value="userpages.streams.edit.details.copyStreamId" />
-                            }
-                        </Button>
-                    </SplitControl>
+                    <div className={styles.textInput}>
+                        <TextInput
+                            label={I18n.t('userpages.streams.edit.details.streamId')}
+                            type="text"
+                            name="id"
+                            value={(stream && stream.id) || ''}
+                            preserveLabelSpace
+                            readOnly
+                            disabled={disabled}
+                            actions={[
+                                <DropdownActions.Item onClick={() => onCopy(stream.id)}>
+                                    <Translate value="userpages.keyField.copy" />
+                                </DropdownActions.Item>,
+                            ]}
+                        />
+                    </div>
                     <h5 className={styles.partitions}>{I18n.t('userpages.streams.edit.details.partitions')}</h5>
                     <PartitionsView disabled={disabled} />
                 </React.Fragment>

--- a/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/InfoView/index.jsx
@@ -109,7 +109,7 @@ export const InfoView = ({ disabled }: Props) => {
                             readOnly
                             disabled={disabled}
                             actions={[
-                                <DropdownActions.Item onClick={() => onCopy(stream.id)}>
+                                <DropdownActions.Item key="copy" onClick={() => onCopy(stream.id)}>
                                     <Translate value="userpages.keyField.copy" />
                                 </DropdownActions.Item>,
                             ]}

--- a/app/src/userpages/tests/components/KeyField/KeyField.test.jsx
+++ b/app/src/userpages/tests/components/KeyField/KeyField.test.jsx
@@ -33,9 +33,11 @@ describe('KeyField', () => {
                 value="testValue"
             />)
 
-            const actions = el.find(DropdownActions).children()
+            const actions = el.find(TextInput).prop('actions').map((action) => (
+                shallow(action)
+            ))
             assert(actions.length === 1)
-            assert(actions.at(0).find('Translate').shallow().text() === 'copy')
+            assert(actions[0].find('Translate').shallow().text() === 'copy')
         })
     })
 
@@ -59,10 +61,10 @@ describe('KeyField', () => {
 
             assert(el.find(TextInput).prop('type') === 'password')
 
-            const action = el.find(DropdownActions).childAt(0)
+            const action = shallow(el.find(TextInput).prop('actions')[0])
             assert(action.find('Translate').shallow().text() === 'reveal')
-            action.simulate('click')
 
+            el.instance().toggleHidden()
             assert(el.find(TextInput).prop('type') === 'text')
         })
 
@@ -74,13 +76,13 @@ describe('KeyField', () => {
             />)
             assert(el.find(TextInput).prop('type') === 'password')
 
-            const action = el.find(DropdownActions).childAt(0)
+            const action = shallow(el.find(TextInput).prop('actions')[0])
             assert(action.find('Translate').shallow().text() === 'reveal')
-            action.simulate('click')
+            el.instance().toggleHidden()
 
             assert(el.find(TextInput).prop('type') === 'text')
 
-            action.simulate('click')
+            el.instance().toggleHidden()
             assert(el.find(TextInput).prop('type') === 'password')
         })
     })
@@ -93,7 +95,7 @@ describe('KeyField', () => {
                 allowEdit
             />)
 
-            const action = el.find(DropdownActions).childAt(1)
+            const action = shallow(el.find(TextInput).prop('actions')[1])
             assert(action.find('Translate').shallow().text() === 'edit')
         })
 
@@ -104,8 +106,7 @@ describe('KeyField', () => {
                 allowEdit
             />)
 
-            const action = el.find(DropdownActions).childAt(1)
-            action.simulate('click')
+            el.instance().onEdit()
 
             assert(el.find(TextInput).length === 0)
             assert(el.find(KeyFieldEditor).length === 1)
@@ -121,8 +122,7 @@ describe('KeyField', () => {
                 onSave={onSaveStub}
             />)
 
-            const action = el.find(DropdownActions).childAt(1)
-            action.simulate('click')
+            el.instance().onEdit()
 
             const editor = el.find(KeyFieldEditor).shallow().instance()
             editor.setState({
@@ -146,7 +146,7 @@ describe('KeyField', () => {
                 allowDelete
             />)
 
-            const action = el.find(DropdownActions).childAt(1)
+            const action = shallow(el.find(TextInput).prop('actions')[1])
             assert(action.find('Translate').shallow().text() === 'delete')
             assert(action.prop('disabled') !== true)
         })
@@ -159,7 +159,7 @@ describe('KeyField', () => {
                 disableDelete
             />)
 
-            const action = el.find(DropdownActions).childAt(1)
+            const action = shallow(el.find(TextInput).prop('actions')[1])
             assert(action.prop('disabled') === true)
         })
 
@@ -172,8 +172,7 @@ describe('KeyField', () => {
                 onDelete={spy}
             />)
 
-            const action = el.find(DropdownActions).childAt(1)
-            action.simulate('click')
+            el.instance().onDelete()
 
             assert(spy.calledOnce)
         })

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -234,6 +234,24 @@ story('Text Field/Text')
         <TextInput preserveLabelSpace label="With invalid value" value="Something invalid" error="Oh, something went wrong!" />
     ))
 
+story('Text Field/With actions')
+    .addWithJSX('basic', () => (
+        <TextInput
+            preserveLabelSpace
+            label="I have a Meatball menu"
+            actions={
+                [
+                    <DropdownActions.Item>
+                        Test 1
+                    </DropdownActions.Item>,
+                    <DropdownActions.Item>
+                        Test 2
+                    </DropdownActions.Item>,
+                ]
+            }
+        />
+    ))
+
 story('Text Field/Password')
     .addWithJSX('basic', () => (
         <TextInput preserveLabelSpace label="Password…" value={text('value', '')} type="password" measureStrength />

--- a/app/stories/shared.stories.jsx
+++ b/app/stories/shared.stories.jsx
@@ -251,6 +251,23 @@ story('Text Field/With actions')
             }
         />
     ))
+    .addWithJSX('disabled', () => (
+        <TextInput
+            preserveLabelSpace
+            disabled
+            label="I have a Meatball menu"
+            actions={
+                [
+                    <DropdownActions.Item>
+                        Test 1
+                    </DropdownActions.Item>,
+                    <DropdownActions.Item>
+                        Test 2
+                    </DropdownActions.Item>,
+                ]
+            }
+        />
+    ))
 
 story('Text Field/Password')
     .addWithJSX('basic', () => (


### PR DESCRIPTION
Moved some actions (streamId copy, field delete) behind a meatball menu on input.

Refactored `TextField` to support providing actions array, which contains `DropdownActions.Item`s.