### PR TITLE
[PLATFORM-1197] Remove Community Product debug info from editor

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/index.jsx
+++ b/app/src/marketplace/containers/EditProductPage/index.jsx
@@ -164,7 +164,9 @@ const EditProductPage = ({ product }: { product: Product }) => {
             })}
             loading={isSaving}
         >
-            <ProductEditorDebug />
+            {process.env.DATA_UNIONS && (
+                <ProductEditorDebug />
+            )}
             {isPreview && (
                 <Preview />
             )}


### PR DESCRIPTION
Hide editor debug unless DATA_UNIONS flag is present