### PR TITLE
[PLATFORM-760] Move charset declaration to top of index.html 

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-
 <% const title = 'Streamr Core' %>
 <% const description = 'Data done differently' %>
-
 <html>
 <head>
+    <meta charset="UTF-8">
     <title><%= title %></title>
 
     <link href="https://streamr.network/resources/favicon-16x16.png" rel="icon" size="16" type="image/png">
@@ -21,7 +20,6 @@
     <link href="https://streamr.network/resources/apple-icon-180x180.png" rel="apple-touch-icon" size="180" type="image/png">
     <link href="https://streamr.network/resources/android-icon-192x192.png" rel="icon" size="192" type="image/png">
 
-    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="<%= description %>">
     <meta property="og:title" content="<%= title %>">


### PR DESCRIPTION
Moved before `title`, which helps ensure `charset` meta tag exists within first 1024 bytes.

![image](https://user-images.githubusercontent.com/43438/70609538-eb543000-1c3c-11ea-907a-f42777b75eba.png)

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset


