### PR TITLE
[PLATFORM-1219] Fix live preview to show empty table if there's no data

### DIFF
--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -48,6 +48,8 @@ const prettyPrintData = (data: ?{}, compact: boolean = false) => stringifyObject
     inlineCharacterLimit: compact ? Infinity : 5,
 })
 
+const getNumberOfRows = (isMobile: boolean) => (isMobile ? 5 : 8)
+
 const StreamLivePreview = ({
     streamId,
     selectedDataPoint,
@@ -100,7 +102,7 @@ const StreamLivePreview = ({
             />
             <MediaQuery maxWidth={sm.max}>
                 {(isMobile) => {
-                    const data = isMobile ? visibleData.slice(0, 5) : visibleData.slice(0, 8)
+                    const data = visibleData.slice(0, getNumberOfRows(isMobile))
                     return (
                         <div className={styles.streamLivePreview}>
                             {(isMobile) ? (
@@ -144,7 +146,17 @@ const StreamLivePreview = ({
                                                                 {formatDateTime(d.metadata
                                                                     && d.metadata.messageId && d.metadata.messageId.timestamp, tz)}
                                                             </td>
-                                                        </tr>))}
+                                                        </tr>
+                                                    ))}
+                                                    {
+                                                        userpagesPreview &&
+                                                        data.length === 0 &&
+                                                        [...Array(getNumberOfRows(isMobile)).keys()].map((index) => (
+                                                            <tr key={index}>
+                                                                <td className={styles.timestampColumn} />
+                                                            </tr>
+                                                        ))
+                                                    }
                                                 </tbody>
                                             </Table>
                                             <Table className={classnames(
@@ -175,6 +187,15 @@ const StreamLivePreview = ({
                                                             </td>
                                                         </tr>
                                                     ))}
+                                                    {
+                                                        userpagesPreview &&
+                                                        data.length === 0 &&
+                                                        [...Array(getNumberOfRows(isMobile)).keys()].map((index) => (
+                                                            <tr key={index}>
+                                                                <td className={styles.messageColumn} />
+                                                            </tr>
+                                                        ))
+                                                    }
                                                 </tbody>
                                             </Table>
                                         </SwipeableViews>
@@ -227,6 +248,16 @@ const StreamLivePreview = ({
                                                 </td>
                                             </tr>
                                         ))}
+                                        {
+                                            userpagesPreview &&
+                                            data.length === 0 &&
+                                            [...Array(getNumberOfRows(isMobile)).keys()].map((index) => (
+                                                <tr key={index}>
+                                                    <td className={styles.timestampColumn} />
+                                                    <td className={styles.messageColumn} />
+                                                </tr>
+                                            ))
+                                        }
                                     </tbody>
                                 </Table>
                             )}

--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -96,6 +96,12 @@ const StreamLivePreview = ({
                     id: streamId,
                 }}
                 resendLast={LOCAL_DATA_LIST_LENGTH}
+                onSubscribed={() => {
+                    // Clear data when subscribed to make sure
+                    // we don't get duplicate messages with resend
+                    setVisibleData([])
+                    dataRef.current = []
+                }}
                 isActive={run}
                 onMessage={onData}
                 onErrorMessage={() => setDataError(true)}

--- a/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/StreamLivePreview/index.jsx
@@ -102,7 +102,16 @@ const StreamLivePreview = ({
             />
             <MediaQuery maxWidth={sm.max}>
                 {(isMobile) => {
-                    const data = visibleData.slice(0, getNumberOfRows(isMobile))
+                    const length = getNumberOfRows(isMobile)
+                    let data = visibleData.slice(0, length)
+
+                    // Pad array with nulls to fill preview length
+                    if (userpagesPreview) {
+                        const originalLength = data.length
+                        data.length = length
+                        data = data.fill(null, originalLength, length)
+                    }
+
                     return (
                         <div className={styles.streamLivePreview}>
                             {(isMobile) ? (
@@ -137,25 +146,29 @@ const StreamLivePreview = ({
                                                     </tr>
                                                 </thead>
                                                 <tbody>
-                                                    {data.map((d) => (
-                                                        <tr
-                                                            key={JSON.stringify(d.metadata.messageId)}
-                                                            onClick={() => onSelectDataPoint(d)}
-                                                        >
-                                                            <td className={styles.timestampColumn}>
-                                                                {formatDateTime(d.metadata
-                                                                    && d.metadata.messageId && d.metadata.messageId.timestamp, tz)}
-                                                            </td>
-                                                        </tr>
-                                                    ))}
                                                     {
-                                                        userpagesPreview &&
-                                                        data.length === 0 &&
-                                                        [...Array(getNumberOfRows(isMobile)).keys()].map((index) => (
-                                                            <tr key={index}>
-                                                                <td className={styles.timestampColumn} />
-                                                            </tr>
-                                                        ))
+                                                        data.map((d, index) => {
+                                                            if (d == null) {
+                                                                return (
+                                                                    // eslint-disable-next-line react/no-array-index-key
+                                                                    <tr key={index}>
+                                                                        <td className={styles.timestampColumn} />
+                                                                    </tr>
+                                                                )
+                                                            }
+
+                                                            return (
+                                                                <tr
+                                                                    key={JSON.stringify(d.metadata.messageId)}
+                                                                    onClick={() => onSelectDataPoint(d)}
+                                                                >
+                                                                    <td className={styles.timestampColumn}>
+                                                                        {formatDateTime(d.metadata
+                                                                            && d.metadata.messageId && d.metadata.messageId.timestamp, tz)}
+                                                                    </td>
+                                                                </tr>
+                                                            )
+                                                        })
                                                     }
                                                 </tbody>
                                             </Table>
@@ -175,26 +188,30 @@ const StreamLivePreview = ({
                                                     </tr>
                                                 </thead>
                                                 <tbody>
-                                                    {data.map((d) => (
-                                                        <tr
-                                                            key={JSON.stringify(d.metadata.messageId)}
-                                                            onClick={() => onSelectDataPoint(d)}
-                                                        >
-                                                            <td className={styles.messageColumn}>
-                                                                <div className={styles.messagePreview}>
-                                                                    {prettyPrintData(d.data, true)}
-                                                                </div>
-                                                            </td>
-                                                        </tr>
-                                                    ))}
                                                     {
-                                                        userpagesPreview &&
-                                                        data.length === 0 &&
-                                                        [...Array(getNumberOfRows(isMobile)).keys()].map((index) => (
-                                                            <tr key={index}>
-                                                                <td className={styles.messageColumn} />
-                                                            </tr>
-                                                        ))
+                                                        data.map((d, index) => {
+                                                            if (d == null) {
+                                                                return (
+                                                                    // eslint-disable-next-line react/no-array-index-key
+                                                                    <tr key={index}>
+                                                                        <td className={styles.messageColumn} />
+                                                                    </tr>
+                                                                )
+                                                            }
+
+                                                            return (
+                                                                <tr
+                                                                    key={JSON.stringify(d.metadata.messageId)}
+                                                                    onClick={() => onSelectDataPoint(d)}
+                                                                >
+                                                                    <td className={styles.messageColumn}>
+                                                                        <div className={styles.messagePreview}>
+                                                                            {prettyPrintData(d.data, true)}
+                                                                        </div>
+                                                                    </td>
+                                                                </tr>
+                                                            )
+                                                        })
                                                     }
                                                 </tbody>
                                             </Table>
@@ -233,30 +250,34 @@ const StreamLivePreview = ({
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        {data.map((d) => (
-                                            <tr
-                                                key={JSON.stringify(d.metadata.messageId)}
-                                                onClick={() => onSelectDataPoint(d)}
-                                            >
-                                                <td className={styles.timestampColumn}>
-                                                    {formatDateTime(d.metadata && d.metadata.messageId && d.metadata.messageId.timestamp, tz)}
-                                                </td>
-                                                <td className={styles.messageColumn}>
-                                                    <div className={styles.messagePreview}>
-                                                        {prettyPrintData(d.data, true)}
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        ))}
                                         {
-                                            userpagesPreview &&
-                                            data.length === 0 &&
-                                            [...Array(getNumberOfRows(isMobile)).keys()].map((index) => (
-                                                <tr key={index}>
-                                                    <td className={styles.timestampColumn} />
-                                                    <td className={styles.messageColumn} />
-                                                </tr>
-                                            ))
+                                            data.map((d, index) => {
+                                                if (d == null) {
+                                                    return (
+                                                        // eslint-disable-next-line react/no-array-index-key
+                                                        <tr key={index}>
+                                                            <td className={styles.timestampColumn} />
+                                                            <td className={styles.messageColumn} />
+                                                        </tr>
+                                                    )
+                                                }
+
+                                                return (
+                                                    <tr
+                                                        key={JSON.stringify(d.metadata.messageId)}
+                                                        onClick={() => onSelectDataPoint(d)}
+                                                    >
+                                                        <td className={styles.timestampColumn}>
+                                                            {formatDateTime(d.metadata && d.metadata.messageId && d.metadata.messageId.timestamp, tz)}
+                                                        </td>
+                                                        <td className={styles.messageColumn}>
+                                                            <div className={styles.messagePreview}>
+                                                                {prettyPrintData(d.data, true)}
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                )
+                                            })
                                         }
                                     </tbody>
                                 </Table>

--- a/app/src/shared/components/Button/index.jsx
+++ b/app/src/shared/components/Button/index.jsx
@@ -53,7 +53,7 @@ const Button = ({
                 [styles.outline]: outline,
             }, className)
         }
-        onClick={onClick}
+        onClick={disabled ? ((e) => e.preventDefault()) : onClick}
         disabled={disabled || waiting}
         tabIndex={disabled ? -1 : 0}
     >

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
@@ -21,7 +21,7 @@ type Props = {
 
 const PreviewView = ({ stream, currentUser }: Props) => {
     const [isRunning, setIsRunning] = useState(true)
-    const [hasData, setHasData] = useState(false)
+    const [hasData, setHasData] = useState(true)
 
     const onToggleRun = useCallback(() => {
         setIsRunning((wasRunning) => !wasRunning)
@@ -33,15 +33,13 @@ const PreviewView = ({ stream, currentUser }: Props) => {
 
     return (
         <ClientProvider>
-            <Translate value="userpages.streams.edit.preview.description" className={styles.longText} tag="p" />
-            {!hasData ?
-                <p className={styles.longText}>
-                    <Translate value="userpages.streams.edit.preview.noDataPre" />
-                    <Link to={routes.docsGettingStarted()}>Docs</Link>
-                    <Translate value="userpages.streams.edit.preview.noDataEnd" />
-                </p>
-                : null
-            }
+            <Translate
+                value="userpages.streams.edit.preview.description"
+                className={styles.longText}
+                tag="p"
+                dangerousHTML
+                docsLink={routes.docsGettingStarted()}
+            />
             <div
                 className={cx(styles.previewContainer, {
                     [styles.hasData]: hasData,

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/index.jsx
@@ -3,7 +3,6 @@
 import React, { useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { Translate } from 'react-redux-i18n'
-import cx from 'classnames'
 
 import type { Stream } from '$shared/flowtype/stream-types'
 import type { User } from '$shared/flowtype/user-types'
@@ -21,7 +20,7 @@ type Props = {
 
 const PreviewView = ({ stream, currentUser }: Props) => {
     const [isRunning, setIsRunning] = useState(true)
-    const [hasData, setHasData] = useState(true)
+    const [hasData, setHasData] = useState(false)
 
     const onToggleRun = useCallback(() => {
         setIsRunning((wasRunning) => !wasRunning)
@@ -41,9 +40,7 @@ const PreviewView = ({ stream, currentUser }: Props) => {
                 docsLink={routes.docsGettingStarted()}
             />
             <div
-                className={cx(styles.previewContainer, {
-                    [styles.hasData]: hasData,
-                })}
+                className={styles.previewContainer}
             >
                 <StreamLivePreview
                     key={stream.id}
@@ -60,6 +57,7 @@ const PreviewView = ({ stream, currentUser }: Props) => {
                         kind="secondary"
                         className={styles.playPauseButton}
                         onClick={onToggleRun}
+                        disabled={!hasData}
                     >
                         {!isRunning ?
                             <Translate value="userpages.streams.edit.preview.start" /> :
@@ -74,6 +72,7 @@ const PreviewView = ({ stream, currentUser }: Props) => {
                             to={routes.userPageStreamPreview({
                                 streamId: stream.id,
                             })}
+                            disabled={!hasData}
                         >
                             <Translate value="userpages.streams.edit.preview.inspect" />
                         </Button>

--- a/app/src/userpages/components/StreamPage/Show/PreviewView/previewView.pcss
+++ b/app/src/userpages/components/StreamPage/Show/PreviewView/previewView.pcss
@@ -10,12 +10,16 @@
 }
 
 .previewContainer {
-  display: none;
+  display: grid;
   grid-template-rows: 1fr 72px;
   position: relative;
   max-width: 682px;
   margin: 2em 0;
   background-color: #FDFDFD;
+
+  a {
+    text-decoration: none;
+  }
 
   .previewControls {
     .inspectButton {
@@ -24,13 +28,5 @@
 
     .playPauseButton {
     }
-  }
-}
-
-.hasData {
-  display: grid;
-
-  a {
-    text-decoration: none;
   }
 }

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -475,9 +475,8 @@ msgid "userpages##streams##edit##configure##historicalStoragePeriod##label"
 msgstr "Period to retain historical data until auto-removal"
 
 msgid "userpages##streams##edit##preview##description"
-msgstr ""
-"You can configure your stream’s fields and preview the live data here. "
-"Use the Inspector to view details, and the transport controls to check the data is flowing correctly."
+msgstr "You can preview the stream's live data here. Use the Inspector to view details and use the transport controls to check the data is flowing correctly. "
+"If you need help pushing data to your stream, see the <a href=\"%{docsLink}\">docs</a>."
 
 msgid "userpages##streams##edit##preview##inspect"
 msgstr "Inspect data"
@@ -487,12 +486,6 @@ msgstr "Start"
 
 msgid "userpages##streams##edit##preview##stop"
 msgstr "Stop"
-
-msgid "userpages##streams##edit##preview##noDataPre"
-msgstr "This Stream has no data yet. Check out the "
-
-msgid "userpages##streams##edit##preview##noDataEnd"
-msgstr " for a guide to push data to your stream."
 
 msgid "userpages##streams##delete##confirmTitle"
 msgstr "Delete this stream?"


### PR DESCRIPTION
Included stream data live preview table with empty rows when there's no data in the stream.

Also tweaked the intro text for preview section to include docs link. I had to revert the description text to previous version since Abstract (still) has wrong text for the preview section (there's no possibility to configure fields there). I remember getting this current version from Matt some time ago.

Details here: https://streamr.atlassian.net/browse/PLATFORM-1219

What do you think about including the docs link to the section description even if there's data in the stream? I included it because otherwise there would a noticeable "bump" in the UI when data starts to flow.