### PR TITLE
Fix dupped keys in SecurityView’s slider

### DIFF
--- a/app/src/userpages/components/StreamPage/Show/SecurityView/Slider.jsx
+++ b/app/src/userpages/components/StreamPage/Show/SecurityView/Slider.jsx
@@ -82,7 +82,8 @@ export default function Slider({ index: selectedIndex = 0, selector } = {}) {
             >
                 {positions.positions.map((p, index) => (
                     <div
-                        key={p.left}
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={index}
                         className={cx(styles.SliderStop, {
                             [styles.highlighted]: index <= selectedIndex,
                             [styles.selected]: index === selectedIndex,


### PR DESCRIPTION
Quick little thing. `getBoundingClientRect` gives an object with zeros when the slider is invisible (mobile). `p.left` is a 0 for all positions.