### PR TITLE
[PLATFORM-1286] Purchases page - Add recent sort option, refactor subscription handling

### DIFF
--- a/app/src/marketplace/flowtype/product-types.js
+++ b/app/src/marketplace/flowtype/product-types.js
@@ -45,11 +45,21 @@ export type Product = {
     pendingChanges?: PendingChanges,
 }
 
+export type ProductSubscriptionId = string
+
+export type ProductSubscriptionIdList = Array<ProductSubscriptionId>
+
 export type ProductSubscription = {
-    address: Address,
+    id: ProductSubscriptionId,
+    address?: Address,
+    user?: string,
     endsAt: Date,
     product: Product,
+    dateCreated: Date,
+    lastUpdated: Date,
 }
+
+export type ProductSubscriptionList = Array<ProductSubscription>
 
 export type EditProduct = Product
 

--- a/app/src/marketplace/flowtype/store-state.js
+++ b/app/src/marketplace/flowtype/store-state.js
@@ -46,7 +46,8 @@ export type MyProductListState = {
 
 // my purchases
 export type MyPurchaseListState = {
-    ids: ProductIdList,
+    products: ProductIdList,
+    subscriptions: ProductIdList,
     fetching: boolean,
     error: ?ErrorInUi,
     filter: ?UserpagesFilter,

--- a/app/src/marketplace/modules/myPurchaseList/reducer.js
+++ b/app/src/marketplace/modules/myPurchaseList/reducer.js
@@ -14,10 +14,12 @@ import type {
     MyPurchasesAction,
     MyPurchasesErrorAction,
     MyPurchasesFilterAction,
+    MySubscriptionsAction,
 } from './types'
 
 export const initialState: MyPurchaseListState = {
-    ids: [],
+    products: [],
+    subscriptions: [],
     fetching: false,
     error: null,
     filter: null,
@@ -30,9 +32,9 @@ const reducer: (MyPurchaseListState) => MyPurchaseListState = handleActions({
         error: null,
     }),
 
-    [GET_MY_PURCHASES_SUCCESS]: (state: MyPurchaseListState, action: MyPurchasesAction) => ({
+    [GET_MY_PURCHASES_SUCCESS]: (state: MyPurchaseListState, action: MySubscriptionsAction) => ({
         ...state,
-        ids: action.payload.products,
+        subscriptions: action.payload.subscriptions,
         fetching: false,
     }),
 
@@ -49,7 +51,7 @@ const reducer: (MyPurchaseListState) => MyPurchaseListState = handleActions({
 
     [UPDATE_RESULTS]: (state: MyPurchaseListState, action: MyPurchasesAction) => ({
         ...state,
-        ids: action.payload.products,
+        products: action.payload.products,
     }),
 
 }, initialState)

--- a/app/src/marketplace/modules/myPurchaseList/selectors.js
+++ b/app/src/marketplace/modules/myPurchaseList/selectors.js
@@ -5,7 +5,12 @@ import { denormalize } from 'normalizr'
 
 import type { MyPurchaseListState, StoreState } from '../../flowtype/store-state'
 import type { EntitiesState } from '$shared/flowtype/store-state'
-import type { ProductIdList, ProductList, ProductSubscription } from '../../flowtype/product-types'
+import type {
+    ProductIdList,
+    ProductList,
+    ProductSubscriptionList,
+    ProductSubscriptionIdList,
+} from '../../flowtype/product-types'
 import type { ErrorInUi } from '$shared/flowtype/common-types'
 import type { Filter } from '$userpages/flowtype/common-types'
 
@@ -19,15 +24,27 @@ export const selectFetchingMyPurchaseList: (state: StoreState) => boolean = crea
     (subState: MyPurchaseListState): boolean => subState.fetching,
 )
 
+export const selectMyPurchaseListSubscriptionIds: (state: StoreState) => ProductSubscriptionIdList = createSelector(
+    selectMyPurchaseListState,
+    (subState: MyPurchaseListState) => subState.subscriptions,
+)
+
+export const selectMyPurchaseListProductIds: (state: StoreState) => ProductIdList = createSelector(
+    selectMyPurchaseListState,
+    (subState: MyPurchaseListState) => subState.products,
+)
+
 export const selectMyPurchaseListIds: (state: StoreState) => ProductIdList = createSelector(
     selectMyPurchaseListState,
-    (subState: MyPurchaseListState) => subState.ids,
+    (subState: MyPurchaseListState) => subState.products,
 )
 
 export const selectMyPurchaseList: (StoreState) => ProductList = createSelector(
-    selectMyPurchaseListIds,
+    selectMyPurchaseListProductIds,
     selectEntities,
-    (result: ProductIdList, entities: EntitiesState): ProductList => denormalize(result, productsSchema, entities),
+    (result: ProductIdList, entities: EntitiesState): ProductList => (
+        denormalize(result, productsSchema, entities)
+    ),
 )
 
 export const selectMyPurchaseListError: (StoreState) => ?ErrorInUi = createSelector(
@@ -35,18 +52,12 @@ export const selectMyPurchaseListError: (StoreState) => ?ErrorInUi = createSelec
     (subState: MyPurchaseListState): ?ErrorInUi => subState.error,
 )
 
-export const selectSubscriptions: (StoreState) => Array<ProductSubscription> = createSelector(
-    selectMyPurchaseListIds,
+export const selectSubscriptions: (StoreState) => ProductSubscriptionList = createSelector(
+    selectMyPurchaseListSubscriptionIds,
     selectEntities,
-    (result: ProductIdList, entities: EntitiesState): Array<ProductSubscription> => denormalize(result, subscriptionsSchema, entities),
-)
-
-export const selectAllSubscriptions: (StoreState) => Array<ProductSubscription> = createSelector(
-    selectEntities,
-    (entities: EntitiesState): Array<ProductSubscription> => {
-        const ids = entities.subscriptions != null ? Object.keys(entities.subscriptions) : []
-        return denormalize(ids, subscriptionsSchema, entities)
-    },
+    (result: ProductSubscriptionIdList, entities: EntitiesState): ProductSubscriptionList => (
+        denormalize(result, subscriptionsSchema, entities)
+    ),
 )
 
 export const selectFilter: (StoreState) => ?Filter = createSelector(

--- a/app/src/marketplace/modules/myPurchaseList/types.js
+++ b/app/src/marketplace/modules/myPurchaseList/types.js
@@ -1,13 +1,13 @@
 // @flow
 
 import type { ErrorInUi, PayloadAction } from '$shared/flowtype/common-types'
-import type { ProductId, ProductIdList } from '../../flowtype/product-types'
+import type { ProductIdList, ProductSubscriptionIdList } from '../../flowtype/product-types'
 import type { Filter } from '$userpages/flowtype/common-types'
 
-export type MyPurchaseIdAction = PayloadAction<{
-    id: ProductIdList,
+export type MySubscriptionsAction = PayloadAction<{
+    subscriptions: ProductSubscriptionIdList,
 }>
-export type MyPurchaseIdActionCreator = (ProductId) => MyPurchaseIdAction
+export type MySubscriptionsActionCreator = (ProductSubscriptionIdList) => MySubscriptionsAction
 
 export type MyPurchasesAction = PayloadAction<{
     products: ProductIdList,

--- a/app/src/marketplace/modules/product/selectors.js
+++ b/app/src/marketplace/modules/product/selectors.js
@@ -12,7 +12,7 @@ import type { StreamIdList, StreamList } from '$shared/flowtype/stream-types'
 import type { ErrorInUi } from '$shared/flowtype/common-types'
 import type { Category } from '../../flowtype/category-types'
 import { selectEntities } from '$shared/modules/entities/selectors'
-import { selectMyPurchaseList, selectSubscriptions } from '../myPurchaseList/selectors'
+import { selectSubscriptions } from '../myPurchaseList/selectors'
 import { productSchema, streamsSchema, categorySchema } from '$shared/modules/entities/schema'
 import { isActive } from '../../utils/time'
 import { selectAccountId } from '../web3/selectors'
@@ -93,17 +93,15 @@ export const selectProductIsFree: (state: StoreState) => boolean = createSelecto
 )
 
 export const selectProductIsPurchased: (state: StoreState) => boolean = createSelector(
-    selectMyPurchaseList,
     selectProductId,
     selectSubscriptions,
-    (purchasedPurchases, productId, subscriptions) => {
+    (productId, subscriptions) => {
         if (!productId) {
             return false
         }
 
-        const product = purchasedPurchases && purchasedPurchases.find((p) => p.id === productId)
-        const subscription = subscriptions && subscriptions.find((s) => s.product.id === productId)
-        return !!product && isActive(subscription.endsAt || '')
+        const subscription = subscriptions && subscriptions.find((s) => s.id === productId)
+        return !!subscription && isActive(subscription.endsAt || '')
     },
 )
 

--- a/app/src/shared/modules/entities/schema.js
+++ b/app/src/shared/modules/entities/schema.js
@@ -19,9 +19,6 @@ export const subscriptionSchema = new schema.Entity(
     {
         product: productSchema,
     },
-    {
-        idAttribute: (value) => value.product.id,
-    },
 )
 export const subscriptionsSchema = [subscriptionSchema]
 

--- a/app/src/shared/test/modules/entities/reducer.test.js
+++ b/app/src/shared/test/modules/entities/reducer.test.js
@@ -85,12 +85,14 @@ describe('entities - reducer', () => {
         ]
         const subscriptions = [
             {
+                id: products[0].id,
                 endsAt: Date(),
                 product: {
                     ...products[0],
                 },
             },
             {
+                id: products[1].id,
                 endsAt: Date(),
                 product: {
                     ...products[1],
@@ -114,6 +116,7 @@ describe('entities - reducer', () => {
             subscriptions: subscriptions.reduce((result, value) => ({
                 ...result,
                 [value.product.id]: {
+                    id: value.product.id,
                     endsAt: value.endsAt,
                     product: value.product.id,
                 },

--- a/app/src/userpages/components/PurchasesPage/index.jsx
+++ b/app/src/userpages/components/PurchasesPage/index.jsx
@@ -34,6 +34,7 @@ const PurchasesPage = () => {
     const sortOptions = useMemo(() => {
         const filters = getFilters()
         return [
+            filters.RECENT,
             filters.NAME_ASC,
             filters.NAME_DESC,
             filters.ACTIVE,

--- a/app/test/unit/containers/ProductPage/ProductPage.test.jsx
+++ b/app/test/unit/containers/ProductPage/ProductPage.test.jsx
@@ -99,7 +99,8 @@ describe('ProductPage', () => {
                 },
             },
             myPurchaseList: {
-                ids: [],
+                products: [],
+                subscriptions: [],
                 fetching: false,
                 error: null,
             },

--- a/app/test/unit/modules/myPurchaseList/actions.test.js
+++ b/app/test/unit/modules/myPurchaseList/actions.test.js
@@ -29,6 +29,7 @@ describe('myPurchaseList - actions', () => {
             }
             const subscriptions = [
                 {
+                    id: product.id,
                     user: 'test-user-1',
                     endsAt: '2010-10-10T10:10:10Z',
                     product,
@@ -61,7 +62,7 @@ describe('myPurchaseList - actions', () => {
                 {
                     type: constants.GET_MY_PURCHASES_SUCCESS,
                     payload: {
-                        products: result,
+                        subscriptions: result,
                     },
                 },
             ]

--- a/app/test/unit/modules/myPurchaseList/reducer.test.js
+++ b/app/test/unit/modules/myPurchaseList/reducer.test.js
@@ -24,14 +24,14 @@ describe('myPurchaseList - reducer', () => {
     it('handles success', () => {
         const expectedState = {
             ...initialState,
-            ids: [1, 2, 3],
+            subscriptions: [1, 2, 3],
             fetching: false,
             error: null,
         }
         const reducerState = reducer(undefined, {
             type: constants.GET_MY_PURCHASES_SUCCESS,
             payload: {
-                products: [1, 2, 3],
+                subscriptions: [1, 2, 3],
             },
         })
         assert.deepStrictEqual(reducerState, expectedState)
@@ -42,7 +42,7 @@ describe('myPurchaseList - reducer', () => {
 
         const expectedState = {
             ...initialState,
-            ids: [],
+            subscriptions: [],
             fetching: false,
             error,
         }

--- a/app/test/unit/modules/myPurchaseList/selectors.test.js
+++ b/app/test/unit/modules/myPurchaseList/selectors.test.js
@@ -24,16 +24,19 @@ const normalizedProducts = normalize(products, productsSchema)
 
 const subscriptions = [
     {
+        id: products[0].id,
         user: 'test-user-1',
         endsAt: '2010-10-10T10:10:10Z',
         product: products[0],
     },
     {
+        id: products[1].id,
         user: 'test-user-1',
         endsAt: '2010-11-10T10:10:10Z',
         product: products[1],
     },
     {
+        id: products[2].id,
         user: 'test-user-1',
         endsAt: '2010-12-10T10:10:10Z',
         product: products[2],
@@ -47,7 +50,8 @@ const state = {
     myPurchaseList: {
         fetching: false,
         error: null,
-        ids: normalizedProducts.result,
+        products: normalizedProducts.result,
+        subscriptions: normalizedProducts.result,
     },
     entities: merge(
         normalizedProducts.entities,
@@ -61,7 +65,7 @@ describe('myPurchaseList - selectors', () => {
     })
 
     it('selects my purchase list ids', () => {
-        assert.deepStrictEqual(all.selectMyPurchaseListIds(state), state.myPurchaseList.ids)
+        assert.deepStrictEqual(all.selectMyPurchaseListIds(state), state.myPurchaseList.products)
     })
 
     it('selects purchase list', () => {

--- a/app/test/unit/modules/product/selectors.test.js
+++ b/app/test/unit/modules/product/selectors.test.js
@@ -56,11 +56,13 @@ const normalizedProducts = normalize(products, productsSchema)
 
 const subscriptions = [
     {
+        id: '1337',
         address: '0x123',
         endsAt: Date.now() + 100000,
         product: products[0],
     },
     {
+        id: '1338',
         address: '0x1263e6',
         endsAt: 0,
         product: products[1],
@@ -91,7 +93,8 @@ const state = {
         },
     },
     myPurchaseList: {
-        ids: ['1337', '1338'],
+        products: ['1337', '1338'],
+        subscriptions: ['1337', '1338'],
     },
     otherData: 42,
     entities: merge(


### PR DESCRIPTION
This adds a default "Recent" filter to purchases page (date fields are exposed in PR https://github.com/streamr-dev/engine-and-editor/pull/739, make sure you update the env before testing).

The PR also refactors how subscriptions are handled, I noticed that if a product is purchased with different accounts, the products end up showing up twice (+ an error in console about duplicate keys). I've changed the logic to reduce the subscription list to only unique products so that the subscription `lastUpdated` and `endsAt` times are updated to the most recent one.