### PR TITLE
[PLATFORM-1144] Add unit support for storage days

### DIFF
--- a/app/src/shared/components/FormControl/formControl.pcss
+++ b/app/src/shared/components/FormControl/formControl.pcss
@@ -46,5 +46,5 @@
 
 .withLabelSpace {
   margin-top: 1.5rem;
-  max-width: 488px;
+  max-width: 536px;
 }

--- a/app/src/shared/components/TextField/index.jsx
+++ b/app/src/shared/components/TextField/index.jsx
@@ -8,7 +8,7 @@ import TextFieldWithActions from './TextFieldWithActions'
 import styles from './textField.pcss'
 
 type Props = {
-    className?: string,
+    className?: ?string,
     onAutoComplete?: (boolean) => void,
     type?: string,
     actions?: Array<any>,

--- a/app/src/shared/components/TextInput/index.jsx
+++ b/app/src/shared/components/TextInput/index.jsx
@@ -43,6 +43,7 @@ const TextInput = ({
             return (
                 <TextField
                     {...rest}
+                    className={className}
                     value={value}
                     onBlur={onBlur}
                     onFocus={onFocus}

--- a/app/src/shared/i18n/en.po
+++ b/app/src/shared/i18n/en.po
@@ -232,6 +232,30 @@ msgstr "No data yet"
 msgid "shared##status##error"
 msgstr "Inactive"
 
+msgid "shared##date##day"
+msgstr "Day"
+
+msgid "shared##date##day_plural"
+msgstr "Days"
+
+msgid "shared##date##week"
+msgstr "Week"
+
+msgid "shared##date##week_plural"
+msgstr "Weeks"
+
+msgid "shared##date##month"
+msgstr "Month"
+
+msgid "shared##date##month_plural"
+msgstr "Months"
+
+msgid "shared##date##year"
+msgstr "Year"
+
+msgid "shared##date##year_plural"
+msgstr "Years"
+
 msgid "general##docs"
 msgstr "Docs"
 

--- a/app/src/shared/i18n/en.po
+++ b/app/src/shared/i18n/en.po
@@ -167,6 +167,9 @@ msgstr "https://streamr.network/whitepaper"
 msgid "modal##common##cancel"
 msgstr "Cancel"
 
+msgid "modal##common##confirm"
+msgstr "Confirm"
+
 msgid "modal##common##continue"
 msgstr "Continue"
 

--- a/app/src/userpages/components/KeyField/keyField.pcss
+++ b/app/src/userpages/components/KeyField/keyField.pcss
@@ -1,6 +1,5 @@
 .container {
   position: relative;
-  max-width: 488px;
 }
 
 .withMenu {

--- a/app/src/userpages/components/SplitControl/splitControl.pcss
+++ b/app/src/userpages/components/SplitControl/splitControl.pcss
@@ -1,6 +1,6 @@
 .root {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(auto, 488px) 130px;
-  grid-column-gap: 3rem;
+  grid-template-columns: minmax(auto, 536px) 130px;
+  grid-column-gap: 1rem;
 }

--- a/app/src/userpages/components/StreamPage/ConfirmCsvImportDialog/confirmCsvImportDialog.pcss
+++ b/app/src/userpages/components/StreamPage/ConfirmCsvImportDialog/confirmCsvImportDialog.pcss
@@ -20,10 +20,5 @@
 }
 
 .customInput {
-  :global(label),
-  :global(.shared_underline_root),
-  :global(.shared_underline_root::after),
-  :global(.shared_underline_root::before) {
-    z-index: 0;
-  }
+  margin-bottom: 1rem;
 }

--- a/app/src/userpages/components/StreamPage/ConfirmCsvImportDialog/index.jsx
+++ b/app/src/userpages/components/StreamPage/ConfirmCsvImportDialog/index.jsx
@@ -144,7 +144,7 @@ export class ConfirmCsvImportView extends Component<Props, State> {
     }
 
     render() {
-        const { csvUploadState, onClose } = this.props
+        const { csvUploadState, onClose, errorMessage } = this.props
         const {
             dateFormat,
             dateSelector,
@@ -188,6 +188,7 @@ export class ConfirmCsvImportView extends Component<Props, State> {
                                 value={timestampColumnSelector || headers[0]}
                                 onChange={this.onTimestampColumnIndexChange}
                                 required
+                                preserveLabelSpace
                             />
                         </div>
 
@@ -206,7 +207,9 @@ export class ConfirmCsvImportView extends Component<Props, State> {
                                 }
                                 value={dateSelector}
                                 onChange={(value) => this.onDateFormatChange(value)}
+                                error={errorMessage || ''}
                                 required
+                                preserveLabelSpace
                             />
                             {dateFormat && dateFormats[dateFormat] && (
                                 <span className={styles.helpText}>

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/historyView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/historyView.pcss
@@ -99,3 +99,7 @@
   grid-template-columns: 5rem 11rem;
   grid-column-gap: 1rem;
 }
+
+.storageAmount {
+  text-align: center;
+}

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/historyView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/historyView.pcss
@@ -2,9 +2,11 @@
   max-width: 682px;
 }
 
-.fileUpload {
-  margin-bottom: 3rem;
+.row {
+  margin-bottom: 1rem;
+}
 
+.fileUpload {
   &:--enter {
     cursor: pointer !important;
 
@@ -90,4 +92,10 @@
 .historicalStoragePeriod {
   margin: 2em 0 1em;
   display: block;
+}
+
+.storageContainer {
+  display: grid;
+  grid-template-columns: 5rem 11rem;
+  grid-column-gap: 1rem;
 }

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
@@ -84,6 +84,7 @@ class HistoryView extends Component<Props, State> {
 
     componentDidMount() {
         this.mounted = true
+        this.loadData()
     }
 
     componentWillUnmount() {
@@ -202,10 +203,10 @@ class HistoryView extends Component<Props, State> {
                 .then(() => {
                     this.closeConfigurationModal()
                 })
-                .catch(() => {
+                .catch((error) => {
                     if (this.mounted) {
                         this.setState({
-                            confirmError: I18n.t('userpages.streams.edit.history.parseError'),
+                            confirmError: error.message || I18n.t('userpages.streams.edit.history.parseError'),
                         })
                     }
                     // Backend will destroy file reference on error

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
@@ -385,7 +385,7 @@ class HistoryView extends Component<Props, State> {
                             kind="secondary"
                             className={styles.deleteButton}
                             onClick={() => this.deleteDataUpTo(streamId, deleteDate)}
-                            disabled={deleteDate == null || disabled}
+                            disabled={deleteDate == null || disabled || deleteInProgress}
                         >
                             <Translate value="userpages.streams.edit.history.deleteRange" />
                             {deleteInProgress &&

--- a/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/HistoryView/index.jsx
@@ -72,12 +72,32 @@ const DropTarget = ({ mouseOver }: { mouseOver: boolean }) => (
     </div>
 )
 
-const convertFromStorageDays = (days: number) => ({
-    amount: (days % 30 === 0) ? days / 30 : days,
-    unit: (days % 30 === 0) ? 'months' : 'days',
-})
+const convertFromStorageDays = (days: number) => {
+    let amount = days
+    let unit = 'days'
 
-const convertToStorageDays = (amount: number, unit: string) => (unit === 'days' ? amount : amount * 30)
+    if (days % 30 === 0) {
+        amount = days / 30
+        unit = 'months'
+    } else if (days % 7 === 0) {
+        amount = days / 7
+        unit = 'weeks'
+    }
+
+    return {
+        amount,
+        unit,
+    }
+}
+
+const convertToStorageDays = (amount: number, unit: string) => {
+    if (unit === 'months') {
+        return amount * 30
+    } else if (unit === 'weeks') {
+        return amount * 7
+    }
+    return amount
+}
 
 class HistoryView extends Component<Props, State> {
     state = {
@@ -288,11 +308,15 @@ class HistoryView extends Component<Props, State> {
         const unitOptions: Array<any> = [
             {
                 value: 'days',
-                label: I18n.t('userpages.streams.inactivityDays'),
+                label: I18n.t('shared.date.day', { count: storageAmount }),
+            },
+            {
+                value: 'weeks',
+                label: I18n.t('shared.date.week', { count: storageAmount }),
             },
             {
                 value: 'months',
-                label: I18n.t('userpages.streams.inactivityMonths'),
+                label: I18n.t('shared.date.month', { count: storageAmount }),
             },
         ]
 
@@ -374,9 +398,9 @@ class HistoryView extends Component<Props, State> {
                     </SplitControl>
                 )}
                 {stream && stream.storageDays !== undefined &&
-                    <div className={styles.storageContainer}>
+                    <div className={cx(styles.row, styles.storageContainer)}>
                         <TextInput
-                            className={styles.row}
+                            className={styles.storageAmount}
                             label={I18n.t('userpages.streams.edit.configure.historicalStoragePeriod.label')}
                             value={storageAmount}
                             onChange={this.onStorageAmountChange}

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -356,11 +356,8 @@ msgstr "Waiting..."
 msgid "userpages##streams##edit##configure##requireSignedData"
 msgstr "Require all messages in this stream to be signed"
 
-msgid "userpages##streams##edit##configure##historicalStoragePeriod##description"
-msgstr "Please select how long your historical data is retained before it is automatically removed from the system."
-
 msgid "userpages##streams##edit##configure##historicalStoragePeriod##label"
-msgstr "Historical data storage period (days)"
+msgstr "Period to retain historical data until auto-removal"
 
 msgid "userpages##streams##edit##preview##description"
 msgstr "This stream's most recent data is shown here live. Use the Inspector to view the full details of the messages."
@@ -471,6 +468,9 @@ msgstr "Hours"
 
 msgid "userpages##streams##inactivityDays"
 msgstr "Days"
+
+msgid "userpages##streams##inactivityMonths"
+msgstr "Months"
 
 msgid "userpages##streams##inactivityLabel"
 msgstr "Inactivity threshold"

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -469,9 +469,6 @@ msgstr "Hours"
 msgid "userpages##streams##inactivityDays"
 msgstr "Days"
 
-msgid "userpages##streams##inactivityMonths"
-msgstr "Months"
-
 msgid "userpages##streams##inactivityLabel"
 msgstr "Inactivity threshold"
 

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -422,6 +422,9 @@ msgstr "Drop your .CSV file here to upload"
 msgid "userpages##streams##edit##history##saveFirst"
 msgstr "Cannot add historical data to a stream that has not been saved yet. Please save your changes and try again."
 
+msgid "userpages##streams##edit##history##parseError"
+msgstr "Could not parse timestamp column"
+
 msgid "userpages##streams##edit##history##confirmCsv##title"
 msgstr "Clarify the CSV file fields"
 

--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -500,10 +500,6 @@ export const uploadCsvFile = (id: StreamId, file: File) => (dispatch: Function) 
         .catch((error) => {
             const e = getError(error)
             dispatch(uploadCsvFileFailure(e))
-            Notification.push({
-                title: e.message,
-                icon: NotificationIcon.ERROR,
-            })
             throw error
         })
 }
@@ -520,10 +516,6 @@ export const confirmCsvFileUpload = (id: StreamId, fileUrl: string, dateFormat: 
         })
         .catch((e) => {
             dispatch(confirmCsvFileUploadFailure(e))
-            Notification.push({
-                title: e.message,
-                icon: NotificationIcon.ERROR,
-            })
             throw e
         })
 }

--- a/app/src/userpages/modules/userPageStreams/reducer.js
+++ b/app/src/userpages/modules/userPageStreams/reducer.js
@@ -55,6 +55,7 @@ const initialState = {
     },
     savingStreamFields: false,
     fetching: false,
+    deleting: false,
     error: null,
     csvUpload: null,
     editedStream: null,
@@ -74,7 +75,6 @@ export default function (state: UserPageStreamsState = initialState, action: Str
         case UPDATE_STREAM_REQUEST:
         case GET_MY_STREAM_PERMISSIONS_REQUEST:
         case DELETE_STREAM_REQUEST:
-        case DELETE_DATA_UP_TO_REQUEST:
             return {
                 ...state,
                 fetching: true,
@@ -282,10 +282,16 @@ export default function (state: UserPageStreamsState = initialState, action: Str
             }
         }
 
+        case DELETE_DATA_UP_TO_REQUEST:
+            return {
+                ...state,
+                deleting: true,
+            }
+
         case DELETE_DATA_UP_TO_SUCCESS: {
             return {
                 ...state,
-                fetching: false,
+                deleting: false,
                 deleteDataError: null,
             }
         }
@@ -293,7 +299,7 @@ export default function (state: UserPageStreamsState = initialState, action: Str
         case DELETE_DATA_UP_TO_FAILURE: {
             return {
                 ...state,
-                fetching: false,
+                deleting: false,
                 deleteDataError: action.error,
             }
         }


### PR DESCRIPTION
Add unit selection for storage period (this still gets stored as days on the backend).

Also did some fixes for CSV upload process. I removed invisible toast notifications (because of modal) and moved the error messages to the input element instead.

This seems to include same fixes Juha implemented in https://github.com/streamr-dev/streamr-platform/pull/808 already but they shouldn't be an issue.