### PR TITLE
[PLATFORM-1228] Improve the layout of Set Price section for standard products

### DIFF
--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -172,7 +172,7 @@ const MarketplaceRouter = () => (process.env.DATA_UNIONS ? [
     <Route exact path={formatPath(marketplace.products, ':id', 'publish')} component={ProductPublishPage} key="ProductPublishPage" />,
     <Route exact path={formatPath(marketplace.products, ':id', 'streamPreview', ':streamId')} component={StreamPreviewPage} key="StreamPreview" />,
     <Route exact path={formatPath(marketplace.products, ':id')} component={ProductPage} key="ProductPage" />,
-    <Route exact path={routes.editProduct()} component={EditProductAuth} key="EditProduct" />,
+    <Route exact path={formatPath(marketplace.products, ':id', 'edit')} component={EditProductAuth} key="EditProduct" />,
 ])
 
 const DocsRouter = () => ([

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -146,9 +146,11 @@ const BeneficiaryAddress = ({
                 htmlFor="beneficiaryAddress"
                 className={cx(styles.root, styles.BeneficiaryAddress, className)}
             >
-                <strong>
-                    <Translate value="editProductPage.setPrice.setRecipientEthAddress" />
-                </strong>
+                <Translate
+                    value="editProductPage.setPrice.setRecipientEthAddress"
+                    tag="div"
+                    className={styles.label}
+                />
                 <ActionsDropdown
                     disabled={disabled}
                     actions={[

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -19,6 +19,7 @@ import { selectEthereumIdentities } from '$shared/modules/integrationKey/selecto
 import { fetchIntegrationKeys } from '$shared/modules/integrationKey/actions'
 import { truncate } from '$shared/utils/text'
 import useAccountAddress from '$shared/hooks/useAccountAddress'
+import Label from '$ui/Label'
 
 import styles from './beneficiaryAddress.pcss'
 
@@ -144,12 +145,12 @@ const BeneficiaryAddress = ({
         <form autoComplete="off" onSubmit={(e) => e.preventDefault()}>
             <label
                 htmlFor="beneficiaryAddress"
-                className={cx(styles.root, styles.BeneficiaryAddress, className)}
+                className={cx(styles.root, className)}
             >
-                <Translate
+                <Label
+                    as={Translate}
                     value="editProductPage.setPrice.setRecipientEthAddress"
                     tag="div"
-                    className={styles.label}
                 />
                 <ActionsDropdown
                     disabled={disabled}

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
@@ -121,7 +121,12 @@ const PriceSelector = () => {
                         <div className={styles.fixPrice}>
                             <label htmlFor="fixPrice">
                                 <Translate value={`editProductPage.setPrice.${isDataUnion ? 'dataUnion' : 'dataProduct'}.fixPrice`} />
-                                <SvgIcon name="outlineQuestionMark" className={styles.helpIcon} />
+                                <div className={styles.tooltipContainer}>
+                                    <SvgIcon name="outlineQuestionMark" className={styles.helpIcon} />
+                                    <div className={styles.tooltip}>
+                                        <Translate value="modal.setPrice.fixedPriceSelector.tooltip" />
+                                    </div>
+                                </div>
                             </label>
                             <Toggle
                                 id="fixPrice"

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
@@ -118,7 +118,10 @@ const PriceSelector = () => {
                                 disabled={isFreeProduct || isLoadingOrSaving}
                             />
                         )}
-                        <div className={styles.fixPrice}>
+                        <div className={cx(styles.fixPrice, {
+                            [styles.fixPriceWithoutAddress]: !!isDataUnion,
+                        })}
+                        >
                             <label htmlFor="fixPrice">
                                 <Translate value={`editProductPage.setPrice.${isDataUnion ? 'dataUnion' : 'dataProduct'}.fixPrice`} />
                                 <div className={styles.tooltipContainer}>

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
@@ -12,6 +12,7 @@ import { selectDataPerUsd } from '$mp/modules/global/selectors'
 import RadioButtonGroup from '$shared/components/RadioButtonGroup'
 import SetPrice from '$mp/components/SetPrice'
 import Toggle from '$shared/components/Toggle'
+import SvgIcon from '$shared/components/SvgIcon'
 import { selectContractProduct } from '$mp/modules/contractProduct/selectors'
 
 import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
@@ -63,6 +64,7 @@ const PriceSelector = () => {
     }, [updatePriceCurrency])
 
     const isFreeProduct = !!product.isFree
+    const isDataUnion = isDataUnionProduct(product)
 
     const { isValid, message } = useValidation('pricePerSecond')
 
@@ -103,25 +105,32 @@ const PriceSelector = () => {
                         dataPerUsd={dataPerUsd}
                         error={isTouched('pricePerSecond') && !isValid ? message : undefined}
                     />
-                    {!isDataUnionProduct(product) && (
-                        <BeneficiaryAddress
-                            className={styles.beneficiaryAddress}
-                            address={product.beneficiaryAddress}
-                            onChange={updateBeneficiaryAddress}
-                            disabled={isFreeProduct || isLoadingOrSaving}
-                        />
-                    )}
-                    <div className={styles.fixPrice}>
-                        <label htmlFor="fixPrice">
-                            <Translate value="editProductPage.setPrice.fixPrice" />
-                        </label>
-                        <Toggle
-                            id="fixPrice"
-                            className={styles.toggle}
-                            value={fixInFiat}
-                            onChange={onFixPriceChange}
-                            disabled={isFreeProduct || isLoadingOrSaving}
-                        />
+                    <div
+                        className={cx({
+                            [styles.priceOptions]: !!isDataUnion,
+                            [styles.priceOptionsWithAddress]: !isDataUnion,
+                        })}
+                    >
+                        {!isDataUnion && (
+                            <BeneficiaryAddress
+                                address={product.beneficiaryAddress}
+                                onChange={updateBeneficiaryAddress}
+                                disabled={isFreeProduct || isLoadingOrSaving}
+                            />
+                        )}
+                        <div className={styles.fixPrice}>
+                            <label htmlFor="fixPrice">
+                                <Translate value={`editProductPage.setPrice.${isDataUnion ? 'dataUnion' : 'dataProduct'}.fixPrice`} />
+                                <SvgIcon name="outlineQuestionMark" className={styles.helpIcon} />
+                            </label>
+                            <Toggle
+                                id="fixPrice"
+                                className={styles.toggle}
+                                value={fixInFiat}
+                                onChange={onFixPriceChange}
+                                disabled={isFreeProduct || isLoadingOrSaving}
+                            />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.pcss
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.pcss
@@ -26,6 +26,10 @@
   position: relative;
 }
 
+.fixPriceWithoutAddress {
+  font-weight: var(--medium);
+}
+
 .helpIcon {
   height: 16px;
   width: 16px;
@@ -50,6 +54,7 @@
     line-height: 20px;
     top: 2rem;
     right: 0;
+    font-weight: var(--regular);
   }
 
   &:hover {

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.pcss
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.pcss
@@ -17,16 +17,29 @@
   margin-top: 2.5rem;
 }
 
-.beneficiaryAddress {
-  margin-top: 3rem;
+.priceOptionsWithAddress {
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: 1fr 208px;
+  grid-column-gap: 1.5rem;
+}
+
+.priceOptions {
+  margin-top: 3.25rem;
 }
 
 .fixPrice {
-  margin-top: 2.5rem;
+  margin-top: 2rem;
   display: grid;
-  grid-template-columns: 1fr 2.5rem;
+  grid-template-columns: 1fr 36px;
   grid-column-gap: 1rem;
-  align-items: center;
+  line-height: 20px;
+}
+
+.helpIcon {
+  height: 16px;
+  width: 16px;
+  margin-left: 0.5rem;
 }
 
 .toggle {

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.pcss
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.pcss
@@ -18,7 +18,7 @@
 }
 
 .fixPrice {
-  margin-top: 2rem;
+  margin-top: 1.9rem;
   display: grid;
   grid-template-columns: 1fr 36px;
   grid-column-gap: 1rem;
@@ -34,6 +34,7 @@
   height: 16px;
   width: 16px;
   margin-left: 0.5rem;
+  margin-bottom: 3px;
   display: none;
 }
 

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.pcss
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.pcss
@@ -13,17 +13,6 @@
   opacity: 0.5;
 }
 
-.priceSelector {
-  margin-top: 2.5rem;
-}
-
-.priceOptionsWithAddress {
-  margin-top: 2.5rem;
-  display: grid;
-  grid-template-columns: 1fr 208px;
-  grid-column-gap: 1.5rem;
-}
-
 .priceOptions {
   margin-top: 3.25rem;
 }
@@ -34,12 +23,55 @@
   grid-template-columns: 1fr 36px;
   grid-column-gap: 1rem;
   line-height: 20px;
+  position: relative;
 }
 
 .helpIcon {
   height: 16px;
   width: 16px;
   margin-left: 0.5rem;
+  display: none;
+}
+
+.tooltipContainer {
+  display: inline-block;
+
+  .tooltip {
+    width: 210px;
+    position: absolute;
+    display: none;
+    padding: 1.125rem;
+    background: white;
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+    font-size: 0.875rem;
+    color: #323232;
+    letter-spacing: 0;
+    line-height: 20px;
+    top: 2rem;
+    right: 0;
+  }
+
+  &:hover {
+    .tooltip {
+      display: block;
+    }
+  }
+}
+
+.priceSelector {
+  margin-top: 2.5rem;
+}
+
+.priceOptionsWithAddress {
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: 1fr 208px;
+  grid-column-gap: 1.5rem;
+
+  .helpIcon {
+    display: inline-block;
+  }
 }
 
 .toggle {

--- a/app/src/marketplace/containers/EditProductPage/ProductEditorDebug.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ProductEditorDebug.jsx
@@ -25,7 +25,7 @@ const ProductEditorDebug = () => {
     const { touched, pendingChanges } = useContext(ValidationContext)
 
     const isDataUnion = isDataUnionProduct(product)
-    const onFixPriceChange = useCallback((checked) => {
+    const onTypeChange = useCallback((checked) => {
         updateType(checked ? productTypes.COMMUNITY : productTypes.NORMAL)
     }, [updateType])
 
@@ -44,7 +44,7 @@ const ProductEditorDebug = () => {
             >
                 Is Data Union? <Toggle
                     value={isDataUnion}
-                    onChange={onFixPriceChange}
+                    onChange={onTypeChange}
                 />
                 product:<br />
                 <pre className={styles.productData}>

--- a/app/src/marketplace/containers/EditProductPage/beneficiaryAddress.pcss
+++ b/app/src/marketplace/containers/EditProductPage/beneficiaryAddress.pcss
@@ -1,12 +1,3 @@
 .root {
   width: 100%;
 }
-
-.BeneficiaryAddress {}
-
-.label {
-  font-weight: var(--medium);
-  font-size: 0.75rem;
-  line-height: 1rem;
-  margin-bottom: 0.5rem;
-}

--- a/app/src/marketplace/containers/EditProductPage/beneficiaryAddress.pcss
+++ b/app/src/marketplace/containers/EditProductPage/beneficiaryAddress.pcss
@@ -1,15 +1,12 @@
 .root {
-  display: grid;
-  grid-template-columns: 14rem 1fr;
-  grid-column-gap: 1rem;
-  line-height: 2rem;
-  color: var(--greyDark);
-  letter-spacing: 0;
-  align-items: center;
-
-  strong {
-    font-weight: var(--medium);
-  }
+  width: 100%;
 }
 
 .BeneficiaryAddress {}
+
+.label {
+  font-weight: var(--medium);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  margin-bottom: 0.5rem;
+}

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -611,7 +611,7 @@ msgid "modal##setPrice##fixedPriceSelector##text"
 msgstr "Fix price in USD"
 
 msgid "modal##setPrice##fixedPriceSelector##tooltip"
-msgstr "Fixing the price in fiat will protect you from changes in the DATA price"
+msgstr "Fixing the price in fiat can give you protection against shifts in the DATA price"
 
 msgid "modal##setPrice##ownerAddress"
 msgstr "Your account Ethereum address (cannot be changed)"

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -142,8 +142,11 @@ msgstr "Set recipient ETH address"
 msgid "editProductPage##setPrice##placeholder##enterEthAddress"
 msgstr "Enter ETH address"
 
-msgid "editProductPage##setPrice##fixPrice"
+msgid "editProductPage##setPrice##dataUnion##fixPrice"
 msgstr "Fix price in fiat for protection against shifts in the DATA price"
+
+msgid "editProductPage##setPrice##dataProduct##fixPrice"
+msgstr "Fix price in fiat"
 
 msgid "editProductPage##productDetails##title"
 msgstr "Add some more details"

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -317,6 +317,16 @@ const sources = {
             />
         </svg>
     ),
+    outlineQuestionMark: (
+        <svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+            <g transform="translate(1 1)" stroke="#323232" fill="none" fillRule="evenodd">
+                <circle cx="8" cy="8" r="8" />
+                <g strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.071">
+                    <path d="M7.925 12.005a.316.316 0 100 .632.316.316 0 000-.632h0M5.398 5.975a2.526 2.526 0 113.369 2.383 1.263 1.263 0 00-.842 1.19v.532" />
+                </g>
+            </g>
+        </svg>
+    ),
     lockOutline: (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 24">
             <g fill="none" fillRule="evenodd" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5">


### PR DESCRIPTION
This adds different layout for standard products price setting:
<img width="691" alt="Screen Shot 2020-02-05 at 21 25 31" src="https://user-images.githubusercontent.com/1064982/73917024-de5f6000-48be-11ea-94e2-de614ad6a9e2.png">

Design: https://share.goabstract.com/53ce3bc8-b8fb-49c8-9859-84c0485e96f0?mode=design&sha=8e5e8db7de798d4970de1594ea92ea8f22776f34

Data union product remains the same:
<img width="692" alt="Screen Shot 2020-02-05 at 21 25 10" src="https://user-images.githubusercontent.com/1064982/73917028-df908d00-48be-11ea-99fc-53bf8201147a.png">

Design: https://share.goabstract.com/f110e1ef-fad8-481d-ba62-5c3f27175290?mode=design&sha=8e5e8db7de798d4970de1594ea92ea8f22776f34