### PR TITLE
[PLATFORM-1196] Fix inconsistent styling in Core > Products

### DIFF
--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -2,7 +2,6 @@
 
 import React, { Fragment, useCallback, useEffect, useMemo } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { Button } from 'reactstrap'
 import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
 import { push } from 'connected-react-router'
@@ -31,8 +30,8 @@ import useCopy from '$shared/hooks/useCopy'
 import useModal from '$shared/hooks/useModal'
 import useCommunityStats from '$mp/modules/communityProduct/hooks/useCommunityStats'
 import routes from '$routes'
-
 import CreateProductModal from '$mp/containers/CreateProductModal'
+import Button from '$shared/components/Button'
 
 import styles from './products.pcss'
 
@@ -44,6 +43,7 @@ const CreateProductButton = () => {
             <Button
                 tag={Link}
                 to={links.marketplace.createProduct}
+                className={styles.createProductButton}
             >
                 <Translate value="userpages.products.createProduct" />
             </Button>


### PR DESCRIPTION
Before in staging:
<img width="1348" alt="Screen Shot 2020-01-20 at 14 11 50" src="https://user-images.githubusercontent.com/1064982/72725680-08124a80-3b8f-11ea-9535-0c057ff5f149.png">

After update (with or without `COMMUNITY_PRODUCTS` flag):
<img width="1349" alt="Screen Shot 2020-01-20 at 14 02 38" src="https://user-images.githubusercontent.com/1064982/72725710-17919380-3b8f-11ea-8c6f-0b238c571949.png">
