### PR TITLE
[PLATFORM-1262] Broken "Forgot password?" link in Change password dialog

### DIFF
--- a/app/src/userpages/components/ProfilePage/ChangePassword/index.jsx
+++ b/app/src/userpages/components/ProfilePage/ChangePassword/index.jsx
@@ -121,7 +121,12 @@ class ChangePasswordDialog extends Component<Props, State> {
                     renderActions={() => (
                         <div className={styles.footer}>
                             <div className={styles.footerText}>
-                                <Link to={routes.forgotPassword()} className={styles.forgotLink}>
+                                <Link
+                                    to={routes.forgotPassword({
+                                        from: 'profile',
+                                    })}
+                                    className={styles.forgotLink}
+                                >
                                     <Translate value="modal.changePassword.forgotPassword.mobile" className={styles.forgotLinkTextMobile} />
                                     <Translate value="modal.changePassword.forgotPassword.desktop" className={styles.forgotLinkTextDesktop} />
                                 </Link>


### PR DESCRIPTION
Forgot password link in user profile (change password dialog) wasn't working because the route wasn't accessible to logged in users. Back link is shown if there is a url parameter, otherwise works as before.