### PR TITLE
[PLATFORM-1263] Show 404 page for non-existing products

### DIFF
--- a/app/src/shared/utils/request.js
+++ b/app/src/shared/utils/request.js
@@ -15,6 +15,7 @@ export const getError = (res: any): ErrorInUi => ({
     message: get(res, 'response.data.error') || get(res, 'response.data.message') || (res && res.message) || 'Something went wrong',
     code: get(res, 'response.data.code') || null,
     statusCode: res && res.response && res.response.status,
+    response: res.response,
 })
 
 export type RequestParams = {


### PR DESCRIPTION
Product pages for non-existing products (both view and edit) take you to /404. This is a shared behaviour between different resources: canvases, dashboards, and now products.

There's a ticket – [`PLATFORM-1283`](https://streamr.atlassian.net/browse/PLATFORM-1283) – for the actual redirections (which I consider to be an issue).