### PR TITLE
Give canvas toolbar its own folder

### DIFF
--- a/app/src/editor/canvas/components/Toolbar/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar/Toolbar.pcss
@@ -256,7 +256,7 @@ body .RealtimeRunButtonMenu {
   & :global(.dropdown-item):active,
   & :global(.dropdown-item):hover,
   & :global(.dropdown-item):global(.active) {
-    background: url('../../../shared/assets/images/tick.svg') no-repeat calc(100% - 14px) 50%;
+    background: url('../../../../shared/assets/images/tick.svg') no-repeat calc(100% - 14px) 50%;
     background-color: #F8F8F8;
     outline: none;
   }

--- a/app/src/editor/canvas/components/Toolbar/index.jsx
+++ b/app/src/editor/canvas/components/Toolbar/index.jsx
@@ -20,15 +20,15 @@ import UseState from '$shared/components/UseState'
 import confirmDialog from '$shared/utils/confirm'
 
 import Toolbar from '$editor/shared/components/Toolbar'
-import useCanvasCamera from '../hooks/useCanvasCamera'
-import { RunTabs } from '../state'
-import { getCanvasMessages, getMaxLevel } from '../state/messages'
+import useCanvasCamera from '../../hooks/useCanvasCamera'
+import { RunTabs } from '../../state'
+import { getCanvasMessages, getMaxLevel } from '../../state/messages'
 
-import ShareDialog from './ShareDialog'
-import CanvasSearch from './CanvasSearch'
-import * as RunController from './CanvasController/Run'
-import { useCameraContext } from './Camera'
-import { MessageIconSimple } from './ConsoleSidebar'
+import ShareDialog from '../ShareDialog'
+import CanvasSearch from '../CanvasSearch'
+import * as RunController from '../CanvasController/Run'
+import { useCameraContext } from '../Camera'
+import { MessageIconSimple } from '../ConsoleSidebar'
 import styles from './Toolbar.pcss'
 
 function ZoomControls({ className, canvas }) {

--- a/app/src/editor/dashboard/components/Toolbar.jsx
+++ b/app/src/editor/dashboard/components/Toolbar.jsx
@@ -16,7 +16,7 @@ import Toolbar from '$editor/shared/components/Toolbar'
 
 import ShareDialog from './ShareDialog'
 
-import styles from '$editor/canvas/components/Toolbar.pcss'
+import styles from '$editor/canvas/components/Toolbar/Toolbar.pcss'
 import dashboardStyles from './Toolbar.pcss'
 
 /* eslint-disable react/no-unused-state */


### PR DESCRIPTION
I'd like to make a couple of structural changes to the toolbar; compact it and make it more readable. A lot is going there and the first step is to give it a folder and keep related (future) components close together.

Opening this PR to avoid unreadable diffs in the near future. Baby steps!

cc @timoxley 