### PR TITLE
[PLATFORM-1201] Add subscriber graph

### DIFF
--- a/app/src/marketplace/containers/ProductPage/SubscriberGraph.jsx
+++ b/app/src/marketplace/containers/ProductPage/SubscriberGraph.jsx
@@ -1,0 +1,107 @@
+// @flow
+
+import React, { useEffect, useState } from 'react'
+import MediaQuery from 'react-responsive'
+
+import { lg } from '$app/scripts/breakpoints'
+import { getSubscribedEvents } from '$mp/modules/contractProduct/services'
+
+import TimeSeriesGraph from '$shared/components/TimeSeriesGraph'
+import WithShownDays from '$shared/components/TimeSeriesGraph/WithShownDays'
+
+type Props = {
+    className?: string,
+    productId: string,
+}
+
+const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
+
+const SubscriberGraph = ({ className, productId }: Props) => {
+    const [graphData, setGraphData] = useState([])
+    const [subscriptionData, setSubscriptionData] = useState([])
+    const [shownDays, setShownDays] = useState(7)
+    const [isLoading, setIsLoading] = useState(false)
+
+    useEffect(() => {
+        const getSubscriptions = async () => {
+            setIsLoading(true)
+            const fromTimestamp = Date.now() - (shownDays * MILLISECONDS_IN_DAY)
+            const subscriptions = await getSubscribedEvents(productId, fromTimestamp)
+            setSubscriptionData(subscriptions)
+            setIsLoading(false)
+        }
+        getSubscriptions()
+    }, [productId, shownDays])
+
+    useEffect(() => {
+        if (subscriptionData.length > 0) {
+            const data = []
+            const subs = subscriptionData
+                .filter((e) => e.start <= Date.now())
+                .map((e) => ({
+                    time: e.start,
+                    type: 's', // s = subscription
+                }))
+            const unsubs = subscriptionData
+                .filter((e) => e.end <= Date.now())
+                .map((e) => ({
+                    time: e.end,
+                    type: 'u', // u = unsubscription
+                }))
+
+            // Combine subscription and unsubscription events to a single array
+            // ordered by event time
+            const events = ([...subs, ...unsubs]).sort((a, b) => a.time - b.time)
+
+            let subCount = 0
+            events.forEach((e) => {
+                // Add a superficial datapoint with "old" count
+                // to happen 1ms before actual one to form a
+                // "staircase" graph
+                data.push({
+                    x: e.time - 1,
+                    y: subCount,
+                })
+
+                if (e.type === 's') {
+                    subCount += 1
+                } else if (e.type === 'u') {
+                    subCount -= 1
+                }
+
+                // Push actual data point with new subscriber
+                // count
+                data.push({
+                    x: e.time,
+                    y: subCount,
+                })
+            })
+
+            setGraphData(data)
+        }
+    }, [subscriptionData])
+
+    return (
+        <MediaQuery maxWidth={lg.max}>
+            {(isTabletOrMobile: boolean) => (
+                <WithShownDays
+                    label="Subscribers"
+                    className={className}
+                    onDaysChange={(days) => setShownDays(days)}
+                >
+                    {({ shownDays: days }) => (
+                        <TimeSeriesGraph
+                            graphData={graphData}
+                            shownDays={days}
+                            width={isTabletOrMobile ? 380 : 540}
+                            height={200}
+                            isLoading={isLoading}
+                        />
+                    )}
+                </WithShownDays>
+            )}
+        </MediaQuery>
+    )
+}
+
+export default SubscriberGraph

--- a/app/src/marketplace/modules/contractProduct/services.js
+++ b/app/src/marketplace/modules/contractProduct/services.js
@@ -60,6 +60,9 @@ export const getMostRecentPurchaseTimestamp = async (id: ProductId, usePublicNod
     return null
 }
 
+// Seeks blocks starting from 'initialBlockNumberGuess' and checks block timestamps
+// until 'targetTimestampMs' is matched.
+// Returns best guess when 'maxTries' is reached.
 export const seekBlockWithTimestamp = async (
     web3: any,
     initialBlockNumberGuess: number,
@@ -80,7 +83,7 @@ export const seekBlockWithTimestamp = async (
         return block.number
     }
 
-    // Try to find closer block
+    // Try to find a closer block
     const blocksToSeek = Math.floor(Math.abs(diff) / blockTime)
 
     if (diff < 0) {
@@ -96,6 +99,9 @@ export const calculateBlockNumber = async (web3: any, timestampMs: number) => {
     const secondsBetween = (latestBlock.timestamp - (timestampMs / 1000))
     const blocksToRewind = Math.floor(secondsBetween / blockTime)
     const predictedBlock = latestBlock.number - blocksToRewind
+
+    // Predicted block will not probably be right so make sure we get the right block
+    // corresponding to given timestamp
     return seekBlockWithTimestamp(web3, predictedBlock, timestampMs, blockTime)
 }
 

--- a/app/src/marketplace/modules/contractProduct/services.js
+++ b/app/src/marketplace/modules/contractProduct/services.js
@@ -23,15 +23,20 @@ export const getProductFromContract = async (id: ProductId, usePublicNode: boole
         })
 )
 
-export const getSubscriberCount = async (id: ProductId, usePublicNode: boolean = false) => {
+export const getMarketplaceEvents = async (id: ProductId, eventName: string, fromBlock: number = 0, usePublicNode: boolean = false) => {
     const contract = getContract(getConfig().marketplace, usePublicNode)
-    const events = await contract.getPastEvents('Subscribed', {
+    const events = await contract.getPastEvents(eventName, {
         filter: {
             productId: getValidId(id),
         },
-        fromBlock: 0,
+        fromBlock,
         toBlock: 'latest',
     })
+    return events
+}
+
+export const getSubscriberCount = async (id: ProductId, usePublicNode: boolean = false) => {
+    const events = await getMarketplaceEvents(id, 'Subscribed', 0, usePublicNode)
     const validSubs = events.filter((e) => (
         e.returnValues && e.returnValues.endTimestamp && ((e.returnValues.endTimestamp.toNumber() * 1000) > Date.now())
     ))
@@ -40,14 +45,7 @@ export const getSubscriberCount = async (id: ProductId, usePublicNode: boolean =
 
 export const getMostRecentPurchaseTimestamp = async (id: ProductId, usePublicNode: boolean = false) => {
     const web3 = usePublicNode ? getPublicWeb3() : getWeb3()
-    const contract = getContract(getConfig().marketplace, usePublicNode)
-    const events = await contract.getPastEvents('Subscribed', {
-        filter: {
-            productId: getValidId(id),
-        },
-        fromBlock: 0,
-        toBlock: 'latest',
-    })
+    const events = await getMarketplaceEvents(id, 'Subscribed', 0, usePublicNode)
 
     if (events.length === 0) {
         return null
@@ -60,4 +58,64 @@ export const getMostRecentPurchaseTimestamp = async (id: ProductId, usePublicNod
     }
 
     return null
+}
+
+export const seekBlockWithTimestamp = async (
+    web3: any,
+    initialBlockNumberGuess: number,
+    targetTimestampMs: number,
+    blockTime: number,
+    maxTries: number = 20,
+) => {
+    const block = await web3.eth.getBlock(initialBlockNumberGuess)
+    const diff = block.timestamp - (targetTimestampMs / 1000)
+
+    // Check if this is close enough block
+    if (Math.abs(diff) <= blockTime) {
+        return block.number
+    }
+
+    // Abort if block cannot be found
+    if (maxTries <= 0) {
+        return block.number
+    }
+
+    // Try to find closer block
+    const blocksToSeek = Math.floor(Math.abs(diff) / blockTime)
+
+    if (diff < 0) {
+        return seekBlockWithTimestamp(web3, block.number + blocksToSeek, targetTimestampMs, blockTime, maxTries - 1)
+    }
+    return seekBlockWithTimestamp(web3, block.number - blocksToSeek, targetTimestampMs, blockTime, maxTries - 1)
+}
+
+export const calculateBlockNumber = async (web3: any, timestampMs: number) => {
+    const latestBlock = await web3.eth.getBlock('latest')
+    const firstBlock = await web3.eth.getBlock(1)
+    const blockTime = (latestBlock.timestamp - firstBlock.timestamp) / (latestBlock.number - firstBlock.number)
+    const secondsBetween = (latestBlock.timestamp - (timestampMs / 1000))
+    const blocksToRewind = Math.floor(secondsBetween / blockTime)
+    const predictedBlock = latestBlock.number - blocksToRewind
+    return seekBlockWithTimestamp(web3, predictedBlock, timestampMs, blockTime)
+}
+
+export const getSubscribedEvents = async (id: ProductId, fromTimestamp: number, usePublicNode: boolean = false) => {
+    const web3 = usePublicNode ? getPublicWeb3() : getWeb3()
+    const fromBlock = await calculateBlockNumber(web3, fromTimestamp)
+    const events = await getMarketplaceEvents(id, 'Subscribed', fromBlock, usePublicNode)
+    const subscriptions = []
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const e of events) {
+        // eslint-disable-next-line no-await-in-loop
+        const block = await web3.eth.getBlock(e.blockHash)
+        if (block && block.timestamp) {
+            subscriptions.push({
+                start: block.timestamp * 1000,
+                end: e.returnValues && e.returnValues.endTimestamp && (e.returnValues.endTimestamp.toNumber() * 1000),
+            })
+        }
+    }
+
+    return subscriptions
 }

--- a/app/src/shared/components/TimeSeriesGraph/index.jsx
+++ b/app/src/shared/components/TimeSeriesGraph/index.jsx
@@ -12,7 +12,22 @@ import '$app/node_modules/react-vis/dist/style.css'
 
 import Spinner from '$shared/components/Spinner'
 
-const axisStyle = {
+const xAxisStyle = {
+    ticks: {
+        fontSize: '12px',
+        fontFamily: "'IBM Plex Sans', sans-serif",
+        color: '#A3A3A3',
+        strokeOpacity: '1',
+        stroke: '#A3A3A3',
+        opacity: '0.5',
+        letterSpacing: '0px',
+    },
+    text: {
+        strokeWidth: '0',
+    },
+}
+
+const yAxisStyle = {
     ticks: {
         fontSize: '12px',
         fontFamily: "'IBM Plex Sans', sans-serif",
@@ -112,13 +127,13 @@ const TimeSeriesGraph = ({
                     />
                     <XAxis
                         hideLine
-                        style={axisStyle}
+                        style={xAxisStyle}
                         tickTotal={7}
                         tickFormat={(value, index, scale, tickTotal) => formatXAxisTicks(value, index, scale, tickTotal, shownDays)}
                     />
                     <YAxis
                         hideLine
-                        style={axisStyle}
+                        style={yAxisStyle}
                         position="middle"
                         orientation="right"
                     />

--- a/app/src/shared/components/TimeSeriesGraph/index.jsx
+++ b/app/src/shared/components/TimeSeriesGraph/index.jsx
@@ -10,6 +10,8 @@ import {
 } from 'react-vis'
 import '$app/node_modules/react-vis/dist/style.css'
 
+import Spinner from '$shared/components/Spinner'
+
 const axisStyle = {
     ticks: {
         fontSize: '12px',
@@ -48,6 +50,7 @@ type Props = {
     shownDays: number,
     width: number,
     height: number,
+    isLoading?: boolean,
 }
 
 const TimeSeriesGraph = ({
@@ -56,6 +59,7 @@ const TimeSeriesGraph = ({
     shownDays,
     width,
     height,
+    isLoading,
 }: Props) => {
     const dataDomain = useMemo(() => {
         const dataValues = (graphData || []).map((d) => d.y)
@@ -73,39 +77,53 @@ const TimeSeriesGraph = ({
 
     return (
         <div className={className}>
-            <XYPlot
-                xType="time"
-                width={width}
-                height={height}
-                /* We need margin to not clip axis labels */
-                margin={{
-                    left: 0,
-                    right: 50,
-                }}
-                yDomain={dataDomain}
-            >
-                <HorizontalGridLines />
-                <LineSeries
-                    curve={null}
-                    color="#0324FF"
-                    opacity={1}
-                    strokeStyle="solid"
-                    strokeWidth="4"
-                    data={graphData}
-                />
-                <XAxis
-                    hideLine
-                    style={axisStyle}
-                    tickTotal={7}
-                    tickFormat={(value, index, scale, tickTotal) => formatXAxisTicks(value, index, scale, tickTotal, shownDays)}
-                />
-                <YAxis
-                    hideLine
-                    style={axisStyle}
-                    position="middle"
-                    orientation="right"
-                />
-            </XYPlot>
+            {isLoading && (
+                <div
+                    style={{
+                        width,
+                        height,
+                        display: 'flex',
+                        justifyContent: 'center',
+                    }}
+                >
+                    <Spinner size="large" color="white" />
+                </div>
+            )}
+            {!isLoading && (
+                <XYPlot
+                    xType="time"
+                    width={width}
+                    height={height}
+                    /* We need margin to not clip axis labels */
+                    margin={{
+                        left: 0,
+                        right: 50,
+                    }}
+                    yDomain={dataDomain}
+                >
+                    <HorizontalGridLines />
+                    <LineSeries
+                        curve={null}
+                        color="#0324FF"
+                        opacity={1}
+                        strokeStyle="solid"
+                        strokeWidth="4"
+                        data={graphData}
+                    />
+                    <XAxis
+                        hideLine
+                        style={axisStyle}
+                        tickTotal={7}
+                        tickFormat={(value, index, scale, tickTotal) => formatXAxisTicks(value, index, scale, tickTotal, shownDays)}
+                    />
+                    <YAxis
+                        hideLine
+                        style={axisStyle}
+                        position="middle"
+                        orientation="right"
+                    />
+                </XYPlot>
+            )}
         </div>
     )
 }

--- a/app/src/userpages/components/ProductsPage/Stats/index.jsx
+++ b/app/src/userpages/components/ProductsPage/Stats/index.jsx
@@ -19,6 +19,7 @@ import useDataUnionStats from '$mp/containers/ProductPage/useDataUnionStats'
 import DataUnionPending from '$mp/components/ProductPage/DataUnionPending'
 import StatsValues from '$shared/components/DataUnionStats/Values'
 import MembersGraph from '$mp/containers/ProductPage/MembersGraph'
+import SubscriberGraph from '$mp/containers/ProductPage/SubscriberGraph'
 
 import styles from './stats.pcss'
 
@@ -71,7 +72,11 @@ const Stats = () => {
                             )}
                         </div>
                         <div className={styles.graphBox}>
-                            TODO: subscribers graph missing
+                            {!!dataUnionDeployed && product && (
+                                <SubscriberGraph
+                                    productId={product.id}
+                                />
+                            )}
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
Adds missing subscriber graph for data union stats page.

It shows a graph of subscriptions read from `Subscribed` events of the marketplace contract. The loading state is just a white spinner currently. We probably want something else there.

![Screenshot 2020-02-11 at 10 38 21](https://user-images.githubusercontent.com/432588/74228699-a34b9b00-4cc9-11ea-8e14-9e320beb858f.png)

You can test the graph by creating a data union (+deploy & publish) and buying the product from marketplace.