### PR TITLE
[PLATFORM-1217] Preserve space for thumbnails

### DIFF
--- a/app/src/shared/components/Tile/tile.pcss
+++ b/app/src/shared/components/Tile/tile.pcss
@@ -18,7 +18,7 @@
     object-fit: cover;
     width: 100%;
     transition: filter 0.05s;
-    height: 200px;
+    height: 100%;
   }
 
   &:hover {
@@ -38,6 +38,7 @@
 }
 
 .imageWrapper {
+  height: 200px;
   position: relative;
   display: block;
 }


### PR DESCRIPTION
In this PR I make sure image wrapper itself is 200px so that enough space is preserved for the actual thumbnail (before it loads).