### PR TITLE
[PLATFORM-1292] Bring Core Stream List hover states into line with design

### DIFF
--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -132,6 +132,7 @@ const StreamList = () => {
     const fetchingPermissions = useSelector(selectFetchingPermissions)
     const permissions = useSelector(selectStreamPermissions)
     const hasMoreResults = useSelector(selectHasMoreSearchResults)
+    const [openedDropdownStreamId, setOpenedDropdownStreamId] = useState(undefined)
 
     useEffect(() => () => {
         cancelStreamStatusFetch()
@@ -163,6 +164,8 @@ const StreamList = () => {
     }, [dispatch])
 
     const onToggleStreamDropdown = useCallback((streamId: StreamId) => async (open: boolean) => {
+        setOpenedDropdownStreamId(open ? streamId : undefined)
+
         if (open && !fetchingPermissions && !permissions[streamId]) {
             try {
                 await dispatch(getResourcePermissions('STREAM', streamId, false))
@@ -325,7 +328,7 @@ const StreamList = () => {
                                                     className={styles.menuColumn}
                                                 >
                                                     <DropdownActions
-                                                        title={<Meatball alt={I18n.t('userpages.streams.actions')} />}
+                                                        title={<Meatball alt={I18n.t('userpages.streams.actions.title')} />}
                                                         noCaret
                                                         onMenuToggle={onToggleStreamDropdown(stream.id)}
                                                         menuProps={{
@@ -336,6 +339,11 @@ const StreamList = () => {
                                                                     offset: '-100%p + 100%',
                                                                 },
                                                             },
+                                                        }}
+                                                        toggleProps={{
+                                                            className: cx(styles.dropdownActions, {
+                                                                [styles.dropdownActionsOpen]: openedDropdownStreamId === stream.id,
+                                                            }),
                                                         }}
                                                     >
                                                         <DropdownActions.Item onClick={() => showStream(stream.id)}>

--- a/app/src/userpages/components/StreamPage/List/streamsList.pcss
+++ b/app/src/userpages/components/StreamPage/List/streamsList.pcss
@@ -68,6 +68,20 @@
   width: 12px;
 }
 
+.dropdownActions {
+  visibility: hidden;
+}
+
+.streamRow:hover .dropdownActions,
+.streamRow:focus-within .dropdownActions,
+.dropdownActionsOpen {
+  visibility: visible;
+}
+
+.dropdownActionsOpen > * {
+  opacity: 1;
+}
+
 @media (--md-down) {
   .createStreamButton {
     display: none;

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -324,6 +324,9 @@ msgstr "Status"
 msgid "userpages##streams##list##actions"
 msgstr "Select"
 
+msgid "userpages##streams##actions##title"
+msgstr "Actions"
+
 msgid "userpages##streams##actions##addToCanvas"
 msgstr "Add to canvas"
 


### PR DESCRIPTION
Current implementation shows a meatball menu for every stream, always. Design shows a meatball menu only for the currently hovered stream, with a separate (darker) state when the icon itself is hovered

Prototype:
![hover](https://user-images.githubusercontent.com/1064982/76072947-83925480-5fa1-11ea-81df-ee26fed0a364.gif)

Implementation:
![ezgif-2-d426858b6b54](https://user-images.githubusercontent.com/1064982/76072968-8a20cc00-5fa1-11ea-8572-3325658b2db4.gif)
