### PR TITLE
[PLATFORM-1231] Fix cover image not appearing in Community Products deploy process modal

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
@@ -16,6 +16,7 @@ import routes from '$routes'
 import useEditableProductActions from '../ProductController/useEditableProductActions'
 import { isEthereumAddress } from '$mp/utils/validate'
 import { areAddressesEqual } from '$mp/utils/smartContract'
+import useEditableProductUpdater from '../ProductController/useEditableProductUpdater'
 
 import * as State from '../EditProductPage/state'
 import useModal from '$shared/hooks/useModal'
@@ -41,6 +42,7 @@ function useEditController(product: Product) {
     const savePending = usePending('product.SAVE')
     const { updateBeneficiaryAddress } = useEditableProductActions()
     const originalProduct = useSelector(selectProduct)
+    const { replaceProduct } = useEditableProductUpdater()
 
     useEffect(() => {
         const handleBeforeunload = (event) => {
@@ -122,6 +124,8 @@ function useEditController(product: Product) {
                     nextProduct.imageUrl = newImageUrl
                     nextProduct.thumbnailUrl = newThumbnailUrl
                     delete nextProduct.newImageToUpload
+
+                    replaceProduct(() => nextProduct)
                 } catch (e) {
                     console.error('Could not upload image', e)
                 }
@@ -144,6 +148,7 @@ function useEditController(product: Product) {
         savePending,
         redirectToProductList,
         originalProduct,
+        replaceProduct,
     ])
 
     const validate = useCallback(() => {


### PR DESCRIPTION
Fixes a bug where cover images added to Community Products do not show in the deploy onboarding modal unless the user has clicked Save & exit at least once.

To test:
- Create a new community product
- Input some info on all fields and upload a cover image
- Click continue to deploy the community

Result:
Uploaded image is shown in the modal preview.