### PR TITLE
Font fallbacks

### DIFF
--- a/app/.storybook/config.js
+++ b/app/.storybook/config.js
@@ -8,6 +8,7 @@ import { xs, sm, md, lg } from '$app/scripts/breakpoints'
 
 // To import the global styling
 import '$shared/assets/stylesheets'
+import '@ibm/plex/css/ibm-plex.css'
 
 setAddon(JSXAddon)
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3367,6 +3367,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz",
       "integrity": "sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA=="
     },
+    "@ibm/plex": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ibm/plex/-/plex-4.0.2.tgz",
+      "integrity": "sha512-MCOHPVSyQwuacyjCmVUhKuV7wc21eSaj/RdMM7BIL6YHMwKv6y4I9AqOa7V0Vcuzuyaj0YL8KgXj25+hVUObMA=="
+    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -86,6 +86,7 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
+    "@ibm/plex": "^4.0.2",
     "@mdx-js/loader": "^1.1.1",
     "@mdx-js/react": "^1.1.1",
     "@sambego/storybook-styles": "^1.0.0",

--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import '$shared/assets/stylesheets'
+import '@ibm/plex/css/ibm-plex.css'
 
 import React from 'react'
 import { Route as RouterRoute, Switch, Redirect, type Location } from 'react-router-dom'

--- a/app/src/auth/components/AuthPanelNav/authPanelNav.pcss
+++ b/app/src/auth/components/AuthPanelNav/authPanelNav.pcss
@@ -1,7 +1,7 @@
 .root {
   color: #897FFD;
   display: flex;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 0.75em;
   font-weight: var(--semiBold);
   justify-content: space-between;

--- a/app/src/auth/components/Button/button.pcss
+++ b/app/src/auth/components/Button/button.pcss
@@ -5,7 +5,7 @@
   color: white;
   cursor: pointer;
   flex-shrink: 0;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 1em;
   font-weight: 600;
   line-height: 3em;

--- a/app/src/auth/components/Footer/footer.pcss
+++ b/app/src/auth/components/Footer/footer.pcss
@@ -4,7 +4,7 @@
 
 .inner {
   color: #897FFD;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 0.625em;
   font-weight: var(--medium);
   letter-spacing: 1px;

--- a/app/src/docs/components/CanvasModuleHelp/canvasModuleHelp.pcss
+++ b/app/src/docs/components/CanvasModuleHelp/canvasModuleHelp.pcss
@@ -9,7 +9,7 @@ section.root {
 
   code {
     color: #323232;
-    font-family: 'IBM Plex Mono', monospace;
+    font-family: var(--mono);
     font-size: 12px;
     background-color: #EFEFEF;
     padding: 2px 4px;

--- a/app/src/docs/components/DocsLayout/docsLayout.pcss
+++ b/app/src/docs/components/DocsLayout/docsLayout.pcss
@@ -43,7 +43,7 @@
   li {
     code {
       color: #323232;
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 12px;
       background-color: #EFEFEF;
       padding: 2px 4px;
@@ -53,7 +53,7 @@
 
   .streamrHighlight {
     color: #FFFFFF;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     font-size: 14px;
     background-color: #0424FF;
     padding: 4px 8px;
@@ -63,7 +63,7 @@
 
   .greenHighlight {
     color: #FFFFFF;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     font-size: 14px;
     background-color: #2AC437;
     padding: 4px 8px;
@@ -85,7 +85,7 @@
   .mdP {
     color: var(--greyDark);
     font-weight: var(--regular);
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     letter-spacing: 0;
     text-align: initial;
     padding: 0;
@@ -247,7 +247,7 @@
 
   kbd {
     color: #323232;
-    font-family: 'IBM Plex Mono', monospace;
+    font-family: var(--mono);
     font-size: 12px;
     background-color: #EFEFEF;
     padding: 2px 4px;

--- a/app/src/docs/components/DocsPages/Introduction/introduction.pcss
+++ b/app/src/docs/components/DocsPages/Introduction/introduction.pcss
@@ -52,7 +52,7 @@
     display: block;
     font-size: 20px;
     font-weight: var(--medium);
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     letter-spacing: 0;
     line-height: 22px;
     color: var(--streamrBlue);

--- a/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.pcss
+++ b/app/src/editor/canvas/components/CodeEditor/CodeEditorWindow.pcss
@@ -26,7 +26,7 @@
   color: #EFEFEF;
   box-shadow: none;
   border: none;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   letter-spacing: 0;
   line-height: 14px;
@@ -34,7 +34,7 @@
 
 .editor {
   color: #2AC437;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 12px;
   letter-spacing: 1px;
   line-height: 16px;

--- a/app/src/editor/canvas/components/DraggableCanvasWindow.pcss
+++ b/app/src/editor/canvas/components/DraggableCanvasWindow.pcss
@@ -19,7 +19,7 @@
   background: #F8F8F8;
   padding: 0;
   color: #323232;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 0;
@@ -76,7 +76,7 @@
     border: 1px solid #EFEFEF;
     background: #FFFFFF;
     color: #323232;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     font-size: 10px;
     font-weight: 500;
     letter-spacing: 0;

--- a/app/src/editor/canvas/index.pcss
+++ b/app/src/editor/canvas/index.pcss
@@ -8,7 +8,7 @@
 .CanvasEdit {
   flex: 1;
   flex-direction: column;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   display: grid;
   grid-template-areas:
     'canvas sidebar'

--- a/app/src/editor/dashboard/index.pcss
+++ b/app/src/editor/dashboard/index.pcss
@@ -9,7 +9,7 @@
   position: relative;
   flex: 1;
   flex-direction: column;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   display: grid;
   grid-template-areas:
     'canvas'

--- a/app/src/editor/shared/components/KeyboardShortcutsSidebar/KeyboardShortcutsSidebar.pcss
+++ b/app/src/editor/shared/components/KeyboardShortcutsSidebar/KeyboardShortcutsSidebar.pcss
@@ -11,7 +11,7 @@
   border: 1px solid #EFEFEF;
   border-radius: 4px;
   color: #525252;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 0;

--- a/app/src/editor/shared/components/Sidebar/sidebar.pcss
+++ b/app/src/editor/shared/components/Sidebar/sidebar.pcss
@@ -38,7 +38,7 @@
         margin: 0;
         margin-right: auto;
         color: #323232;
-        font-family: 'IBM Plex Sans', sans-serif;
+        font-family: var(--sans);
         font-size: 20px;
         font-weight: 500;
         letter-spacing: 0;
@@ -64,7 +64,7 @@
 
   .appInfo {
     color: #ADADAD;
-    font-family: 'IBM Plex Mono', monospace;
+    font-family: var(--mono);
     font-size: 10px;
     font-weight: 500;
     letter-spacing: 1px;
@@ -117,7 +117,7 @@
   margin: 0;
   width: 100%;
   color: #323232;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 16px;
   font-weight: 500;
   letter-spacing: 0;
@@ -142,7 +142,7 @@
 .sidebarSectionContent {
   padding-top: 20px;
   color: #525252;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 14px;
   letter-spacing: 0;
   line-height: 24px;

--- a/app/src/editor/shared/components/modules/Comment.pcss
+++ b/app/src/editor/shared/components/modules/Comment.pcss
@@ -15,7 +15,7 @@ body .Comment {
     top: 0;
     padding: 0.8rem 1.4rem;
     color: #525252;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     font-size: 10px;
     font-weight: 500;
     letter-spacing: 0;
@@ -24,7 +24,7 @@ body .Comment {
   }
 
   textarea::placeholder {
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     color: #ADADAD;
     font-size: 10px;
     font-weight: 500;

--- a/app/src/editor/shared/components/modules/ExportCSV.pcss
+++ b/app/src/editor/shared/components/modules/ExportCSV.pcss
@@ -3,7 +3,7 @@
 }
 
 .text {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 10px;
   font-weight: 500;
   color: #525252;

--- a/app/src/editor/shared/components/modules/Label.pcss
+++ b/app/src/editor/shared/components/modules/Label.pcss
@@ -1,7 +1,7 @@
 .Label {
   padding: 0.8rem 1.4rem;
   color: #525252;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 10px;
   font-weight: 500;
   letter-spacing: 0;

--- a/app/src/editor/shared/components/modules/Scheduler.pcss
+++ b/app/src/editor/shared/components/modules/Scheduler.pcss
@@ -1,5 +1,5 @@
 .schedulerContainer {
-  font-family: 'IBM Plex Mono', sans-serif;
+  font-family: var(--mono);
   font-size: 10px;
   font-weight: 500;
   letter-spacing: 0;
@@ -9,7 +9,7 @@
   border-top: 1px solid #EFEFEF;
   padding: 12px 24px;
   color: #525252;
-  font-family: 'IBM Plex Mono', sans-serif;
+  font-family: var(--mono);
   font-size: 10px;
   font-weight: 500;
   letter-spacing: 0;

--- a/app/src/editor/shared/components/modules/Table.pcss
+++ b/app/src/editor/shared/components/modules/Table.pcss
@@ -21,13 +21,13 @@
 }
 
 .table th {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-weight: 500;
   line-height: 32px;
 }
 
 .table td {
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   line-height: 24px;
   vertical-align: baseline;
 }

--- a/app/src/editor/shared/components/modules/TextField.pcss
+++ b/app/src/editor/shared/components/modules/TextField.pcss
@@ -14,7 +14,7 @@ body .TextField {
     background: transparent;
     padding: 0.8rem 1.4rem;
     color: #525252;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     font-size: 10px;
     font-weight: 500;
     letter-spacing: 0;
@@ -23,7 +23,7 @@ body .TextField {
   }
 
   textarea::placeholder {
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     color: #ADADAD;
     font-size: 10px;
     font-weight: 500;

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -52,6 +52,5 @@
     </script>
     <div id="root"></div> <!-- React root -->
     <div id="modal-root"></div> <!-- Modal root -->
-    <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:400,500,600|IBM+Plex+Sans:200,300,400,400i,500,500i,600,700&display=swap" rel="stylesheet">
 </body>
 </html>

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -33,7 +33,8 @@
     <meta name="msapplication-TileImage" content="https://streamr.network/resources/ms-icon-144x144.png">
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
     <style>@-ms-viewport { width: device-width; }</style>
-
+</head>
+<body>
     <%/*
         Global site tag (gtag.js) - Google Analytics
         Is added here so that it can be read without rendering js on the page.
@@ -49,9 +50,8 @@
             'send_page_view': false,
         })
     </script>
-</head>
-<body>
     <div id="root"></div> <!-- React root -->
     <div id="modal-root"></div> <!-- Modal root -->
+    <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:400,500,600|IBM+Plex+Sans:200,300,400,400i,500,500i,600,700&display=swap" rel="stylesheet">
 </body>
 </html>

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -31,7 +31,7 @@
     <meta name="twitter:image" content="https://streamr.network/resources/social.jpg">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="https://streamr.network/resources/ms-icon-144x144.png">
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+    <script src="https://cdn.polyfill.io/v3/polyfill.min.js"></script>
     <style>@-ms-viewport { width: device-width; }</style>
 </head>
 <body>

--- a/app/src/marketplace/components/ActionBar/SearchInput/searchInput.pcss
+++ b/app/src/marketplace/components/ActionBar/SearchInput/searchInput.pcss
@@ -14,7 +14,7 @@
   }
 
   .input {
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     color: #CDCDCD;
     border: none;
     background: none;

--- a/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/TimeUnitSelector/timeUnitSelector.pcss
+++ b/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/TimeUnitSelector/timeUnitSelector.pcss
@@ -30,7 +30,7 @@
   width: 100%;
   height: 48px;
   font-weight: var(--light);
-  font-family: IBMPlexSans, sans-serif;
+  font-family: var(--sans);
   letter-spacing: normal;
   color: #323232;
 

--- a/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/chooseAccessPeriod.pcss
+++ b/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/chooseAccessPeriod.pcss
@@ -38,7 +38,7 @@ Mainly fonts and color constants
   font-weight: var(--light);
   font-size: 20px;
   line-height: 22px;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
 }
 
 .accessPeriodNumber:focus {

--- a/app/src/marketplace/components/ProductTile/productTile.pcss
+++ b/app/src/marketplace/components/ProductTile/productTile.pcss
@@ -2,7 +2,7 @@
   display: block;
   margin: 1em auto 0;
   border-radius: 2px;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 16px;
   text-align: left;
 

--- a/app/src/marketplace/components/StreamSelector/streamSelector.pcss
+++ b/app/src/marketplace/components/StreamSelector/streamSelector.pcss
@@ -102,7 +102,7 @@
   margin: 0;
   background: none;
   cursor: inherit;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 14px;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/app/src/marketplace/components/deprecated/ChooseAccessPeriodDialog/chooseAccessPeriod.pcss
+++ b/app/src/marketplace/components/deprecated/ChooseAccessPeriodDialog/chooseAccessPeriod.pcss
@@ -38,7 +38,7 @@ Mainly fonts and color constants
   font-weight: var(--light);
   font-size: 20px;
   line-height: 22px;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
 }
 
 .accessPeriodNumber:focus {

--- a/app/src/marketplace/components/deprecated/ProductPageEditor/StreamSelector/productPageStreamSelector.pcss
+++ b/app/src/marketplace/components/deprecated/ProductPageEditor/StreamSelector/productPageStreamSelector.pcss
@@ -73,7 +73,7 @@
   margin: 0;
   background: none;
   cursor: inherit;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 14px;
 
   &:focus {

--- a/app/src/shared/assets/stylesheets/buttons.pcss
+++ b/app/src/shared/assets/stylesheets/buttons.pcss
@@ -3,7 +3,7 @@
     background: rgba(0, 0, 0, 0);
     border-radius: 2px;
     cursor: pointer;
-    font-family: 'IBM Plex Mono', sans-serif;
+    font-family: var(--mono);
     height: 48px;
     font-weight: bold;
     overflow: hidden;
@@ -118,7 +118,7 @@
       box-shadow: none;
       text-decoration: none;
       color: var(--greyDark2);
-      font-family: 'IBM Plex Mono', sans-serif;
+      font-family: var(--mono);
       text-transform: capitalize;
       font-weight: var(--regular);
 

--- a/app/src/shared/assets/stylesheets/common.pcss
+++ b/app/src/shared/assets/stylesheets/common.pcss
@@ -15,7 +15,7 @@
       line-height: 49px;
 
       .subtitle {
-        font-family: 'IBM Plex Mono', monospace;
+        font-family: var(--mono);
         font-weight: var(--medium);
         text-transform: uppercase;
         margin: 6px 0 0 0;

--- a/app/src/shared/assets/stylesheets/fonts/ibm-plex.css
+++ b/app/src/shared/assets/stylesheets/fonts/ibm-plex.css
@@ -1,1 +1,0 @@
-@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Mono:400,500,600|IBM+Plex+Sans:200,300,400,400i,500,500i,600,700&display=swap');

--- a/app/src/shared/assets/stylesheets/forms.pcss
+++ b/app/src/shared/assets/stylesheets/forms.pcss
@@ -1,7 +1,7 @@
 :global {
   form {
     input {
-      font-family: 'IBM Plex Sans', sans-serif;
+      font-family: var(--sans);
     }
 
     .form-control {
@@ -10,7 +10,7 @@
       font-size: 1rem;
       padding: 0.9rem 1rem;
       color: var(--purple2);
-      font-family: 'IBM Plex Sans', sans-serif;
+      font-family: var(--sans);
       background: var(--white) none;
 
       &:active,

--- a/app/src/shared/assets/stylesheets/index.js
+++ b/app/src/shared/assets/stylesheets/index.js
@@ -1,6 +1,5 @@
 import '$shared/assets/stylesheets/bootstrap.scss'
 import '@streamr/streamr-icons/styles.css'
-import './fonts/ibm-plex.css'
 import './variables.css'
 
 import './buttons.pcss'

--- a/app/src/shared/assets/stylesheets/layout.pcss
+++ b/app/src/shared/assets/stylesheets/layout.pcss
@@ -12,7 +12,7 @@
 
   body {
     color: var(--white) !important;
-    font-family: 'IBM Plex Sans', 'Hiragino Sans GB', '冬青黑体', 'SimHei', '黑体', sans-serif;
+    font-family: var(--sans);
     line-height: 2em;
     -webkit-overflow-scrolling: touch;
 
@@ -46,11 +46,7 @@
     }
 
     .ff-plex-mono {
-      font-family: 'IBM Plex Mono', 'Hiragino Sans GB', '冬青黑体', 'SimHei', '黑体', sans-serif;
-    }
-
-    .ff-realtime {
-      font-family: 'realtime', 'Hiragino Sans GB', '冬青黑体', 'SimHei', '黑体', sans-serif;
+      font-family: var(--mono);
     }
 
     .fw-200 {

--- a/app/src/shared/assets/stylesheets/navs.pcss
+++ b/app/src/shared/assets/stylesheets/navs.pcss
@@ -34,7 +34,7 @@
     .navbar-nav li.nav-item,
     .dropdown-item {
       outline: none !important;
-      font-family: 'IBM Plex Mono', sans-serif;
+      font-family: var(--mono);
       font-weight: 500;
       text-transform: uppercase;
       color: var(--purpleDark2);
@@ -310,7 +310,7 @@
             flex: 0 0 50%;
             max-width: 50%;
             padding-top: 10px;
-            font-family: 'IBM Plex Sans', sans-serif;
+            font-family: var(--sans);
             color: var(--purpleDark2);
             text-transform: none;
             font-size: 1.1rem;

--- a/app/src/shared/assets/stylesheets/variables.css
+++ b/app/src/shared/assets/stylesheets/variables.css
@@ -1,7 +1,7 @@
 :root {
   --fontSize: 1rem;
-  --mono: 'IBM Plex Mono', monospace;
-  --sans: 'IBM Plex Sans', sans-serif;
+  --mono: 'IBM Plex Mono', 'Lucida Console', 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace;
+  --sans: 'IBM Plex Sans', 'Helvetica', 'Verdana', system-ui, sans-serif;
   --um: 16px; /* Wishful thinking: Future 1rem? — Mariusz */
 
   /* Colors */

--- a/app/src/shared/assets/stylesheets/variables.css
+++ b/app/src/shared/assets/stylesheets/variables.css
@@ -1,7 +1,7 @@
 :root {
   --fontSize: 1rem;
-  --mono: 'IBM Plex Mono', 'Lucida Console', 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace;
-  --sans: 'IBM Plex Sans', 'Helvetica', 'Verdana', system-ui, sans-serif;
+  --mono: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --sans: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
   --um: 16px; /* Wishful thinking: Future 1rem? — Mariusz */
 
   /* Colors */

--- a/app/src/shared/components/BackButton/backButton.pcss
+++ b/app/src/shared/components/BackButton/backButton.pcss
@@ -1,6 +1,6 @@
 .root {
   color: var(--greyDark2);
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   font-size: 0.875rem;
   font-weight: var(--semiBold);
   letter-spacing: 1.5px;

--- a/app/src/shared/components/Buttons/ExternalLinkButton/externalLinkButton.pcss
+++ b/app/src/shared/components/Buttons/ExternalLinkButton/externalLinkButton.pcss
@@ -5,7 +5,7 @@
     background: var(--greyLight3);
     border-radius: 4px 4px 4px 4px;
     font-size: 14px;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     letter-spacing: 0;
     line-height: 32px;
     text-transform: none;

--- a/app/src/shared/components/ContextMenu/ContextMenuItem/contextMenuItem.pcss
+++ b/app/src/shared/components/ContextMenu/ContextMenuItem/contextMenuItem.pcss
@@ -1,6 +1,6 @@
 .item {
   color: #323232;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   letter-spacing: 0;
   line-height: 20px;

--- a/app/src/shared/components/Dialog/TitleBar/titleBar.pcss
+++ b/app/src/shared/components/Dialog/TitleBar/titleBar.pcss
@@ -3,7 +3,7 @@
   padding: 24px;
   font-size: 20px;
   line-height: 32px;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-weight: normal;
   text-align: center;
   position: relative;

--- a/app/src/shared/components/Dropdown/dropdown.pcss
+++ b/app/src/shared/components/Dropdown/dropdown.pcss
@@ -40,7 +40,7 @@
   Normal toggle styles
 */
 .toggle {
-  font-family: 'IBM Plex Mono', sans-serif;
+  font-family: var(--mono);
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 2px;

--- a/app/src/shared/components/Table/table.pcss
+++ b/app/src/shared/components/Table/table.pcss
@@ -29,7 +29,7 @@
   }
 
   thead {
-    font-family: 'IBM Plex Mono', monospace;
+    font-family: var(--mono);
     font-size: 12px;
     font-weight: normal;
     letter-spacing: 0;

--- a/app/src/shared/components/Tile/tile.pcss
+++ b/app/src/shared/components/Tile/tile.pcss
@@ -2,7 +2,7 @@
   position: relative;
   display: block;
   border-radius: 2px;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 16px;
   text-align: left;
   height: 100%;
@@ -43,7 +43,7 @@
 }
 
 .title {
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 16px;
   font-weight: var(--medium);
   color: #323232;
@@ -53,7 +53,7 @@
 }
 
 .description {
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   font-weight: var(--regular);
   color: #A3A3A3;
@@ -62,7 +62,7 @@
 }
 
 .status {
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   color: #323232;
   font-weight: var(--regular);
@@ -71,7 +71,7 @@
 }
 
 .tag {
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   text-transform: capitalize;
   color: #A3A3A3;

--- a/app/src/shared/components/Tooltip/tooltip.pcss
+++ b/app/src/shared/components/Tooltip/tooltip.pcss
@@ -7,7 +7,7 @@
   background-color: #323232 !important;
   border-radius: 2px;
   color: #EFEFEF !important;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   letter-spacing: 0;
   line-height: 14px;

--- a/app/src/shared/styles/pcss/buttons.pcss
+++ b/app/src/shared/styles/pcss/buttons.pcss
@@ -5,7 +5,7 @@
 
   .btn {
     height: 40px;
-    font-family: 'IBM Plex Mono', 'Hiragino Sans GB', '冬青黑体', 'SimHei', '黑体', sans-serif;
+    font-family: var(--mono);
     font-weight: var(--medium);
     text-transform: uppercase;
     letter-spacing: 1.5px;
@@ -123,7 +123,7 @@
     padding: 8px;
     text-transform: none;
     line-height: 1;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     font-size: 12px;
     border-radius: 5px;
     letter-spacing: 0;
@@ -150,7 +150,7 @@
     text-decoration: none;
     line-height: 40px;
     text-transform: uppercase;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     font-weight: var(--medium);
     letter-spacing: 1px;
     will-change: transform;
@@ -174,7 +174,7 @@
   .btn-outline-userpages,
   .btn.btn-userpages {
     text-transform: none;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     font-size: 14px;
     border-radius: 4px;
     letter-spacing: 0;

--- a/app/src/userpages/components/Avatar/NameAndEmail/nameAndEmail.pcss
+++ b/app/src/userpages/components/Avatar/NameAndEmail/nameAndEmail.pcss
@@ -5,7 +5,7 @@
 .name {
   color: #323232;
   font-size: 28px;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   letter-spacing: 0;
   line-height: 32px;
 }
@@ -14,7 +14,7 @@
   display: inline-block;
   color: #525252;
   font-size: 12px;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   letter-spacing: 0;
   background: #EFEFEF;
   border-radius: 2px;

--- a/app/src/userpages/components/ProfilePage/APICredentials/CredentialsControl/credentialsControl.pcss
+++ b/app/src/userpages/components/ProfilePage/APICredentials/CredentialsControl/credentialsControl.pcss
@@ -17,7 +17,7 @@
 
 .permissionColHeading {
   font-size: 12px;
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   letter-spacing: 0;
   line-height: 20px;
 }

--- a/app/src/userpages/components/PurchasesPage/purchases.pcss
+++ b/app/src/userpages/components/PurchasesPage/purchases.pcss
@@ -1,5 +1,5 @@
 .title {
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 16px;
   color: #323232;
   letter-spacing: 0;
@@ -8,7 +8,7 @@
 }
 
 .owner {
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   color: #A3A3A3;
   letter-spacing: 0;
@@ -16,7 +16,7 @@
 }
 
 .status {
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   font-size: 12px;
   color: #323232;
   letter-spacing: 0;

--- a/app/src/userpages/components/ShareDialog/EmbedDialogContent/embedDialogContent.pcss
+++ b/app/src/userpages/components/ShareDialog/EmbedDialogContent/embedDialogContent.pcss
@@ -17,7 +17,7 @@
 }
 
 .textarea {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: var(--mono);
   color: rgb(50, 50, 50);
   font-size: 0.875rem;
   letter-spacing: 0;

--- a/app/src/userpages/components/ShareDialog/ShareDialogTabs/shareDialogTabs.pcss
+++ b/app/src/userpages/components/ShareDialog/ShareDialogTabs/shareDialogTabs.pcss
@@ -41,7 +41,7 @@
   letter-spacing: 0;
   line-height: 2rem;
   font-weight: var(--regular);
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: var(--sans);
   display: flex;
   align-items: center;
   border: 1px solid transparent;

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/newFieldEditor.pcss
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/NewFieldEditor/newFieldEditor.pcss
@@ -33,7 +33,7 @@
     background-color: white;
     color: #323232;
     min-width: 128px;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     text-transform: capitalize;
     font-weight: 400;
     font-size: 14px;

--- a/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/ConfigureView/configureView.pcss
@@ -83,7 +83,7 @@
     color: #323232 !important;
     height: 32px;
     min-width: 128px;
-    font-family: 'IBM Plex Sans', sans-serif;
+    font-family: var(--sans);
     text-transform: capitalize;
     font-weight: 400;
     font-size: 14px;


### PR DESCRIPTION
Google blocked in china so the app seems to get stuck waiting for google analytics/fonts.

update: might not be fully *blocked*, but app still blocked for an unreasonable amount of time waiting on fonts.

Took these out of the `head` so they don't block, this might have unwanted "flash of wrong font" effects but I can't really test. Added some fallbacks for both sans and mono fonts. @mondoreale perhaps you can take a look and help me find a good middleground? We could of course consider hosting the font files on our cdn.

If you want to test what this looks like:
* Make sure you disable any locally installed Plex Sans/Mono font
* Disable requests to https://fonts.googleapis.com in devtools
* Reload page without cache.
* Sometimes .css/.pcss files won't rebuild on changing branch, make sure to edit `src/shared/assets/stylesheets/variables.css` and/or `src/shared/assets/stylesheets/index.js`

Might also want to do something similar for https://streamr.network/