### PR TITLE
[PLATFORM-1189] Handle key loading failures

### DIFF
--- a/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
@@ -12,6 +12,8 @@ import type { StoreState } from '$shared/flowtype/store-state'
 import type { ResourceKeyId, ResourceKey, ResourcePermission } from '$shared/flowtype/resource-key-types'
 import { addStreamResourceKey, editStreamResourceKey, removeStreamResourceKey, getStreamResourceKeys } from '$shared/modules/resourceKey/actions'
 import { selectOpenStreamId, selectOpenStreamResourceKeys } from '$userpages/modules/userPageStreams/selectors'
+import Notification from '$shared/utils/Notification'
+import { NotificationIcon } from '$shared/utils/constants'
 
 import PermissionCredentialsControl from './PermissionCredentialsControl'
 
@@ -47,9 +49,19 @@ export class KeyView extends Component<Props> {
         }
     }
 
-    getKeys = () => {
-        if (this.props.disabled || this.props.streamId == null) { return }
-        this.props.getKeys(this.props.streamId)
+    getKeys = async () => {
+        const { disabled, streamId, getKeys } = this.props
+
+        if (disabled || streamId == null) { return }
+        try {
+            await getKeys(streamId)
+        } catch (error) {
+            Notification.push({
+                title: 'Loading keys failed.',
+                icon: NotificationIcon.ERROR,
+                error,
+            })
+        }
     }
 
     addKey = async (keyName: string, permission: ?ResourcePermission): Promise<void> => {
@@ -102,7 +114,7 @@ export const mapStateToProps = (state: StoreState): StateProps => ({
 
 export const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
     getKeys(streamId: StreamId) {
-        dispatch(getStreamResourceKeys(streamId))
+        return dispatch(getStreamResourceKeys(streamId))
     },
     addKey(streamId: StreamId, keyName: string, keyPermission: ResourcePermission) {
         return dispatch(addStreamResourceKey(streamId, keyName, keyPermission))

--- a/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
@@ -38,7 +38,10 @@ type DispatchProps = {
 type Props = DispatchProps & OwnProps & StateProps
 
 export class KeyView extends Component<Props> {
+    mounted: boolean = false
+
     componentDidMount() {
+        this.mounted = true
         this.getKeys()
     }
 
@@ -49,6 +52,10 @@ export class KeyView extends Component<Props> {
         }
     }
 
+    componentWillUnmount() {
+        this.mounted = false
+    }
+
     getKeys = async () => {
         const { disabled, streamId, getKeys } = this.props
 
@@ -56,11 +63,13 @@ export class KeyView extends Component<Props> {
         try {
             await getKeys(streamId)
         } catch (error) {
-            Notification.push({
-                title: 'Loading keys failed.',
-                icon: NotificationIcon.ERROR,
-                error,
-            })
+            if (this.mounted) {
+                Notification.push({
+                    title: 'Loading keys failed.',
+                    icon: NotificationIcon.ERROR,
+                    error,
+                })
+            }
         }
     }
 

--- a/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/KeyView/index.jsx
@@ -40,6 +40,8 @@ type Props = DispatchProps & OwnProps & StateProps
 export class KeyView extends Component<Props> {
     mounted: boolean = false
 
+    getKeysRequestCount = 0
+
     componentDidMount() {
         this.mounted = true
         this.getKeys()
@@ -59,11 +61,16 @@ export class KeyView extends Component<Props> {
     getKeys = async () => {
         const { disabled, streamId, getKeys } = this.props
 
+        this.getKeysRequestCount += 1
+
         if (disabled || streamId == null) { return }
+
+        const numRequests = this.getKeysRequestCount
+
         try {
             await getKeys(streamId)
         } catch (error) {
-            if (this.mounted) {
+            if (this.mounted && numRequests === this.getKeysRequestCount) {
                 Notification.push({
                     title: 'Loading keys failed.',
                     icon: NotificationIcon.ERROR,

--- a/app/src/userpages/components/StreamPage/Show/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/index.jsx
@@ -151,6 +151,7 @@ export class StreamShowView extends Component<Props, State> {
             isFetching,
         } = this.props
         const hasWritePermission = (permissions && permissions.some((p) => p === 'write')) || false
+        const hasSharePermission = (permissions && permissions.some((p) => p === 'share')) || false
         const isLoading = !!(!editedStream || isFetching)
         const disabled = !!(isLoading || !hasWritePermission)
 
@@ -250,7 +251,7 @@ export class StreamShowView extends Component<Props, State> {
                             title="API Access"
                             customStyled
                         >
-                            <KeyView disabled={disabled} />
+                            <KeyView disabled={disabled || !hasSharePermission} />
                         </TOCPage.Section>
                         <TOCPage.Section
                             id="historical-data"


### PR DESCRIPTION
In this PR I make the app notify about key loading failures, altho I'm not sure if this is the best way. Normally it wouldn't be a failure. It simply wouldn't show (?) sections a user can't modify, I guess.

Any suggestions on how to make it better?