### PR TITLE
[PLATFORM-1276] Rename to use new data union endpoints

### DIFF
--- a/app/src/marketplace/components/Modal/DeployingDataUnionDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/DeployingDataUnionDialog/index.jsx
@@ -55,7 +55,7 @@ const DeployingDataUnionDialog = ({
                             <React.Fragment>
                                 <span className={styles.estimatedTime}>{formatSeconds(estimate)}</span>
                                 &nbsp;
-                                <Translate value="modal.deployCommunity.deploying.estimatedDeploymentTime" />
+                                <Translate value="modal.deployDataUnion.deploying.estimatedDeploymentTime" />
                             </React.Fragment>
                         )}
                     </div>

--- a/app/src/marketplace/components/ProductTypeChooser/index.jsx
+++ b/app/src/marketplace/components/ProductTypeChooser/index.jsx
@@ -76,7 +76,7 @@ const ProductTypeChooser = ({ className }: Props) => (
                         className={styles.button}
                         tag={Link}
                         to={routes.newProduct({
-                            type: productTypes.COMMUNITY,
+                            type: productTypes.DATAUNION,
                         })}
                     >
                         <Translate value="productTypeChooser.dataUnion.linkTitle" />

--- a/app/src/marketplace/containers/EditProductPage/ProductEditorDebug.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ProductEditorDebug.jsx
@@ -26,7 +26,7 @@ const ProductEditorDebug = () => {
 
     const isDataUnion = isDataUnionProduct(product)
     const onTypeChange = useCallback((checked) => {
-        updateType(checked ? productTypes.COMMUNITY : productTypes.NORMAL)
+        updateType(checked ? productTypes.DATAUNION : productTypes.NORMAL)
     }, [updateType])
 
     return (

--- a/app/src/marketplace/containers/EditProductPage/tests/productState.test.js
+++ b/app/src/marketplace/containers/EditProductPage/tests/productState.test.js
@@ -120,7 +120,7 @@ describe('Product State', () => {
                 name: 'My Product',
                 description: 'My nice product',
                 state: productStates.NOT_DEPLOYED,
-                type: productTypes.COMMUNITY,
+                type: productTypes.DATAUNION,
             }
             expect(State.update(product, (p) => ({
                 ...p,
@@ -202,7 +202,7 @@ describe('Product State', () => {
                 name: 'My Product',
                 description: 'My nice product',
                 state: productStates.NOT_DEPLOYED,
-                type: productTypes.COMMUNITY,
+                type: productTypes.DATAUNION,
             }
             expect(State.getPendingChanges(product)).toMatchObject({})
         })
@@ -213,7 +213,7 @@ describe('Product State', () => {
                 name: 'My Product',
                 description: 'My nice product',
                 state: productStates.NOT_DEPLOYED,
-                type: productTypes.COMMUNITY,
+                type: productTypes.DATAUNION,
             }
             expect(State.getPendingChanges({
                 ...product,
@@ -253,7 +253,7 @@ describe('Product State', () => {
                 description: 'My nice product',
                 adminFee: '0.2',
                 state: productStates.DEPLOYED,
-                type: productTypes.COMMUNITY,
+                type: productTypes.DATAUNION,
             }
             expect(State.getPendingChanges({
                 ...product,
@@ -276,7 +276,7 @@ describe('Product State', () => {
                 description: 'My nice product',
                 adminFee: '0.2',
                 state: productStates.NOT_DEPLOYED,
-                type: productTypes.COMMUNITY,
+                type: productTypes.DATAUNION,
             }
             expect(State.getPendingChanges(State.update(product, (p) => ({
                 ...p,
@@ -314,7 +314,7 @@ describe('Product State', () => {
                 name: 'My Product',
                 description: 'My nice product',
                 state: productStates.NOT_DEPLOYED,
-                type: productTypes.COMMUNITY,
+                type: productTypes.DATAUNION,
             }
             const nextProduct = {
                 ...product,
@@ -377,7 +377,7 @@ describe('Product State', () => {
                 description: 'My nice product',
                 adminFee: '0.2',
                 state: productStates.NOT_DEPLOYED,
-                type: productTypes.COMMUNITY,
+                type: productTypes.DATAUNION,
             }
             expect(State.withPendingChanges({
                 ...product,
@@ -392,7 +392,7 @@ describe('Product State', () => {
                 description: 'My nice product',
                 adminFee: '0.5',
                 state: productStates.NOT_DEPLOYED,
-                type: productTypes.COMMUNITY,
+                type: productTypes.DATAUNION,
             })
         })
 

--- a/app/src/marketplace/containers/Products/index.jsx
+++ b/app/src/marketplace/containers/Products/index.jsx
@@ -48,7 +48,7 @@ const Products = () => {
     const { api: createProductModal } = useModal('marketplace.createProduct')
 
     const loadCategories = useCallback(() => dispatch(getCategories(false)), [dispatch])
-    const { load: loadCommunities, members } = useMemberStats()
+    const { load: loadDataUnions, members } = useMemberStats()
 
     const loadProducts = useCallback(() => dispatch(getProducts()), [dispatch])
 
@@ -69,12 +69,12 @@ const Products = () => {
 
     useEffect(() => {
         loadCategories()
-        loadCommunities()
+        loadDataUnions()
 
         if (productsRef.current && productsRef.current.length === 0) {
             clearFiltersAndReloadProducts()
         }
-    }, [loadCommunities, loadCategories, clearFiltersAndReloadProducts])
+    }, [loadDataUnions, loadCategories, clearFiltersAndReloadProducts])
 
     return (
         <Layout

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -833,7 +833,7 @@ msgstr ""
 "<br />"
 "this dialogue and get notified when your product is ready."
 
-msgid "modal##deployCommunity##deploying##estimatedDeploymentTime"
+msgid "modal##deployDataUnion##deploying##estimatedDeploymentTime"
 msgstr "Estimated deployment time"
 
 msgid "noProductsView##keywordHint"

--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -18,6 +18,7 @@ import { post, del, get, put } from '$shared/utils/api'
 import { formatApiUrl } from '$shared/utils/url'
 import { postStream, getMyStreamPermissions } from '$userpages/modules/userPageStreams/services'
 import { getWeb3, getPublicWeb3 } from '$shared/web3/web3Provider'
+import analytics from '$app/src/analytics'
 
 import type { Secret } from './types'
 
@@ -169,14 +170,25 @@ export const getDataUnionStats = (id: DataUnionId): ApiResult<Object> => get({
 })
 
 export const getDataUnions = async (): ApiResult<Array<Object>> => {
-    const { dataunions } = await get({
+    // TODO: Currently data union server returns 'communities' but after refactoring
+    // it will use 'dataunions'. Read both properties from the response for now and
+    // use whichever is defined.
+    const { dataunions, communities } = await get({
         url: formatApiUrl('dataunions'),
         useAuthorization: false,
     })
 
-    return Object.keys(dataunions || {}).map((id) => ({
+    if (communities == null) {
+        const message = 'Data union server has been updated to use "dataunions" instead of "communities" ' +
+                        'Old code can be removed from function getDataUnions at /marketplace/modules/dataUnion/services.js'
+        console.error(message)
+        analytics.reportError(new Error(message))
+    }
+
+    const unions = dataunions || communities
+    return Object.keys(unions || {}).map((id) => ({
         id: id.toLowerCase(),
-        ...dataunions[id],
+        ...unions[id],
     }))
 }
 

--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -164,19 +164,19 @@ export const getJoinPartStreamId = (address: DataUnionId, usePublicNode: boolean
     call(getCommunityContract(address, usePublicNode).methods.joinPartStream())
 
 export const getDataUnionStats = (id: DataUnionId): ApiResult<Object> => get({
-    url: formatApiUrl('communities', id, 'stats'),
+    url: formatApiUrl('dataunions', id, 'stats'),
     useAuthorization: false,
 })
 
 export const getDataUnions = async (): ApiResult<Array<Object>> => {
-    const { communities } = await get({
-        url: formatApiUrl('communities'),
+    const { dataunions } = await get({
+        url: formatApiUrl('dataunions'),
         useAuthorization: false,
     })
 
-    return Object.keys(communities || {}).map((id) => ({
+    return Object.keys(dataunions || {}).map((id) => ({
         id: id.toLowerCase(),
-        ...communities[id],
+        ...dataunions[id],
     }))
 }
 
@@ -198,7 +198,7 @@ type GetSecrets = {
 }
 
 export const getSecrets = ({ dataUnionId }: GetSecrets): ApiResult<Array<Secret>> => get({
-    url: formatApiUrl('communities', dataUnionId, 'secrets'),
+    url: formatApiUrl('dataunions', dataUnionId, 'secrets'),
 })
 
 type PostSecrect = {
@@ -208,7 +208,7 @@ type PostSecrect = {
 }
 
 export const postSecret = ({ dataUnionId, name, secret }: PostSecrect): ApiResult<Secret> => post({
-    url: formatApiUrl('communities', dataUnionId, 'secrets'),
+    url: formatApiUrl('dataunions', dataUnionId, 'secrets'),
     data: {
         name,
         secret,
@@ -222,7 +222,7 @@ type PutSecrect = {
 }
 
 export const putSecret = ({ dataUnionId, secretId, name }: PutSecrect): ApiResult<Secret> => put({
-    url: formatApiUrl('communities', dataUnionId, 'secrets', secretId),
+    url: formatApiUrl('dataunions', dataUnionId, 'secrets', secretId),
     data: {
         name,
     },
@@ -234,7 +234,7 @@ type DeleteSecrect = {
 }
 
 export const deleteSecret = ({ dataUnionId, secretId }: DeleteSecrect): ApiResult<void> => del({
-    url: formatApiUrl('communities', dataUnionId, 'secrets', secretId),
+    url: formatApiUrl('dataunions', dataUnionId, 'secrets', secretId),
 })
 
 type GetJoinRequests = {
@@ -243,7 +243,7 @@ type GetJoinRequests = {
 }
 
 export const getJoinRequests = ({ dataUnionId, params }: GetJoinRequests): ApiResult<any> => get({
-    url: formatApiUrl('communities', dataUnionId, 'joinRequests'),
+    url: formatApiUrl('dataunions', dataUnionId, 'joinRequests'),
     options: {
         params,
     },
@@ -256,7 +256,7 @@ type PutJoinRequest = {
 }
 
 export const updateJoinRequest = async ({ dataUnionId, joinRequestId, state }: PutJoinRequest): ApiResult<any> => put({
-    url: formatApiUrl('communities', dataUnionId, 'joinRequests', joinRequestId),
+    url: formatApiUrl('dataunions', dataUnionId, 'joinRequests', joinRequestId),
     data: {
         state,
     },
@@ -268,7 +268,7 @@ type PostJoinRequest = {
 }
 
 export const addJoinRequest = async ({ dataUnionId, memberAddress }: PostJoinRequest): ApiResult<any> => post({
-    url: formatApiUrl('communities', dataUnionId, 'joinRequests'),
+    url: formatApiUrl('dataunions', dataUnionId, 'joinRequests'),
     data: {
         memberAddress,
     },
@@ -280,5 +280,5 @@ type DeleteJoinRequest = {
 }
 
 export const removeJoinRequest = async ({ dataUnionId, joinRequestId }: DeleteJoinRequest): ApiResult<void> => del({
-    url: formatApiUrl('communities', dataUnionId, 'joinRequests', joinRequestId),
+    url: formatApiUrl('dataunions', dataUnionId, 'joinRequests', joinRequestId),
 })

--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -40,7 +40,7 @@ export const deletePermission = (id: StreamId, permissionId: $PropertyType<Permi
 export const createJoinPartStream = async (productId: ?ProductId = undefined): Promise<Stream> => {
     const newStream: NewStream = {
         name: productId ? `JoinPart stream for data union ${productId}` : 'JoinPart stream',
-        description: 'Automatically created JoinPart stream for community product contract',
+        description: 'Automatically created JoinPart stream for data union',
     }
 
     let stream

--- a/app/src/marketplace/utils/constants.js
+++ b/app/src/marketplace/utils/constants.js
@@ -43,7 +43,5 @@ export const searchCharMax = 250
 
 export const productTypes = {
     NORMAL: 'NORMAL',
-    DATA_UNION: 'DATA_UNION',
-    // deprecated, remove when not supported by API
-    COMMUNITY: 'COMMUNITY',
+    DATAUNION: 'DATAUNION',
 }

--- a/app/src/marketplace/utils/product.js
+++ b/app/src/marketplace/utils/product.js
@@ -17,7 +17,7 @@ export const isDataUnionProduct = (productOrProductType?: Product | ProductType)
         type: productOrProductType,
     } : (productOrProductType || {})
 
-    return type === productTypes.COMMUNITY
+    return type === productTypes.DATAUNION
 }
 
 export const validateProductPriceCurrency = (priceCurrency: string) => {

--- a/app/stories/modal.stories.jsx
+++ b/app/stories/modal.stories.jsx
@@ -306,7 +306,7 @@ story('Product Editor/GuidedDeployDataUnionDialog')
             product={{
                 id: '1',
                 name: 'Example product',
-                type: 'COMMUNITY',
+                type: 'DATAUNION',
             }}
             onClose={action('onClose')}
             onContinue={action('onContinue')}
@@ -320,7 +320,7 @@ story('Product Editor/ConfirmDeployCommunityDialog')
             product={{
                 id: '1',
                 name: 'Example product',
-                type: 'COMMUNITY',
+                type: 'DATAUNION',
             }}
             onClose={action('onClose')}
             onContinue={action('onContinue')}
@@ -335,7 +335,7 @@ story('Product Editor/DeployingCommunityDialog')
             product={{
                 id: '1',
                 name: 'Example product',
-                type: 'COMMUNITY',
+                type: 'DATAUNION',
             }}
             estimate={number('Estimate', 360)}
             onClose={action('onClose')}
@@ -348,7 +348,7 @@ story('Product Editor/DeployingCommunityDialog')
             product={{
                 id: '1',
                 name: 'Example product',
-                type: 'COMMUNITY',
+                type: 'DATAUNION',
             }}
             estimate={number('Estimate', 360)}
             onClose={action('onClose')}

--- a/app/test/unit/utils/product.test.js
+++ b/app/test/unit/utils/product.test.js
@@ -28,7 +28,7 @@ describe('product utils', () => {
         it('detects data union product from object', () => {
             const product1 = {
                 id: 'text',
-                type: 'COMMUNITY',
+                type: 'DATAUNION',
             }
             assert.equal(all.isDataUnionProduct(product1), true)
             const product2 = {
@@ -43,7 +43,7 @@ describe('product utils', () => {
         })
 
         it('detects data union product from value', () => {
-            assert.equal(all.isDataUnionProduct('COMMUNITY'), true)
+            assert.equal(all.isDataUnionProduct('DATAUNION'), true)
             assert.equal(all.isDataUnionProduct('NORMAL'), false)
         })
 


### PR DESCRIPTION
Renames product type `COMMUNITY` to `DATAUNION`. This value will be sent to the API when e.g. creating products.

Also calls to `/communities` have been renamed to use `/dataunions` instead.

Needs https://github.com/streamr-dev/engine-and-editor/pull/736 to work.