### PR TITLE
[PLATFORM-1289] Avoid hard crash when no data coin on deprecated Purchase Modal

### DIFF
--- a/app/src/marketplace/components/Modal/NoBalanceDialog/index.jsx
+++ b/app/src/marketplace/components/Modal/NoBalanceDialog/index.jsx
@@ -47,6 +47,11 @@ const NoBalanceDialog = ({
             }
             break
         case paymentCurrencies.DATA:
+            // Bandaid fix to avoid deprecated purchase modal crash
+            if (!currentDataBalance) {
+                return <GetDataTokensDialog onCancel={onCancel} />
+            }
+
             if (currentDataBalance.isZero()) {
                 return <GetDataTokensDialog onCancel={onCancel} />
             }


### PR DESCRIPTION
I didn't want to spend too much time getting to the root of the problem since this will fix itself shortly, once MP2 is released. This fix will avoid the hard crash when there's no DATAcoin in the wallet. 

https://streamr.atlassian.net/browse/PLATFORM-1289