### PR TITLE
[PLATFORM-1188] Pre-fill recipient ETH address

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -108,11 +108,21 @@ const BeneficiaryAddress = ({
 
     const [focused, setFocused] = useState(false)
 
+    const [ownAddress, setOwnAddress] = useState(addressProp || '')
+
+    useEffect(() => {
+        setOwnAddress(addressProp || '')
+    }, [addressProp])
+
+    const onOwnAddressChange = useCallback((e: SyntheticInputEvent<EventTarget>) => {
+        setOwnAddress(e.target.value)
+    }, [])
+
     const address: string = useMemo(() => (
-        focused ? (addressProp || '') : truncate(addressProp || '', {
+        focused ? ownAddress : truncate(ownAddress, {
             maxLength: 30,
         })
-    ), [focused, addressProp])
+    ), [focused, ownAddress])
 
     const onFocus = useCallback((e: SyntheticFocusEvent<EventTarget>) => {
         setFocused(true)
@@ -166,10 +176,12 @@ const BeneficiaryAddress = ({
                     ]}
                 >
                     <Text
+                        key={addressProp}
                         id="beneficiaryAddress"
                         autoComplete="off"
-                        defaultValue={address}
+                        value={address}
                         onCommit={onChange}
+                        onChange={onOwnAddressChange}
                         placeholder={I18n.t('editProductPage.setPrice.placeholder.enterEthAddress')}
                         invalid={invalid}
                         disabled={disabled}

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -146,7 +146,7 @@ const BeneficiaryAddress = ({
                             onClick={useCurrentWalletAddress}
                             disabled={!accountAddress}
                         >
-                            <AddressItem name="wallet address" address={accountAddress} />
+                            <AddressItem name="wallet address" address={accountAddress || 'Wallet locked'} />
                         </DropdownActions.Item>,
                         ...integrationKeysFiltered.map(({ id, name, json }) => (
                             <DropdownActions.Item

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -150,6 +150,7 @@ const BeneficiaryAddress = ({
                     <Translate value="editProductPage.setPrice.setRecipientEthAddress" />
                 </strong>
                 <ActionsDropdown
+                    disabled={disabled}
                     actions={[
                         <DropdownActions.Item
                             key="useCurrent"

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -4,6 +4,7 @@ import React, { useContext, Fragment, useCallback, useEffect, useMemo } from 're
 import cx from 'classnames'
 import { Translate, I18n } from 'react-redux-i18n'
 import { useSelector, useDispatch } from 'react-redux'
+import styled from 'styled-components'
 
 import useValidation from '../ProductController/useValidation'
 import Text from '$ui/Text'
@@ -29,6 +30,31 @@ type Props = {
 }
 
 const EMPTY = []
+
+type AddressItemProps = {
+    address?: ?string,
+    className?: ?string,
+    name: string,
+}
+
+const UnstyledAddressItem = ({ className, name, address }: AddressItemProps) => (
+    <Fragment>
+        {`Fill ${name}`}
+        {!!address && (
+            <div className={className}>
+                {truncate(address, {
+                    maxLength: 15,
+                })}
+            </div>
+        )}
+    </Fragment>
+)
+
+const AddressItem = styled(UnstyledAddressItem)`
+    color: #adadad;
+    font-size: 10px;
+    margin-top: -16px;
+`
 
 const BeneficiaryAddress = ({ address, onChange, disabled, className }: Props) => {
     const { isValid, message } = useValidation('beneficiaryAddress')
@@ -83,19 +109,16 @@ const BeneficiaryAddress = ({ address, onChange, disabled, className }: Props) =
                             onClick={useCurrentWalletAddress}
                             disabled={!accountAddress}
                         >
-                            Use current wallet address
+                            <AddressItem name="wallet address" address={accountAddress} />
                         </DropdownActions.Item>,
                         ...integrationKeysFiltered.map(({ id, name, json }) => (
                             <DropdownActions.Item
                                 key={id}
                                 onClick={() => onChange(json.address)}
                             >
-                                {`Use ${truncate(json.address, {
-                                    maxLength: 15,
-                                })} (${name})`}
+                                <AddressItem name={name} address={json.address} />
                             </DropdownActions.Item>
                         )),
-                        <DropdownActions.Item key="divider" divider />,
                         <DropdownActions.Item
                             key="copy"
                             disabled={!address}

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useContext, Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useContext, Fragment, useCallback, useEffect, useMemo } from 'react'
 import cx from 'classnames'
 import { Translate, I18n } from 'react-redux-i18n'
 import { useSelector, useDispatch } from 'react-redux'

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -95,9 +95,7 @@ const BeneficiaryAddress = ({ address, onChange, disabled, className }: Props) =
                                 })} (${name})`}
                             </DropdownActions.Item>
                         )),
-                        (integrationKeysFiltered.length > 0 && (
-                            <DropdownActions.Item key="divider" divider />
-                        )),
+                        <DropdownActions.Item key="divider" divider />,
                         <DropdownActions.Item
                             key="copy"
                             disabled={!address}

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useState, useCallback, useContext } from 'react'
+import React, { useState, useCallback, useContext, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
 import { Translate } from 'react-redux-i18n'
@@ -13,6 +13,7 @@ import RadioButtonGroup from '$shared/components/RadioButtonGroup'
 import SetPrice from '$mp/components/SetPrice'
 import Toggle from '$shared/components/Toggle'
 import { selectContractProduct } from '$mp/modules/contractProduct/selectors'
+import useAccountAddress from '$shared/hooks/useAccountAddress'
 
 import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
 import useEditableProduct from '../ProductController/useEditableProduct'
@@ -64,6 +65,14 @@ const PriceSelector = () => {
     const isFreeProduct = !!product.isFree
 
     const { isValid, message } = useValidation('pricePerSecond')
+
+    const accountAddress = useAccountAddress()
+
+    useEffect(() => {
+        if (!product.beneficiaryAddress && accountAddress) {
+            updateBeneficiaryAddress(accountAddress)
+        }
+    }, [product.beneficiaryAddress, updateBeneficiaryAddress, accountAddress])
 
     return (
         <section id="price" className={cx(styles.root, styles.PriceSelector)}>

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useState, useCallback, useContext, useEffect } from 'react'
+import React, { useState, useCallback, useContext } from 'react'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
 import { Translate } from 'react-redux-i18n'
@@ -13,7 +13,6 @@ import RadioButtonGroup from '$shared/components/RadioButtonGroup'
 import SetPrice from '$mp/components/SetPrice'
 import Toggle from '$shared/components/Toggle'
 import { selectContractProduct } from '$mp/modules/contractProduct/selectors'
-import useAccountAddress from '$shared/hooks/useAccountAddress'
 
 import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
 import useEditableProduct from '../ProductController/useEditableProduct'
@@ -65,14 +64,6 @@ const PriceSelector = () => {
     const isFreeProduct = !!product.isFree
 
     const { isValid, message } = useValidation('pricePerSecond')
-
-    const accountAddress = useAccountAddress()
-
-    useEffect(() => {
-        if (!product.beneficiaryAddress && accountAddress) {
-            updateBeneficiaryAddress(accountAddress)
-        }
-    }, [product.beneficiaryAddress, updateBeneficiaryAddress, accountAddress])
 
     return (
         <section id="price" className={cx(styles.root, styles.PriceSelector)}>

--- a/app/src/shared/components/ActionsDropdown.jsx
+++ b/app/src/shared/components/ActionsDropdown.jsx
@@ -20,10 +20,11 @@ const ActionContainer = styled.div`
 
 type Props = {
     actions?: Array<typeof DropdownActions.Item>,
+    disabled?: boolean,
     children?: Node,
 }
 
-const UnstyledActionsDropdown = ({ actions, children = null, ...props }: Props) => {
+const UnstyledActionsDropdown = ({ actions, disabled, children = null, ...props }: Props) => {
     const [open, setOpen]: UseStateTuple<boolean> = useState(false)
 
     return !actions || !actions.length ? (
@@ -33,6 +34,7 @@ const UnstyledActionsDropdown = ({ actions, children = null, ...props }: Props) 
             {children}
             <ActionContainer open={open}>
                 <DropdownActions
+                    disabled={disabled}
                     title={(
                         <Meatball alt="Actions" gray />
                     )}

--- a/app/src/shared/components/Ui/Text/SelectAllOnFocusDecorator.jsx
+++ b/app/src/shared/components/Ui/Text/SelectAllOnFocusDecorator.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { type ComponentType, useCallback, forwardRef } from 'react'
+import useIsMounted from '$shared/hooks/useIsMounted'
 
 export type Props = {
     selectAllOnFocus?: boolean,
@@ -9,15 +10,21 @@ export type Props = {
 
 const SelectAllOnFocusDecorator = (WrappedComponent: ComponentType<any>) => {
     const SelectAllOnFocusDecoratorWrapper = ({ onFocus: onFocusProp, ...props }: Props, ref: any) => {
+        const isMounted = useIsMounted()
+
         const onFocus = useCallback((e: SyntheticFocusEvent<EventTarget>) => {
-            if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
-                e.target.select()
-            }
+            e.persist()
+
+            setTimeout(() => {
+                if (isMounted() && (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement)) {
+                    e.target.select()
+                }
+            }, 0)
 
             if (onFocusProp) {
                 onFocusProp(e)
             }
-        }, [onFocusProp])
+        }, [onFocusProp, isMounted])
 
         return (
             <WrappedComponent

--- a/app/src/shared/hooks/useAccountAddress.js
+++ b/app/src/shared/hooks/useAccountAddress.js
@@ -1,0 +1,29 @@
+// @flow
+
+import { useState, useEffect } from 'react'
+import { getWeb3 } from '$shared/web3/web3Provider'
+import Web3Poller from '$shared/web3/web3Poller'
+
+export default (): ?string => {
+    const [address, setAddress] = useState()
+
+    useEffect(() => {
+        (async () => {
+            try {
+                return await getWeb3().getDefaultAccount()
+            } catch (e) {
+                return undefined
+            }
+        })().then(setAddress)
+    }, [])
+
+    useEffect(() => {
+        Web3Poller.subscribe(Web3Poller.events.ACCOUNT, setAddress)
+
+        return () => {
+            Web3Poller.unsubscribe(Web3Poller.events.ACCOUNT, setAddress)
+        }
+    }, [])
+
+    return address
+}

--- a/app/src/shared/hooks/useAccountAddress.js
+++ b/app/src/shared/hooks/useAccountAddress.js
@@ -23,10 +23,18 @@ export default (): ?string => {
             }
         })
 
+        const setLocked = () => {
+            if (isMounted()) {
+                setAddress(undefined)
+            }
+        }
+
         Web3Poller.subscribe(Web3Poller.events.ACCOUNT, setAddress)
+        Web3Poller.subscribe(Web3Poller.events.ACCOUNT_ERROR, setLocked)
 
         return () => {
             Web3Poller.unsubscribe(Web3Poller.events.ACCOUNT, setAddress)
+            Web3Poller.unsubscribe(Web3Poller.events.ACCOUNT_ERROR, setLocked)
         }
     }, [isMounted])
 

--- a/app/src/shared/hooks/useAccountAddress.js
+++ b/app/src/shared/hooks/useAccountAddress.js
@@ -3,9 +3,12 @@
 import { useState, useEffect } from 'react'
 import { getWeb3 } from '$shared/web3/web3Provider'
 import Web3Poller from '$shared/web3/web3Poller'
+import useIsMounted from '$shared/hooks/useIsMounted'
 
 export default (): ?string => {
     const [address, setAddress] = useState()
+
+    const isMounted = useIsMounted()
 
     useEffect(() => {
         (async () => {
@@ -14,7 +17,11 @@ export default (): ?string => {
             } catch (e) {
                 return undefined
             }
-        })().then(setAddress)
+        })().then((addr) => {
+            if (isMounted()) {
+                setAddress(addr)
+            }
+        })
 
         Web3Poller.subscribe(Web3Poller.events.ACCOUNT, setAddress)
 

--- a/app/src/shared/hooks/useAccountAddress.js
+++ b/app/src/shared/hooks/useAccountAddress.js
@@ -15,9 +15,7 @@ export default (): ?string => {
                 return undefined
             }
         })().then(setAddress)
-    }, [])
 
-    useEffect(() => {
         Web3Poller.subscribe(Web3Poller.events.ACCOUNT, setAddress)
 
         return () => {

--- a/app/src/shared/hooks/useAccountAddress.js
+++ b/app/src/shared/hooks/useAccountAddress.js
@@ -28,7 +28,7 @@ export default (): ?string => {
         return () => {
             Web3Poller.unsubscribe(Web3Poller.events.ACCOUNT, setAddress)
         }
-    }, [])
+    }, [isMounted])
 
     return address
 }


### PR DESCRIPTION
I created another hook – `useAccountAddress`. It returns the address of the current eth account. This way may be different to what we used to do for the previous version of the creator. I didn't want to spend too much time digging that up.

lmk if you have any suggestions!

Demo:

![Jan-07-2020 14-33-56](https://user-images.githubusercontent.com/320066/71901034-553df780-315f-11ea-9941-6cc40b950a58.gif)
