### PR TITLE
[PLATFORM-1247] Fix KeyField component margins

### DIFF
--- a/app/src/userpages/components/PermissionKeyField/PermissionKeyFieldEditor/index.jsx
+++ b/app/src/userpages/components/PermissionKeyField/PermissionKeyFieldEditor/index.jsx
@@ -118,7 +118,7 @@ class PermissionKeyFieldEditor extends React.Component<Props, State> {
                     </div>
                     <div>
                         <Label>
-                            Permission
+                            {I18n.t('userpages.keyFieldEditor.permission')}
                         </Label>
                         <Select
                             options={permissionOptions}

--- a/app/src/userpages/components/PermissionKeyField/index.jsx
+++ b/app/src/userpages/components/PermissionKeyField/index.jsx
@@ -234,7 +234,7 @@ class PermissionKeyField extends React.Component<Props, State> {
                     <SplitControl>
                         {this.renderInput()}
                         <div>
-                            <Label>
+                            <Label className={styles.permissionHeader}>
                                 {showPermissionHeader && I18n.t('userpages.streams.edit.configure.permission')}
                             </Label>
                             <Select

--- a/app/src/userpages/components/PermissionKeyField/permissionKeyField.pcss
+++ b/app/src/userpages/components/PermissionKeyField/permissionKeyField.pcss
@@ -16,3 +16,10 @@
 
 .select {
 }
+
+.permissionHeader {
+  &:empty::after {
+    content: ' ';
+    white-space: pre;
+  }
+}

--- a/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/integrationKeyList.pcss
+++ b/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/integrationKeyList.pcss
@@ -5,7 +5,7 @@
 }
 
 .keyField + .keyField {
-  margin-top: 2.5rem;
+  margin-top: 1.5rem;
 }
 
 .singleKey {

--- a/app/src/userpages/components/ProfilePage/ProfileSettings/profileSettings.pcss
+++ b/app/src/userpages/components/ProfilePage/ProfileSettings/profileSettings.pcss
@@ -7,9 +7,9 @@
 }
 
 .email {
-  margin-top: 1.5rem;
+  margin-top: 2rem;
 }
 
 .password {
-  margin-top: 1rem;
+  margin-top: 2rem;
 }

--- a/app/src/userpages/components/StreamPage/Show/KeyView/PermissionCredentialsControl/permissionCredentialsControl.pcss
+++ b/app/src/userpages/components/StreamPage/Show/KeyView/PermissionCredentialsControl/permissionCredentialsControl.pcss
@@ -2,7 +2,7 @@
 .root {}
 
 .singleKey + .singleKey {
-  margin-top: 1rem;
+  margin-top: 1.5rem;
 }
 
 .addKey {

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -891,6 +891,10 @@ msgstr "Save"
 
 msgid "userpages##keyFieldEditor##cancel"
 msgstr "Cancel"
+
+msgid "userpages##keyFieldEditor##permission"
+msgstr "Permission"
+
 msgid "modal##changePassword##defaultTitle"
 msgstr "Change password"
 


### PR DESCRIPTION
Address spacing between various `KeyField` component fields.

Profile Eth keys:
<img width="575" alt="Screen Shot 2020-02-11 at 9 49 28" src="https://user-images.githubusercontent.com/1064982/74218991-26fa8d00-4cb4-11ea-855a-9309cfac5b01.png">

Profile Api keys:
<img width="580" alt="Screen Shot 2020-02-11 at 9 49 38" src="https://user-images.githubusercontent.com/1064982/74218985-1d712500-4cb4-11ea-90ed-c229caa0ff38.png">

Stream Api credentials:
<img width="735" alt="Screen Shot 2020-02-11 at 9 49 56" src="https://user-images.githubusercontent.com/1064982/74218953-05010a80-4cb4-11ea-8186-44a3a30225b3.png">

Also fixed profile form spacing:
<img width="584" alt="Screen Shot 2020-02-11 at 9 50 09" src="https://user-images.githubusercontent.com/1064982/74218941-fc103900-4cb3-11ea-8f60-794b0580f96b.png">