### PR TITLE
[PLATFORM-1193] Drop momentjs locales from the build

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -188,6 +188,8 @@ module.exports = {
                 openAnalyzer: false,
             }),
         ] : []),
+        // Ignore all locale files of moment.js
+        new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     ].concat(isProduction() ? [
         new CleanWebpackPlugin([dist]),
         // Production plugins


### PR DESCRIPTION
I would argue that they don't bring enough value given this is an English app.

**Before:**
<img width="331" alt="Screenshot 2020-01-03 at 15 12 40" src="https://user-images.githubusercontent.com/1593398/71725491-c79b9880-2e3c-11ea-8acd-2b527cd931a0.png">

**After:**
<img width="335" alt="Screenshot 2020-01-03 at 15 09 53" src="https://user-images.githubusercontent.com/1593398/71725504-d1bd9700-2e3c-11ea-8fb8-21496f5cfcb8.png">
