### PR TITLE
[PLATFORM-1269] Fix stream selector search

### DIFF
--- a/app/src/shared/components/EditableText/index.jsx
+++ b/app/src/shared/components/EditableText/index.jsx
@@ -24,6 +24,7 @@ type Props = {
     placeholder?: ?string,
     probe?: Node,
     setEditing: (boolean) => void,
+    immediateCommit?: boolean,
 }
 
 function isBlank(str) {
@@ -46,6 +47,7 @@ const EditableText = ({
     probe,
     setEditing,
     title,
+    immediateCommit,
     ...props
 }: Props) => {
     const children = (childrenProp == null) ? EditableText.defaultProps.children : childrenProp
@@ -117,7 +119,7 @@ const EditableText = ({
                     <Fragment>
                         <TextControl
                             {...props}
-                            immediateCommit={false}
+                            immediateCommit={immediateCommit}
                             autoComplete="off"
                             autoFocus
                             flushHistoryOnBlur


### PR DESCRIPTION
Fixes this bug in the editor:

**Steps to reproduce**

* Edit canvas
* Add any stream module with stream search
* Type to search stream, select one
* Click outside of module to blur text field
* Focus stream field, start typing

**Expected outcome**

Stream list is refreshed with new results

**Actual outcome**

Only the current result (= stream selected from first search results) is shown 

Fix was to pass the `immediateCommit` to `EditableText` which was `false` by default.