### PR TITLE
[PLATFORM-1225] Purchase modal styling updates

### DIFF
--- a/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/chooseAccessPeriod.pcss
+++ b/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/chooseAccessPeriod.pcss
@@ -1,7 +1,5 @@
-.modalOverrides {
-  :global(.shared_contentArea_modalContentArea) {
-    padding: 0;
-  }
+.noPadding {
+  padding: 0;
 }
 
 .root {
@@ -89,13 +87,14 @@
   line-height: 24px;
 }
 
-.uniswapMsg {
+.root .uniswapMsg {
   color: #D8D8D7;
   font-size: 12px;
   font-family: var(--sans);
   text-align: center;
   letter-spacing: 0;
   line-height: 24px;
+  margin-bottom: 1rem;
 }
 
 .loadingIndicator {

--- a/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/ChooseAccessPeriodDialog/index.jsx
@@ -177,7 +177,7 @@ export const ChooseAccessPeriodDialog = ({
                         disabled: !isValidTime() || loading,
                     },
                 }}
-                className={styles.modalOverrides}
+                contentClassName={styles.noPadding}
             >
                 <div className={styles.root}>
                     <div className={styles.accessPeriod}>
@@ -221,7 +221,7 @@ export const ChooseAccessPeriodDialog = ({
                         onChange={(c) => onPaymentCurrencyChange(c)}
                         paymentCurrency={paymentCurrency}
                     />
-                    {isMobile() ?
+                    {isMobile() && paymentCurrency !== paymentCurrencies.DATA ?
                         <Translate
                             value="modal.chooseAccessPeriod.uniswap"
                             className={styles.uniswapMsg}

--- a/app/src/marketplace/components/Modal/PurchaseSummaryDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/PurchaseSummaryDialog/index.jsx
@@ -6,8 +6,12 @@ import BN from 'bignumber.js'
 
 import ModalPortal from '$shared/components/ModalPortal'
 import Dialog from '$shared/components/Dialog'
-import type { TimeUnit, PaymentCurrency } from '$shared/flowtype/common-types'
-import { paymentCurrencies } from '$shared/utils/constants'
+import type { TimeUnit, PaymentCurrency, NumberString } from '$shared/flowtype/common-types'
+import { paymentCurrencies, contractCurrencies } from '$shared/utils/constants'
+import { formatDecimals, dataToUsd } from '$mp/utils/price'
+import { isMobile } from '$shared/utils/platform'
+
+import styles from './purchaseSummaryDialog.pcss'
 
 export type Props = {
     name: string,
@@ -16,6 +20,7 @@ export type Props = {
     price: BN,
     ethPrice: BN,
     daiPrice: BN,
+    dataPerUsd: NumberString,
     purchaseStarted: boolean,
     onCancel: () => void,
     onPay: () => void | Promise<void>,
@@ -29,6 +34,7 @@ export const PurchaseSummaryDialog = ({
     price,
     ethPrice,
     daiPrice,
+    dataPerUsd,
     purchaseStarted,
     onCancel,
     onPay,
@@ -36,12 +42,14 @@ export const PurchaseSummaryDialog = ({
 }: Props) => {
     const priceInChosenCurrency = () => {
         if (paymentCurrency === paymentCurrencies.ETH) {
-            return ethPrice.toFixed(4)
+            return formatDecimals(ethPrice, paymentCurrencies.ETH)
         } else if (paymentCurrency === paymentCurrencies.DAI) {
-            return daiPrice.toFixed(2)
+            return formatDecimals(daiPrice, paymentCurrencies.DAI)
         }
-        return price.toFixed(4)
+        return formatDecimals(price, paymentCurrencies.DATA)
     }
+
+    const approxUsd = () => formatDecimals(dataToUsd(price, dataPerUsd), contractCurrencies.USD)
 
     if (purchaseStarted) {
         return (
@@ -78,32 +86,38 @@ export const PurchaseSummaryDialog = ({
                 title={I18n.t('modal.purchaseSummary.title')}
                 actions={{
                     cancel: {
-                        title: I18n.t('modal.common.cancel'),
+                        title: isMobile() ? I18n.t('modal.purchaseSummary.back') : I18n.t('modal.common.cancel'),
                         kind: 'link',
                         onClick: onCancel,
                     },
                     next: {
-                        title: I18n.t('modal.purchaseSummary.pay'),
+                        title: I18n.t('modal.purchaseSummary.payNow'),
                         kind: 'primary',
                         onClick: () => onPay(),
                     },
                 }}
+                contentClassName={styles.purchaseSummaryContent}
             >
-                <h6>{name}</h6>
-                <p>
+                <p className={styles.purchaseInfo}>
+                    <strong>{name}</strong>
                     <Translate
-                        value="modal.purchaseSummary.access"
+                        value="modal.purchaseSummary.time"
                         time={time}
                         timeUnit={I18n.t(`common.timeUnit.${timeUnit}`)}
+                        className={styles.time}
                     />
                 </p>
-                <p>
-                    <Translate
-                        value="modal.purchaseSummary.price"
-                        price={priceInChosenCurrency()}
-                        priceCurrency={paymentCurrency}
-                    />
-                </p>
+                <div>
+                    <span className={styles.priceValue}>
+                        {priceInChosenCurrency()}
+                        <span className={styles.priceCurrency}>
+                            {paymentCurrency}
+                        </span>
+                    </span>
+                    <p className={styles.usdEquiv}>
+                        {I18n.t('modal.chooseAccessPeriod.approx')} {approxUsd()} {contractCurrencies.USD}
+                    </p>
+                </div>
             </Dialog>
         </ModalPortal>
     )

--- a/app/src/marketplace/components/Modal/PurchaseSummaryDialog/purchaseSummaryDialog.pcss
+++ b/app/src/marketplace/components/Modal/PurchaseSummaryDialog/purchaseSummaryDialog.pcss
@@ -1,0 +1,49 @@
+.purchaseSummaryContent {
+  background: #F8F8F8;
+  border: none;
+}
+
+.purchaseInfo {
+  strong {
+    font-weight: 500;
+    color: #323232;
+    margin-right: 0.25rem;
+  }
+}
+
+.time {
+  color: #525252;
+}
+
+.price {
+  text-align: center;
+}
+
+.priceValue {
+  font-size: 44px;
+  font-family: var(--sans);
+  font-weight: var(--light);
+  letter-spacing: 0;
+  line-height: 60px;
+}
+
+.priceCurrency {
+  text-transform: uppercase;
+  font-size: 12px;
+  font-family: var(--sans);
+  font-weight: var(--medium);
+  letter-spacing: 0.5px;
+  line-height: 24px;
+  margin-left: 0.5rem;
+}
+
+.usdEquiv {
+  text-transform: uppercase;
+  color: #A3A3A3;
+  font-size: 12px;
+  font-family: var(--sans);
+  font-weight: var(--medium);
+  text-align: center;
+  letter-spacing: 0;
+  line-height: 24px;
+}

--- a/app/src/marketplace/containers/ProductPage/PurchaseModal.jsx
+++ b/app/src/marketplace/containers/ProductPage/PurchaseModal.jsx
@@ -427,6 +427,7 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
                 price={purchasePrice}
                 ethPrice={ethPrice}
                 daiPrice={daiPrice}
+                dataPerUsd={dataPerUsd}
                 onCancel={onClose}
                 onPay={onApprovePurchase}
                 paymentCurrency={paymentCurrency}

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -443,8 +443,14 @@ msgstr ""
 msgid "modal##purchaseSummary##access"
 msgstr "%{time} %{timeUnit} access"
 
+msgid "modal##purchaseSummary##back"
+msgstr "Back"
+
 msgid "modal##purchaseSummary##pay"
 msgstr "Pay"
+
+msgid "modal##purchaseSummary##payNow"
+msgstr "Pay now"
 
 msgid "modal##purchaseSummary##price"
 msgstr "%{price} %{priceCurrency}"
@@ -453,6 +459,9 @@ msgid "modal##purchaseSummary##started##message"
 msgstr ""
 "You need to confirm the transaction <br /> in your wallet to purchase this "
 "product."
+
+msgid "modal##purchaseSummary##time"
+msgstr "%{time} %{timeUnit}"
 
 msgid "modal##purchaseSummary##started##title"
 msgstr "Purchase confirmation"

--- a/app/src/shared/components/Dialog/dialog.pcss
+++ b/app/src/shared/components/Dialog/dialog.pcss
@@ -24,7 +24,7 @@
   }
 
   .buttons {
-    padding: 20px 37px;
+    padding: 1.5rem;
   }
 }
 
@@ -32,6 +32,10 @@
   .dialog {
     width: 100%;
     padding: 0 24px;
+  }
+
+  .dialog .buttons {
+    justify-content: space-between;
   }
 }
 

--- a/app/stories/modal.stories.jsx
+++ b/app/stories/modal.stories.jsx
@@ -445,6 +445,7 @@ story('Marketplace/PurchaseSummaryDialog')
             price={BN(123)}
             ethPrice={BN(124)}
             daiPrice={BN(125)}
+            dataPerUsd="0.1"
             paymentCurrency="DATA"
             time="24"
             timeUnit="hour"
@@ -458,6 +459,7 @@ story('Marketplace/PurchaseSummaryDialog')
             price={BN(123)}
             ethPrice={BN(124)}
             daiPrice={BN(125)}
+            dataPerUsd="0.1"
             paymentCurrency="DATA"
             time="24"
             timeUnit="hour"


### PR DESCRIPTION
Mainly changes to **'Complete your purchase'** some tweaks to **'Choose your access period'** too. Tested with and without CP flag. 

**Complete your purchase (desktop design)**
<img width="572" alt="Screenshot 2020-01-16 at 10 11 57" src="https://user-images.githubusercontent.com/1593398/72509975-e6405d00-3848-11ea-9cd4-3ee00964e3a5.png">

**Complete your purchase (desktop implemented)**
<img width="590" alt="Screenshot 2020-01-15 at 16 58 13" src="https://user-images.githubusercontent.com/1593398/72509779-906bb500-3848-11ea-8259-5ec4e86c0625.png">

**Complete your purchase (mobile implemented)**
<img width="405" alt="Screenshot 2020-01-15 at 17 02 30" src="https://user-images.githubusercontent.com/1593398/72510105-1d167300-3849-11ea-94de-34e8768cffcf.png">

**Complete your purchase (mobile design)**
<img width="380" alt="Screenshot 2020-01-16 at 10 14 52" src="https://user-images.githubusercontent.com/1593398/72510220-52bb5c00-3849-11ea-9d4e-7ff2c7d2065e.png">