### PR TITLE
[PLATFORM-960] Fix image upload responsive text

### DIFF
--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -262,6 +262,9 @@ msgstr "Drag & drop to replace your cover image <br /> or click to browse for on
 msgid "imageUpload##coverImage##tabletUpload"
 msgstr "Tap to take a photo or browse for one"
 
+msgid "imageUpload##coverImage##mobileUpload"
+msgstr "Tap to take a photo<br />or browse for one"
+
 msgid "imageUpload##coverImage##upload"
 msgstr "Drag & drop to upload a cover image <br /> or click to browse for one"
 

--- a/app/src/shared/components/ImageUpload/imageUpload.pcss
+++ b/app/src/shared/components/ImageUpload/imageUpload.pcss
@@ -23,6 +23,18 @@
   line-height: 1.5rem;
 }
 
+.uploadAdviceDesktop {
+  display: none;
+}
+
+.uploadAdviceTablet {
+  display: none;
+}
+
+.uploadAdviceMobile {
+  display: none;
+}
+
 .imageUploaded {
   .dropzoneAdvice {
     display: none;
@@ -105,7 +117,7 @@
 @media (--md-down) {
   .root {
     height: auto;
-    min-height: 180px;
+    min-height: 250px;
     font-size: 14px;
   }
 }
@@ -116,8 +128,48 @@
   }
 }
 
+@media (--lg-up) {
+  .uploadAdviceDesktop {
+    display: block;
+  }
+
+  .uploadAdviceTablet {
+    display: none;
+  }
+
+  .uploadAdviceMobile {
+    display: none;
+  }
+}
+
+@media (--sm-up) and (--lg-down) {
+  .uploadAdviceDesktop {
+    display: none;
+  }
+
+  .uploadAdviceTablet {
+    display: block;
+  }
+
+  .uploadAdviceMobile {
+    display: none;
+  }
+}
+
 @media (--sm-down) {
   .previewImage {
     height: 100%;
+  }
+
+  .uploadAdviceDesktop {
+    display: none;
+  }
+
+  .uploadAdviceTablet {
+    display: none;
+  }
+
+  .uploadAdviceMobile {
+    display: block;
   }
 }

--- a/app/src/shared/components/ImageUpload/imageUpload.pcss
+++ b/app/src/shared/components/ImageUpload/imageUpload.pcss
@@ -18,7 +18,7 @@
 
 .uploadAdvice {
   font-weight: var(--medium);
-  font-size: 1rem;
+  font-size: 1um;
   letter-spacing: 0;
   line-height: 1.5rem;
 }

--- a/app/src/shared/components/ImageUpload/imageUpload.stories.jsx
+++ b/app/src/shared/components/ImageUpload/imageUpload.stories.jsx
@@ -30,11 +30,25 @@ const ImageUploadContainer = ({ disabled, defaultImage }: Props) => {
     )
 }
 
-// onUploadError={this.onUploadError}
-
 stories.add('default', () => (
     <ImageUploadContainer />
 ))
+
+stories.add('default (tablet)', () => (
+    <ImageUploadContainer />
+), {
+    viewport: {
+        defaultViewport: 'md',
+    },
+})
+
+stories.add('default (mobile)', () => (
+    <ImageUploadContainer />
+), {
+    viewport: {
+        defaultViewport: 'sm',
+    },
+})
 
 stories.add('with default image', () => (
     <ImageUploadContainer

--- a/app/src/shared/components/ImageUpload/index.jsx
+++ b/app/src/shared/components/ImageUpload/index.jsx
@@ -4,9 +4,7 @@ import React, { Fragment, useState, useCallback, useMemo } from 'react'
 import { useDropzone } from 'react-dropzone'
 import cx from 'classnames'
 import { Translate, I18n } from 'react-redux-i18n'
-import MediaQuery from 'react-responsive'
 
-import breakpoints from '$app/scripts/breakpoints'
 import { maxFileSizeForImageUpload } from '$shared/utils/constants'
 import PngIcon from '$shared/components/PngIcon'
 import useIsMounted from '$shared/hooks/useIsMounted'
@@ -15,8 +13,6 @@ import type { DropzoneFile } from '$shared/components/FileUpload'
 
 import Notification from '$shared/utils/Notification'
 import styles from './imageUpload.pcss'
-
-const { lg } = breakpoints
 
 export type OnUploadError = (errorMessage: string) => void
 
@@ -123,12 +119,21 @@ const ImageUpload = ({
                         <Translate value="imageUpload.coverImage.replace" dangerousHTML />
                     ) : (
                         <Fragment>
-                            <MediaQuery minWidth={lg.min}>
-                                <Translate value="imageUpload.coverImage.upload" className={styles.uploadAdvice} dangerousHTML />
-                            </MediaQuery>
-                            <MediaQuery maxWidth={lg.min}>
-                                <Translate value="imageUpload.coverImage.tabletUpload" className={styles.uploadAdvice} dangerousHTML />
-                            </MediaQuery>
+                            <Translate
+                                value="imageUpload.coverImage.upload"
+                                className={cx(styles.uploadAdvice, styles.uploadAdviceDesktop)}
+                                dangerousHTML
+                            />
+                            <Translate
+                                value="imageUpload.coverImage.tabletUpload"
+                                className={cx(styles.uploadAdvice, styles.uploadAdviceTablet)}
+                                dangerousHTML
+                            />
+                            <Translate
+                                value="imageUpload.coverImage.mobileUpload"
+                                className={cx(styles.uploadAdvice, styles.uploadAdviceMobile)}
+                                dangerousHTML
+                            />
                         </Fragment>
                     )}
                 </p>


### PR DESCRIPTION
Minor fix to Avatar upload responsive view (line break)

Desktop:
<img width="544" alt="Screen Shot 2020-02-10 at 13 53 30" src="https://user-images.githubusercontent.com/1064982/74154999-6bd2e500-4c1c-11ea-915c-e73cfceddf4c.png">

Tablet:
<img width="543" alt="Screen Shot 2020-02-10 at 13 53 46" src="https://user-images.githubusercontent.com/1064982/74155027-77261080-4c1c-11ea-9eaa-fc1cc138f666.png">

Mobile:
<img width="547" alt="Screen Shot 2020-02-10 at 13 53 53" src="https://user-images.githubusercontent.com/1064982/74155034-7c835b00-4c1c-11ea-9b08-c750b47882d2.png">
