### PR TITLE
[PLATFORM-1145] Canvas message log sidebar

### DIFF
--- a/app/src/editor/canvas/components/Canvas.jsx
+++ b/app/src/editor/canvas/components/Canvas.jsx
@@ -53,6 +53,9 @@ export default function Canvas(props) {
         moduleSidebarOpen: (...args) => (
             propsRef.current.moduleSidebarOpen(...args)
         ),
+        consoleSidebarOpen: (...args) => (
+            propsRef.current.consoleSidebarOpen(...args)
+        ),
         updateModule: (...args) => (
             propsRef.current.updateModule(...args)
         ),

--- a/app/src/editor/canvas/components/CanvasController/Run.jsx
+++ b/app/src/editor/canvas/components/CanvasController/Run.jsx
@@ -8,6 +8,7 @@ import get from 'lodash/get'
 import useIsMountedRef from '$shared/hooks/useIsMountedRef'
 import * as SubscriptionStatus from '$shared/contexts/SubscriptionStatus'
 import usePending from '$shared/hooks/usePending'
+import { pushErrorNotification } from '$editor/canvas/hooks/useCanvasNotifications'
 
 import * as services from '../../services'
 import * as CanvasState from '../../state'
@@ -78,7 +79,12 @@ function useRunController(canvas = EMPTY) {
                 }
 
                 if (isMountedRef.current) { setIsStarting(false) }
-                throw err
+                if (err.response) {
+                    pushErrorNotification(err.response.data)
+                } else {
+                    pushErrorNotification(err)
+                }
+                return canvas
             })
 
         if (!isMountedRef.current) { return }
@@ -114,7 +120,8 @@ function useRunController(canvas = EMPTY) {
                 }
 
                 if (isMountedRef.current) { setIsStopping(false) }
-                throw err
+                pushErrorNotification(err)
+                return canvas
             })
     }, [stopPending, setIsStopping, isMountedRef, unlinkParent, replaceCanvas])
 

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.jsx
@@ -28,6 +28,15 @@ function fixTooltipParent(cameraContext) {
     }
 }
 
+function toErrorAnnotations({ line, message }) {
+    return {
+        row: line - 1,
+        column: 1,
+        text: message,
+        type: 'error',
+    }
+}
+
 export default class CodeEditorWindow extends React.Component {
     static contextType = CameraContext
     state = {
@@ -42,6 +51,9 @@ export default class CodeEditorWindow extends React.Component {
     componentDidMount() {
         this.editor.current.editor.focus()
         fixTooltipParent(this.context)
+        if (this.props.code) {
+            this.onApply()
+        }
     }
 
     componentWillUnmount() {
@@ -88,12 +100,7 @@ export default class CodeEditorWindow extends React.Component {
                 if (!e.moduleErrors) { throw e } // unexpected error
                 this.setState({
                     sending: false,
-                    errors: e.moduleErrors.map(({ line, message }) => ({
-                        row: line - 1,
-                        column: 1,
-                        text: message,
-                        type: 'error',
-                    })),
+                    errors: e.moduleErrors.map(toErrorAnnotations),
                 })
             }
         })

--- a/app/src/editor/canvas/components/ConsoleSidebar.jsx
+++ b/app/src/editor/canvas/components/ConsoleSidebar.jsx
@@ -25,6 +25,15 @@ export function MessageIcon({ level, ...props }) {
     )
 }
 
+export function MessageIconSimple({ level, className, ...props }) {
+    return (
+        <div
+            {...props}
+            className={cx(className, styles.MessageSimpleIcon, styles[level])}
+        />
+    )
+}
+
 function MessageRow({ msg }) {
     return (
         <div className={cx(styles.MessageRow, styles[msg.level])}>

--- a/app/src/editor/canvas/components/ConsoleSidebar.jsx
+++ b/app/src/editor/canvas/components/ConsoleSidebar.jsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import cx from 'classnames'
+import groupBy from 'lodash/groupBy'
+import sortBy from 'lodash/sortBy'
+
+import SvgIcon from '$shared/components/SvgIcon'
+import { Header, Content } from '$editor/shared/components/Sidebar'
+import { Translate } from 'react-redux-i18n'
+
+import * as CanvasState from '../state'
+import * as CanvasMessages from '../state/messages'
+import styles from './ConsoleSidebar.pcss'
+
+const Icons = {
+    error: 'errorBadge',
+    warn: 'warnBadge',
+    info: 'infoBadge',
+}
+
+export function MessageIcon({ level, ...props }) {
+    return (
+        <div {...props}>
+            <SvgIcon name={Icons[level]} />
+        </div>
+    )
+}
+
+function MessageRow({ msg }) {
+    return (
+        <div className={cx(styles.MessageRow, styles[msg.level])}>
+            <MessageIcon level={msg.level} className={styles.messageIcon} />
+            <div className={styles.messageRhs}>
+                <div className={styles.messageTitle}>
+                    {!msg.translate ? msg.title : (
+                        <Translate value={msg.title} {...msg.details} dangerousHTML />
+                    )}
+                </div>
+                <div className={styles.messageContent}>
+                    {!msg.translate ? msg.content : (
+                        <Translate value={msg.content} {...msg.details} dangerousHTML />
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function ConsoleMessages({ canvas, messages, selectedModuleHash, selectModule }) {
+    const groupedMessages = groupBy(messages, 'moduleHash')
+    const maxMessageLevel = (msgs) => Math.max(...msgs.map(({ level }) => CanvasMessages.LEVELS.indexOf(level)))
+    const sortedMessageEntries = sortBy(Object.entries(groupedMessages), ([, msgs]) => maxMessageLevel(msgs)).reverse()
+
+    return (
+        <div className={styles.ConsoleMessages}>
+            <div className={styles.messageList}>
+                {sortedMessageEntries.map(([moduleHash, msgs]) => {
+                    moduleHash = Number(moduleHash)
+                    return (
+                        /* eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
+                        <div
+                            key={moduleHash}
+                            className={cx(styles.messageGroup, {
+                                [styles.selectedGroup]: selectedModuleHash === moduleHash,
+                            })}
+                            onClick={() => selectModule({ hash: moduleHash })}
+                        >
+                            <div className={styles.messageGroupTitle}>
+                                {CanvasState.getDisplayName(CanvasState.getModule(canvas, moduleHash))}
+                            </div>
+                            {sortBy(msgs, (level) => CanvasMessages.LEVELS.indexOf(level)).reverse().map((msg, index) => (
+                                /* eslint-disable-next-line react/no-array-index-key */
+                                <MessageRow key={index} msg={msg} />
+                            ))}
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+export default function ConsoleSidebar({ canvas, selectedModuleHash, selectModule, onClose }) {
+    const canvasMessages = CanvasMessages.getCanvasMessages(canvas)
+
+    return (
+        <React.Fragment>
+            <Header title="Console" onClose={onClose} />
+            <Content className={styles.content}>
+                <ConsoleMessages
+                    canvas={canvas}
+                    messages={canvasMessages}
+                    selectedModuleHash={selectedModuleHash}
+                    selectModule={selectModule}
+                />
+            </Content>
+        </React.Fragment>
+    )
+}

--- a/app/src/editor/canvas/components/ConsoleSidebar.jsx
+++ b/app/src/editor/canvas/components/ConsoleSidebar.jsx
@@ -61,6 +61,7 @@ function MessageGroup({
                 behavior: 'smooth',
                 block: 'start',
                 inline: 'nearest',
+                scrollMode: 'if-needed',
             })
         }
     }, [isSelected])

--- a/app/src/editor/canvas/components/ConsoleSidebar.pcss
+++ b/app/src/editor/canvas/components/ConsoleSidebar.pcss
@@ -32,6 +32,7 @@
   color: #323232;
   font-weight: var(--medium);
   padding: 0.7um 1um;
+  padding-left: 2.5um;
 }
 
 .MessageRow {

--- a/app/src/editor/canvas/components/ConsoleSidebar.pcss
+++ b/app/src/editor/canvas/components/ConsoleSidebar.pcss
@@ -15,7 +15,7 @@
 }
 
 .messageGroupTitle {
-  font-weight: var(--bold);
+  font-weight: var(--medium);
   padding: 0.5um 1um;
 }
 
@@ -53,7 +53,7 @@
   }
 
   .messageTitle {
-    font-weight: var(--bold);
+    font-weight: var(--medium);
   }
 
   .messageContent {

--- a/app/src/editor/canvas/components/ConsoleSidebar.pcss
+++ b/app/src/editor/canvas/components/ConsoleSidebar.pcss
@@ -4,6 +4,10 @@
 
 }
 
+.ConsoleMessages {
+  border-top: 1px solid #EFEFEF;
+}
+
 .messageGroup {
   font-size: 12px;
   line-height: 18px;

--- a/app/src/editor/canvas/components/ConsoleSidebar.pcss
+++ b/app/src/editor/canvas/components/ConsoleSidebar.pcss
@@ -10,6 +10,47 @@
   position: relative;
 
   &::after {
+    transition: box-shadow 0.1s;
+    box-shadow: inset 0 0 #0324FF;
+    z-index: 1;
+    content: ' ';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+  }
+
+  &.selectedGroup::after {
+    box-shadow: inset 4px 0 #0324FF;
+  }
+}
+
+.messageGroupTitle {
+  color: #323232;
+  font-weight: var(--medium);
+  padding: 0.7um 1um;
+}
+
+.MessageRow {
+  padding: 1um;
+  display: grid;
+  grid-template-columns: 1um 1fr;
+  grid-column-gap: 0.5um;
+  border-bottom: 1px solid #FFFFFF;
+  position: relative;
+
+  a,
+  a:active,
+  a:hover,
+  a:visited {
+    color: #0324FF;
+    text-decoration: underline;
+  }
+
+  &::after {
+    z-index: 1;
     content: ' ';
     position: absolute;
     top: 0;
@@ -22,29 +63,8 @@
     transition: opacity 0.1s;
   }
 
-  &:hover::after,
-  &.selectedGroup::after {
+  &:hover::after {
     opacity: 0.05;
-  }
-}
-
-.messageGroupTitle {
-  font-weight: var(--medium);
-  padding: 0.5um 1um;
-}
-
-.MessageRow {
-  padding: 1um;
-  display: grid;
-  grid-template-columns: 1um 1fr;
-  grid-column-gap: 0.5um;
-
-  a,
-  a:active,
-  a:hover,
-  a:visited {
-    color: #0324FF;
-    text-decoration: underline;
   }
 
   .messageIcon {

--- a/app/src/editor/canvas/components/ConsoleSidebar.pcss
+++ b/app/src/editor/canvas/components/ConsoleSidebar.pcss
@@ -1,0 +1,62 @@
+@import '../../shared/components/variables.pcss';
+
+.root {
+
+}
+
+.messageGroup {
+  font-size: 14px;
+  line-height: 18px;
+
+  &.selectedGroup {
+    outline: 1px solid var(--focus-border-color);
+    outline-offset: -1px;
+  }
+}
+
+.messageGroupTitle {
+  font-weight: var(--bold);
+  padding: 0.5um 1um;
+}
+
+.MessageRow {
+  padding: 1um;
+  display: grid;
+  grid-template-columns: 1um 1fr;
+  grid-column-gap: 0.5um;
+
+  a,
+  a:active,
+  a:hover,
+  a:visited {
+    color: #0324FF;
+    text-decoration: underline;
+  }
+
+  .messageIcon {
+    width: 0.5um;
+
+    /* aligns icon with baseline of title */
+    height: 1um;
+  }
+
+  &.info {
+    background: #F5F7FF;
+  }
+
+  &.warn {
+    background: #FFFAF7;
+  }
+
+  &.error {
+    background: #FFF4F5;
+  }
+
+  .messageTitle {
+    font-weight: var(--bold);
+  }
+
+  .messageContent {
+
+  }
+}

--- a/app/src/editor/canvas/components/ConsoleSidebar.pcss
+++ b/app/src/editor/canvas/components/ConsoleSidebar.pcss
@@ -7,10 +7,24 @@
 .messageGroup {
   font-size: 14px;
   line-height: 18px;
+  position: relative;
 
-  &.selectedGroup {
-    outline: 1px solid var(--focus-border-color);
-    outline-offset: -1px;
+  &::after {
+    content: ' ';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    background: #323232;
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+
+  &:hover::after,
+  &.selectedGroup::after {
+    opacity: 0.05;
   }
 }
 

--- a/app/src/editor/canvas/components/ConsoleSidebar.pcss
+++ b/app/src/editor/canvas/components/ConsoleSidebar.pcss
@@ -60,3 +60,19 @@
 
   }
 }
+
+.MessageSimpleIcon {
+  border-radius: 100%;
+
+  &.info {
+    background: #0324FF;
+  }
+
+  &.warn {
+    background: #FF5C00;
+  }
+
+  &.error {
+    background: #F90E2B;
+  }
+}

--- a/app/src/editor/canvas/components/ConsoleSidebar.pcss
+++ b/app/src/editor/canvas/components/ConsoleSidebar.pcss
@@ -5,7 +5,7 @@
 }
 
 .messageGroup {
-  font-size: 14px;
+  font-size: 12px;
   line-height: 18px;
   position: relative;
 
@@ -28,6 +28,7 @@
 }
 
 .messageGroupTitle {
+  font-size: 14px;
   color: #323232;
   font-weight: var(--medium);
   padding: 0.7um 1um;
@@ -87,6 +88,7 @@
   }
 
   .messageTitle {
+    font-size: 14px;
     font-weight: var(--medium);
   }
 

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -11,6 +11,8 @@ import * as RunController from './CanvasController/Run'
 import { useCameraState } from './Camera'
 
 import ModuleStyles from '$editor/shared/components/Module.pcss'
+import { getModuleMessages, getMaxLevel } from '$editor/canvas/state/messages'
+
 import styles from './Module.pcss'
 import ModuleRenderer from './ModuleRenderer'
 import { AutosaveContext } from './CanvasController/Autosave'
@@ -110,6 +112,8 @@ class CanvasModule extends React.PureComponent {
 
         const { layout } = this.state
 
+        const badgeLevel = getMaxLevel(getModuleMessages(canvas, module.hash))
+
         return (
             <ModuleRenderer
                 interactive
@@ -130,6 +134,7 @@ class CanvasModule extends React.PureComponent {
                 onRename={this.onChangeModuleName}
                 onResize={this.onResize}
                 uiEmitter={this.uiEmitter}
+                badgeLevel={badgeLevel}
                 {...props}
             />
         )

--- a/app/src/editor/canvas/components/Module.pcss
+++ b/app/src/editor/canvas/components/Module.pcss
@@ -95,3 +95,15 @@
   width: 0;
   height: 0;
 }
+
+.ModuleBadge {
+  position: absolute;
+  width: 1um;
+  height: 1um;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
+  border-radius: 100%;
+  z-index: 1;
+  display: inline-grid;
+}

--- a/app/src/editor/canvas/components/ModuleRenderer/ModuleRenderer.stories.jsx
+++ b/app/src/editor/canvas/components/ModuleRenderer/ModuleRenderer.stories.jsx
@@ -2,15 +2,17 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import * as modules from './modules'
 import ModuleRenderer from '.'
+import { LEVELS } from '$editor/canvas/state/messages'
 
 const stories = storiesOf('Editor/ModuleRenderer', module)
 
-export const Module = ({ src }) => (
+export const Module = ({ src, ...props }) => (
     <ModuleRenderer
         canvasEditable={false}
         canvasAdjustable={false}
         api={{
             moduleSidebarOpen: () => {},
+            consoleSidebarOpen: () => {},
             port: {
                 onChange: () => {},
                 setPortOptions: () => {},
@@ -25,6 +27,7 @@ export const Module = ({ src }) => (
             position: 'static',
             width: 'fit-content',
         }}
+        {...props}
     />
 )
 
@@ -59,6 +62,29 @@ Object.keys(groupedModules).sort().forEach((group) => {
                     />
                 </div>
             ))}
+        </div>
+    ))
+})
+
+const badgeStories = storiesOf('Editor/ModuleRenderer/badges', module)
+LEVELS.forEach((level) => {
+    badgeStories.add(level, () => (
+        <div
+            style={{
+                padding: '0 2rem',
+                marginTop: '2rem',
+            }}
+        >
+            <Module
+                badgeLevel={level}
+                src={{
+                    name: '<Empty>',
+                    params: [],
+                    inputs: [],
+                    outputs: [],
+                }}
+                canvasEditable
+            />
         </div>
     ))
 })

--- a/app/src/editor/canvas/components/ModuleRenderer/index.jsx
+++ b/app/src/editor/canvas/components/ModuleRenderer/index.jsx
@@ -7,6 +7,7 @@ import Probe from '../Resizable/SizeConstraintProvider/Probe'
 import Ports from '../Ports'
 import styles from '../Module.pcss'
 import { noCameraControl } from '../Camera'
+import { MessageIcon } from '../ConsoleSidebar'
 import useIsCanvasRunning from '../../hooks/useIsCanvasRunning'
 import useModule, { ModuleContext } from './useModule'
 import useModuleApi, { ModuleApiContext } from './useModuleApi'
@@ -59,11 +60,13 @@ const ModuleRenderer = React.memo(({
     const {
         moduleClassNames,
         isResizable,
+        messageLevel,
         module,
         isCanvasEditable: isEditable,
         isCanvasAdjustable: isAdjustable,
         hasWritePermission,
     } = useModule()
+
     const { hash, displayName, name, canRefresh } = module
 
     const stopPropagation = useCallback((e) => {
@@ -77,7 +80,7 @@ const ModuleRenderer = React.memo(({
         }
     }, [isRunning, uiEmitter])
 
-    const { selectModule, moduleSidebarOpen, port: { onChange: onPortChange } } = useModuleApi()
+    const { selectModule, moduleSidebarOpen, consoleSidebarOpen, port: { onChange: onPortChange } } = useModuleApi()
 
     const onTriggerOptions = useCallback((e) => {
         e.stopPropagation()
@@ -127,6 +130,13 @@ const ModuleRenderer = React.memo(({
         >
             <div className={styles.body} ref={innerRef}>
                 <Probe group="ModuleHeight" height="auto" />
+                {(isEditable && messageLevel !== 'none') && (
+                    <MessageIcon
+                        level={messageLevel}
+                        className={cx(styles.ModuleBadge, styles[messageLevel])}
+                        onClick={() => consoleSidebarOpen()}
+                    />
+                )}
                 <ModuleHeader
                     className={cx(styles.header, ModuleStyles.dragHandle)}
                     editable={isEditable}

--- a/app/src/editor/canvas/components/ModuleRenderer/index.jsx
+++ b/app/src/editor/canvas/components/ModuleRenderer/index.jsx
@@ -36,6 +36,7 @@ type Props = {
     scale: number,
     interactive?: boolean,
     isLoading?: boolean,
+    badgeLevel?: string,
 }
 
 const ModuleRenderer = React.memo(({
@@ -52,6 +53,7 @@ const ModuleRenderer = React.memo(({
     scale,
     interactive,
     isLoading,
+    badgeLevel = 'none',
     ...props
 }: Props) => {
     const isRunning = useIsCanvasRunning()
@@ -60,7 +62,6 @@ const ModuleRenderer = React.memo(({
     const {
         moduleClassNames,
         isResizable,
-        messageLevel,
         module,
         isCanvasEditable: isEditable,
         isCanvasAdjustable: isAdjustable,
@@ -130,10 +131,10 @@ const ModuleRenderer = React.memo(({
         >
             <div className={styles.body} ref={innerRef}>
                 <Probe group="ModuleHeight" height="auto" />
-                {(isEditable && messageLevel !== 'none') && (
+                {(isEditable && badgeLevel !== 'none') && (
                     <MessageIcon
-                        level={messageLevel}
-                        className={cx(styles.ModuleBadge, styles[messageLevel])}
+                        level={badgeLevel}
+                        className={cx(styles.ModuleBadge, styles[badgeLevel])}
                         onClick={() => consoleSidebarOpen()}
                     />
                 )}

--- a/app/src/editor/canvas/components/ModuleRenderer/useModule.js
+++ b/app/src/editor/canvas/components/ModuleRenderer/useModule.js
@@ -3,6 +3,7 @@
 import { createContext, useContext, type Context, useMemo } from 'react'
 import ModuleStyles from '$editor/shared/components/Module.pcss'
 import isModuleResizable from '$editor/canvas/utils/isModuleResizable'
+import { getModuleMessageLevel } from '$editor/canvas/state/messages'
 import useCanvas from '../CanvasController/useCanvas'
 
 type Module = {
@@ -28,6 +29,7 @@ type ModuleManifest = {
     isCanvasEditable?: boolean,
     hasWritePermission?: boolean,
     module: Module,
+    messageLevel?: string,
 }
 
 type UseModuleHook = {
@@ -75,6 +77,8 @@ export default (): UseModuleHook => {
         widget,
     })
 
+    const messageLevel = getModuleMessageLevel(canvas, mod.hash)
+
     return useMemo(() => ({
         canvas,
         isCanvasAdjustable,
@@ -83,6 +87,7 @@ export default (): UseModuleHook => {
         isResizable,
         module: mod,
         moduleClassNames,
+        messageLevel,
     }), [
         canvas,
         isCanvasAdjustable,
@@ -91,5 +96,6 @@ export default (): UseModuleHook => {
         isResizable,
         mod,
         moduleClassNames,
+        messageLevel,
     ])
 }

--- a/app/src/editor/canvas/components/ModuleRenderer/useModule.js
+++ b/app/src/editor/canvas/components/ModuleRenderer/useModule.js
@@ -3,7 +3,6 @@
 import { createContext, useContext, type Context, useMemo } from 'react'
 import ModuleStyles from '$editor/shared/components/Module.pcss'
 import isModuleResizable from '$editor/canvas/utils/isModuleResizable'
-import { getModuleMessageLevel } from '$editor/canvas/state/messages'
 import useCanvas from '../CanvasController/useCanvas'
 
 type Module = {
@@ -29,7 +28,6 @@ type ModuleManifest = {
     isCanvasEditable?: boolean,
     hasWritePermission?: boolean,
     module: Module,
-    messageLevel?: string,
 }
 
 type UseModuleHook = {
@@ -77,8 +75,6 @@ export default (): UseModuleHook => {
         widget,
     })
 
-    const messageLevel = getModuleMessageLevel(canvas, mod.hash)
-
     return useMemo(() => ({
         canvas,
         isCanvasAdjustable,
@@ -87,7 +83,6 @@ export default (): UseModuleHook => {
         isResizable,
         module: mod,
         moduleClassNames,
-        messageLevel,
     }), [
         canvas,
         isCanvasAdjustable,
@@ -96,6 +91,5 @@ export default (): UseModuleHook => {
         isResizable,
         mod,
         moduleClassNames,
-        messageLevel,
     ])
 }

--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -13,7 +13,6 @@ import cx from 'classnames'
 import type { Stream } from '$shared/flowtype/stream-types'
 import SvgIcon from '$shared/components/SvgIcon'
 import { type Ref } from '$shared/flowtype/common-types'
-import { getModuleBounds, findNonOverlappingPosition } from '$editor/shared/utils/bounds'
 
 import { getModuleCategories, getStreams } from '../services'
 import { moduleSearch } from '../state'
@@ -304,20 +303,11 @@ class ModuleSearch extends React.PureComponent<Props, State> {
         const { camera = {} } = this.props
 
         const canvasRect = camera.elRef.current.getBoundingClientRect()
-        const myBB = camera.cameraToWorldBounds({
+        return camera.cameraToWorldBounds({
             // Align module to the top right corner of ModuleSearch with a 32px offset
             x: (selfRect.right - canvasRect.left - 20) + 32,
             y: selfRect.top - canvasRect.top,
-            // TODO: It would be nice to use actual module size here but we know
-            //       it only after the module has been added to the canvas
-            width: 100,
-            height: 50,
         })
-
-        const boundingBoxes = this.props.canvas.modules.map((m) => getModuleBounds(m))
-
-        const stackOffset = 16 // pixels
-        return findNonOverlappingPosition(myBB, boundingBoxes, stackOffset)
     }
 
     renderMenu = (): Array<Element<typeof ModuleMenuCategory>> => {

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -22,11 +22,13 @@ import confirmDialog from '$shared/utils/confirm'
 import Toolbar from '$editor/shared/components/Toolbar'
 import useCanvasCamera from '../hooks/useCanvasCamera'
 import { RunTabs } from '../state'
+import { getCanvasMessages, getMaxLevel } from '../state/messages'
 
 import ShareDialog from './ShareDialog'
 import CanvasSearch from './CanvasSearch'
 import * as RunController from './CanvasController/Run'
 import { useCameraContext } from './Camera'
+import { MessageIcon } from './ConsoleSidebar'
 import styles from './Toolbar.pcss'
 
 function ZoomControls({ className, canvas }) {
@@ -157,6 +159,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
         const canShare = runController.hasSharePermission
         const { settings = {} } = canvas
         const { editorState = {} } = settings
+        const badgeLevel = getMaxLevel(getCanvasMessages(canvas))
         return (
             <div
                 ref={this.elRef}
@@ -464,6 +467,9 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         className={cx(styles.ToolbarButton, styles.ConsoleButton)}
                                         onClick={() => this.props.consoleSidebarOpen()}
                                     >
+                                        {(badgeLevel && badgeLevel !== 'none') && (
+                                            <MessageIcon level={badgeLevel} className={styles.consoleButtonBadge} />
+                                        )}
                                         <SvgIcon name="console" />
                                     </R.Button>
                                 </Tooltip>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -28,7 +28,7 @@ import ShareDialog from './ShareDialog'
 import CanvasSearch from './CanvasSearch'
 import * as RunController from './CanvasController/Run'
 import { useCameraContext } from './Camera'
-import { MessageIcon } from './ConsoleSidebar'
+import { MessageIconSimple } from './ConsoleSidebar'
 import styles from './Toolbar.pcss'
 
 function ZoomControls({ className, canvas }) {
@@ -468,7 +468,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         onClick={() => this.props.consoleSidebarOpen()}
                                     >
                                         {(badgeLevel && badgeLevel !== 'none') && (
-                                            <MessageIcon level={badgeLevel} className={styles.consoleButtonBadge} />
+                                            <MessageIconSimple level={badgeLevel} className={styles.consoleButtonBadge} />
                                         )}
                                         <SvgIcon name="console" />
                                     </R.Button>

--- a/app/src/editor/canvas/components/Toolbar.jsx
+++ b/app/src/editor/canvas/components/Toolbar.jsx
@@ -459,6 +459,14 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 </div>
                             </div>
                             <div className={styles.ModalButtons}>
+                                <Tooltip container={this.elRef.current} value="Console">
+                                    <R.Button
+                                        className={cx(styles.ToolbarButton, styles.ConsoleButton)}
+                                        onClick={() => this.props.consoleSidebarOpen()}
+                                    >
+                                        <SvgIcon name="console" />
+                                    </R.Button>
+                                </Tooltip>
                                 <Tooltip container={this.elRef.current} value="Share">
                                     <R.Button
                                         className={cx(styles.ToolbarButton, styles.ShareButton)}

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -113,6 +113,23 @@
   }
 }
 
+.ConsoleButton {
+  position: relative;
+  overflow: visible;
+
+  .consoleButtonBadge {
+    position: absolute;
+    width: 0.5um;
+    height: 0.5um;
+    top: 0;
+    left: 0;
+    transform: translate(-50%, -50%);
+    border-radius: 100%;
+    z-index: 1;
+    display: inline-grid;
+  }
+}
+
 .CanvasToolbar .DropdownMenu .DropdownMenuMenu {
   padding-top: 4px;
   padding-bottom: 4px;

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -134,6 +134,7 @@
   padding-bottom: 4px;
   margin-bottom: 10px;
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.05);
+  font-size: 12px;
 
   & .show {
     display: grid;

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -121,10 +121,9 @@
     position: absolute;
     width: 0.5um;
     height: 0.5um;
-    top: 0;
-    left: 0;
-    transform: translate(-50%, -50%);
-    border-radius: 100%;
+    top: 11px;
+    right: 10px;
+    transform: translate(50%, -50%);
     z-index: 1;
     display: inline-grid;
   }

--- a/app/src/editor/canvas/components/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar.pcss
@@ -100,6 +100,7 @@
   margin-left: 8px;
 }
 
+.ConsoleButton,
 .ShareButton,
 .KeyboardButton {
   padding: 0 !important;

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -15,6 +15,7 @@ import copyToClipboard from 'copy-to-clipboard'
 import links from '../../links'
 import routes from '$routes'
 
+import { findNonOverlappingPositionForModule } from '$editor/shared/utils/bounds'
 import isEditableElement from '$editor/shared/utils/isEditableElement'
 import UndoControls from '$editor/shared/components/UndoControls'
 import Button from '$shared/components/Button'
@@ -204,6 +205,8 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
     addModule = async ({ id, configuration }) => {
         const { canvas, canvasController } = this.props
         const action = { type: 'Add Module' }
+
+        configuration.layout.position = findNonOverlappingPositionForModule(canvas, configuration)
         const moduleData = await canvasController.loadModule(canvas, {
             ...configuration,
             id,
@@ -398,6 +401,7 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
             // doesn't look like a module
             return
         }
+
         this.addAndSelectModule({
             id: moduleData.id,
             configuration: {

--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -28,6 +28,7 @@ import BodyClass from '$shared/components/BodyClass'
 import Sidebar from '$editor/shared/components/Sidebar'
 import { useCanvasSelection, SelectionProvider } from './components/CanvasController/useCanvasSelection'
 import ModuleSidebar from './components/ModuleSidebar'
+import ConsoleSidebar from './components/ConsoleSidebar'
 import KeyboardShortcutsSidebar from './components/KeyboardShortcutsSidebar'
 import { CameraProvider, cameraControl } from './components/Camera'
 import { useCanvasCameraEffects } from './hooks/useCanvasCamera'
@@ -58,6 +59,7 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
         moduleSearchIsOpen: true,
         moduleSidebarIsOpen: false,
         keyboardShortcutIsOpen: false,
+        consoleSidebarIsOpen: false,
     }
 
     setCanvas = (action, fn, done) => {
@@ -78,6 +80,7 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
 
     moduleSidebarOpen = (show = true) => {
         this.setState({
+            consoleSidebarIsOpen: false,
             moduleSidebarIsOpen: !!show,
             keyboardShortcutIsOpen: false,
         })
@@ -87,9 +90,22 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
         this.moduleSidebarOpen(false)
     }
 
+    consoleSidebarOpen = (show = true) => {
+        this.setState({
+            consoleSidebarIsOpen: !!show,
+            moduleSidebarIsOpen: false,
+            keyboardShortcutIsOpen: false,
+        })
+    }
+
+    consoleSidebarClose = () => {
+        this.consoleSidebarOpen(false)
+    }
+
     keyboardShortcutOpen = (show = true) => {
         this.setState({
-            moduleSidebarIsOpen: !!show,
+            consoleSidebarIsOpen: false,
+            moduleSidebarIsOpen: false,
             keyboardShortcutIsOpen: !!show,
         })
     }
@@ -99,16 +115,14 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
     }
 
     selectModule = async ({ hash } = {}) => {
-        this.setState(({ moduleSidebarIsOpen, keyboardShortcutIsOpen }) => {
-            // this logic is nonsense, please redo the sidebar code
+        this.setState(({ moduleSidebarIsOpen, consoleSidebarIsOpen, keyboardShortcutIsOpen }) => {
             const noSelection = hash == null
-            const keyboardShortcutIsOpenNew = (noSelection && keyboardShortcutIsOpen) ? false : keyboardShortcutIsOpen
-            const moduleSidebarIsOpenNew = noSelection ? false : moduleSidebarIsOpen
             return {
                 selectedModuleHash: hash,
                 // close sidebar if no selection
-                moduleSidebarIsOpen: moduleSidebarIsOpenNew,
-                keyboardShortcutIsOpen: !moduleSidebarIsOpenNew && keyboardShortcutIsOpenNew,
+                moduleSidebarIsOpen: moduleSidebarIsOpen && !noSelection,
+                keyboardShortcutIsOpen: keyboardShortcutIsOpen && !noSelection,
+                consoleSidebarIsOpen: consoleSidebarIsOpen && !noSelection,
             }
         })
         if (hash == null) {
@@ -145,23 +159,16 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
             this.selectModule({ hash: undefined })
         }
 
-        // ignore if not meta key down
-        if (!(event.metaKey || event.ctrlKey)) { return }
-
-        // copy
-        if (event.key === 'c') {
-            event.preventDefault()
-            event.stopPropagation()
-            copyToClipboard(JSON.stringify(CanvasState.getModuleCopy(this.props.canvas, hash)))
-        }
-
-        // cut
-        if (event.key === 'x') {
-            event.preventDefault()
-            event.stopPropagation()
-            copyToClipboard(JSON.stringify(CanvasState.getModuleCopy(this.props.canvas, hash)))
-            if (runController.isEditable) {
-                this.removeModule({ hash })
+        if ((event.metaKey || event.ctrlKey)) {
+            // copy|cut
+            if (event.key === 'c' || event.key === 'x') {
+                event.preventDefault()
+                event.stopPropagation()
+                copyToClipboard(JSON.stringify(CanvasState.getModuleCopy(this.props.canvas, hash)))
+                // cut
+                if (event.key === 'x' && runController.isEditable) {
+                    this.removeModule({ hash })
+                }
             }
         }
     }
@@ -410,7 +417,7 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
             )
         }
         const { isEditable } = runController
-        const { moduleSidebarIsOpen, keyboardShortcutIsOpen } = this.state
+        const { moduleSidebarIsOpen, keyboardShortcutIsOpen, consoleSidebarIsOpen } = this.state
         const { settings } = canvas
         const resendFrom = settings.beginDate
         const resendTo = settings.endDate
@@ -434,7 +441,8 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
                     updateModule={this.updateModule}
                     renameModule={this.renameModule}
                     moduleSidebarOpen={this.moduleSidebarOpen}
-                    moduleSidebarIsOpen={moduleSidebarIsOpen && !keyboardShortcutIsOpen}
+                    moduleSidebarIsOpen={moduleSidebarIsOpen}
+                    consoleSidebarOpen={this.consoleSidebarOpen}
                     setCanvas={this.setCanvas}
                     pushNewDefinition={this.pushNewDefinition}
                 >
@@ -456,6 +464,7 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
                             duplicateCanvas={this.duplicateCanvas}
                             moduleSearchIsOpen={this.state.moduleSearchIsOpen}
                             moduleSearchOpen={this.moduleSearchOpen}
+                            consoleSidebarOpen={this.consoleSidebarOpen}
                             setRunTab={this.setRunTab}
                             setHistorical={this.setHistorical}
                             setSpeed={this.setSpeed}
@@ -467,19 +476,27 @@ const CanvasEditComponent = class CanvasEdit extends PureComponent {
                         />
                         <Sidebar
                             className={styles.ModuleSidebar}
-                            isOpen={moduleSidebarIsOpen || keyboardShortcutIsOpen}
+                            isOpen={moduleSidebarIsOpen || keyboardShortcutIsOpen || consoleSidebarIsOpen}
                         >
                             {keyboardShortcutIsOpen && (
                                 <KeyboardShortcutsSidebar
                                     onClose={this.keyboardShortcutClose}
                                 />
                             )}
-                            {moduleSidebarIsOpen && !keyboardShortcutIsOpen && (
+                            {moduleSidebarIsOpen && (
                                 <ModuleSidebar
                                     onClose={this.moduleSidebarClose}
                                     canvas={canvas}
                                     selectedModuleHash={this.props.selection.last()}
                                     setModuleOptions={this.setModuleOptions}
+                                />
+                            )}
+                            {consoleSidebarIsOpen && (
+                                <ConsoleSidebar
+                                    onClose={this.consoleSidebarClose}
+                                    canvas={canvas}
+                                    selectedModuleHash={this.props.selection.last()}
+                                    selectModule={this.selectModule}
                                 />
                             )}
                         </Sidebar>

--- a/app/src/editor/canvas/index.pcss
+++ b/app/src/editor/canvas/index.pcss
@@ -23,6 +23,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .CanvasToolbar {
@@ -37,4 +38,8 @@
 
 :global(.react-draggable-transparent-selection) {
   user-select: none;
+}
+
+body:global(.editor) {
+  overflow: hidden;
 }

--- a/app/src/editor/canvas/state/index.js
+++ b/app/src/editor/canvas/state/index.js
@@ -5,6 +5,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import uniqBy from 'lodash/uniqBy'
 import uuid from 'uuid'
 import isEqual from 'lodash/isEqual'
+import { nextUniqueName } from '$editor/shared/utils/uniqueName'
 import * as diff from './diff'
 
 const MISSING_ENTITY = 'EDITOR/MISSING_ENTITY'
@@ -589,7 +590,7 @@ export function connectPorts(canvas, portIdA, portIdB) {
 
     let nextCanvas = canvas
 
-    const displayName = getDisplayNameFromPort(output)
+    const displayName = getDisplayName(output)
     const outputModule = getModuleForPort(nextCanvas, output.id)
     const { contract } = outputModule || {}
 
@@ -672,11 +673,29 @@ export function updatePortConnection(canvas, portId) {
     }, canvas)
 
     const connected = isPortConnected(nextCanvas, portId)
-    if (connected === getPort(nextCanvas, portId).connected) { return nextCanvas }
-    return updatePort(nextCanvas, portId, (port) => ({
-        ...port,
-        connected,
-    }))
+    const isOutput = getIsOutput(canvas, portId)
+    let sourceId
+    // if connected input, make sure sourceId set correctly
+    if (connected && !isOutput) {
+        // eslint-disable-next-line prefer-destructuring
+        sourceId = getConnectedPortIds(canvas, portId)[0]
+    }
+
+    const nextPort = getPort(nextCanvas, portId)
+    if (connected === nextPort.connected && sourceId === nextPort.sourceId) {
+        // no change
+        return nextCanvas
+    }
+    return updatePort(nextCanvas, portId, (port) => {
+        const p = {
+            ...port,
+            connected,
+        }
+        if (!isOutput) {
+            p.sourceId = sourceId
+        }
+        return p
+    })
 }
 
 export function updateModulePortConnections(canvas, moduleHash) {
@@ -725,7 +744,14 @@ function getHash(canvas, iterations = 0) {
  */
 
 export function addModule(canvas, moduleData) {
-    return addModuleData(canvas, makeModuleUnique(moduleData))
+    return addModuleData(canvas, makeModuleUnique(canvas, moduleData))
+}
+
+function getModuleUniqueDisplayName(canvas, moduleData) {
+    const moduleName = getDisplayName(moduleData)
+    const existingNames = canvas.modules.map((m) => getDisplayName(m))
+    if (!existingNames.includes(moduleName)) { return moduleName }
+    return nextUniqueName(moduleName, existingNames)
 }
 
 /**
@@ -743,8 +769,9 @@ function addModuleData(canvas, moduleData) {
     const canvasModule = {
         ...moduleData,
         hash: getHash(canvas), // TODO: better IDs
+        displayName: getModuleUniqueDisplayName(canvas, moduleData),
         layout: {
-            ...defaultModuleLayout, // TODO: read position from mouse
+            ...defaultModuleLayout, // TODO: smarter module positioning
             ...moduleData.layout,
         },
     }
@@ -856,7 +883,7 @@ export function getPortPlaceholder(canvas, portId) {
     }
 
     const port = getPort(canvas, portId)
-    return getDisplayNameFromPort(port)
+    return getDisplayName(port)
 }
 
 export function getPortValue(canvas, portId) {
@@ -1098,7 +1125,7 @@ function getVariadicLongName(canvas, portId, portIndex) {
     }
 
     const sourcePort = getPort(canvas, portId)
-    return `${m.name}.${getDisplayNameFromPort(sourcePort)}`
+    return `${m.name}.${getDisplayName(sourcePort)}`
 }
 
 function updateVariadics(canvas, moduleHash, type) {
@@ -1259,8 +1286,8 @@ function updateVariadicModuleForType(canvas, moduleHash, type) {
     return updateVariadics(canvas, moduleHash, type)
 }
 
-function getDisplayNameFromPort(port) {
-    return port.displayName || port.name
+export function getDisplayName(obj) {
+    return obj.displayName || obj.name
 }
 
 export function updateVariadicModule(canvas, moduleHash) {
@@ -1467,24 +1494,14 @@ export function applyChanges({ sent, received, current }) {
     return nextCanvas
 }
 
-export function makeModuleUnique(moduleData) {
-    const tempCanvas = addModuleData(emptyCanvas(), moduleData)
-    return getModuleCopy(tempCanvas, tempCanvas.modules[0].hash)
-}
-
-export function getModuleCopy(canvas, moduleHash) {
+function makeModuleUnique(canvas, moduleData) {
     // apply transformations on temp canvas
+    let tempCanvas = addModuleData(emptyCanvas(), moduleData)
+    const moduleHash = tempCanvas.modules[0].hash
+
     // ensure all ports disconnected
-    let tempCanvas = disconnectAllModulePorts(canvas, moduleHash)
+    tempCanvas = disconnectAllModulePorts(tempCanvas, moduleHash)
     let m = getModule(tempCanvas, moduleHash)
-    // offset new module by 32px
-    const top = ((m.layout && parseFloat(m.layout.position.top)) + 32) || 0
-    const left = ((m.layout && parseFloat(m.layout.position.left)) + 32) || 0
-    tempCanvas = updateCanvas(updateModulePosition(tempCanvas, moduleHash, {
-        top,
-        left,
-    }))
-    m = getModule(tempCanvas, moduleHash)
 
     const portIds = getModulePortIds(tempCanvas, moduleHash)
     // give all ports fresh ids
@@ -1549,10 +1566,20 @@ export function getModuleCopy(canvas, moduleHash) {
         }))
     })
 
+    tempCanvas = updateCanvas(tempCanvas)
+
     m = getModule(tempCanvas, moduleHash)
     return {
         ...m,
         hash: undefined, // always remove hash
+    }
+}
+
+export function getModuleCopy(canvas, moduleHash) {
+    const m = getModule(canvas, moduleHash)
+    return {
+        ...m,
+        displayName: `${getDisplayName(m)} Copy`,
     }
 }
 

--- a/app/src/editor/canvas/state/messages.js
+++ b/app/src/editor/canvas/state/messages.js
@@ -1,0 +1,120 @@
+import startCase from 'lodash/startCase'
+import sortBy from 'lodash/sortBy'
+
+import routes from '$routes'
+
+import * as CanvasState from './index'
+
+export const LEVELS = [
+    'none',
+    'info',
+    'warn',
+    'error',
+]
+
+function NoFieldsConfiguredMessage(canvas, moduleHash) {
+    const streamModule = CanvasState.getModule(canvas, moduleHash)
+    const streamParam = streamModule.params.find(({ name }) => name === 'stream')
+    const streamId = streamParam && streamParam.value
+    const streamLink = routes.userPageStreamShow({ streamId })
+    return {
+        level: 'warn',
+        translate: true,
+        title: 'editor.canvas.msg.NoFieldsConfiguredTitle',
+        content: 'editor.canvas.msg.NoFieldsConfiguredMessage',
+        canvasId: canvas.id,
+        moduleHash,
+        details: {
+            streamLink,
+        },
+    }
+}
+
+function NoStreamSelectedMessage(canvas, moduleHash) {
+    return {
+        level: 'warn',
+        title: 'No stream selected',
+        content: 'Please select a stream',
+        canvasId: canvas.id,
+        moduleHash,
+    }
+}
+
+const EMPTY = []
+const STREAM_MODULE_ID = 147
+const SEND_TO_STREAM_MODULE_ID = 197
+
+/**
+ * Adds messages to Stream & Send to Stream modules
+ */
+
+function StreamModuleMesssages(canvas, moduleHash) {
+    const m = CanvasState.getModuleIfExists(canvas, moduleHash)
+    if (!m) { return EMPTY }
+
+    if (m.id === STREAM_MODULE_ID || m.id === SEND_TO_STREAM_MODULE_ID) {
+        const streamParam = m.params.find(({ name }) => name === 'stream')
+        const streamId = streamParam && streamParam.value
+        if (!streamId) {
+            // no stream selected
+            return [NoStreamSelectedMessage(canvas, moduleHash)]
+        }
+
+        // if no fields:
+        // stream module *outputs* will be empty
+        // send to stream module *inputs* will be empty
+        const target = m.id === STREAM_MODULE_ID ? 'outputs' : 'inputs'
+        if (!m[target].length) {
+            // did not find any fields
+            return [NoFieldsConfiguredMessage(canvas, moduleHash)]
+        }
+
+        return EMPTY
+    }
+
+    return EMPTY
+}
+
+/*
+ * Looks for errors in canvas.moduleErrors.
+ * e.g. java module compileErrors
+ */
+
+function ModuleErrorMesssages(canvas, moduleHash) {
+    const m = CanvasState.getModuleIfExists(canvas, moduleHash)
+    if (!m) { return EMPTY }
+    const { moduleErrors = [] } = canvas
+    const currentModuleErrors = moduleErrors.filter(({ module }) => module === moduleHash)
+    if (!currentModuleErrors.length) { return EMPTY }
+    // sort by ascending line number (if line available)
+    return sortBy(currentModuleErrors, 'line').reverse().map(({ type, message, line }) => ({
+        level: 'error',
+        title: startCase(type),
+        content: `${line != null ? `Line ${line}: ` : ''}${message}`,
+        canvasId: canvas.id,
+        moduleHash,
+    }))
+}
+
+export function getModuleMessages(canvas, moduleHash) {
+    const m = CanvasState.getModuleIfExists(canvas, moduleHash)
+    if (!m) { return EMPTY }
+    return [
+        StreamModuleMesssages(canvas, moduleHash),
+        ModuleErrorMesssages(canvas, moduleHash),
+    ].flat().map((msg) => ({
+        subject: CanvasState.getDisplayName(m),
+        ...msg,
+    }))
+}
+
+export function getModuleMessageLevel(canvas, moduleHash) {
+    const levelIndex = getModuleMessages(canvas, moduleHash).reduce((maxLevel, msg) => (
+        Math.max(maxLevel, LEVELS.indexOf(msg.level))
+    ), 0)
+    return LEVELS[levelIndex]
+}
+
+export function getCanvasMessages(canvas) {
+    return canvas.modules.map((m) => getModuleMessages(canvas, m.hash)).flat()
+}

--- a/app/src/editor/canvas/state/messages.js
+++ b/app/src/editor/canvas/state/messages.js
@@ -108,8 +108,8 @@ export function getModuleMessages(canvas, moduleHash) {
     }))
 }
 
-export function getModuleMessageLevel(canvas, moduleHash) {
-    const levelIndex = getModuleMessages(canvas, moduleHash).reduce((maxLevel, msg) => (
+export function getMaxLevel(moduleMessages) {
+    const levelIndex = moduleMessages.reduce((maxLevel, msg) => (
         Math.max(maxLevel, LEVELS.indexOf(msg.level))
     ), 0)
     return LEVELS[levelIndex]

--- a/app/src/editor/canvas/tests/copyPaste.test.js
+++ b/app/src/editor/canvas/tests/copyPaste.test.js
@@ -31,6 +31,16 @@ describe('copy/paste with getModuleCopy', () => {
         expect(updatedClockPorts).toEqual(clockPorts)
     })
 
+    it('adds "Copy" to name', async () => {
+        let canvas = State.emptyCanvas()
+        canvas = State.addModule(canvas, await loadModuleDefinition('Clock'))
+        const [clock] = canvas.modules
+        const clockCopyDefn = State.getModuleCopy(canvas, clock.hash)
+        canvas = State.addModule(canvas, clockCopyDefn)
+        const [, clock2] = canvas.modules
+        expect(clock2.displayName).toEqual(`${clock.displayName} Copy`)
+    })
+
     it('can be applied without creating duplicate ports', async () => {
         let canvas = State.emptyCanvas()
         canvas = State.addModule(canvas, await loadModuleDefinition('Clock'))

--- a/app/src/editor/canvas/tests/state.test.js
+++ b/app/src/editor/canvas/tests/state.test.js
@@ -46,6 +46,21 @@ describe('Canvas State', () => {
         })
     })
 
+    describe('addModule', () => {
+        test('gives modules unique displayName', () => {
+            let canvas = State.addModule(State.emptyCanvas(), Clock)
+            canvas = State.addModule(canvas, Clock)
+            canvas = State.addModule(canvas, Clock)
+            const clock1 = canvas.modules[0]
+            expect(canvas.modules[1]).toMatchObject({
+                displayName: `${clock1.displayName} 02`,
+            })
+            expect(canvas.modules[2]).toMatchObject({
+                displayName: `${clock1.displayName} 03`,
+            })
+        })
+    })
+
     describe('getModule/findModule', () => {
         let canvas
 

--- a/app/src/editor/i18n/en.po
+++ b/app/src/editor/i18n/en.po
@@ -70,3 +70,10 @@ msgstr "15 seconds"
 
 msgid "editor##timeRange##1000"
 msgstr "1 second"
+
+msgid "editor##canvas##msg##NoFieldsConfiguredTitle"
+msgstr "No fields configured."
+
+msgid "editor##canvas##msg##NoFieldsConfiguredMessage"
+msgstr "The selected stream should have fields configured. "
+"<a href=\"%{streamLink}\" target=\"_blank\" rel=\"noopener noreferrer\">Configure Fields</a>"

--- a/app/src/editor/shared/components/Sidebar/sidebar.pcss
+++ b/app/src/editor/shared/components/Sidebar/sidebar.pcss
@@ -26,8 +26,20 @@
     bottom: 0;
   }
 
+  .iconButton {
+    height: 32px;
+    width: 32px;
+    cursor: pointer;
+  }
+
+  .icon {
+    height: 10px;
+    width: 10px;
+    color: #CDCDCD;
+  }
+
   .header {
-    padding: 21px 39px 12px;
+    padding: 19px 39px 12px;
     user-select: none;
 
     .titleRow {
@@ -54,10 +66,17 @@
         color: #CDCDCD;
         padding: 0;
         margin: 0;
+        display: flex;
       }
 
       button:focus {
         outline: none;
+      }
+
+      .iconButton {
+        /* close button */
+        height: 10px;
+        width: 10px;
       }
     }
   }
@@ -77,18 +96,6 @@
   .content {
     color: #525252;
     padding-bottom: 40px; /* ensure there's always a little to scroll at the end */
-  }
-
-  .iconButton {
-    height: 32px;
-    width: 32px;
-    cursor: pointer;
-  }
-
-  .icon {
-    height: 10px;
-    width: 10px;
-    color: #CDCDCD;
   }
 }
 

--- a/app/src/editor/shared/utils/bounds.js
+++ b/app/src/editor/shared/utils/bounds.js
@@ -120,3 +120,20 @@ export const findNonOverlappingPosition = (
 
     return findNonOverlappingPosition(nextBB, boundingBoxes, stackOffset, false)
 }
+
+export function findNonOverlappingPositionForModule(canvas: any, moduleData: any): any {
+    const moduleBounds = {
+        x: parseInt(moduleData.layout.position.left, 10) || 0,
+        y: parseInt(moduleData.layout.position.top, 10) || 0,
+        width: parseInt(moduleData.layout.width, 10) || 150,
+        height: parseInt(moduleData.layout.height, 10) || 100,
+    }
+    const boundingBoxes = canvas.modules.map((m) => getModuleBounds(m))
+
+    const stackOffset = 16 // pixels
+    const pos = findNonOverlappingPosition(moduleBounds, boundingBoxes, stackOffset)
+    return {
+        left: `${pos.x}px`,
+        top: `${pos.y}px`,
+    }
+}

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -360,6 +360,48 @@ const sources = {
             </g>
         </svg>
     ),
+    infoBadge: (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+            <g fill="none" fillRule="evenodd" transform="matrix(1 0 0 -1 0 16)">
+                <circle cx="8" cy="8" r="8" fill="#0324FF" />
+                <path
+                    stroke="#FFF"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M8 11.5v.1m0-2.8V4"
+                />
+            </g>
+        </svg>
+    ),
+    warnBadge: (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+            <g fill="none" fillRule="evenodd">
+                <circle cx="8" cy="8" r="8" fill="#FF5C00" />
+                <path
+                    stroke="#FFF"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M8 11.5v.1m0-2.8V4"
+                />
+            </g>
+        </svg>
+    ),
+    errorBadge: (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+            <g fill="none" fillRule="evenodd">
+                <circle cx="8" cy="8" r="8" fill="#FF0F2D" />
+                <path
+                    stroke="#FFF"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M4.606 4.606l6.788 6.788m0-6.788l-6.788 6.788"
+                />
+            </g>
+        </svg>
+    ),
     clear: (
         <svg viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
             <g transform="translate(.25 .25)" fill="none">
@@ -403,6 +445,21 @@ const sources = {
                 <path d="M1.314 10.81C-.656 8.111-.216 4.416 2.34 2.22c2.555-2.197 6.413-2.197 8.968 0 2.556 2.197 2.997 5.892 1.026 8.591" />
                 <ellipse cx="6.824" cy="6.978" rx="2.042" ry="1.969" />
                 <path d="M10.111 11.76c-.487-1.348-1.805-2.251-3.286-2.251-1.48 0-2.798.903-3.285 2.25h6.571z" />
+            </g>
+        </svg>
+    ),
+    console: (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 20">
+            <g
+                fill="none"
+                fillRule="evenodd"
+                stroke="#A3A3A3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+            >
+                <path d="M2.525 18.775a1.35 1.35 0 01-1.35-1.35V2.678a1.458 1.458 0 011.453-1.453h17.35a1.45 1.45 0 011.447 1.446v14.65a1.458 1.458 0 01-1.454 1.454H2.525zm18.9-13.5H1.175m10.8 6.75h4.05" />
+                <path d="M6.575 9.325l2.7 2.7-2.7 2.7" />
             </g>
         </svg>
     ),


### PR DESCRIPTION
Following a discussion with Matt, this sidebar now only contains validation messages rather than validation messages and a log of the notifications sent, at least for this first version. It wasn't immediately clear how the validation messages should/could work within an event log.

 Main motivation for this feature is to start being able to help users with common issues e.g. selecting a stream with no fields configured. Realtime log much lower value than being able to provide these messages.

Needs some additional design feedback e.g. for the message grouping headers, which I will collect from Matt if/when the PR deploys.

Added frontend "validation" for:

* Stream module with no stream selected.
* Stream module with a stream selected but that stream has no fields configured.
* Also grabbed module errors from `canvas.moduleErrors`. Afaik only the Java module's compile errors appear here at the moment.

Going forward we should probably produce warnings/errors for at least:

* Solidity Module with no account selected
* Canvas Module with no canvas selected
* And the solidity module should probably also use the same `canvas.moduleErrors` like the Java module.

So while we can add additional validation on the frontend, it's possible we should actually look at updating e&e so it produces the above messages into `canvas.moduleErrors`, and perhaps also change the name from `moduleErrors` to `moduleMessages` or even just `messages`. 

Perhaps also need backend to start adding an additional flag for inputs/params that require a value.

#### Also

* Dedupes module names e.g. "Stream" -> "Stream 02" -> "Stream 03". No deduping if you edit module name manually, only on module creation. This is so modules can be differentiated in sidebar.
* Adds "Copy" to name of copied modules
* Uses "smart" offset finding when pasting. Before it just added 32px offset from original position, so didn't stack.
* Immediately "applies" when opening the Java module, this allows annotations to appear.
* Might have fixed at least one instance of that weird scrolled canvas issue @fonty1 mentioned.

#### To Test

1. Create Stream module
2. Note badge on stream module and on console icon in toolbar
3. Clicking either badge or console icon in toolbar opens console sidebar
4. Console sidebar should say "no stream selected"
5. Select any Stream
6. Error in sidebar should go away if selected stream has fields
7. Create a stream with no fields
8. Select that stream
9. Console sidebar should complain that stream has no fields, and provide a link to edit stream.
10. Add Java module
11. Edit code so there's multiple errors. Errors should appear in console sidebar.
12. Selecting a module with the console sidebar open should scroll to that module's errors in the console sidebar.
13. Selecting an error in the sidebar should select & pan to the associated module. Note that currently "pan to selected module" doesn't take sidebar position into account, so panned to module may be behind sidebar.
14. Copy/pasting a module will dedupe the name, and find appropriate offset position. This name is used in the sidebar to disambiguate modules.

Also note if you're playing around with this:

* If there's errors in the Java module, Stream modules won't update their ports from the backend until the Java module errors are fixed.
* You can't copy/paste a Java module that has errors, gives a null pointer exception on server.

----

![image](https://user-images.githubusercontent.com/43438/70128548-001e4a00-16b8-11ea-81fb-d63e9eff0cf1.png)

![image](https://user-images.githubusercontent.com/43438/70128722-55f2f200-16b8-11ea-8dff-4fd1fcaf294d.png)


