### PR TITLE
[PLATFORM-959] Fix password change layout on mobile

### DIFF
--- a/app/src/userpages/components/ProfilePage/ChangePassword/changePassword.pcss
+++ b/app/src/userpages/components/ProfilePage/ChangePassword/changePassword.pcss
@@ -46,8 +46,6 @@
   &:active,
   &:focus,
   &:visited {
-    color: #0324FF;
-    text-decoration: none;
     font-size: 0.875um;
   }
 }

--- a/app/src/userpages/components/ProfilePage/ChangePassword/changePassword.pcss
+++ b/app/src/userpages/components/ProfilePage/ChangePassword/changePassword.pcss
@@ -48,6 +48,7 @@
   &:visited {
     color: #0324FF;
     text-decoration: none;
+    font-size: 0.875um;
   }
 }
 

--- a/app/src/userpages/components/ProfilePage/ChangePassword/changePassword.pcss
+++ b/app/src/userpages/components/ProfilePage/ChangePassword/changePassword.pcss
@@ -1,23 +1,7 @@
 .content {
   text-align: left;
-
-  a {
-    color: #0324FF !important;
-    font-size: 0.75em;
-    outline: 0 !important;
-    text-decoration: none;
-
-    &:hover,
-    &:focus {
-      text-decoration: underline;
-    }
-  }
-}
-
-@media (--md-down) {
-  .content {
-    padding: 24px;
-  }
+  border-bottom: 0;
+  padding: 1.5rem;
 }
 
 .currentPassword,
@@ -39,13 +23,91 @@
   margin-top: 1rem;
 }
 
+.footer {
+  padding: 1.5rem;
+  padding-top: 0;
+  display: grid;
+  grid-column-gap: 1rem;
+  grid-row-gap: 1rem;
+  grid-template-columns: 1fr 96px;
+}
+
+.footerText {
+  grid-row: 2;
+  grid-column: 1;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
 .forgotLink {
-  position: absolute;
-  left: 2.4rem;
-  bottom: 1.5rem;
-  z-index: 100;
+  &,
+  &:hover,
+  &:active,
+  &:focus,
+  &:visited {
+    color: #0324FF;
+    text-decoration: none;
+  }
+}
+
+.forgotLinkTextMobile {
+  display: inline-block;
+}
+
+.forgotLinkTextDesktop {
+  display: none;
+}
+
+.cancelButton {
+  grid-row: 2;
+  grid-column: 2;
+}
+
+.saveButton {
+  grid-row-start: 1;
+  grid-column-start: 1;
+  grid-column-end: 3;
 }
 
 .dialogContainerOverride {
   top: 40%;
+}
+
+@media (--md-down) {
+  .content {
+    padding-bottom: 1rem;
+  }
+}
+
+@media (--md-up) {
+  .footer {
+    border-top: 1px solid #F2F1F1;
+    grid-column-gap: 1rem;
+    grid-template-columns: 1fr 96px 96px;
+    padding-top: 1.5rem;
+  }
+
+  .footerText {
+    grid-row: 1;
+    grid-column: 1;
+  }
+
+  .cancelButton {
+    grid-row: 1;
+    grid-column: 2;
+  }
+
+  .saveButton {
+    grid-row: 1;
+    grid-column: 3;
+  }
+
+  .forgotLinkTextMobile {
+    display: none;
+  }
+
+  .forgotLinkTextDesktop {
+    display: inline-block;
+  }
 }

--- a/app/src/userpages/components/ProfilePage/ChangePassword/index.jsx
+++ b/app/src/userpages/components/ProfilePage/ChangePassword/index.jsx
@@ -118,25 +118,35 @@ class ChangePasswordDialog extends Component<Props, State> {
                     contentClassName={styles.content}
                     title={I18n.t('modal.changePassword.defaultTitle')}
                     onClose={this.props.onToggle}
-                    actions={{
-                        cancel: {
-                            title: I18n.t('modal.common.cancel'),
-                            outline: true,
-                            kind: 'link',
-                            onClick: () => this.props.onToggle(),
-                        },
-                        save: {
-                            title: I18n.t('modal.common.save'),
-                            kind: 'primary',
-                            onClick: this.onSubmit,
-                            disabled: !allPasswordsGiven || !passWordsMatch || !strongEnoughPassword || updating,
-                            spinner: updating,
-                        },
-                    }}
+                    renderActions={() => (
+                        <div className={styles.footer}>
+                            <div className={styles.footerText}>
+                                <Link to={routes.forgotPassword()} className={styles.forgotLink}>
+                                    <Translate value="modal.changePassword.forgotPassword.mobile" className={styles.forgotLinkTextMobile} />
+                                    <Translate value="modal.changePassword.forgotPassword.desktop" className={styles.forgotLinkTextDesktop} />
+                                </Link>
+                            </div>
+                            <Button
+                                type="button"
+                                kind="link"
+                                onClick={() => this.props.onToggle()}
+                                className={styles.cancelButton}
+                            >
+                                {I18n.t('modal.common.cancel')}
+                            </Button>
+                            <Button
+                                type="button"
+                                kind="primary"
+                                onClick={this.onSubmit}
+                                disabled={!allPasswordsGiven || !passWordsMatch || !strongEnoughPassword || updating}
+                                waiting={updating}
+                                className={styles.saveButton}
+                            >
+                                {I18n.t('modal.common.save')}
+                            </Button>
+                        </div>
+                    )}
                 >
-                    <Link to={routes.forgotPassword()} className={styles.forgotLink}>
-                        <Translate value="modal.changePassword.forgotPassword" />
-                    </Link>
                     <div className={styles.currentPassword}>
                         <Label htmlFor="currentPassword">
                             {I18n.t('modal.changePassword.currentPassword')}

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -903,8 +903,11 @@ msgstr "New password"
 msgid "modal##changePassword##confirmNewPassword"
 msgstr "Confirm new password"
 
-msgid "modal##changePassword##forgotPassword"
+msgid "modal##changePassword##forgotPassword##desktop"
 msgstr "Forgot password?"
+
+msgid "modal##changePassword##forgotPassword##mobile"
+msgstr "Forgot?"
 
 msgid "modal##changePassword##passwordsDoNotMatch"
 msgstr "The passwords do not match"

--- a/app/stories/modal.stories.jsx
+++ b/app/stories/modal.stories.jsx
@@ -775,6 +775,24 @@ story('Profile/ChangePasswordDialog')
             />
         )
     })
+    .add('mobile', () => {
+        const updatePassword = action('updatePassword')
+        const updateAction = (...args) => new Promise((resolve) => {
+            updatePassword(...args)
+            resolve()
+        })
+        return (
+            <ChangePasswordDialog
+                isOpen
+                updatePassword={updateAction}
+                onToggle={action('onToggle')}
+            />
+        )
+    }, {
+        viewport: {
+            defaultViewport: 'sm',
+        },
+    })
 
 story('EthereumIdentity/IdentityChallengeDialog')
     .add('signature request', () => (


### PR DESCRIPTION
Adds responsive view for the password change modal.

Desktop:
<img width="555" alt="Screen Shot 2020-02-07 at 16 24 40" src="https://user-images.githubusercontent.com/1064982/74041724-7d22b400-49c6-11ea-8fc4-f36bcc85b632.png">

Mobile:
<img width="554" alt="Screen Shot 2020-02-07 at 16 14 22" src="https://user-images.githubusercontent.com/1064982/74041422-e2c27080-49c5-11ea-8846-9e630dfe9ab4.png">

Forgot password link doesn't seem to work, though. @mondoreale Any ideas where it should lead?