### PR TITLE
[PLATFORM-1271] Add support for empty subscriber graph

### DIFF
--- a/app/src/shared/components/TimeSeriesGraph/index.jsx
+++ b/app/src/shared/components/TimeSeriesGraph/index.jsx
@@ -44,9 +44,11 @@ const formatXAxisTicks = (value, index, scale, tickTotal, dayCount) => {
         return scale.tickFormat(tickTotal, '%a %d')(value)
     }
 
-    // Include month only for the first item and when month
-    // changes.
-    if (index === 0 || value.getDate() === 1) {
+    const previousTickDate = index > 0 ? scale.ticks()[index - 1] : null
+    const monthChanged = previousTickDate != null ? value.getMonth() !== previousTickDate.getMonth() : false
+
+    // Include month name only for the first item and when month changes
+    if (index === 0 || monthChanged) {
         return scale.tickFormat(tickTotal, '%b %d')(value)
     }
 
@@ -111,7 +113,7 @@ const TimeSeriesGraph = ({
                     height={height}
                     /* We need margin to not clip axis labels */
                     margin={{
-                        left: 0,
+                        left: 10,
                         right: 50,
                     }}
                     yDomain={dataDomain}

--- a/app/src/shared/components/TimeSeriesGraph/index.jsx
+++ b/app/src/shared/components/TimeSeriesGraph/index.jsx
@@ -113,7 +113,7 @@ const TimeSeriesGraph = ({
                     height={height}
                     /* We need margin to not clip axis labels */
                     margin={{
-                        left: 10,
+                        left: 0,
                         right: 50,
                     }}
                     yDomain={dataDomain}


### PR DESCRIPTION
Subscriber graph now draws a zero line when there are no purchases for given product. Previously it would render nothing.