### PR TITLE
[PLATFORM-1257] Freeze TimeSeriesGraph’s S/B stories in time

### DIFF
--- a/app/src/shared/components/TimeSeriesGraph/timeSeriesGraph.stories.jsx
+++ b/app/src/shared/components/TimeSeriesGraph/timeSeriesGraph.stories.jsx
@@ -18,7 +18,7 @@ const stories =
         }))
         .addDecorator(withKnobs)
 
-const today = new Date().getTime()
+const today = new Date('2035-01-01').getTime()
 
 const MSEC_DAILY = 86400000
 

--- a/app/src/shared/components/TimeSeriesGraph/timeSeriesGraph.stories.jsx
+++ b/app/src/shared/components/TimeSeriesGraph/timeSeriesGraph.stories.jsx
@@ -18,9 +18,9 @@ const stories =
         }))
         .addDecorator(withKnobs)
 
-const today = new Date('2035-01-01').getTime()
-
 const MSEC_DAILY = 86400000
+
+const today = new Date('2035-01-01').getTime() + Math.floor(MSEC_DAILY / 2)
 
 const graphData = [{
     x: today,


### PR DESCRIPTION
This way graphs are shown always for the same date range. It fixes the “new day, new non-empty chromatic diff” issue.