### PR TITLE
[PLATFORM-1300] Fix deploying badge

### DIFF
--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -89,18 +89,19 @@ const Tile = ({ product, members }: any) => {
 
     useEffect(() => {
         (async () => {
+            let result = false
+
             if (isDataUnion && isEthereumAddress(beneficiaryAddress)) {
                 try {
-                    const result = await getAdminFee(beneficiaryAddress, true) != null
-                    if (isMounted()) {
-                        setIsDeploying(result)
-                    }
-                    return
+                    result = await getAdminFee(beneficiaryAddress, true) != null
                 } catch (e) {
                     // Ignore.
                 }
             }
-            setIsDeploying(false)
+
+            if (isMounted()) {
+                setIsDeploying(result)
+            }
         })()
     }, [isDataUnion, beneficiaryAddress, isMounted])
 

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -139,7 +139,7 @@ const ProductsPage = () => {
                         const { id, beneficiaryAddress, state } = product
                         const isDataUnion = isDataUnionProduct(product.type)
                         const memberCount = isDataUnion ? members[(beneficiaryAddress || '').toLowerCase()] : undefined
-                        const isDeploying = !fetchingDataUnionStats && typeof memberCount !== 'undefined'
+                        const isDeploying = state === productStates.DEPLOYING
                         const deployed = state === productStates.DEPLOYED
                         const publishable = deployed || state === productStates.NOT_DEPLOYED
 

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -139,7 +139,7 @@ const ProductsPage = () => {
                         const { id, beneficiaryAddress, state } = product
                         const isDataUnion = isDataUnionProduct(product.type)
                         const memberCount = isDataUnion ? members[(beneficiaryAddress || '').toLowerCase()] : undefined
-                        const isDeploying = state === productStates.DEPLOYING
+                        const isDeploying = isDataUnion && !fetchingDataUnionStats && !!beneficiaryAddress && typeof memberCount === 'undefined'
                         const deployed = state === productStates.DEPLOYED
                         const publishable = deployed || state === productStates.NOT_DEPLOYED
 

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -90,7 +90,7 @@ const ProductsPage = () => {
     const products = useSelector(selectMyProductList)
     const fetching = useSelector(selectFetching)
     const dispatch = useDispatch()
-    const { load: loadDataUnionStats, members, fetching: fetchingDataUnionStats } = useMemberStats()
+    const { load: loadDataUnionStats, members } = useMemberStats()
 
     useEffect(() => {
         dispatch(getMyProducts(filter))


### PR DESCRIPTION
I used `Product#state` to indicated ongoing deployment. I ported the previous behaviour (the 1 I fix here) from before #907 but never understood why fetching members indicates deploying.

@juhah @tumppi can you confirm that's the correct way? 