### PR TITLE
[PLATFORM-1186] Fix partition field

### DIFF
--- a/app/src/shared/components/TextField/NumberField/index.jsx
+++ b/app/src/shared/components/TextField/NumberField/index.jsx
@@ -15,6 +15,7 @@ type Props = {
     max?: number,
     step?: number,
     hideButtons?: boolean,
+    onChange?: (SyntheticInputEvent<EventTarget>) => void,
 }
 
 const NumberField = ({
@@ -25,13 +26,18 @@ const NumberField = ({
     max,
     step,
     hideButtons,
+    onChange: onChangeProp,
     ...props
 }: Props) => {
     const [internalValue, setInternalValue] = useState(value)
 
     const onChange = useCallback((event: SyntheticInputEvent<EventTarget>) => {
         setInternalValue(event.target.value)
-    }, [])
+
+        if (onChangeProp) {
+            onChangeProp(event)
+        }
+    }, [onChangeProp])
 
     const addValue = useCallback((val) => {
         let parsedValue = Number.parseFloat(internalValue != null ? internalValue : '')

--- a/app/src/shared/components/TextInput/index.jsx
+++ b/app/src/shared/components/TextInput/index.jsx
@@ -7,24 +7,49 @@ import TextField from '../TextField'
 
 type Props = FormControlProps & {
     className?: ?string,
+    onBlur?: (SyntheticInputEvent<EventTarget>) => void,
+    onFocus?: (SyntheticInputEvent<EventTarget>) => void,
 }
 
-const TextInput = ({ label, className, passwordStrengthUpdate, ...props }: Props) => (
+const TextInput = ({
+    label,
+    className,
+    passwordStrengthUpdate,
+    onBlur: onBlurProp,
+    onFocus: onFocusProp,
+    ...props
+}: Props) => (
     <FormControl
         {...props}
         passwordStrengthUpdate={passwordStrengthUpdate}
         label={label}
         noUnderline
     >
-        {({ value, onFocusChange, setAutoCompleted, ...rest }) => (
-            <TextField
-                {...rest}
-                value={value}
-                onBlur={onFocusChange}
-                onFocus={onFocusChange}
-                onAutoComplete={setAutoCompleted}
-            />
-        )}
+        {({ value, onFocusChange: onFocusChangeProp, setAutoCompleted, ...rest }) => {
+            const onBlur = (...args) => {
+                onFocusChangeProp(...args)
+                if (onBlurProp) {
+                    onBlurProp(...args)
+                }
+            }
+
+            const onFocus = (...args) => {
+                onFocusChangeProp(...args)
+                if (onFocusProp) {
+                    onFocusProp(...args)
+                }
+            }
+
+            return (
+                <TextField
+                    {...rest}
+                    value={value}
+                    onBlur={onBlur}
+                    onFocus={onFocus}
+                    onAutoComplete={setAutoCompleted}
+                />
+            )
+        }}
     </FormControl>
 )
 


### PR DESCRIPTION
2 bugs here:
1. Not being able to override TextInput's `onBlur` and `onFocus`, and
2. `NumberField` not pushing changes to its parents when requested (unable to override `onChange`).

Both fixed.

Other known issues:

`+` and `-` buttons on the `NumberField` don't trigger `onChange`.