### PR TITLE
[PLATFORM-1268] Fix allowance dialog wait states

### DIFF
--- a/app/src/marketplace/containers/ProductPage/PurchaseModal.jsx
+++ b/app/src/marketplace/containers/ProductPage/PurchaseModal.jsx
@@ -378,7 +378,7 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
             <ReplaceAllowanceDialog
                 onCancel={onClose}
                 onSet={onSetDataAllowance}
-                settingDataAllowance={resettingDataAllowance}
+                settingAllowance={resettingDataAllowance}
             />
         )
     }
@@ -388,7 +388,7 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
             <SetAllowanceDialog
                 onCancel={onClose}
                 onSet={onSetDataAllowance}
-                settingDataAllowance={settingDataAllowance}
+                settingAllowance={settingDataAllowance}
                 paymentCurrency={paymentCurrency}
             />
         )
@@ -399,7 +399,7 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
             <ReplaceAllowanceDialog
                 onCancel={onClose}
                 onSet={onSetDaiAllowance}
-                settingDaiAllowance={resettingDaiAllowance}
+                settingAllowance={resettingDaiAllowance}
             />
         )
     }
@@ -409,7 +409,7 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
             <SetAllowanceDialog
                 onCancel={onClose}
                 onSet={onSetDaiAllowance}
-                settingDaiAllowance={settingDaiAllowance}
+                settingAllowance={settingDaiAllowance}
                 paymentCurrency={paymentCurrency}
             />
         )


### PR DESCRIPTION
Wait states were not being shown because of wrong prop names.

> Also setting the allowance higher than the current allowance should reset the allowance to zero first and then set the correct allowance. 

 Setting a DATA allowance, and then setting higher allowance works ok (reset before setting again). DAI doesn't work at least locally due to this code returning always `0` even after setting an allowance:

```js
export const getMyDaiAllowance = (): SmartContractCall<BN> => {
    const web3 = getWeb3()
    return web3.getDefaultAccount()
        .then((myAddress) => call(daiTokenContractMethods().allowance(myAddress, marketplaceContract().options.address)))
        .then(fromAtto)
}
```

Let's test in staging, see if it works.