### PR TITLE
[PLATFORM-1279] Fix overflowing identity names

### DIFF
--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -165,8 +165,11 @@ const KeyField = ({
                     className={cx(styles.keyFieldContainer, keyFieldClassName)}
                 >
                     <div className={styles.labelWrapper}>
-                        <Label htmlFor="keyName">
-                            {keyName}
+                        <Label htmlFor="keyName" className={styles.label}>
+                            &zwnj;
+                            <div className={styles.keyNameHolder}>
+                                {keyName}
+                            </div>
                         </Label>
                         <div>
                             {labelComponent}

--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -168,7 +168,9 @@ const KeyField = ({
                         <Label htmlFor="keyName">
                             {keyName}
                         </Label>
-                        {labelComponent || <div />}
+                        <div>
+                            {labelComponent}
+                        </div>
                     </div>
                     <ActionsDropdown actions={inputActions}>
                         <Text

--- a/app/src/userpages/components/KeyField/keyField.pcss
+++ b/app/src/userpages/components/KeyField/keyField.pcss
@@ -10,3 +10,18 @@
   display: flex;
   justify-content: space-between;
 }
+
+.keyNameHolder {
+  left: 0;
+  max-width: 100%;
+  overflow: hidden;
+  position: absolute;
+  text-overflow: ellipsis;
+  top: 0;
+}
+
+.label {
+  flex-grow: 1;
+  margin-right: 0.5um;
+  position: relative;
+}

--- a/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/index.jsx
@@ -7,6 +7,7 @@ import type { IntegrationKeyId, IntegrationKey, IntegrationKeyList as Integratio
 import KeyField from '$userpages/components/KeyField'
 import { useBalance, BalanceType } from '$shared/hooks/useBalance'
 import styles from './integrationKeyList.pcss'
+import Label from '$ui/Label'
 
 type CommonProps = {|
     hideValues?: boolean,
@@ -58,7 +59,7 @@ const IntegrationKeyItem = ({
                 onToggleEditor={setEditing}
                 valueLabel="address"
                 labelComponent={!editing && (
-                    <div className={styles.balances}>
+                    <Label as="div">
                         <span className={styles.balanceLabel}>DATA</span>
                         <span className={styles.balanceValue}>
                             {!fetchingDataBalance && !dataBalanceError && (dataBalance)}
@@ -69,7 +70,7 @@ const IntegrationKeyItem = ({
                             {!fetchingEthBalance && !ethBalanceError && (ethBalance)}
                             {!fetchingEthBalance && !!ethBalanceError && '-'}
                         </span>
-                    </div>
+                    </Label>
                 )}
             />
         </div>

--- a/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/integrationKeyList.pcss
+++ b/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/integrationKeyList.pcss
@@ -11,16 +11,6 @@
 .singleKey {
 }
 
-.balances {
-  line-height: 1rem;
-  margin-bottom: 8px;
-  font-family: var(--sans);
-  font-size: 0.75rem;
-  font-weight: var(--medium);
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
 .balanceLabel {
   color: #525252;
 }


### PR DESCRIPTION
I fix 2 things here.

First one is this vertical alignment issue:

<img width="688" alt="Screenshot 2020-02-21 11 25 47" src="https://user-images.githubusercontent.com/320066/75029667-c7b22f00-54a2-11ea-8ca8-a4e78131eb72.png">

I do it with class, naturally, in 0d6d5fb! 💃 

The second is name's ability to adopt to available space – subject of [`PLATFORM-1279`](https://streamr.atlassian.net/browse/PLATFORM-1279). Here's how it's gon' be now:

![Feb-21-2020 11-54-34](https://user-images.githubusercontent.com/320066/75029808-119b1500-54a3-11ea-8757-a1b431b797e0.gif)

I preserve a round 8px of space between the balance and the name.