### PR TITLE
Fix broken test cases

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4961,8 +4961,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -4980,13 +4979,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4999,18 +4996,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5113,8 +5107,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5124,7 +5117,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5137,20 +5129,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5167,7 +5156,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5240,8 +5228,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5251,7 +5238,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5327,8 +5313,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5358,7 +5343,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5376,7 +5360,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5415,13 +5398,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -9311,11 +9292,6 @@
         "@types/node": "*"
       }
     },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -13200,14 +13176,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -13843,8 +13811,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -13862,13 +13829,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13881,18 +13846,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13995,8 +13957,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14006,7 +13967,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14019,20 +13979,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14049,7 +14006,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14122,8 +14078,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14133,7 +14088,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14209,8 +14163,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14240,7 +14193,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14258,7 +14210,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14297,13 +14248,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -17092,11 +17041,6 @@
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
       "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg=="
     },
-    "diff-sequences": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.0.0.tgz",
-      "integrity": "sha512-6KdBSVCp69YOkwCFmAhmJ23A05e4VSrDpnx0gRHkkLGHotSw/r7gSZH9sqP41Z5iAgeXE8UEZNFGO5sH90vXkg=="
-    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -18526,66 +18470,6 @@
         }
       }
     },
-    "expect": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-25.0.0.tgz",
-      "integrity": "sha512-irRlenvI1Wh6DbUpiDR1usYTSs9MsmBEMdqs6gH9fI3Dy2j7g00p+Gn4qYQW0v3SsXUYXtWeRFmrkGx91uJQgg==",
-      "requires": {
-        "@jest/types": "^25.0.0",
-        "ansi-styles": "^4.0.0",
-        "jest-get-type": "^25.0.0",
-        "jest-matcher-utils": "^25.0.0",
-        "jest-message-util": "^25.0.0",
-        "jest-regex-util": "^25.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.0.0.tgz",
-          "integrity": "sha512-svDFfLCX2CNXTFxdK3aonxEtASl+KXUd4YOGDJtWNrdgKYHYu1BQRk3/bAKYLoKM80QCpLoqPKJ4Rn9SeNQeXQ==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
-          "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "jest-get-type": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.0.0.tgz",
-          "integrity": "sha512-cdBdr6EMdslO7u2Lo6E/kVdA/ktz73hjnXbRukPp7wMKHOZP3wodWJp9n1iujW3urGK/CbGg+fXqO3HoLQCXaA=="
-        }
-      }
-    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -19286,24 +19170,6 @@
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
       "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
     },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      },
-      "dependencies": {
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
-      }
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -19942,8 +19808,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -19964,14 +19829,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -19986,20 +19849,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -20116,8 +19976,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -20129,7 +19988,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -20144,7 +20002,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -20152,14 +20009,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -20178,7 +20033,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -20259,8 +20113,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -20272,7 +20125,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -20358,8 +20210,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "optional": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -20395,7 +20246,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -20415,7 +20265,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -20459,14 +20308,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "optional": true
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -22556,11 +22403,6 @@
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-    },
     "is-number-object": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
@@ -23546,85 +23388,6 @@
         }
       }
     },
-    "jest-diff": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.0.0.tgz",
-      "integrity": "sha512-EiuiwtK/s8XCKKOWqozCgMKZeJn+ukjwqDNeo5eaWlHb8vMoH02sw5xE3JkXy2XqSWMyEbzdpDxwniNHToPYWg==",
-      "requires": {
-        "chalk": "^2.0.1",
-        "diff-sequences": "^25.0.0",
-        "jest-get-type": "^25.0.0",
-        "pretty-format": "^25.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.0.0.tgz",
-          "integrity": "sha512-svDFfLCX2CNXTFxdK3aonxEtASl+KXUd4YOGDJtWNrdgKYHYu1BQRk3/bAKYLoKM80QCpLoqPKJ4Rn9SeNQeXQ==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
-          "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "jest-get-type": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.0.0.tgz",
-          "integrity": "sha512-cdBdr6EMdslO7u2Lo6E/kVdA/ktz73hjnXbRukPp7wMKHOZP3wodWJp9n1iujW3urGK/CbGg+fXqO3HoLQCXaA=="
-        },
-        "pretty-format": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.0.0.tgz",
-          "integrity": "sha512-0neOC1g/eAISiEeRzK2QRF/8U5o1EE3jZwuHSc49qYMdCLgckxeK7bnMw31YdbP34zcWYD4nvWnldNZ+S3okMw==",
-          "requires": {
-            "@jest/types": "^25.0.0",
-            "ansi-regex": "^4.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.8.4"
-          }
-        },
-        "react-is": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
-        }
-      }
-    },
     "jest-docblock": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
@@ -24241,8 +24004,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -24260,13 +24022,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -24279,18 +24039,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -24393,8 +24150,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -24404,7 +24160,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -24417,20 +24172,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -24447,7 +24199,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -24528,8 +24279,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -24539,7 +24289,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -24615,8 +24364,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -24646,7 +24394,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -24664,7 +24411,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -24703,13 +24449,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -25225,188 +24969,6 @@
       "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.3.0.tgz",
       "integrity": "sha512-Lk+awEPuIz0PSERHtnsXyMVLvf/4mZ3sZBEjKG5sJHvey2/i2JfQmmb/NHhialMbHXZILBORzuH64YXhWGlLsQ=="
     },
-    "jest-matcher-utils": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.0.0.tgz",
-      "integrity": "sha512-Zw23jQ5PAgzCmdRFR3LjGAEXIEso5pTeBJjdEf6avEUrnfRe3nXyO0D+Qx88XYcshj9l6WppIvFBQ0u/bo5gcQ==",
-      "requires": {
-        "chalk": "^2.0.1",
-        "jest-diff": "^25.0.0",
-        "jest-get-type": "^25.0.0",
-        "pretty-format": "^25.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.0.0.tgz",
-          "integrity": "sha512-svDFfLCX2CNXTFxdK3aonxEtASl+KXUd4YOGDJtWNrdgKYHYu1BQRk3/bAKYLoKM80QCpLoqPKJ4Rn9SeNQeXQ==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
-          "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "jest-get-type": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.0.0.tgz",
-          "integrity": "sha512-cdBdr6EMdslO7u2Lo6E/kVdA/ktz73hjnXbRukPp7wMKHOZP3wodWJp9n1iujW3urGK/CbGg+fXqO3HoLQCXaA=="
-        },
-        "pretty-format": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.0.0.tgz",
-          "integrity": "sha512-0neOC1g/eAISiEeRzK2QRF/8U5o1EE3jZwuHSc49qYMdCLgckxeK7bnMw31YdbP34zcWYD4nvWnldNZ+S3okMw==",
-          "requires": {
-            "@jest/types": "^25.0.0",
-            "ansi-regex": "^4.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.8.4"
-          }
-        },
-        "react-is": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
-        }
-      }
-    },
-    "jest-message-util": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.0.0.tgz",
-      "integrity": "sha512-xEwyO0ef2ovQyWs+gTHVws8muOJQgaikaS6CcufW0V3Z8Gt75aQhkm5M5qavq2ZwUmtO51FQf5SWPpmvPj+3HA==",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@jest/test-result": "^25.0.0",
-        "@jest/types": "^25.0.0",
-        "@types/stack-utils": "^1.0.1",
-        "chalk": "^2.0.1",
-        "micromatch": "^4.0.2",
-        "slash": "^3.0.0",
-        "stack-utils": "^1.0.1"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-          "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@jest/console": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.0.0.tgz",
-          "integrity": "sha512-Yu/Uv9+VfWqyTVxTWmFUwPBhaH5daoeO/FPb0QadbRbNbJtV63bhNHGXOo52mTBI5r0YQaMV3x0swRfDgSthcA==",
-          "requires": {
-            "@jest/source-map": "^25.0.0",
-            "chalk": "^2.0.1",
-            "slash": "^3.0.0"
-          }
-        },
-        "@jest/source-map": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.0.0.tgz",
-          "integrity": "sha512-L9BMRO692tDYYt0VmrDKDD0AKOIugTOT2qAAzYiA0qXzqqg0a573+HqvP9CXg1l3fJiMIhEkDHiK6V1SfnVO/w==",
-          "requires": {
-            "callsites": "^3.0.0",
-            "graceful-fs": "^4.1.15",
-            "source-map": "^0.6.0"
-          }
-        },
-        "@jest/test-result": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.0.0.tgz",
-          "integrity": "sha512-QhGMvMBPpukW+80H3t6sQ5Slv5v/a1hVojZWisZcdAJagDiqqz+R2KO9qtSekYdqpRTJhLEtkB33FVfiSKy1lA==",
-          "requires": {
-            "@jest/console": "^25.0.0",
-            "@jest/types": "^25.0.0",
-            "@types/istanbul-lib-coverage": "^2.0.0"
-          }
-        },
-        "@jest/types": {
-          "version": "25.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.0.0.tgz",
-          "integrity": "sha512-svDFfLCX2CNXTFxdK3aonxEtASl+KXUd4YOGDJtWNrdgKYHYu1BQRk3/bAKYLoKM80QCpLoqPKJ4Rn9SeNQeXQ==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
-          "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "callsites": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-        },
-        "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-        },
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
     "jest-mock": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
@@ -25439,11 +25001,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ=="
-    },
-    "jest-regex-util": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.0.0.tgz",
-      "integrity": "sha512-WJ6YhqP6ypf4wIX6aReDP48+/WrhQnp3YujfFXScKgkYEi9jzTa+shQCET0p4KbRC51ML7dNVkXYo9kO3mUliQ=="
     },
     "jest-resolve": {
       "version": "24.9.0",
@@ -28612,15 +28169,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
       "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g=="
-    },
-    "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-      "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
-      }
     },
     "miller-rabin": {
       "version": "4.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -148,7 +148,6 @@
     "eslint-plugin-react-hooks": "^1.6.0",
     "ethereumjs-util": "^6.1.0",
     "events": "^3.0.0",
-    "expect": "^25.0.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.9",
     "file-saver": "^2.0.2",

--- a/app/src/userpages/tests/components/KeyField/KeyField.test.jsx
+++ b/app/src/userpages/tests/components/KeyField/KeyField.test.jsx
@@ -20,7 +20,7 @@ describe('KeyField', () => {
                 value="testValue"
             />)
 
-            assert(el.find('Label').text() === 'myKey')
+            assert(el.find('Label').text().replace(/\u200c/g, '') === 'myKey') // get rid of invisible &zwnj;
             assert(el.find(Text).prop('value') === 'testValue')
             assert(el.find(Text).prop('type') === 'text')
         })

--- a/app/src/userpages/tests/modules/canvas/actions.test.js
+++ b/app/src/userpages/tests/modules/canvas/actions.test.js
@@ -1,6 +1,5 @@
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
-import expect from 'expect'
 import moxios from 'moxios'
 import sinon from 'sinon'
 

--- a/app/src/userpages/tests/modules/canvas/actions.test.js
+++ b/app/src/userpages/tests/modules/canvas/actions.test.js
@@ -100,7 +100,7 @@ describe('Canvas actions', () => {
 
         await store.dispatch(actions.getCanvases())
             .catch(() => {
-                expect(store.getActions()).toEqual(expectedActions)
+                expect(store.getActions()).toMatchObject(expectedActions)
             })
 
         await wait

--- a/app/src/userpages/tests/modules/canvas/reducer.test.js
+++ b/app/src/userpages/tests/modules/canvas/reducer.test.js
@@ -1,4 +1,3 @@
-import expect from 'expect'
 import reducer from '../../../modules/canvas/reducer'
 import * as actions from '../../../modules/canvas/actions'
 

--- a/app/src/userpages/tests/modules/dashboard/actions.test.js
+++ b/app/src/userpages/tests/modules/dashboard/actions.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert-diff'
+import expect from 'expect'
 import thunk from 'redux-thunk'
 import configureMockStore from 'redux-mock-store'
 import moxios from 'moxios'
@@ -72,7 +72,7 @@ describe('Dashboard actions', () => {
             }]
 
             await store.dispatch(actions.getDashboards())
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
         it('creates GET_ALL_INTEGRATION_KEYS_FAILURE when fetching integration keys has failed', async (done) => {
             moxios.stubRequest(new RegExp(`${process.env.STREAMR_API_URL}/dashboards*`), {
@@ -97,7 +97,7 @@ describe('Dashboard actions', () => {
             try {
                 await store.dispatch(actions.getDashboards())
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions)
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions)
                 done()
             }
         })
@@ -129,7 +129,7 @@ describe('Dashboard actions', () => {
             }]
 
             await store.dispatch(actions.getDashboard(id))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
 
         it('creates GET_ALL_INTEGRATION_KEYS_FAILURE when fetching integration keys has failed', async (done) => {
@@ -155,7 +155,7 @@ describe('Dashboard actions', () => {
             try {
                 await store.dispatch(actions.getDashboards())
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions)
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions)
                 done()
             }
         })
@@ -189,7 +189,7 @@ describe('Dashboard actions', () => {
             }]
 
             await store.dispatch(actions.updateAndSaveDashboard(db))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
         it('creates also CHANGE_ID if the id has changed', async () => {
             const id = 'test'
@@ -225,7 +225,7 @@ describe('Dashboard actions', () => {
                 type: actions.UPDATE_AND_SAVE_DASHBOARD_SUCCESS,
             }]
             await store.dispatch(actions.updateAndSaveDashboard(db))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
         it('creates UPDATE_AND_SAVE_DASHBOARD_FAILURE when fetching a dashboard has failed', async (done) => {
             const id = 'test'
@@ -258,8 +258,8 @@ describe('Dashboard actions', () => {
             try {
                 await store.dispatch(actions.updateAndSaveDashboard(db))
             } catch (e) {
-                assert.deepStrictEqual(store.getActions()[0], expectedActions[0])
-                assert.deepStrictEqual(store.getActions()[1], expectedActions[1])
+                expect(store.getActions()[0]).toMatchObject(expectedActions[0])
+                expect(store.getActions()[1]).toMatchObject(expectedActions[1])
                 done()
             }
         })
@@ -267,8 +267,8 @@ describe('Dashboard actions', () => {
             const wait = moxios.promiseWait()
                 .then(() => {
                     const request = moxios.requests.mostRecent()
-                    assert.equal(request.url, `${process.env.STREAMR_API_URL}/dashboards`)
-                    assert.equal(request.config.method.toLowerCase(), 'post')
+                    expect(request.url).toEqual(`${process.env.STREAMR_API_URL}/dashboards`)
+                    expect(request.config.method.toLowerCase()).toEqual('post')
                     request.respondWith({
                         status: 200,
                         response: request.config.data,
@@ -286,8 +286,8 @@ describe('Dashboard actions', () => {
             const wait = moxios.promiseWait()
                 .then(() => {
                     const request = moxios.requests.mostRecent()
-                    assert.equal(request.url, `${process.env.STREAMR_API_URL}/dashboards/${id}`)
-                    assert.equal(request.config.method.toLowerCase(), 'put')
+                    expect(request.url).toEqual(`${process.env.STREAMR_API_URL}/dashboards/${id}`)
+                    expect(request.config.method.toLowerCase()).toEqual('put')
                     request.respondWith({
                         status: 200,
                         response: request.config.data,
@@ -309,7 +309,7 @@ describe('Dashboard actions', () => {
             const wait = moxios.promiseWait()
                 .then(() => {
                     const request = moxios.requests.mostRecent()
-                    assert.equal(request.config.method, 'delete')
+                    expect(request.config.method).toEqual('delete')
                     request.respondWith({
                         status: 200,
                     })
@@ -324,7 +324,7 @@ describe('Dashboard actions', () => {
             }]
 
             await store.dispatch(originalActions.deleteDashboard('test'))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
             await wait
         })
 
@@ -332,7 +332,7 @@ describe('Dashboard actions', () => {
             const wait = moxios.promiseWait()
                 .then(() => {
                     const request = moxios.requests.mostRecent()
-                    assert.equal(request.config.method, 'delete')
+                    expect(request.config.method).toEqual('delete')
                     request.respondWith({
                         status: 500,
                         response: {
@@ -357,7 +357,7 @@ describe('Dashboard actions', () => {
             try {
                 await store.dispatch(originalActions.deleteDashboard('test'))
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions)
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions)
             }
 
             await wait
@@ -391,7 +391,7 @@ describe('Dashboard actions', () => {
             }]
 
             await store.dispatch(originalActions.getMyDashboardPermissions(id))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
         it('creates GET_MY_DASHBOARD_PERMISSIONS_FAILURE when fetching permissions has failed', async (done) => {
             const id = 'asdfasdfasasd'
@@ -419,7 +419,7 @@ describe('Dashboard actions', () => {
             try {
                 await store.dispatch(originalActions.getMyDashboardPermissions(id))
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions)
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions)
                 done()
             }
         })
@@ -436,8 +436,8 @@ describe('Dashboard actions', () => {
             const expectedActions = [{
                 type: 'updateEntities',
             }]
-            assert(updateEntitiesStub.calledOnce)
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(updateEntitiesStub.calledOnce).toEqual(true)
+            expect(store.getActions()).toEqual(expectedActions)
         })
 
         describe('addDashboardItem', () => {
@@ -476,7 +476,7 @@ describe('Dashboard actions', () => {
                         saved: false,
                     },
                 }]
-                assert.deepStrictEqual(store.getActions(), expectedActions)
+                expect(store.getActions()).toEqual(expectedActions)
             })
         })
 
@@ -520,7 +520,7 @@ describe('Dashboard actions', () => {
                         saved: false,
                     },
                 }]
-                assert.deepStrictEqual(store.getActions(), expectedActions)
+                expect(store.getActions()).toEqual(expectedActions)
             })
         })
 
@@ -561,7 +561,7 @@ describe('Dashboard actions', () => {
                     },
                 }]
 
-                assert.deepStrictEqual(store.getActions(), expectedActions)
+                expect(store.getActions()).toEqual(expectedActions)
             })
         })
     })
@@ -604,14 +604,14 @@ describe('Dashboard actions', () => {
             await store.dispatch(originalActions.updateDashboardChanges('test', {
                 name: 'test3',
             }))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
     })
 
     describe('openDashboard', () => {
         const id = 'test'
         it('must return correct action', () => {
-            assert.deepStrictEqual(originalActions.openDashboard(id), {
+            expect(originalActions.openDashboard(id)).toEqual({
                 type: originalActions.OPEN_DASHBOARD,
                 id,
             })

--- a/app/src/userpages/tests/modules/dashboard/actions.test.js
+++ b/app/src/userpages/tests/modules/dashboard/actions.test.js
@@ -1,4 +1,3 @@
-import expect from 'expect'
 import thunk from 'redux-thunk'
 import configureMockStore from 'redux-mock-store'
 import moxios from 'moxios'

--- a/app/src/userpages/tests/modules/permission/actions.test.js
+++ b/app/src/userpages/tests/modules/permission/actions.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert-diff'
+import expect from 'expect'
 import thunk from 'redux-thunk'
 import configureMockStore from 'redux-mock-store'
 import moxios from 'moxios'
@@ -33,7 +33,7 @@ describe('Permission actions', () => {
             store.dispatch(actions.getResourcePermissions('DASHBOARD', id))
             await moxios.promiseWait()
             const request = moxios.requests.mostRecent()
-            assert(request.url.match(`dashboards/${id}/permissions`))
+            expect(request.url).toMatch(`dashboards/${id}/permissions`)
             done()
             request.respondWith({
                 status: 200,
@@ -44,7 +44,7 @@ describe('Permission actions', () => {
             store.dispatch(actions.getResourcePermissions('CANVAS', id))
             await moxios.promiseWait()
             const request = moxios.requests.mostRecent()
-            assert(request.url.match(`canvases/${id}/permissions`))
+            expect(request.url).toMatch(`canvases/${id}/permissions`)
             done()
             request.respondWith({
                 status: 200,
@@ -55,7 +55,7 @@ describe('Permission actions', () => {
             store.dispatch(actions.getResourcePermissions('STREAM', id))
             await moxios.promiseWait()
             const request = moxios.requests.mostRecent()
-            assert(request.url.match(`streams/${id}/permissions`))
+            expect(request.url).toMatch(`streams/${id}/permissions`)
             done()
             request.respondWith({
                 status: 200,
@@ -86,7 +86,7 @@ describe('Permission actions', () => {
             }]
 
             await store.dispatch(actions.getResourcePermissions(resourceType, resourceId))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
         it('creates GET_RESOURCE_PERMISSIONS_FAILURE with the error when fetching permissions failed', async (done) => {
             const resourceType = 'DASHBOARD'
@@ -113,7 +113,7 @@ describe('Permission actions', () => {
             try {
                 await store.dispatch(actions.getResourcePermissions(resourceType, resourceId))
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions)
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions)
                 done()
             }
         })
@@ -127,7 +127,7 @@ describe('Permission actions', () => {
                 user: 'test',
                 operation: 'test',
             }
-            assert.deepEqual(actions.addResourcePermission(resourceType, resourceId, permission), {
+            expect(actions.addResourcePermission(resourceType, resourceId, permission)).toEqual({
                 type: actions.ADD_RESOURCE_PERMISSION,
                 resourceType,
                 resourceId,
@@ -143,7 +143,7 @@ describe('Permission actions', () => {
             const permission = {
                 id: 'test',
             }
-            assert.deepEqual(actions.removeResourcePermission(resourceType, resourceId, permission), {
+            expect(actions.removeResourcePermission(resourceType, resourceId, permission)).toEqual({
                 type: actions.REMOVE_RESOURCE_PERMISSION,
                 resourceType,
                 resourceId,
@@ -185,10 +185,10 @@ describe('Permission actions', () => {
                 store.dispatch(actions.saveUpdatedResourcePermissions(resourceType, resourceId))
                 await moxios.promiseWait()
                 const { requests } = moxios
-                assert.equal(requests.at(0).config.method, 'post')
-                assert.equal(requests.at(1).config.method, 'post')
-                assert.deepStrictEqual(JSON.parse(requests.at(0).config.data), permissions[0])
-                assert.deepStrictEqual(JSON.parse(requests.at(1).config.data), permissions[1])
+                expect(requests.at(0).config.method).toEqual('post')
+                expect(requests.at(1).config.method).toEqual('post')
+                expect(JSON.parse(requests.at(0).config.data)).toEqual(permissions[0])
+                expect(JSON.parse(requests.at(1).config.data)).toEqual(permissions[1])
                 done()
             })
             it('should create SAVE_ADDED_RESOURCE_PERMISSION_SUCCESS for succeeded permissions', async () => {
@@ -254,7 +254,7 @@ describe('Permission actions', () => {
                 }]
 
                 await store.dispatch(actions.saveUpdatedResourcePermissions(resourceType, resourceId))
-                assert.deepStrictEqual(store.getActions().slice(0, 4), expectedActions)
+                expect(store.getActions().slice(0, 4)).toEqual(expectedActions)
             })
             it('should create SAVE_ADDED_RESOURCE_PERMISSION_FAILURE for failed permissions', async (done) => {
                 const resourceType = 'DASHBOARD'
@@ -343,7 +343,7 @@ describe('Permission actions', () => {
                 try {
                     await store.dispatch(actions.saveUpdatedResourcePermissions(resourceType, resourceId))
                 } catch (e) {
-                    assert.deepStrictEqual(store.getActions().slice(0, 4), expectedActions)
+                    expect(store.getActions().slice(0, 4)).toMatchObject(expectedActions)
                     done()
                 }
             })
@@ -381,10 +381,10 @@ describe('Permission actions', () => {
                 store.dispatch(actions.saveUpdatedResourcePermissions(resourceType, resourceId))
                 await moxios.promiseWait()
                 const { requests } = moxios
-                assert.equal(requests.at(0).config.method, 'delete')
-                assert.equal(requests.at(1).config.method, 'delete')
-                assert.equal(requests.at(0).url, `${process.env.STREAMR_API_URL}/dashboards/${resourceId}/permissions/2`)
-                assert.equal(requests.at(1).url, `${process.env.STREAMR_API_URL}/dashboards/${resourceId}/permissions/3`)
+                expect(requests.at(0).config.method).toEqual('delete')
+                expect(requests.at(1).config.method).toEqual('delete')
+                expect(requests.at(0).url).toEqual(`${process.env.STREAMR_API_URL}/dashboards/${resourceId}/permissions/2`)
+                expect(requests.at(1).url).toEqual(`${process.env.STREAMR_API_URL}/dashboards/${resourceId}/permissions/3`)
             })
             it('should create SAVE_REMOVED_RESOURCE_PERMISSION_SUCCESS for succeeded permissions', async () => {
                 const resourceType = 'DASHBOARD'
@@ -448,7 +448,7 @@ describe('Permission actions', () => {
                 }]
 
                 await store.dispatch(actions.saveUpdatedResourcePermissions(resourceType, resourceId))
-                assert.deepStrictEqual(store.getActions().slice(0, 4), expectedActions)
+                expect(store.getActions().slice(0, 4)).toEqual(expectedActions)
             })
             it('should create SAVE_REMOVED_RESOURCE_PERMISSION_FAILURE for failed permissions', async (done) => {
                 const resourceType = 'DASHBOARD'
@@ -536,7 +536,7 @@ describe('Permission actions', () => {
                 try {
                     await store.dispatch(actions.saveUpdatedResourcePermissions(resourceType, resourceId))
                 } catch (e) {
-                    assert.deepStrictEqual(store.getActions().slice(0, 4), expectedActions)
+                    expect(store.getActions().slice(0, 4)).toMatchObject(expectedActions)
                     done()
                 }
             })
@@ -605,7 +605,7 @@ describe('Permission actions', () => {
             }]
 
             store.dispatch(actions.removeAllResourcePermissionsByUser(resourceType, resourceId, user))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
     })
 
@@ -641,7 +641,7 @@ describe('Permission actions', () => {
                     permission,
                 }))
                 store.dispatch(actions.setResourceHighestOperationForUser(resourceType, resourceId, user, 'share'))
-                assert.deepStrictEqual(store.getActions(), expectedActions)
+                expect(store.getActions()).toEqual(expectedActions)
             })
         })
         describe('giving lower operation removes permissions', () => {
@@ -672,7 +672,7 @@ describe('Permission actions', () => {
                     permission,
                 }))
                 store.dispatch(actions.setResourceHighestOperationForUser(resourceType, resourceId, user, 'read'))
-                assert.deepStrictEqual(store.getActions(), expectedActions)
+                expect(store.getActions()).toEqual(expectedActions)
             })
         })
     })

--- a/app/src/userpages/tests/modules/permission/actions.test.js
+++ b/app/src/userpages/tests/modules/permission/actions.test.js
@@ -1,4 +1,3 @@
-import expect from 'expect'
 import thunk from 'redux-thunk'
 import configureMockStore from 'redux-mock-store'
 import moxios from 'moxios'

--- a/app/src/userpages/tests/modules/userPagesStreams/actions.test.js
+++ b/app/src/userpages/tests/modules/userPagesStreams/actions.test.js
@@ -1,4 +1,3 @@
-import expect from 'expect'
 import thunk from 'redux-thunk'
 import configureMockStore from 'redux-mock-store'
 import sinon from 'sinon'

--- a/app/src/userpages/tests/modules/userPagesStreams/actions.test.js
+++ b/app/src/userpages/tests/modules/userPagesStreams/actions.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert-diff'
+import expect from 'expect'
 import thunk from 'redux-thunk'
 import configureMockStore from 'redux-mock-store'
 import sinon from 'sinon'
@@ -60,7 +60,7 @@ describe('Stream actions', () => {
             }]
 
             await store.dispatch(actions.createStream(stream))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
         it('creates CREATE_STREAM_FAILURE when creating stream has failed', async () => {
             const stream = {
@@ -87,9 +87,9 @@ describe('Stream actions', () => {
 
             try {
                 await store.dispatch(actions.createStream(stream))
-                assert(false, 'Did not fail!')
+                expect(false).toBe(true) // fail on purpose because action did not throw
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions.slice(0, 2))
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions.slice(0, 2))
             }
         })
     })
@@ -117,7 +117,7 @@ describe('Stream actions', () => {
                 stream: 'test',
             }]
             await store.dispatch(actions.getStream(id))
-            assert.deepStrictEqual(store.getActions(), expectedActions)
+            expect(store.getActions()).toEqual(expectedActions)
         })
         it('creates GET_STREAM_FAILURE when fetching stream has failed', async () => {
             const id = 'asdfasdfasasd'
@@ -143,7 +143,7 @@ describe('Stream actions', () => {
             try {
                 await store.dispatch(actions.getStream(id))
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions)
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions)
             }
         })
     })
@@ -174,7 +174,7 @@ describe('Stream actions', () => {
             }]
 
             await store.dispatch(actions.updateStream(stream))
-            assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions.slice(0, 2))
+            expect(store.getActions().slice(0, 2)).toEqual(expectedActions.slice(0, 2))
         })
         it('creates UPDATE_STREAM_FAILURE and CREATE_NOTIFICATION when updating a stream has failed', async () => {
             const id = 'test'
@@ -204,7 +204,7 @@ describe('Stream actions', () => {
             try {
                 await store.dispatch(actions.updateStream(db))
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions.slice(0, 2))
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions.slice(0, 2))
             }
         })
         it('uses PUT request', async () => {
@@ -215,8 +215,8 @@ describe('Stream actions', () => {
             }))
             await moxios.promiseWait()
             const request = moxios.requests.mostRecent()
-            assert.equal(request.url, `${process.env.STREAMR_API_URL}/streams/${id}`)
-            assert.equal(request.config.method.toLowerCase(), 'put')
+            expect(request.url).toEqual(`${process.env.STREAMR_API_URL}/streams/${id}`)
+            expect(request.config.method.toLowerCase()).toEqual('put')
         })
     })
 
@@ -228,8 +228,8 @@ describe('Stream actions', () => {
             store.dispatch(actions.deleteStream(stream.id))
             await moxios.promiseWait()
             const request = moxios.requests.mostRecent()
-            assert.equal(request.url, `${process.env.STREAMR_API_URL}/streams/${stream.id}`)
-            assert.equal(request.config.method, 'delete')
+            expect(request.url).toEqual(`${process.env.STREAMR_API_URL}/streams/${stream.id}`)
+            expect(request.config.method.toLowerCase()).toEqual('delete')
         })
         it('creates DELETE_STREAM_SUCCESS when deleting stream has succeeded', async () => {
             const stream = {
@@ -247,7 +247,7 @@ describe('Stream actions', () => {
             }]
 
             await store.dispatch(actions.deleteStream(stream.id))
-            assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions.slice(0, 2))
+            expect(store.getActions().slice(0, 2)).toEqual(expectedActions.slice(0, 2))
         })
         it('creates DELETE_STREAM_FAILURE when deleting stream has failed', async () => {
             const stream = {
@@ -273,9 +273,9 @@ describe('Stream actions', () => {
             }]
             try {
                 await store.dispatch(actions.deleteStream(stream.id))
-                assert(false, 'Did not fail!')
+                expect(false).toBe(true) // fail on purpose because action did not throw
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions.slice(0, 2))
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions.slice(0, 2))
             }
         })
     })
@@ -294,9 +294,9 @@ describe('Stream actions', () => {
             store.dispatch(actions.saveFields(id, fields))
             await moxios.promiseWait()
             const request = moxios.requests.mostRecent()
-            assert.equal(request.url, `${process.env.STREAMR_API_URL}/streams/${id}/fields`)
-            assert.equal(request.config.method, 'post')
-            assert.deepStrictEqual(JSON.parse(request.config.data), fields)
+            expect(request.url).toEqual(`${process.env.STREAMR_API_URL}/streams/${id}/fields`)
+            expect(request.config.method).toEqual('post')
+            expect(JSON.parse(request.config.data)).toEqual(fields)
         })
         it('creates SAVE_STREAM_FIELDS_SUCCESS when saving fields has succeeded', async () => {
             const id = 'sfasldkfjsaldkfj'
@@ -326,7 +326,7 @@ describe('Stream actions', () => {
             }]
 
             await store.dispatch(actions.saveFields(id, fields))
-            assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions.slice(0, 2))
+            expect(store.getActions().slice(0, 2)).toEqual(expectedActions.slice(0, 2))
         })
         it('creates SAVE_STREAM_FIELDS_FAILURE when saving fields has failed', async () => {
             const id = 'sfasldkfjsaldkfj'
@@ -358,16 +358,16 @@ describe('Stream actions', () => {
 
             try {
                 await store.dispatch(actions.saveFields(id, fields))
-                assert(false, 'Did not fail!')
+                expect(false).toBe(true) // fail on purpose because action did not throw
             } catch (e) {
-                assert.deepStrictEqual(store.getActions().slice(0, 2), expectedActions.slice(0, 2))
+                expect(store.getActions().slice(0, 2)).toMatchObject(expectedActions.slice(0, 2))
             }
         })
     })
 
     it('must dispatch OPEN_STREAM when opening stream', () => {
         const id = 'askdfjasldkfjasdlkf'
-        assert.deepStrictEqual(actions.openStream(id), {
+        expect(actions.openStream(id)).toEqual({
             type: actions.OPEN_STREAM,
             id,
         })


### PR DESCRIPTION
Use `toMatchObject` instead of `toEqual` so that new property `response` in error objects will not cause problems.

I migrated these files to use `expect` instead of `assert-diff` so that one day we only have one assertion library. Also removed library `expect` from `package.json` because it's part of jest already.