### PR TITLE
[PLATFORM-1187] Redirect back to the creator after successful login

### DIFF
--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -15,6 +15,7 @@ import StreamPreviewPage from '$mp/containers/StreamPreviewPage'
 import EditProductPage from '$mp/containers/deprecated/EditProductPage'
 import EditProductPage2 from '$mp/containers/EditProductPage'
 import Products from '$mp/containers/Products'
+import NewProductPage from '$mp/components/NewProductPage'
 
 // Auth
 import SessionProvider from '$auth/components/SessionProvider'
@@ -163,6 +164,7 @@ const MarketplaceRouter = () => (process.env.COMMUNITY_PRODUCTS ? [
     <Route exact path={marketplace.main} component={Products} key="Products" />,
     <Route exact path={formatPath(marketplace.products, ':id', 'streamPreview', ':streamId')} component={StreamPreviewPage} key="StreamPreview" />,
     <Route exact path={formatPath(marketplace.products, ':id')} component={ProductPage2} key="ProductPage2" />,
+    <Route exact path={routes.newProduct()} component={NewProductPage} key="NewProductPage" />,
 ] : [
     <Route exact path={marketplace.main} component={Products} key="Products" />,
     <Route exact path={links.marketplace.createProduct} component={CreateProductAuth} key="CreateProduct" />,

--- a/app/src/marketplace/components/ErrorPageView/index.jsx
+++ b/app/src/marketplace/components/ErrorPageView/index.jsx
@@ -53,7 +53,7 @@ const ErrorPageView = () => (
                 kind="special"
                 tag={Link}
                 to={links.userpages.products}
-                className="d-none d-md-inline-block"
+                className="d-none d-md-flex"
             >
                 <Translate value="general.products" />
             </Button>

--- a/app/src/marketplace/components/NewProductPage.jsx
+++ b/app/src/marketplace/components/NewProductPage.jsx
@@ -1,0 +1,63 @@
+// @flow
+
+import React, { useEffect, useState } from 'react'
+import { type Location } from 'react-router-dom'
+import styled from 'styled-components'
+import qs from 'query-string'
+import { useDispatch } from 'react-redux'
+import { replace } from 'connected-react-router'
+import { postEmptyProduct } from '$mp/modules/deprecated/editProduct/services'
+import LoadingIndicator from '$userpages/components/LoadingIndicator'
+import routes from '$routes'
+import { type ProductType } from '$mp/flowtype/product-types'
+import useIsMounted from '$shared/hooks/useIsMounted'
+import { productTypes } from '$mp/utils/constants'
+
+type Props = {
+    className?: ?string,
+    location: Location,
+}
+
+const sanitizedType = (type: ?string): ProductType => (
+    productTypes[(type || '').toUpperCase()] || productTypes.NORMAL
+)
+
+const UnstyledNewProductPage = ({ className, location: { search } }: Props) => {
+    const dispatch = useDispatch()
+
+    const isMounted = useIsMounted()
+
+    const [error, setError] = useState()
+
+    useEffect(() => {
+        const { type } = qs.parse(search)
+
+        postEmptyProduct(sanitizedType(type))
+            .then(({ id }) => {
+                if (isMounted()) {
+                    dispatch(replace(routes.editProduct({
+                        id,
+                    })))
+                }
+            })
+            .catch(setError)
+    }, [dispatch, isMounted, search])
+
+    useEffect(() => {
+        if (error) {
+            throw error
+        }
+    }, [error])
+
+    return (
+        <LoadingIndicator className={className} loading />
+    )
+}
+
+const NewProductPage = styled(UnstyledNewProductPage)`
+    position: absolute;
+    top: 0;
+    height: 2px;
+`
+
+export default NewProductPage

--- a/app/src/marketplace/components/NewProductPage.jsx
+++ b/app/src/marketplace/components/NewProductPage.jsx
@@ -39,8 +39,7 @@ const UnstyledNewProductPage = ({ className, location: { search } }: Props) => {
                         id,
                     })))
                 }
-            })
-            .catch(setError)
+            }, setError)
     }, [dispatch, isMounted, search])
 
     useEffect(() => {

--- a/app/src/marketplace/components/ProductTypeChooser/index.jsx
+++ b/app/src/marketplace/components/ProductTypeChooser/index.jsx
@@ -3,24 +3,23 @@
 import * as React from 'react'
 import { Translate, I18n } from 'react-redux-i18n'
 import cx from 'classnames'
+import { Link } from 'react-router-dom'
 
 import Button from '$shared/components/Button'
 import standardProductImage from '$mp/assets/product_standard.png'
 import standardProductImage2x from '$mp/assets/product_standard@2x.png'
 import communityProductImage from '$mp/assets/product_community.png'
 import communityProductImage2x from '$mp/assets/product_community@2x.png'
-import type { ProductType } from '$mp/flowtype/product-types'
 import routes from '$routes'
+import { productTypes } from '$mp/utils/constants'
 
 import styles from './productTypeChooser.pcss'
 
 type Props = {
-    onSelect: (type: ProductType) => void,
     className?: string,
-    disabled?: boolean,
 }
 
-const ProductTypeChooser = ({ onSelect, className, disabled }: Props) => (
+const ProductTypeChooser = ({ className }: Props) => (
     <div className={cx(styles.root, className)}>
         <div className={styles.pageTitle}>
             <Translate value="productTypeChooser.title" />
@@ -48,8 +47,10 @@ const ProductTypeChooser = ({ onSelect, className, disabled }: Props) => (
                     <Button
                         kind="special"
                         className={styles.button}
-                        onClick={() => onSelect('NORMAL')}
-                        disabled={disabled}
+                        tag={Link}
+                        to={routes.newProduct({
+                            type: productTypes.NORMAL,
+                        })}
                     >
                         <Translate value="productTypeChooser.standard.linkTitle" />
                     </Button>
@@ -73,8 +74,10 @@ const ProductTypeChooser = ({ onSelect, className, disabled }: Props) => (
                     <Button
                         kind="special"
                         className={styles.button}
-                        onClick={() => onSelect('COMMUNITY')}
-                        disabled={disabled}
+                        tag={Link}
+                        to={routes.newProduct({
+                            type: productTypes.COMMUNITY,
+                        })}
                     >
                         <Translate value="productTypeChooser.community.linkTitle" />
                     </Button>

--- a/app/src/marketplace/containers/CreateProductModal/createProductModal.pcss
+++ b/app/src/marketplace/containers/CreateProductModal/createProductModal.pcss
@@ -38,9 +38,3 @@
     height: 14px;
   }
 }
-
-.loadingIndicator {
-  position: absolute;
-  top: 0;
-  height: 2px;
-}

--- a/app/src/marketplace/containers/CreateProductModal/index.jsx
+++ b/app/src/marketplace/containers/CreateProductModal/index.jsx
@@ -1,19 +1,12 @@
 // @flow
 
-import React, { useCallback, useState } from 'react'
-import { useDispatch } from 'react-redux'
-import { push } from 'connected-react-router'
+import React, { useCallback } from 'react'
 
 import useModal from '$shared/hooks/useModal'
-import type { ProductType } from '$mp/flowtype/product-types'
-import { postEmptyProduct } from '$mp/modules/deprecated/editProduct/services'
 import ProductTypeChooser from '$mp/components/ProductTypeChooser'
 import ModalPortal from '$shared/components/ModalPortal'
 import ModalDialog from '$shared/components/ModalDialog'
 import SvgIcon from '$shared/components/SvgIcon'
-import LoadingIndicator from '$userpages/components/LoadingIndicator'
-import useIsMounted from '$shared/hooks/useIsMounted'
-import routes from '$routes'
 
 import styles from './createProductModal.pcss'
 
@@ -22,59 +15,23 @@ type Props = {
 }
 
 const CreateProductModal = ({ api }: Props) => {
-    const dispatch = useDispatch()
-    const isMounted = useIsMounted()
-    const [processing, setProcessing] = useState(false)
-
     const onClose = useCallback(() => {
         api.close()
     }, [api])
-
-    const createProduct = useCallback(async (type: ProductType) => {
-        setProcessing(true)
-        try {
-            const product = await postEmptyProduct(type)
-
-            if (isMounted()) {
-                setProcessing(false)
-                onClose()
-                dispatch(push(routes.editProduct({
-                    id: product.id,
-                })))
-            }
-        } catch (err) {
-            console.error('Could not create an empty product', err)
-
-            if (isMounted()) {
-                setProcessing(false)
-            }
-        }
-    }, [dispatch, isMounted, onClose])
-
-    const onTypeSelect = useCallback((type: ProductType) => {
-        createProduct(type)
-    }, [createProduct])
 
     return (
         <ModalPortal>
             <ModalDialog onClose={onClose}>
                 <div className={styles.root}>
-                    <LoadingIndicator
-                        className={styles.loadingIndicator}
-                        loading={processing}
-                    />
                     <button
                         type="button"
                         className={styles.closeButton}
                         onClick={onClose}
-                        disabled={processing}
                     >
                         <SvgIcon name="crossMedium" />
                     </button>
                     <ProductTypeChooser
-                        onSelect={onTypeSelect}
                         className={styles.chooser}
-                        disabled={processing}
                     />
                 </div>
             </ModalDialog>

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -14,6 +14,7 @@
     "contactJobs": "mailto:jobs@streamr.com",
     "contactLabs": "mailto:labs@streamr.com",
     "contactMedia": "mailto:media@streamr.com",
+    "newProduct": "/core/products/new",
     "createProduct": "/marketplace/products/create",
     "dashboardEditor": "/dashboard/editor",
     "dashboards": "/core/dashboards",

--- a/app/src/userpages/components/LoadingIndicator/index.jsx
+++ b/app/src/userpages/components/LoadingIndicator/index.jsx
@@ -9,7 +9,7 @@ import styles from './loadingIndicator.pcss'
 
 type Props = {
     loading?: boolean,
-    className?: string
+    className?: ?string
 }
 
 const LoadingIndicator = ({ loading, className }: Props) => {

--- a/app/stories/marketplace.stories.jsx
+++ b/app/stories/marketplace.stories.jsx
@@ -39,7 +39,7 @@ story('ProductList')
 
 story('ProductTypeChooser')
     .addWithJSX('basic', () => (
-        <ProductTypeChooser onSelect={() => {}} />
+        <ProductTypeChooser />
     ))
 
 story('ExpirationCounter')


### PR DESCRIPTION
Instead of creating products directly in `CreateProductModal` we now do it in `NewProductPage` component. It's a page-like component that comes with an endpoint – `/core/products/new`. This way if the product creation fails for a 403/401-reason the app takes us to the login page and, after successful login, takes us back to the product creator – plays really well with the interceptor logic we have for general unauthorized access.

If the backend creation fails for a non-auth reason the user is gonna see the generic error page instead of previous nothing.

It's subjective, of course, but I feel like this way is also much cleaner.