### PR TITLE
[PLATFORM-1238] Add a "Recent" sort option to Core Products view

### DIFF
--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -163,10 +163,11 @@ const ProductsPage = () => {
     const sortOptions = useMemo(() => {
         const filters = getFilters()
         return [
+            filters.RECENT,
             filters.NAME_ASC,
             filters.NAME_DESC,
             filters.PUBLISHED,
-            filters.DRAFT,
+            filters.DRAFTS,
         ]
     }, [])
     const {

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -92,8 +92,8 @@ msgstr "Z to A"
 msgid "userpages##filter##published"
 msgstr "Published"
 
-msgid "userpages##filter##draft"
-msgstr "Draft"
+msgid "userpages##filter##drafts"
+msgstr "Drafts"
 
 msgid "userpages##filter##active"
 msgstr "Active"

--- a/app/src/userpages/utils/constants.js
+++ b/app/src/userpages/utils/constants.js
@@ -45,15 +45,17 @@ export const getFilters = (): { [string]: SortOption } => {
                 id: 'published',
                 key: 'states',
                 value: 'DEPLOYED',
+                sortBy: 'lastUpdated',
                 order: 'desc',
             },
         },
-        DRAFT: {
-            displayName: I18n.t('userpages.filter.draft'),
+        DRAFTS: {
+            displayName: I18n.t('userpages.filter.drafts'),
             filter: {
                 id: 'draft',
                 key: 'states',
                 value: 'NOT_DEPLOYED',
+                sortBy: 'lastUpdated',
                 order: 'desc',
             },
         },


### PR DESCRIPTION
Added "Recent" default sort option. Also "Published" and "Drafts" (renamed from "Draft") are sorted by the `lastUpdated` field. 

For purchases, we don’t have the information when the purchase was made, only when the subscription ends so left that as it is for now.