### PR TITLE
[PLATFORM-1166] Editor's toolbar rearranged for better resize behaviour

### DIFF
--- a/app/src/editor/canvas/components/Toolbar/Toolbar.pcss
+++ b/app/src/editor/canvas/components/Toolbar/Toolbar.pcss
@@ -2,28 +2,6 @@
   border-top: 1px solid #FF0F2D;
 }
 
-.ToolbarInner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background: #F5F5F5;
-  color: #A3A3A3;
-  padding: 20px 30px;
-  font-size: 12px;
-}
-
-.ToolbarInner > * {
-  display: flex;
-  align-items: center;
-  flex-wrap: nowrap;
-}
-
-.LeftControls {
-  display: flex;
-  justify-content: space-between;
-  flex: 0.45;
-}
-
 .StateSelectorContainer {
   display: flex;
 }
@@ -37,7 +15,6 @@
   position: relative;
   display: flex;
   flex-wrap: nowrap;
-  margin: 0 1um;
 }
 
 .CanvasToolbar .CanvasSearch {
@@ -148,7 +125,6 @@
 .CanvasNameContainer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
 }
 
 .CanvasNameContainer .DropdownMenu svg {
@@ -300,7 +276,7 @@ body .RealtimeRunButtonMenu {
 }
 
 .CanvasToolbar .runTabToggle {
-  margin: 0 16px;
+  margin-right: 16px;
   white-space: nowrap;
   position: relative;
 }
@@ -448,7 +424,6 @@ body .RealtimeRunButtonMenu {
  */
 
 .ToolbarZoomControls {
-  margin: 0 1um;
 }
 
 .ZoomControls {

--- a/app/src/editor/canvas/components/Toolbar/ToolbarInner.jsx
+++ b/app/src/editor/canvas/components/Toolbar/ToolbarInner.jsx
@@ -1,0 +1,45 @@
+// @flow
+
+import React from 'react'
+import styled from 'styled-components'
+
+type Props = {
+    className?: ?string,
+}
+
+const UnstyledToolbarInner = ({ className, ...props }: Props) => (
+    <div {...props} className={className} />
+)
+
+const ToolbarInner = styled(UnstyledToolbarInner)`
+    box-sizing: content-box;
+    align-items: center;
+    background: #f5f5f5;
+    color: #a3a3a3;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    font-size: 12px;
+    height: 40px;
+    justify-content: space-between;
+    padding: 20px 30px;
+
+    > * {
+        display: flex;
+        align-items: center;
+        flex-wrap: nowrap;
+    }
+
+    .ToolbarInner-left,
+    .ToolbarInner-right,
+    .ToolbarInner-center {
+        justify-content: space-between;
+    }
+
+    .ToolbarInner-left > * + *,
+    .ToolbarInner-right > * + *,
+    .ToolbarInner-center > * + * {
+        margin-left: 16px;
+    }
+`
+
+export default ToolbarInner

--- a/app/src/editor/canvas/components/Toolbar/ToolbarInner.jsx
+++ b/app/src/editor/canvas/components/Toolbar/ToolbarInner.jsx
@@ -7,6 +7,12 @@ type Props = {
     className?: ?string,
 }
 
+const classNames = {
+    CENTER: 'ToolbarInner-center',
+    LEFT: 'ToolbarInner-left',
+    RIGHT: 'ToolbarInner-right',
+}
+
 const UnstyledToolbarInner = ({ className, ...props }: Props) => (
     <div {...props} className={className} />
 )
@@ -29,17 +35,19 @@ const ToolbarInner = styled(UnstyledToolbarInner)`
         flex-wrap: nowrap;
     }
 
-    .ToolbarInner-left,
-    .ToolbarInner-right,
-    .ToolbarInner-center {
+    .${classNames.LEFT},
+    .${classNames.RIGHT},
+    .${classNames.CENTER} {
         justify-content: space-between;
     }
 
-    .ToolbarInner-left > * + *,
-    .ToolbarInner-right > * + *,
-    .ToolbarInner-center > * + * {
+    .${classNames.LEFT} > * + *,
+    .${classNames.RIGHT} > * + *,
+    .${classNames.CENTER} > * + * {
         margin-left: 16px;
     }
 `
+
+ToolbarInner.classNames = classNames
 
 export default ToolbarInner

--- a/app/src/editor/canvas/components/Toolbar/ToolbarLayout.jsx
+++ b/app/src/editor/canvas/components/Toolbar/ToolbarLayout.jsx
@@ -8,16 +8,16 @@ type Props = {
 }
 
 const classNames = {
-    CENTER: 'ToolbarInner-center',
-    LEFT: 'ToolbarInner-left',
-    RIGHT: 'ToolbarInner-right',
+    CENTER: 'ToolbarLayout-center',
+    LEFT: 'ToolbarLayout-left',
+    RIGHT: 'ToolbarLayout-right',
 }
 
-const UnstyledToolbarInner = ({ className, ...props }: Props) => (
+const UnstyledToolbarLayout = ({ className, ...props }: Props) => (
     <div {...props} className={className} />
 )
 
-const ToolbarInner = styled(UnstyledToolbarInner)`
+const ToolbarLayout = styled(UnstyledToolbarLayout)`
     box-sizing: content-box;
     align-items: center;
     background: #f5f5f5;
@@ -48,6 +48,6 @@ const ToolbarInner = styled(UnstyledToolbarInner)`
     }
 `
 
-ToolbarInner.classNames = classNames
+ToolbarLayout.classNames = classNames
 
-export default ToolbarInner
+export default ToolbarLayout

--- a/app/src/editor/canvas/components/Toolbar/index.jsx
+++ b/app/src/editor/canvas/components/Toolbar/index.jsx
@@ -171,7 +171,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                 <ModalContainer modalId="ShareDialog">
                     {({ api: shareDialog }) => (
                         <ToolbarInner>
-                            <div className="ToolbarInner-left">
+                            <div className={ToolbarInner.classNames.LEFT}>
                                 <UseState initialValue={false}>
                                     {(editing, setEditing) => (
                                         <div className={styles.CanvasNameContainer}>
@@ -264,7 +264,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 <ZoomControls className={styles.ToolbarZoomControls} canvas={canvas} />
                                 <div />
                             </div>
-                            <div className="ToolbarInner-center">
+                            <div className={ToolbarInner.classNames.CENTER}>
                                 <div>
                                     <R.ButtonGroup
                                         className={cx(styles.RunButtonGroup, {
@@ -370,7 +370,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     </R.ButtonGroup>
                                 </div>
                             </div>
-                            <div className="ToolbarInner-right">
+                            <div className={ToolbarInner.classNames.RIGHT}>
                                 <div />
                                 <div className={styles.StateSelectorContainer}>
                                     <div className={styles.StateSelector}>

--- a/app/src/editor/canvas/components/Toolbar/index.jsx
+++ b/app/src/editor/canvas/components/Toolbar/index.jsx
@@ -30,6 +30,7 @@ import * as RunController from '../CanvasController/Run'
 import { useCameraContext } from '../Camera'
 import { MessageIconSimple } from '../ConsoleSidebar'
 import styles from './Toolbar.pcss'
+import ToolbarInner from './ToolbarInner'
 
 function ZoomControls({ className, canvas }) {
     const camera = useCameraContext()
@@ -169,8 +170,8 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
             >
                 <ModalContainer modalId="ShareDialog">
                     {({ api: shareDialog }) => (
-                        <div className={styles.ToolbarInner}>
-                            <div className={styles.LeftControls}>
+                        <ToolbarInner>
+                            <div className="ToolbarInner-left">
                                 <UseState initialValue={false}>
                                     {(editing, setEditing) => (
                                         <div className={styles.CanvasNameContainer}>
@@ -260,238 +261,244 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                         </R.Button>
                                     </Tooltip>
                                 </div>
+                                <ZoomControls className={styles.ToolbarZoomControls} canvas={canvas} />
+                                <div />
                             </div>
-                            <ZoomControls className={styles.ToolbarZoomControls} canvas={canvas} />
-                            <div>
-                                <R.ButtonGroup
-                                    className={cx(styles.RunButtonGroup, {
-                                        [styles.RunButtonStopped]: !(isActive || canvas.adhoc),
-                                        [styles.RunButtonRunning]: isActive || canvas.adhoc,
-                                    })}
-                                >
-                                    <R.Button
-                                        disabled={!canChangeRunState}
-                                        onClick={() => {
-                                            if (isRunning) {
-                                                return canvasStop()
-                                            }
-                                            if (canvas.adhoc) {
-                                                return canvasExit()
-                                            }
-                                            return canvasStart()
-                                        }}
-                                        className={styles.RunButton}
+                            <div className="ToolbarInner-center">
+                                <div>
+                                    <R.ButtonGroup
+                                        className={cx(styles.RunButtonGroup, {
+                                            [styles.RunButtonStopped]: !(isActive || canvas.adhoc),
+                                            [styles.RunButtonRunning]: isActive || canvas.adhoc,
+                                        })}
                                     >
-                                        {((() => {
-                                            if (isActive) { return 'Stop' }
-                                            if (canvas.adhoc && !isActive) { return 'Clear' }
-                                            if (editorState.runTab === RunTabs.realtime) { return 'Start' }
-                                            return 'Run'
-                                        })())}
-                                    </R.Button>
-                                    {editorState.runTab === RunTabs.historical ? (
-                                        <R.ButtonDropdown
-                                            isOpen={runButtonDropdownOpen}
-                                            toggle={this.onToggleRunButtonMenu}
-                                            className={styles.RunDropdownButton}
+                                        <R.Button
+                                            disabled={!canChangeRunState}
+                                            onClick={() => {
+                                                if (isRunning) {
+                                                    return canvasStop()
+                                                }
+                                                if (canvas.adhoc) {
+                                                    return canvasExit()
+                                                }
+                                                return canvasStart()
+                                            }}
+                                            className={styles.RunButton}
                                         >
-                                            <R.DropdownToggle disabled={!canChangeRunState} caret>
-                                                {!runButtonDropdownOpen && (
-                                                    <SvgIcon name="caretUp" />
-                                                )}
-                                                {runButtonDropdownOpen && (
-                                                    <SvgIcon name="caretDown" />
-                                                )}
-                                            </R.DropdownToggle>
-                                            <R.DropdownMenu
-                                                className={cx(styles.RunButtonMenu, styles.HistoricalRunButtonMenu)}
-                                                disabled={!canChangeRunState}
-                                                right
+                                            {((() => {
+                                                if (isActive) { return 'Stop' }
+                                                if (canvas.adhoc && !isActive) { return 'Clear' }
+                                                if (editorState.runTab === RunTabs.realtime) { return 'Start' }
+                                                return 'Run'
+                                            })())}
+                                        </R.Button>
+                                        {editorState.runTab === RunTabs.historical ? (
+                                            <R.ButtonDropdown
+                                                isOpen={runButtonDropdownOpen}
+                                                toggle={this.onToggleRunButtonMenu}
+                                                className={styles.RunDropdownButton}
                                             >
-                                                <R.DropdownItem
-                                                    onClick={() => setSpeed('0')}
-                                                    active={!settings.speed || settings.speed === '0'}
+                                                <R.DropdownToggle disabled={!canChangeRunState} caret>
+                                                    {!runButtonDropdownOpen && (
+                                                        <SvgIcon name="caretUp" />
+                                                    )}
+                                                    {runButtonDropdownOpen && (
+                                                        <SvgIcon name="caretDown" />
+                                                    )}
+                                                </R.DropdownToggle>
+                                                <R.DropdownMenu
+                                                    className={cx(styles.RunButtonMenu, styles.HistoricalRunButtonMenu)}
+                                                    disabled={!canChangeRunState}
+                                                    right
                                                 >
-                                                    Full
-                                                </R.DropdownItem>
-                                                <R.DropdownItem
-                                                    onClick={() => setSpeed('1')}
-                                                    active={settings.speed === '1'}
-                                                >
-                                                    1x
-                                                </R.DropdownItem>
-                                                <R.DropdownItem
-                                                    onClick={() => setSpeed('10')}
-                                                    active={settings.speed === '10'}
-                                                >
-                                                    10x
-                                                </R.DropdownItem>
-                                                <R.DropdownItem
-                                                    onClick={() => setSpeed('100')}
-                                                    active={settings.speed === '100'}
-                                                >
-                                                    100x
-                                                </R.DropdownItem>
-                                                <R.DropdownItem
-                                                    onClick={() => setSpeed('1000')}
-                                                    active={settings.speed === '1000'}
-                                                >
-                                                    1000x
-                                                </R.DropdownItem>
-                                            </R.DropdownMenu>
-                                        </R.ButtonDropdown>
-                                    ) : (
-                                        <R.ButtonDropdown
-                                            isOpen={runButtonDropdownOpen}
-                                            toggle={this.onToggleRunButtonMenu}
-                                            className={styles.RunDropdownButton}
-                                        >
-                                            <R.DropdownToggle disabled={!canEdit} caret>
-                                                {!runButtonDropdownOpen && (
-                                                    <SvgIcon name="caretUp" />
-                                                )}
-                                                {runButtonDropdownOpen && (
-                                                    <SvgIcon name="caretDown" />
-                                                )}
-                                            </R.DropdownToggle>
-                                            <R.DropdownMenu className={cx(styles.RunButtonMenu, styles.RealtimeRunButtonMenu)} right>
-                                                <R.DropdownItem
-                                                    onClick={() => canvasStart({ clearState: true })}
-                                                    disabled={!canEdit}
-                                                >
-                                                    Reset &amp; Start
-                                                </R.DropdownItem>
-                                            </R.DropdownMenu>
-                                        </R.ButtonDropdown>
-                                    )}
-                                </R.ButtonGroup>
-                            </div>
-                            <div className={styles.StateSelectorContainer}>
-                                <div className={styles.StateSelector}>
-                                    <div className={styles.runTabToggle}>
-                                        <button
-                                            type="button"
-                                            onClick={() => setRunTab(RunTabs.realtime)}
-                                            disabled={!canEdit}
-                                            className={cx(styles.ToolbarSolidButton, styles.firstButton, {
-                                                [styles.StateSelectorActive]: editorState.runTab !== RunTabs.historical,
-                                            })}
-                                        >
-                                            Realtime
-                                        </button>
-                                        <button
-                                            type="button"
-                                            onClick={() => setRunTab(RunTabs.historical)}
-                                            disabled={!canEdit}
-                                            className={cx(styles.ToolbarSolidButton, styles.lastButton, {
-                                                [styles.StateSelectorActive]: editorState.runTab === RunTabs.historical,
-                                            })}
-                                        >
-                                            Historical
-                                        </button>
-                                    </div>
-                                    {editorState.runTab === RunTabs.historical ? (
-                                        <div className={styles.runTabValueToggle}>
-                                            <WithCalendar
-                                                date={!!settings.beginDate && new Date(settings.beginDate)}
-                                                className={styles.CalendarRoot}
-                                                wrapperClassname={styles.CalendarWrapper}
-                                                onChange={this.getOnChangeHistorical('beginDate')}
-                                            >
-                                                {({ toggleCalendar }) => (
-                                                    <button
-                                                        type="button"
-                                                        disabled={!canEdit}
-                                                        onClick={toggleCalendar}
-                                                        className={cx(styles.ToolbarSolidButton, styles.firstButton, {
-                                                            [styles.StateSelectorActive]: !!settings.beginDate,
-                                                        })}
+                                                    <R.DropdownItem
+                                                        onClick={() => setSpeed('0')}
+                                                        active={!settings.speed || settings.speed === '0'}
                                                     >
-                                                        {!settings.beginDate && ('From')}
-                                                        {!!settings.beginDate && dateFormatter('DD/MM/YYYY')(settings.beginDate)}
-                                                    </button>
-                                                )}
-                                            </WithCalendar>
-                                            <WithCalendar
-                                                date={!!settings.endDate && new Date(settings.endDate)}
-                                                className={styles.CalendarRoot}
-                                                wrapperClassname={styles.CalendarWrapper}
-                                                onChange={this.getOnChangeHistorical('endDate')}
-                                            >
-                                                {({ toggleCalendar }) => (
-                                                    <button
-                                                        type="button"
-                                                        disabled={!canEdit}
-                                                        onClick={toggleCalendar}
-                                                        className={cx(styles.ToolbarSolidButton, styles.lastButton, {
-                                                            [styles.StateSelectorActive]: !!settings.endDate,
-                                                        })}
+                                                        Full
+                                                    </R.DropdownItem>
+                                                    <R.DropdownItem
+                                                        onClick={() => setSpeed('1')}
+                                                        active={settings.speed === '1'}
                                                     >
-                                                        {!settings.endDate && ('To')}
-                                                        {!!settings.endDate && dateFormatter('DD/MM/YYYY')(settings.endDate)}
-                                                    </button>
-                                                )}
-                                            </WithCalendar>
-                                        </div>
-                                    ) : (
-                                        <div className={styles.runTabValueToggle}>
-                                            <div className={styles.saveStateToggleSection}>
-                                                {/* eslint-disable react/no-unknown-property */}
-                                                <R.Label
-                                                    for="saveStateToggle"
-                                                    className={cx(styles.saveStateToggleLabel, {
-                                                        [styles.StateSelectorActive]: settings.serializationEnabled === 'true',
-                                                    })}
-
-                                                >
-                                                    Save state
-                                                </R.Label>
-                                                {/* eslint-enable react/no-unknown-property */}
-                                                {/* eslint-disable max-len */}
-                                                <Toggle
-                                                    id="saveStateToggle"
-                                                    className={styles.saveStateToggle}
-                                                    value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
-                                                    onChange={(value) => setSaveState(value)}
-                                                    disabled={!canEdit}
-                                                />
-                                                {/* eslint-enable max-len */}
-                                            </div>
-                                        </div>
-                                    )}
+                                                        1x
+                                                    </R.DropdownItem>
+                                                    <R.DropdownItem
+                                                        onClick={() => setSpeed('10')}
+                                                        active={settings.speed === '10'}
+                                                    >
+                                                        10x
+                                                    </R.DropdownItem>
+                                                    <R.DropdownItem
+                                                        onClick={() => setSpeed('100')}
+                                                        active={settings.speed === '100'}
+                                                    >
+                                                        100x
+                                                    </R.DropdownItem>
+                                                    <R.DropdownItem
+                                                        onClick={() => setSpeed('1000')}
+                                                        active={settings.speed === '1000'}
+                                                    >
+                                                        1000x
+                                                    </R.DropdownItem>
+                                                </R.DropdownMenu>
+                                            </R.ButtonDropdown>
+                                        ) : (
+                                            <R.ButtonDropdown
+                                                isOpen={runButtonDropdownOpen}
+                                                toggle={this.onToggleRunButtonMenu}
+                                                className={styles.RunDropdownButton}
+                                            >
+                                                <R.DropdownToggle disabled={!canEdit} caret>
+                                                    {!runButtonDropdownOpen && (
+                                                        <SvgIcon name="caretUp" />
+                                                    )}
+                                                    {runButtonDropdownOpen && (
+                                                        <SvgIcon name="caretDown" />
+                                                    )}
+                                                </R.DropdownToggle>
+                                                <R.DropdownMenu className={cx(styles.RunButtonMenu, styles.RealtimeRunButtonMenu)} right>
+                                                    <R.DropdownItem
+                                                        onClick={() => canvasStart({ clearState: true })}
+                                                        disabled={!canEdit}
+                                                    >
+                                                        Reset &amp; Start
+                                                    </R.DropdownItem>
+                                                </R.DropdownMenu>
+                                            </R.ButtonDropdown>
+                                        )}
+                                    </R.ButtonGroup>
                                 </div>
                             </div>
-                            <div className={styles.ModalButtons}>
-                                <Tooltip container={this.elRef.current} value="Console">
-                                    <R.Button
-                                        className={cx(styles.ToolbarButton, styles.ConsoleButton)}
-                                        onClick={() => this.props.consoleSidebarOpen()}
-                                    >
-                                        {(badgeLevel && badgeLevel !== 'none') && (
-                                            <MessageIconSimple level={badgeLevel} className={styles.consoleButtonBadge} />
+                            <div className="ToolbarInner-right">
+                                <div />
+                                <div className={styles.StateSelectorContainer}>
+                                    <div className={styles.StateSelector}>
+                                        <div className={styles.runTabToggle}>
+                                            <button
+                                                type="button"
+                                                onClick={() => setRunTab(RunTabs.realtime)}
+                                                disabled={!canEdit}
+                                                className={cx(styles.ToolbarSolidButton, styles.firstButton, {
+                                                    [styles.StateSelectorActive]: editorState.runTab !== RunTabs.historical,
+                                                })}
+                                            >
+                                                Realtime
+                                            </button>
+                                            <button
+                                                type="button"
+                                                onClick={() => setRunTab(RunTabs.historical)}
+                                                disabled={!canEdit}
+                                                className={cx(styles.ToolbarSolidButton, styles.lastButton, {
+                                                    [styles.StateSelectorActive]: editorState.runTab === RunTabs.historical,
+                                                })}
+                                            >
+                                                Historical
+                                            </button>
+                                        </div>
+                                        {editorState.runTab === RunTabs.historical ? (
+                                            <div className={styles.runTabValueToggle}>
+                                                <WithCalendar
+                                                    date={!!settings.beginDate && new Date(settings.beginDate)}
+                                                    className={styles.CalendarRoot}
+                                                    wrapperClassname={styles.CalendarWrapper}
+                                                    onChange={this.getOnChangeHistorical('beginDate')}
+                                                >
+                                                    {({ toggleCalendar }) => (
+                                                        <button
+                                                            type="button"
+                                                            disabled={!canEdit}
+                                                            onClick={toggleCalendar}
+                                                            className={cx(styles.ToolbarSolidButton, styles.firstButton, {
+                                                                [styles.StateSelectorActive]: !!settings.beginDate,
+                                                            })}
+                                                        >
+                                                            {!settings.beginDate && ('From')}
+                                                            {!!settings.beginDate && dateFormatter('DD/MM/YYYY')(settings.beginDate)}
+                                                        </button>
+                                                    )}
+                                                </WithCalendar>
+                                                <WithCalendar
+                                                    date={!!settings.endDate && new Date(settings.endDate)}
+                                                    className={styles.CalendarRoot}
+                                                    wrapperClassname={styles.CalendarWrapper}
+                                                    onChange={this.getOnChangeHistorical('endDate')}
+                                                >
+                                                    {({ toggleCalendar }) => (
+                                                        <button
+                                                            type="button"
+                                                            disabled={!canEdit}
+                                                            onClick={toggleCalendar}
+                                                            className={cx(styles.ToolbarSolidButton, styles.lastButton, {
+                                                                [styles.StateSelectorActive]: !!settings.endDate,
+                                                            })}
+                                                        >
+                                                            {!settings.endDate && ('To')}
+                                                            {!!settings.endDate && dateFormatter('DD/MM/YYYY')(settings.endDate)}
+                                                        </button>
+                                                    )}
+                                                </WithCalendar>
+                                            </div>
+                                        ) : (
+                                            <div className={styles.runTabValueToggle}>
+                                                <div className={styles.saveStateToggleSection}>
+                                                    {/* eslint-disable react/no-unknown-property */}
+                                                    <R.Label
+                                                        for="saveStateToggle"
+                                                        className={cx(styles.saveStateToggleLabel, {
+                                                            [styles.StateSelectorActive]: settings.serializationEnabled === 'true',
+                                                        })}
+
+                                                    >
+                                                        Save state
+                                                    </R.Label>
+                                                    {/* eslint-enable react/no-unknown-property */}
+                                                    {/* eslint-disable max-len */}
+                                                    <Toggle
+                                                        id="saveStateToggle"
+                                                        className={styles.saveStateToggle}
+                                                        value={settings.serializationEnabled === 'true' /* yes, it's a string. legacy compatibility */}
+                                                        onChange={(value) => setSaveState(value)}
+                                                        disabled={!canEdit}
+                                                    />
+                                                    {/* eslint-enable max-len */}
+                                                </div>
+                                            </div>
                                         )}
-                                        <SvgIcon name="console" />
-                                    </R.Button>
-                                </Tooltip>
-                                <Tooltip container={this.elRef.current} value="Share">
-                                    <R.Button
-                                        className={cx(styles.ToolbarButton, styles.ShareButton)}
-                                        onClick={() => shareDialog.open()}
-                                        disabled={!canShare}
-                                    >
-                                        <SvgIcon name="share" />
-                                    </R.Button>
-                                </Tooltip>
-                                <Tooltip container={this.elRef.current} value={<React.Fragment>Keyboard<br />shortcuts</React.Fragment>}>
-                                    <R.Button
-                                        className={cx(styles.ToolbarButton, styles.KeyboardButton)}
-                                        onClick={() => this.props.keyboardShortcutOpen()}
-                                    >
-                                        <SvgIcon name="keyboard" />
-                                    </R.Button>
-                                </Tooltip>
+                                    </div>
+                                </div>
+                                <div className={styles.ModalButtons}>
+                                    <Tooltip container={this.elRef.current} value="Console">
+                                        <R.Button
+                                            className={cx(styles.ToolbarButton, styles.ConsoleButton)}
+                                            onClick={() => this.props.consoleSidebarOpen()}
+                                        >
+                                            {(badgeLevel && badgeLevel !== 'none') && (
+                                                <MessageIconSimple level={badgeLevel} className={styles.consoleButtonBadge} />
+                                            )}
+                                            <SvgIcon name="console" />
+                                        </R.Button>
+                                    </Tooltip>
+                                    <Tooltip container={this.elRef.current} value="Share">
+                                        <R.Button
+                                            className={cx(styles.ToolbarButton, styles.ShareButton)}
+                                            onClick={() => shareDialog.open()}
+                                            disabled={!canShare}
+                                        >
+                                            <SvgIcon name="share" />
+                                        </R.Button>
+                                    </Tooltip>
+                                    <Tooltip container={this.elRef.current} value={<React.Fragment>Keyboard<br />shortcuts</React.Fragment>}>
+                                        <R.Button
+                                            className={cx(styles.ToolbarButton, styles.KeyboardButton)}
+                                            onClick={() => this.props.keyboardShortcutOpen()}
+                                        >
+                                            <SvgIcon name="keyboard" />
+                                        </R.Button>
+                                    </Tooltip>
+                                </div>
                             </div>
-                        </div>
+                        </ToolbarInner>
                     )}
                 </ModalContainer>
                 <ShareDialog canvas={canvas} />

--- a/app/src/editor/canvas/components/Toolbar/index.jsx
+++ b/app/src/editor/canvas/components/Toolbar/index.jsx
@@ -30,7 +30,7 @@ import * as RunController from '../CanvasController/Run'
 import { useCameraContext } from '../Camera'
 import { MessageIconSimple } from '../ConsoleSidebar'
 import styles from './Toolbar.pcss'
-import ToolbarInner from './ToolbarInner'
+import ToolbarLayout from './ToolbarLayout'
 
 function ZoomControls({ className, canvas }) {
     const camera = useCameraContext()
@@ -170,8 +170,8 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
             >
                 <ModalContainer modalId="ShareDialog">
                     {({ api: shareDialog }) => (
-                        <ToolbarInner>
-                            <div className={ToolbarInner.classNames.LEFT}>
+                        <ToolbarLayout>
+                            <div className={ToolbarLayout.classNames.LEFT}>
                                 <UseState initialValue={false}>
                                     {(editing, setEditing) => (
                                         <div className={styles.CanvasNameContainer}>
@@ -264,7 +264,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                 <ZoomControls className={styles.ToolbarZoomControls} canvas={canvas} />
                                 <div />
                             </div>
-                            <div className={ToolbarInner.classNames.CENTER}>
+                            <div className={ToolbarLayout.classNames.CENTER}>
                                 <div>
                                     <R.ButtonGroup
                                         className={cx(styles.RunButtonGroup, {
@@ -370,7 +370,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     </R.ButtonGroup>
                                 </div>
                             </div>
-                            <div className={ToolbarInner.classNames.RIGHT}>
+                            <div className={ToolbarLayout.classNames.RIGHT}>
                                 <div />
                                 <div className={styles.StateSelectorContainer}>
                                     <div className={styles.StateSelector}>
@@ -498,7 +498,7 @@ export default withErrorBoundary(ErrorComponentView)(class CanvasToolbar extends
                                     </Tooltip>
                                 </div>
                             </div>
-                        </ToolbarInner>
+                        </ToolbarLayout>
                     )}
                 </ModalContainer>
                 <ShareDialog canvas={canvas} />

--- a/app/src/editor/dashboard/components/Toolbar.jsx
+++ b/app/src/editor/dashboard/components/Toolbar.jsx
@@ -17,7 +17,7 @@ import Toolbar from '$editor/shared/components/Toolbar'
 import ShareDialog from './ShareDialog'
 
 import styles from '$editor/canvas/components/Toolbar/Toolbar.pcss'
-import ToolbarInner from '$editor/canvas/components/Toolbar/ToolbarInner'
+import ToolbarLayout from '$editor/canvas/components/Toolbar/ToolbarLayout'
 
 /* eslint-disable react/no-unused-state */
 
@@ -50,8 +50,8 @@ export default withErrorBoundary(ErrorComponentView)(class DashboardToolbar exte
             <div className={cx(className, styles.CanvasToolbar)} ref={this.elRef}>
                 <ModalContainer modalId="ShareDialog">
                     {({ api: shareDialog }) => (
-                        <ToolbarInner>
-                            <div className={ToolbarInner.classNames.LEFT}>
+                        <ToolbarLayout>
+                            <div className={ToolbarLayout.classNames.LEFT}>
                                 <UseState initialValue={false}>
                                     {(editing, setEditing) => (
                                         <div className={styles.CanvasNameContainer}>
@@ -98,8 +98,8 @@ export default withErrorBoundary(ErrorComponentView)(class DashboardToolbar exte
                                 </div>
                                 <div />
                             </div>
-                            <div className={ToolbarInner.classNames.CENTER} />
-                            <div className={ToolbarInner.classNames.RIGHT}>
+                            <div className={ToolbarLayout.classNames.CENTER} />
+                            <div className={ToolbarLayout.classNames.RIGHT}>
                                 <div />
                                 <div className={cx(styles.ToolbarLeft, styles.DashboardButtons)}>
                                     <div className={styles.ModalButtons}>
@@ -122,7 +122,7 @@ export default withErrorBoundary(ErrorComponentView)(class DashboardToolbar exte
                                     </div>
                                 </div>
                             </div>
-                        </ToolbarInner>
+                        </ToolbarLayout>
                     )}
                 </ModalContainer>
                 <ShareDialog dashboard={dashboard} />

--- a/app/src/editor/dashboard/components/Toolbar.jsx
+++ b/app/src/editor/dashboard/components/Toolbar.jsx
@@ -17,7 +17,7 @@ import Toolbar from '$editor/shared/components/Toolbar'
 import ShareDialog from './ShareDialog'
 
 import styles from '$editor/canvas/components/Toolbar/Toolbar.pcss'
-import dashboardStyles from './Toolbar.pcss'
+import ToolbarInner from '$editor/canvas/components/Toolbar/ToolbarInner'
 
 /* eslint-disable react/no-unused-state */
 
@@ -47,11 +47,11 @@ export default withErrorBoundary(ErrorComponentView)(class DashboardToolbar exte
         }
 
         return (
-            <div className={cx(className, styles.CanvasToolbar, dashboardStyles.DasboardToolbar)} ref={this.elRef}>
+            <div className={cx(className, styles.CanvasToolbar)} ref={this.elRef}>
                 <ModalContainer modalId="ShareDialog">
                     {({ api: shareDialog }) => (
-                        <div className={styles.ToolbarInner}>
-                            <div className={cx(dashboardStyles.LeftControls, styles.LeftControls)}>
+                        <ToolbarInner>
+                            <div className={ToolbarInner.classNames.LEFT}>
                                 <UseState initialValue={false}>
                                     {(editing, setEditing) => (
                                         <div className={styles.CanvasNameContainer}>
@@ -88,7 +88,7 @@ export default withErrorBoundary(ErrorComponentView)(class DashboardToolbar exte
                                         </div>
                                     )}
                                 </UseState>
-                                <div className={styles.ToolbarRight}>
+                                <div>
                                     <R.Button
                                         className={styles.ToolbarButton}
                                         onClick={moduleSearchOpen}
@@ -96,28 +96,33 @@ export default withErrorBoundary(ErrorComponentView)(class DashboardToolbar exte
                                         <SvgIcon name="plus" className={styles.icon} />
                                     </R.Button>
                                 </div>
+                                <div />
                             </div>
-                            <div className={cx(styles.ToolbarLeft, styles.DashboardButtons)}>
-                                <div className={styles.ModalButtons}>
-                                    <Tooltip container={this.elRef.current} value="Share">
-                                        <R.Button
-                                            className={cx(styles.ToolbarButton, styles.ShareButton)}
-                                            onClick={() => shareDialog.open()}
-                                        >
-                                            <SvgIcon name="share" />
-                                        </R.Button>
-                                    </Tooltip>
-                                    <Tooltip container={this.elRef.current} value={<React.Fragment>Keyboard<br />shortcuts</React.Fragment>}>
-                                        <R.Button
-                                            className={cx(styles.ToolbarButton, styles.KeyboardButton)}
-                                            onClick={() => keyboardShortcutOpen()}
-                                        >
-                                            <SvgIcon name="keyboard" />
-                                        </R.Button>
-                                    </Tooltip>
+                            <div className={ToolbarInner.classNames.CENTER} />
+                            <div className={ToolbarInner.classNames.RIGHT}>
+                                <div />
+                                <div className={cx(styles.ToolbarLeft, styles.DashboardButtons)}>
+                                    <div className={styles.ModalButtons}>
+                                        <Tooltip container={this.elRef.current} value="Share">
+                                            <R.Button
+                                                className={cx(styles.ToolbarButton, styles.ShareButton)}
+                                                onClick={() => shareDialog.open()}
+                                            >
+                                                <SvgIcon name="share" />
+                                            </R.Button>
+                                        </Tooltip>
+                                        <Tooltip container={this.elRef.current} value={<React.Fragment>Keyboard<br />shortcuts</React.Fragment>}>
+                                            <R.Button
+                                                className={cx(styles.ToolbarButton, styles.KeyboardButton)}
+                                                onClick={() => keyboardShortcutOpen()}
+                                            >
+                                                <SvgIcon name="keyboard" />
+                                            </R.Button>
+                                        </Tooltip>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
+                        </ToolbarInner>
                     )}
                 </ModalContainer>
                 <ShareDialog dashboard={dashboard} />

--- a/app/src/editor/dashboard/components/Toolbar.pcss
+++ b/app/src/editor/dashboard/components/Toolbar.pcss
@@ -1,5 +1,0 @@
-.DasboardToolbar {
-  .LeftControls {
-    flex: 0.3;
-  }
-}


### PR DESCRIPTION
In this PR I define `ToolbarLayout` component that defines left, center and right "sides" of the toolbar with the following behaviour:
- both left and right have the same width as far as it's possible,
- the one in the center takes as much space as the "start/stop" button group itself needs, that's it.

It's quite nice and flexible.

I used `styled-components` in this one. It's something I'm trying out. lmk if you have strong opinions against it. Otherwise I'll roll with that. 💃 