### PR TITLE
[PLATFORM-1293] Product editor error handling

### DIFF
--- a/app/src/marketplace/components/MarkdownEditor/index.jsx
+++ b/app/src/marketplace/components/MarkdownEditor/index.jsx
@@ -13,7 +13,6 @@ type Props = LastErrorProps & {
     value?: string,
     placeholder?: string,
     onChange?: (string) => void,
-    onCommit?: (string) => void,
     className?: string,
 }
 
@@ -58,7 +57,6 @@ const MarkdownEditor = ({
                     unstyled
                     className={styles.input}
                     onChange={onTextChange}
-                    smartCommit
                     tag="textarea"
                     value={value}
                 />

--- a/app/src/marketplace/components/ProductPage/EditorNav/editorNav.stories.jsx
+++ b/app/src/marketplace/components/ProductPage/EditorNav/editorNav.stories.jsx
@@ -78,10 +78,10 @@ stories.add('basic', () => (
     <EditNavController />
 ))
 
-stories.add('with validation', () => (
-    <EditNavController showValidation />
+stories.add('with errors', () => (
+    <EditNavController showErrors />
 ))
 
-stories.add('with validation & tracking', () => (
-    <EditNavController showValidation trackScrolling />
+stories.add('with errors & tracking', () => (
+    <EditNavController showErrors trackScrolling />
 ))

--- a/app/src/marketplace/components/ProductPage/EditorNav/editorNav.stories.jsx
+++ b/app/src/marketplace/components/ProductPage/EditorNav/editorNav.stories.jsx
@@ -35,7 +35,7 @@ const sections = [{
     heading: 'Details',
 }]
 
-const EditNavController = () => {
+const EditNavController = (props) => {
     const [activeSection, setActiveSection] = useState('')
     const nameStatus = select('Name', statuses, statuses.EMPTY)
     const coverImageStatus = select('Cover Image', statuses, statuses.EMPTY)
@@ -68,6 +68,7 @@ const EditNavController = () => {
             <EditorNav
                 sections={sectionsData}
                 activeSection={activeSection}
+                {...props}
             />
         </div>
     )
@@ -75,4 +76,12 @@ const EditNavController = () => {
 
 stories.add('basic', () => (
     <EditNavController />
+))
+
+stories.add('with validation', () => (
+    <EditNavController showValidation />
+))
+
+stories.add('with validation & tracking', () => (
+    <EditNavController showValidation trackScrolling />
 ))

--- a/app/src/marketplace/components/ProductPage/EditorNav/index.jsx
+++ b/app/src/marketplace/components/ProductPage/EditorNav/index.jsx
@@ -85,19 +85,27 @@ const NavSection = ({
 type Props = {
     sections: Array<Section>,
     activeSection?: string,
+    showValidation?: boolean,
+    trackScrolling?: boolean,
     className?: string,
 }
 
-const EditorNav = ({ sections, activeSection, className }: Props) => {
+const EditorNav = ({
+    sections,
+    activeSection,
+    showValidation,
+    trackScrolling,
+    className,
+}: Props) => {
     const [highestSeenSection, setHighestSeenSection] = useState(-1)
 
-    useEffect(() => {
-        setHighestSeenSection((prev) => {
-            const highest = findLastIndex(sections, ({ id, status }) => id === activeSection || isSet(status))
+    useEffect(() => setHighestSeenSection((prev) => {
+        if (!trackScrolling) { return sections.length - 1 }
 
-            return Math.min(highest > prev ? highest : prev, sections.length - 1)
-        })
-    }, [sections, activeSection])
+        const highest = findLastIndex(sections, ({ id, status }) => id === activeSection || isSet(status))
+
+        return Math.min(highest > prev ? highest : prev, sections.length - 1)
+    }), [trackScrolling, sections, activeSection])
 
     return (
         <div className={cx(styles.root, styles.EditorNav, className)}>
@@ -106,7 +114,7 @@ const EditorNav = ({ sections, activeSection, className }: Props) => {
                 <div
                     className={styles.progressTrack}
                     style={{
-                        height: `${(Math.max(0, highestSeenSection) / Math.max(1, sections.length - 1)) * 100}%`,
+                        height: !trackScrolling ? '100%' : `${(Math.max(0, highestSeenSection) / Math.max(1, sections.length - 1)) * 100}%`,
                     }}
                 />
             </div>
@@ -115,7 +123,7 @@ const EditorNav = ({ sections, activeSection, className }: Props) => {
                     {...rest}
                     key={id}
                     id={id}
-                    status={status}
+                    status={(showValidation || status === statuses.UNPUBLISHED) ? status : statuses.EMPTY}
                     active={id === activeSection}
                     seen={highestSeenSection >= index}
                 />

--- a/app/src/marketplace/components/ProductPage/EditorNav/index.jsx
+++ b/app/src/marketplace/components/ProductPage/EditorNav/index.jsx
@@ -85,7 +85,7 @@ const NavSection = ({
 type Props = {
     sections: Array<Section>,
     activeSection?: string,
-    showValidation?: boolean,
+    showErrors?: boolean,
     trackScrolling?: boolean,
     className?: string,
 }
@@ -93,7 +93,7 @@ type Props = {
 const EditorNav = ({
     sections,
     activeSection,
-    showValidation,
+    showErrors,
     trackScrolling,
     className,
 }: Props) => {
@@ -123,7 +123,7 @@ const EditorNav = ({
                     {...rest}
                     key={id}
                     id={id}
-                    status={(showValidation || status === statuses.UNPUBLISHED) ? status : statuses.EMPTY}
+                    status={(showErrors || status !== statuses.ERROR) ? status : statuses.EMPTY}
                     active={id === activeSection}
                     seen={highestSeenSection >= index}
                 />

--- a/app/src/marketplace/components/ProductPage/EditorNav/index.jsx
+++ b/app/src/marketplace/components/ProductPage/EditorNav/index.jsx
@@ -132,4 +132,8 @@ const EditorNav = ({
     )
 }
 
+EditorNav.defaultProps = {
+    sections: [],
+}
+
 export default EditorNav

--- a/app/src/marketplace/components/ProductPage/EditorNav/test/editorNav.test.jsx
+++ b/app/src/marketplace/components/ProductPage/EditorNav/test/editorNav.test.jsx
@@ -1,0 +1,319 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+
+import EditorNav, { statuses } from '../'
+
+describe('EditorNav', () => {
+    it('renders an empty list by default', () => {
+        const el = shallow(<EditorNav />)
+        expect(el.find('NavSection')).toHaveLength(0)
+    })
+
+    it('renders sections', () => {
+        const sections = [{
+            id: 'name',
+            heading: 'Name',
+        }, {
+            id: 'coverImage',
+            heading: 'Cover Image',
+        }, {
+            id: 'description',
+            heading: 'Description',
+        }, {
+            id: 'streams',
+            heading: 'Streams',
+        }, {
+            id: 'price',
+            heading: 'Price',
+        }, {
+            id: 'details',
+            heading: 'Details',
+        }]
+
+        const el = shallow(<EditorNav sections={sections} />)
+        expect(el.find('NavSection')).toHaveLength(6)
+    })
+
+    it('renders seen icons by default', () => {
+        const sections = [{
+            id: 'name',
+            heading: 'Name',
+        }, {
+            id: 'coverImage',
+            heading: 'Cover Image',
+        }, {
+            id: 'description',
+            heading: 'Description',
+        }, {
+            id: 'streams',
+            heading: 'Streams',
+        }]
+
+        let el
+        act(() => {
+            el = mount(<EditorNav sections={sections} />)
+        })
+        const icons = el.update().find('Icons')
+
+        expect(icons.at(0).prop('name')).toBe('seen')
+        expect(icons.at(1).prop('name')).toBe('seen')
+        expect(icons.at(2).prop('name')).toBe('seen')
+        expect(icons.at(3).prop('name')).toBe('seen')
+    })
+
+    describe('active section', () => {
+        it('highlights the active section', () => {
+            const sections = [{
+                id: 'name',
+                heading: 'Name',
+            }, {
+                id: 'coverImage',
+                heading: 'Cover Image',
+            }, {
+                id: 'description',
+                heading: 'Description',
+            }, {
+                id: 'streams',
+                heading: 'Streams',
+            }, {
+                id: 'price',
+                heading: 'Price',
+            }, {
+                id: 'details',
+                heading: 'Details',
+            }]
+
+            let el
+            act(() => {
+                el = mount(<EditorNav sections={sections} activeSection="price" />)
+            })
+            const nav = el.find('NavSection')
+
+            expect(nav.at(0).prop('active')).toBe(false)
+            expect(nav.at(1).prop('active')).toBe(false)
+            expect(nav.at(2).prop('active')).toBe(false)
+            expect(nav.at(3).prop('active')).toBe(false)
+            expect(nav.at(4).prop('active')).toBe(true)
+            expect(nav.at(5).prop('active')).toBe(false)
+        })
+
+        it('shows different icon for the active section', () => {
+            const sections = [{
+                id: 'name',
+                heading: 'Name',
+            }, {
+                id: 'coverImage',
+                heading: 'Cover Image',
+            }, {
+                id: 'description',
+                heading: 'Description',
+            }, {
+                id: 'streams',
+                heading: 'Streams',
+            }]
+
+            let el
+            act(() => {
+                el = mount(<EditorNav sections={sections} activeSection="description" />)
+            })
+            const icons = el.update().find('Icons')
+
+            expect(icons.at(0).prop('name')).toBe('seen')
+            expect(icons.at(1).prop('name')).toBe('seen')
+            expect(icons.at(2).prop('name')).toBe('active')
+            expect(icons.at(3).prop('name')).toBe('seen')
+        })
+    })
+
+    describe('trackScrolling', () => {
+        it('renders sections as unseen', () => {
+            const sections = [{
+                id: 'name',
+                heading: 'Name',
+            }, {
+                id: 'coverImage',
+                heading: 'Cover Image',
+            }, {
+                id: 'description',
+                heading: 'Description',
+            }, {
+                id: 'streams',
+                heading: 'Streams',
+            }]
+
+            let el
+            act(() => {
+                el = mount(<EditorNav sections={sections} trackScrolling />)
+            })
+            const icons = el.update().find('Icons')
+
+            expect(icons.at(0).prop('name')).toBe('default')
+            expect(icons.at(1).prop('name')).toBe('default')
+            expect(icons.at(2).prop('name')).toBe('default')
+            expect(icons.at(3).prop('name')).toBe('default')
+        })
+
+        it('renders sections as seen up the active section', () => {
+            const sections = [{
+                id: 'name',
+                heading: 'Name',
+            }, {
+                id: 'coverImage',
+                heading: 'Cover Image',
+            }, {
+                id: 'description',
+                heading: 'Description',
+            }, {
+                id: 'streams',
+                heading: 'Streams',
+            }]
+
+            let el
+            act(() => {
+                el = mount(<EditorNav sections={sections} trackScrolling />)
+            })
+
+            let icons = el.update().find('Icons')
+            expect(icons.at(0).prop('name')).toBe('default')
+            expect(icons.at(1).prop('name')).toBe('default')
+            expect(icons.at(2).prop('name')).toBe('default')
+            expect(icons.at(3).prop('name')).toBe('default')
+
+            act(() => {
+                el.setProps({
+                    activeSection: 'description',
+                })
+            })
+            icons = el.update().find('Icons')
+
+            expect(icons.at(0).prop('name')).toBe('seen')
+            expect(icons.at(1).prop('name')).toBe('seen')
+            expect(icons.at(2).prop('name')).toBe('active')
+            expect(icons.at(3).prop('name')).toBe('default')
+        })
+
+        it('renders sections as seen up to a section with status', () => {
+            const sections = [{
+                id: 'name',
+                heading: 'Name',
+            }, {
+                id: 'coverImage',
+                heading: 'Cover Image',
+            }, {
+                id: 'description',
+                heading: 'Description',
+                status: statuses.VALID,
+            }, {
+                id: 'streams',
+                heading: 'Streams',
+            }]
+
+            let el
+            act(() => {
+                el = mount(<EditorNav sections={sections} trackScrolling />)
+            })
+            const icons = el.update().find('Icons')
+
+            expect(icons.at(0).prop('name')).toBe('seen')
+            expect(icons.at(1).prop('name')).toBe('seen')
+            expect(icons.at(2).prop('name')).toBe('seen')
+            expect(icons.at(3).prop('name')).toBe('default')
+        })
+    })
+
+    describe('showValidation', () => {
+        it('shows only unpublished change icon when showValidation is false', () => {
+            const sections = [{
+                id: 'name',
+                heading: 'Name',
+                status: statuses.ERROR,
+            }, {
+                id: 'coverImage',
+                heading: 'Cover Image',
+                status: statuses.VALID,
+            }, {
+                id: 'description',
+                heading: 'Description',
+                status: statuses.UNPUBLISHED,
+            }, {
+                id: 'streams',
+                heading: 'Streams',
+                status: statuses.EMPTY,
+            }]
+
+            let el
+            act(() => {
+                el = mount(<EditorNav sections={sections} />)
+            })
+            const icons = el.update().find('Icons')
+
+            expect(icons.at(0).prop('name')).toBe('seen')
+            expect(icons.at(1).prop('name')).toBe('seen')
+            expect(icons.at(2).prop('name')).toBe('unpublished')
+            expect(icons.at(3).prop('name')).toBe('seen')
+        })
+
+        it('shows status icons when showValidation is true', () => {
+            const sections = [{
+                id: 'name',
+                heading: 'Name',
+                status: statuses.ERROR,
+            }, {
+                id: 'coverImage',
+                heading: 'Cover Image',
+                status: statuses.VALID,
+            }, {
+                id: 'description',
+                heading: 'Description',
+                status: statuses.UNPUBLISHED,
+            }, {
+                id: 'streams',
+                heading: 'Streams',
+                status: statuses.EMPTY,
+            }]
+
+            let el
+            act(() => {
+                el = mount(<EditorNav sections={sections} showValidation />)
+            })
+            const icons = el.update().find('Icons')
+            expect(icons.at(0).prop('name')).toBe('error')
+            expect(icons.at(1).prop('name')).toBe('valid')
+            expect(icons.at(2).prop('name')).toBe('unpublished')
+            expect(icons.at(3).prop('name')).toBe('seen')
+        })
+
+        it('shows different error icon for the active section', () => {
+            const sections = [{
+                id: 'name',
+                heading: 'Name',
+            }, {
+                id: 'coverImage',
+                heading: 'Cover Image',
+            }, {
+                id: 'description',
+                heading: 'Description',
+                status: statuses.ERROR,
+            }, {
+                id: 'streams',
+                heading: 'Streams',
+            }]
+
+            let el
+            act(() => {
+                el = mount(<EditorNav
+                    sections={sections}
+                    activeSection="description"
+                    showValidation
+                />)
+            })
+            const icons = el.update().find('Icons')
+
+            expect(icons.at(0).prop('name')).toBe('seen')
+            expect(icons.at(1).prop('name')).toBe('seen')
+            expect(icons.at(2).prop('name')).toBe('activeError')
+            expect(icons.at(3).prop('name')).toBe('seen')
+        })
+    })
+})

--- a/app/src/marketplace/components/ProductPage/EditorNav/test/editorNav.test.jsx
+++ b/app/src/marketplace/components/ProductPage/EditorNav/test/editorNav.test.jsx
@@ -217,13 +217,13 @@ describe('EditorNav', () => {
 
             expect(icons.at(0).prop('name')).toBe('seen')
             expect(icons.at(1).prop('name')).toBe('seen')
-            expect(icons.at(2).prop('name')).toBe('seen')
+            expect(icons.at(2).prop('name')).toBe('valid')
             expect(icons.at(3).prop('name')).toBe('default')
         })
     })
 
-    describe('showValidation', () => {
-        it('shows only unpublished change icon when showValidation is false', () => {
+    describe('showErrors', () => {
+        it('it doesnt show error icons when showErrors is false', () => {
             const sections = [{
                 id: 'name',
                 heading: 'Name',
@@ -249,12 +249,12 @@ describe('EditorNav', () => {
             const icons = el.update().find('Icons')
 
             expect(icons.at(0).prop('name')).toBe('seen')
-            expect(icons.at(1).prop('name')).toBe('seen')
+            expect(icons.at(1).prop('name')).toBe('valid')
             expect(icons.at(2).prop('name')).toBe('unpublished')
             expect(icons.at(3).prop('name')).toBe('seen')
         })
 
-        it('shows status icons when showValidation is true', () => {
+        it('shows error icons when showErrors is true', () => {
             const sections = [{
                 id: 'name',
                 heading: 'Name',
@@ -275,7 +275,7 @@ describe('EditorNav', () => {
 
             let el
             act(() => {
-                el = mount(<EditorNav sections={sections} showValidation />)
+                el = mount(<EditorNav sections={sections} showErrors />)
             })
             const icons = el.update().find('Icons')
             expect(icons.at(0).prop('name')).toBe('error')
@@ -305,7 +305,7 @@ describe('EditorNav', () => {
                 el = mount(<EditorNav
                     sections={sections}
                     activeSection="description"
-                    showValidation
+                    showErrors
                 />)
             })
             const icons = el.update().find('Icons')

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -8,7 +8,6 @@ import styled from 'styled-components'
 
 import useValidation from '../ProductController/useValidation'
 import Text from '$ui/Text'
-import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
 import Errors, { MarketplaceTheme } from '$ui/Errors'
 import ActionsDropdown from '$shared/components/ActionsDropdown'
 import DropdownActions from '$shared/components/DropdownActions'
@@ -20,6 +19,7 @@ import { fetchIntegrationKeys } from '$shared/modules/integrationKey/actions'
 import { truncate } from '$shared/utils/text'
 import useAccountAddress from '$shared/hooks/useAccountAddress'
 import Label from '$ui/Label'
+import { Context as EditControllerContext } from './EditControllerProvider'
 
 import styles from './beneficiaryAddress.pcss'
 
@@ -68,9 +68,8 @@ const BeneficiaryAddress = ({
     onBlur: onBlurProp,
 }: Props) => {
     const { isValid, message } = useValidation('beneficiaryAddress')
-    const { isTouched } = useContext(ValidationContext)
-    const priceTouched = isTouched('pricePerSecond') || isTouched('beneficiaryAddress')
-    const invalid = priceTouched && !isValid
+    const { publishAttempted } = useContext(EditControllerContext)
+    const invalid = publishAttempted && !isValid
 
     const { copy } = useCopy()
 

--- a/app/src/marketplace/containers/EditProductPage/CoverImage.jsx
+++ b/app/src/marketplace/containers/EditProductPage/CoverImage.jsx
@@ -4,7 +4,6 @@ import React, { useContext, useCallback, useEffect } from 'react'
 import cx from 'classnames'
 import { Translate } from 'react-redux-i18n'
 
-import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
 import useEditableProduct from '../ProductController/useEditableProduct'
 import useValidation from '../ProductController/useValidation'
 import useEditableProductActions from '../ProductController/useEditableProductActions'
@@ -14,17 +13,18 @@ import usePending from '$shared/hooks/usePending'
 import useModal from '$shared/hooks/useModal'
 import useFilePreview from '$shared/hooks/useFilePreview'
 import routes from '$routes'
+import { Context as EditControllerContext } from './EditControllerProvider'
 
 import styles from './coverImage.pcss'
 
 const CoverImage = () => {
     const product = useEditableProduct()
-    const { isTouched } = useContext(ValidationContext)
     const { updateImageFile } = useEditableProductActions()
     const { isValid, message } = useValidation('imageUrl')
     const { isPending } = usePending('product.SAVE')
     const { api: cropImageDialog } = useModal('cropImage')
     const { preview, createPreview } = useFilePreview()
+    const { publishAttempted } = useContext(EditControllerContext)
 
     const onUpload = useCallback(async (image: File) => {
         const newImage = await cropImageDialog.open({
@@ -44,7 +44,7 @@ const CoverImage = () => {
         createPreview(uploadedImage)
     }, [uploadedImage, createPreview])
 
-    const hasError = isTouched('imageUrl') && !isValid
+    const hasError = publishAttempted && !isValid
 
     return (
         <section id="cover-image" className={cx(styles.root, styles.CoverImage)}>

--- a/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
@@ -32,6 +32,7 @@ type ContextProps = {
     publish: () => void | Promise<void>,
     deployDataUnion: () => void | Promise<void>,
     lastSectionRef: any,
+    publishAttempted: boolean,
 }
 
 const EditControllerContext: Context<ContextProps> = React.createContext({})
@@ -47,6 +48,7 @@ function useEditController(product: Product) {
     const originalProduct = useSelector(selectProduct)
     const { replaceProduct } = useEditableProductUpdater()
     const dataUnion = useSelector(selectDataUnion)
+    const [publishAttempted, setPublishAttempted] = useState(false)
 
     useEffect(() => {
         const handleBeforeunload = (event) => {
@@ -165,9 +167,10 @@ function useEditController(product: Product) {
         return true
     }, [errors, dataUnion])
 
-    const isPublic = State.isPublished(product)
     const publish = useCallback(async () => {
-        if (isPublic || validate()) {
+        setPublishAttempted(true)
+
+        if (validate()) {
             await save({
                 redirect: false,
             })
@@ -179,7 +182,7 @@ function useEditController(product: Product) {
                 redirectToProductList()
             }
         }
-    }, [validate, save, publishDialog, redirectToProductList, isPublic])
+    }, [validate, save, publishDialog, redirectToProductList])
 
     const updateBeneficiary = useCallback(async (address) => {
         const { beneficiaryAddress } = productRef.current
@@ -189,6 +192,8 @@ function useEditController(product: Product) {
     }, [updateBeneficiaryAddress])
 
     const deployDataUnion = useCallback(async () => {
+        setPublishAttempted(true)
+
         if (validate()) {
             await save({
                 redirect: false,
@@ -243,6 +248,7 @@ function useEditController(product: Product) {
         publish,
         deployDataUnion,
         lastSectionRef,
+        publishAttempted,
     }), [
         isPreview,
         setIsPreview,
@@ -251,6 +257,7 @@ function useEditController(product: Product) {
         publish,
         deployDataUnion,
         lastSectionRef,
+        publishAttempted,
     ])
 }
 

--- a/app/src/marketplace/containers/EditProductPage/EditorNav.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditorNav.jsx
@@ -28,22 +28,23 @@ const EditorNav = () => {
 
     const [activeSectionId, setActiveSectionId] = useState(undefined)
 
-    const { isValid, isPendingChange } = useContext(ValidationContext)
+    const { isValid, isTouched, isPendingChange } = useContext(ValidationContext)
     const { lastSectionRef, publishAttempted } = useContext(EditControllerContext)
 
     const isDataUnion = isDataUnionProduct(product)
     const isPublic = isPublished(product)
 
     const getStatus = useCallback((name: string) => {
-        const pending = !!isPublic && isPendingChange(name)
-
-        if (!publishAttempted && isNewProduct && !pending) {
+        if (isNewProduct && !isTouched(name)) {
             return statuses.EMPTY
         }
+
+        const pending = !isNewProduct && !!isPublic && isPendingChange(name)
+
         const validState = pending ? statuses.UNPUBLISHED : statuses.VALID
 
-        return (!publishAttempted || isValid(name)) ? validState : statuses.ERROR
-    }, [isPublic, isPendingChange, isNewProduct, isValid, publishAttempted])
+        return isValid(name) ? validState : statuses.ERROR
+    }, [isPublic, isPendingChange, isValid, isNewProduct, isTouched])
 
     const priceStatus = useMemo(() => {
         const price = getStatus('pricePerSecond')
@@ -214,7 +215,7 @@ const EditorNav = () => {
             <EditorNavComponent
                 sections={sectionWithLinks}
                 activeSection={activeSectionId}
-                showValidation={publishAttempted}
+                showErrors={publishAttempted}
                 trackScrolling={isNewProduct}
             />
         </Scrollspy>

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
@@ -15,11 +15,11 @@ import Toggle from '$shared/components/Toggle'
 import SvgIcon from '$shared/components/SvgIcon'
 import { selectContractProduct } from '$mp/modules/contractProduct/selectors'
 
-import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
 import useEditableProduct from '../ProductController/useEditableProduct'
 import useValidation from '../ProductController/useValidation'
 import useEditableProductActions from '../ProductController/useEditableProductActions'
 import { isPublished } from './state'
+import { Context as EditControllerContext } from './EditControllerProvider'
 import routes from '$routes'
 
 import BeneficiaryAddress from './BeneficiaryAddress'
@@ -28,7 +28,7 @@ import styles from './PriceSelector.pcss'
 
 const PriceSelector = () => {
     const product = useEditableProduct()
-    const { isTouched } = useContext(ValidationContext)
+    const { publishAttempted } = useContext(EditControllerContext)
 
     const {
         updateIsFree,
@@ -103,7 +103,7 @@ const PriceSelector = () => {
                         timeUnit={product.timeUnit}
                         onTimeUnitChange={onTimeUnitChange}
                         dataPerUsd={dataPerUsd}
-                        error={isTouched('pricePerSecond') && !isValid ? message : undefined}
+                        error={publishAttempted && !isValid ? message : undefined}
                     />
                     <div
                         className={cx({

--- a/app/src/marketplace/containers/EditProductPage/ProductDescription.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ProductDescription.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useContext, useState, useEffect } from 'react'
+import React, { useContext } from 'react'
 import cx from 'classnames'
 import { Translate } from 'react-redux-i18n'
 
@@ -21,12 +21,6 @@ const ProductDescription = () => {
     const { updateDescription } = useEditableProductActions()
     const { isPending } = usePending('product.SAVE')
 
-    const [description, setDescription] = useState(product.description || '')
-
-    useEffect(() => {
-        setDescription(product.description || '')
-    }, [product.description])
-
     return (
         <section id="description" className={cx(styles.root, styles.ProductDescription)}>
             <div>
@@ -42,9 +36,8 @@ const ProductDescription = () => {
                 />
                 <MarkdownEditor
                     placeholder="Type something great about your product"
-                    value={description}
-                    onChange={setDescription}
-                    onCommit={updateDescription}
+                    value={product.description || ''}
+                    onChange={updateDescription}
                     className={styles.productDescription}
                     error={publishAttempted && !isValid ? message : undefined}
                     disabled={!!isPending}

--- a/app/src/marketplace/containers/EditProductPage/ProductDescription.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ProductDescription.jsx
@@ -8,7 +8,7 @@ import useEditableProduct from '../ProductController/useEditableProduct'
 import useValidation from '../ProductController/useValidation'
 import useEditableProductActions from '../ProductController/useEditableProductActions'
 import MarkdownEditor from '$mp/components/MarkdownEditor'
-import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
+import { Context as EditControllerContext } from './EditControllerProvider'
 import usePending from '$shared/hooks/usePending'
 import routes from '$routes'
 
@@ -16,7 +16,7 @@ import styles from './productDescription.pcss'
 
 const ProductDescription = () => {
     const product = useEditableProduct()
-    const { isTouched } = useContext(ValidationContext)
+    const { publishAttempted } = useContext(EditControllerContext)
     const { isValid, message } = useValidation('description')
     const { updateDescription } = useEditableProductActions()
     const { isPending } = usePending('product.SAVE')
@@ -46,7 +46,7 @@ const ProductDescription = () => {
                     onChange={setDescription}
                     onCommit={updateDescription}
                     className={styles.productDescription}
-                    error={isTouched('description') && !isValid ? message : undefined}
+                    error={publishAttempted && !isValid ? message : undefined}
                     disabled={!!isPending}
                 />
             </div>

--- a/app/src/marketplace/containers/EditProductPage/ProductDetails.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ProductDetails.jsx
@@ -11,7 +11,7 @@ import useEditableProductActions from '../ProductController/useEditableProductAc
 import { usePending } from '$shared/hooks/usePending'
 import SelectField from '$mp/components/SelectField'
 import { isDataUnionProduct } from '$mp/utils/product'
-import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
+import { Context as EditControllerContext } from './EditControllerProvider'
 import { selectAllCategories, selectFetchingCategories } from '$mp/modules/categories/selectors'
 
 import Details from './Details'
@@ -25,7 +25,7 @@ const adminFeeOptions = [10, 20, 30, 40, 50, 60, 70, 80, 90].map((value) => ({
 
 const ProductDetails = () => {
     const product = useEditableProduct()
-    const { isTouched } = useContext(ValidationContext)
+    const { publishAttempted } = useContext(EditControllerContext)
     const categories = useSelector(selectAllCategories)
     const fetching = useSelector(selectFetchingCategories)
 
@@ -62,7 +62,7 @@ const ProductDetails = () => {
                                 value={selectedCategory}
                                 onChange={(option) => updateCategory(option.value)}
                                 isSearchable={false}
-                                error={isTouched('category') && !isCategoryValid ? categoryMessage : undefined}
+                                error={publishAttempted && !isCategoryValid ? categoryMessage : undefined}
                                 disabled={!!isPending}
                             />
                         )}
@@ -75,7 +75,7 @@ const ProductDetails = () => {
                                 value={selectedAdminFee}
                                 onChange={(option) => updateAdminFee(option.value)}
                                 isSearchable={false}
-                                error={isTouched('adminFee') && !isAdminFeeValid ? adminFeeMessage : undefined}
+                                error={publishAttempted && !isAdminFeeValid ? adminFeeMessage : undefined}
                                 disabled={!!isPending}
                             />
                         </Details.Row>

--- a/app/src/marketplace/containers/EditProductPage/ProductName.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ProductName.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useContext } from 'react'
+import React, { useContext, useCallback } from 'react'
 import cx from 'classnames'
 import { Translate } from 'react-redux-i18n'
 
@@ -22,6 +22,10 @@ const ProductName = () => {
     const { publishAttempted } = useContext(EditControllerContext)
     const invalid = publishAttempted && !isValid
 
+    const onChange = useCallback((e: SyntheticInputEvent<EventTarget>) => {
+        updateName(e.target.value)
+    }, [updateName])
+
     return (
         <section id="product-name" className={cx(styles.root, styles.ProductName)}>
             <div>
@@ -31,11 +35,10 @@ const ProductName = () => {
                 />
                 <Text
                     defaultValue={product.name}
-                    onCommit={updateName}
+                    onChange={onChange}
                     placeholder="Product Name"
                     disabled={isPending}
                     selectAllOnFocus
-                    smartCommit
                     invalid={invalid}
                     className={styles.input}
                     theme={SpaciousTheme}

--- a/app/src/marketplace/containers/EditProductPage/ProductName.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ProductName.jsx
@@ -4,11 +4,11 @@ import React, { useContext } from 'react'
 import cx from 'classnames'
 import { Translate } from 'react-redux-i18n'
 
-import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
 import usePending from '$shared/hooks/usePending'
 import useEditableProduct from '../ProductController/useEditableProduct'
 import useValidation from '../ProductController/useValidation'
 import useEditableProductActions from '../ProductController/useEditableProductActions'
+import { Context as EditControllerContext } from './EditControllerProvider'
 import Text, { SpaciousTheme } from '$ui/Text'
 import Errors, { MarketplaceTheme } from '$ui/Errors'
 
@@ -18,9 +18,9 @@ const ProductName = () => {
     const product = useEditableProduct()
     const { isValid, message } = useValidation('name')
     const { updateName } = useEditableProductActions()
-    const { isTouched } = useContext(ValidationContext)
     const { isPending } = usePending('product.SAVE')
-    const invalid = isTouched('name') && !isValid
+    const { publishAttempted } = useContext(EditControllerContext)
+    const invalid = publishAttempted && !isValid
 
     return (
         <section id="product-name" className={cx(styles.root, styles.ProductName)}>

--- a/app/src/marketplace/containers/EditProductPage/ProductStreams.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ProductStreams.jsx
@@ -9,7 +9,7 @@ import StreamSelectorComponent from '$mp/components/StreamSelector'
 import useEditableProduct from '../ProductController/useEditableProduct'
 import useValidation from '../ProductController/useValidation'
 import useEditableProductActions from '../ProductController/useEditableProductActions'
-import { Context as ValidationContext } from '../ProductController/ValidationContextProvider'
+import { Context as EditControllerContext } from './EditControllerProvider'
 import usePending from '$shared/hooks/usePending'
 import { selectStreams, selectFetchingStreams } from '$mp/modules/streams/selectors'
 import routes from '$routes'
@@ -20,7 +20,7 @@ const ProductStreams = () => {
     const product = useEditableProduct()
     const { isValid, message } = useValidation('streams')
     const { updateStreams } = useEditableProductActions()
-    const { isTouched } = useContext(ValidationContext)
+    const { publishAttempted } = useContext(EditControllerContext)
     const { isPending } = usePending('product.SAVE')
     const streams = useSelector(selectStreams)
     const fetching = useSelector(selectFetchingStreams)
@@ -44,7 +44,7 @@ const ProductStreams = () => {
                     onEdit={updateStreams}
                     streams={product.streams}
                     className={styles.streams}
-                    error={isTouched('streams') && !isValid ? message : undefined}
+                    error={publishAttempted && !isValid ? message : undefined}
                     disabled={!!isPending}
                 />
             </div>

--- a/app/src/marketplace/containers/EditProductPage/state.js
+++ b/app/src/marketplace/containers/EditProductPage/state.js
@@ -64,7 +64,7 @@ export function getPendingChanges(product: Product): Object {
 export function hasPendingChange(product: Product, field: string) {
     const pendingChanges = getPendingChanges(product)
 
-    return !!pendingChanges[field]
+    return field in pendingChanges
 }
 
 export function update(product: Product, fn: Function) {

--- a/app/src/marketplace/containers/EditProductPage/tests/productState.test.js
+++ b/app/src/marketplace/containers/EditProductPage/tests/productState.test.js
@@ -346,6 +346,29 @@ describe('Product State', () => {
             expect(State.hasPendingChange(nextProduct, 'name')).toBe(true)
             expect(State.hasPendingChange(nextProduct, 'description')).toBe(true)
         })
+
+        it('it returns true if pending fields are set to empty', () => {
+            const product = {
+                id: '1',
+                name: 'My Product',
+                description: 'My nice product',
+                otherField: 'asd',
+                state: productStates.DEPLOYED,
+            }
+            const nextProduct = {
+                ...product,
+                pendingChanges: {
+                    name: '',
+                    description: null,
+                    otherField: undefined,
+                },
+            }
+            expect(State.hasPendingChange(nextProduct, 'name')).toBe(true)
+            expect(State.hasPendingChange(nextProduct, 'description')).toBe(true)
+
+            // undefined value can't be detected
+            expect(State.hasPendingChange(nextProduct, 'otherField')).toBe(false)
+        })
     })
 
     describe('withPendingChanges', () => {

--- a/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
+++ b/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
@@ -83,10 +83,14 @@ function useValidationContext(): ContextProps {
             throw new Error('validation needs a name')
         }
 
-        setStatusState((state) => ({
-            ...state,
-            [name]: undefined,
-        }))
+        setStatusState((prevState) => {
+            const newState = {
+                ...prevState,
+            }
+            delete newState[name]
+
+            return newState
+        })
     }, [setStatusState, isMounted])
 
     const isValid = useCallback((name: string) => !status[name], [status])

--- a/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
+++ b/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
@@ -7,7 +7,6 @@ import { isEthereumAddress } from '$mp/utils/validate'
 import { isPaidProduct, isDataUnionProduct } from '$mp/utils/product'
 import { isPriceValid } from '$mp/utils/price'
 import { isPublished, getPendingChanges, PENDING_CHANGE_FIELDS } from '../EditProductPage/state'
-import useNewProductMode from './useNewProductMode'
 
 export const INFO = 'info'
 export const WARNING = 'warning'
@@ -36,7 +35,6 @@ function useValidationContext(): ContextProps {
     const [status, setStatusState] = useState({})
     const [pendingChanges, setPendingChanges] = useState({})
     const [touched, setTouched] = useState({})
-    const { isNewProduct } = useNewProductMode()
 
     const touch = useCallback((name: string) => {
         setTouched((existing) => ({
@@ -44,7 +42,7 @@ function useValidationContext(): ContextProps {
             [name]: true,
         }))
     }, [setTouched])
-    const isTouched = useCallback((name: string) => (!isNewProduct || !!touched[name]), [isNewProduct, touched])
+    const isTouched = useCallback((name: string) => !!touched[name], [touched])
 
     const isAnyTouched = useCallback(() => Object.values(touched).some(Boolean), [touched])
 
@@ -149,7 +147,7 @@ function useValidationContext(): ContextProps {
         const changes = getPendingChanges(product)
         const isPublic = isPublished(product)
         PENDING_CHANGE_FIELDS.forEach((field) => {
-            setPendingChange(field, !!changes[field] || (isPublic && isTouched(field)))
+            setPendingChange(field, (field in changes) || (isPublic && isTouched(field)))
         })
     }, [setStatus, clearStatus, isMounted, setPendingChange, isTouched])
 

--- a/app/src/marketplace/containers/ProductController/test/validationContext.test.jsx
+++ b/app/src/marketplace/containers/ProductController/test/validationContext.test.jsx
@@ -1,0 +1,725 @@
+import React, { useContext } from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+
+import { Provider as ValidationContextProvider, Context as ValidationContext } from '../ValidationContextProvider'
+
+describe('validation context', () => {
+    it('creates validation context', () => {
+        let currentContext
+        function Test() {
+            currentContext = useContext(ValidationContext)
+            return null
+        }
+
+        mount((
+            <ValidationContextProvider>
+                <Test />
+            </ValidationContextProvider>
+        ))
+
+        expect(currentContext.status).toStrictEqual({})
+        expect(currentContext.pendingChanges).toStrictEqual({})
+        expect(currentContext.touched).toStrictEqual({})
+    })
+
+    describe('touched fields', () => {
+        it('touch() marks a field as touched', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            expect(currentContext.touched).toStrictEqual({})
+            act(() => {
+                currentContext.touch('myField')
+            })
+            expect(currentContext.touched).toStrictEqual({
+                myField: true,
+            })
+        })
+
+        it('isTouched() returns true for fields marked as touched', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            expect(currentContext.touched).toStrictEqual({})
+            act(() => {
+                currentContext.touch('myField')
+            })
+            expect(currentContext.isTouched('myField')).toBe(true)
+            expect(currentContext.isTouched('anotherField')).toBe(false)
+        })
+
+        it('isAnyTouched() returns true if any field touched', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            expect(currentContext.isAnyTouched()).toBe(false)
+            act(() => {
+                currentContext.touch('myField')
+            })
+            expect(currentContext.isAnyTouched()).toBe(true)
+        })
+    })
+
+    describe('status', () => {
+        it('setStatus() sets field error status', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            expect(currentContext.status).toStrictEqual({})
+            act(() => {
+                currentContext.setStatus('myField', 'info', 'message')
+            })
+            expect(currentContext.status).toStrictEqual({
+                myField: {
+                    level: 'info',
+                    message: 'message',
+                },
+            })
+        })
+
+        it('setStatus() throws error if no name given', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                try {
+                    currentContext.setStatus()
+                } catch (e) {
+                    expect(e.message).toBe('validation needs a name')
+                }
+            })
+        })
+
+        it('setStatus() does nothing if unmounted', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            const result = mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                result.unmount()
+                currentContext.setStatus('myField', 'info', 'message')
+            })
+            expect(currentContext.status).toStrictEqual({})
+        })
+
+        it('clearStatus() removes field error status', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            expect(currentContext.status).toStrictEqual({})
+            act(() => {
+                currentContext.setStatus('myField', 'info', 'message')
+                currentContext.clearStatus('myField')
+            })
+            expect('myField' in currentContext.status).toBe(false)
+        })
+
+        it('clearStatus() throws error if no name given', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                try {
+                    currentContext.clearStatus()
+                } catch (e) {
+                    expect(e.message).toBe('validation needs a name')
+                }
+            })
+        })
+
+        it('clearStatus() does nothing if unmounted', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            const result = mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.setStatus('myField', 'info', 'message')
+            })
+            act(() => {
+                result.unmount()
+                currentContext.clearStatus()
+            })
+            expect(currentContext.status).toStrictEqual({
+                myField: {
+                    level: 'info',
+                    message: 'message',
+                },
+            })
+        })
+
+        it('isValid() returns true if field has no error', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            expect(currentContext.status).toStrictEqual({})
+            act(() => {
+                currentContext.setStatus('myField', 'error', 'message')
+            })
+            expect(currentContext.isValid('myField')).toBe(false)
+            act(() => {
+                currentContext.clearStatus('myField')
+            })
+            expect(currentContext.isValid('myField')).toBe(true)
+        })
+    })
+
+    describe('validate', () => {
+        it('does nothing if product is null', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+            expect(currentContext.status).toStrictEqual({})
+
+            act(() => {
+                currentContext.validate()
+            })
+            expect(currentContext.status).toStrictEqual({})
+        })
+
+        it('does nothing if unmounted', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            const result = mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+            expect(currentContext.status).toStrictEqual({})
+
+            act(() => {
+                result.unmount()
+                currentContext.validate({
+                    name: '',
+                })
+            })
+            expect(currentContext.status).toStrictEqual({})
+        })
+
+        it('validates empty product free data product', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    isFree: true,
+                })
+            })
+
+            expect(currentContext.isValid('name')).toBe(false)
+            expect(currentContext.isValid('description')).toBe(false)
+            expect(currentContext.isValid('category')).toBe(false)
+            expect(currentContext.isValid('imageUrl')).toBe(false)
+            expect(currentContext.isValid('streams')).toBe(false)
+            expect(currentContext.isValid('pricePerSecond')).toBe(true)
+            expect(currentContext.isValid('beneficiaryAddress')).toBe(true)
+            expect(currentContext.isValid('adminFee')).toBe(true)
+        })
+
+        it('validates empty product free data union', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'DATAUNION',
+                    isFree: true,
+                })
+            })
+
+            expect(currentContext.isValid('name')).toBe(false)
+            expect(currentContext.isValid('description')).toBe(false)
+            expect(currentContext.isValid('category')).toBe(false)
+            expect(currentContext.isValid('imageUrl')).toBe(false)
+            expect(currentContext.isValid('streams')).toBe(false)
+            expect(currentContext.isValid('pricePerSecond')).toBe(true)
+            expect(currentContext.isValid('beneficiaryAddress')).toBe(true)
+            expect(currentContext.isValid('adminFee')).toBe(false)
+        })
+
+        it('validates empty product paid data product', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    isFree: false,
+                })
+            })
+
+            expect(currentContext.isValid('name')).toBe(false)
+            expect(currentContext.isValid('description')).toBe(false)
+            expect(currentContext.isValid('category')).toBe(false)
+            expect(currentContext.isValid('imageUrl')).toBe(false)
+            expect(currentContext.isValid('streams')).toBe(false)
+            expect(currentContext.isValid('pricePerSecond')).toBe(false)
+            expect(currentContext.isValid('beneficiaryAddress')).toBe(false)
+            expect(currentContext.isValid('adminFee')).toBe(true)
+        })
+
+        it('validates empty product paid data union', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'DATAUNION',
+                    isFree: false,
+                })
+            })
+
+            expect(currentContext.isValid('name')).toBe(false)
+            expect(currentContext.isValid('description')).toBe(false)
+            expect(currentContext.isValid('category')).toBe(false)
+            expect(currentContext.isValid('imageUrl')).toBe(false)
+            expect(currentContext.isValid('streams')).toBe(false)
+            expect(currentContext.isValid('pricePerSecond')).toBe(false)
+            expect(currentContext.isValid('beneficiaryAddress')).toBe(true)
+            expect(currentContext.isValid('adminFee')).toBe(false)
+        })
+
+        it('validates name, description & category', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                })
+            })
+
+            expect(currentContext.isValid('name')).toBe(false)
+            expect(currentContext.isValid('description')).toBe(false)
+            expect(currentContext.isValid('category')).toBe(false)
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    name: 'new name',
+                    description: 'new description',
+                    category: 'new category',
+                })
+            })
+
+            expect(currentContext.isValid('name')).toBe(true)
+            expect(currentContext.isValid('description')).toBe(true)
+            expect(currentContext.isValid('category')).toBe(true)
+        })
+
+        it('validates image', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                })
+            })
+            expect(currentContext.isValid('imageUrl')).toBe(false)
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    imageUrl: 'http://...',
+                })
+            })
+            expect(currentContext.isValid('imageUrl')).toBe(true)
+
+            act(() => {
+                currentContext.clearStatus('imageUrl')
+                currentContext.validate({
+                    type: 'NORMAL',
+                    newImageToUpload: 'blob',
+                })
+            })
+            expect(currentContext.isValid('imageUrl')).toBe(true)
+        })
+
+        it('validates streams', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                })
+            })
+
+            expect(currentContext.isValid('streams')).toBe(false)
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    streams: ['1', '2'],
+                })
+            })
+
+            expect(currentContext.isValid('streams')).toBe(true)
+        })
+
+        it('validates admin fee', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'DATAUNION',
+                })
+            })
+            expect(currentContext.isValid('adminFee')).toBe(false)
+
+            act(() => {
+                currentContext.validate({
+                    type: 'DATAUNION',
+                    adminFee: 0.3,
+                })
+            })
+            expect(currentContext.isValid('adminFee')).toBe(true)
+
+            act(() => {
+                currentContext.clearStatus('adminFee')
+                currentContext.validate({
+                    type: 'DATAUNION',
+                    adminFee: 0,
+                })
+            })
+            expect(currentContext.isValid('adminFee')).toBe(false)
+
+            act(() => {
+                currentContext.clearStatus('adminFee')
+                currentContext.validate({
+                    type: 'DATAUNION',
+                    adminFee: 1.1,
+                })
+            })
+            expect(currentContext.isValid('adminFee')).toBe(false)
+        })
+
+        it('validates beneficiary address', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    isFree: false,
+                })
+            })
+            expect(currentContext.isValid('beneficiaryAddress')).toBe(false)
+
+            act(() => {
+                currentContext.clearStatus('beneficiaryAddress')
+                currentContext.validate({
+                    type: 'NORMAL',
+                    isFree: false,
+                    beneficiaryAddress: 'invalidAddress',
+                })
+            })
+            expect(currentContext.isValid('beneficiaryAddress')).toBe(false)
+
+            act(() => {
+                currentContext.clearStatus('beneficiaryAddress')
+                currentContext.validate({
+                    type: 'NORMAL',
+                    isFree: false,
+                    beneficiaryAddress: '0x7Ce38183F7851EE6eEB9547B1E537fB362C79C10',
+                })
+            })
+            expect(currentContext.isValid('beneficiaryAddress')).toBe(true)
+        })
+
+        it('validates price', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    isFree: false,
+                })
+            })
+            expect(currentContext.isValid('pricePerSecond')).toBe(false)
+
+            act(() => {
+                currentContext.clearStatus('pricePerSecond')
+                currentContext.validate({
+                    type: 'NORMAL',
+                    isFree: false,
+                    pricePerSecond: '-10',
+                })
+            })
+            expect(currentContext.isValid('pricePerSecond')).toBe(false)
+
+            act(() => {
+                currentContext.clearStatus('pricePerSecond')
+                currentContext.validate({
+                    type: 'NORMAL',
+                    isFree: false,
+                    pricePerSecond: '123',
+                })
+            })
+            expect(currentContext.isValid('pricePerSecond')).toBe(true)
+        })
+    })
+
+    describe('pending changes', () => {
+        it('marks fields as pending for published products if touched', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+            expect(currentContext.isAnyChangePending()).toBe(false)
+
+            act(() => {
+                currentContext.touch('name')
+                currentContext.touch('description')
+            })
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    name: 'name',
+                    description: 'description',
+                    category: 'category',
+                    state: 'DEPLOYED',
+                })
+            })
+            expect(currentContext.isAnyChangePending()).toBe(true)
+            expect(currentContext.isPendingChange('name')).toBe(true)
+            expect(currentContext.isPendingChange('description')).toBe(true)
+            expect(currentContext.isPendingChange('category')).toBe(false)
+        })
+
+        it('ignores pending fields for unpublished product', () => {
+            let currentContext
+            function Test() {
+                currentContext = useContext(ValidationContext)
+                return null
+            }
+
+            mount((
+                <ValidationContextProvider>
+                    <Test />
+                </ValidationContextProvider>
+            ))
+            expect(currentContext.isAnyChangePending()).toBe(false)
+
+            act(() => {
+                currentContext.touch('name')
+                currentContext.touch('description')
+            })
+
+            act(() => {
+                currentContext.validate({
+                    type: 'NORMAL',
+                    name: 'name',
+                    description: 'description',
+                    category: 'category',
+                })
+            })
+            expect(currentContext.isAnyChangePending()).toBe(false)
+            expect(currentContext.isPendingChange('name')).toBe(false)
+            expect(currentContext.isPendingChange('description')).toBe(false)
+            expect(currentContext.isPendingChange('category')).toBe(false)
+        })
+    })
+})


### PR DESCRIPTION
Change editor validation so that errors are only shown when the user publishes a product.

New product with name set:
<img width="467" alt="Screen Shot 2020-03-10 at 16 02 56" src="https://user-images.githubusercontent.com/1064982/76319987-af3a7500-62e8-11ea-8ff2-c7fd87e0e751.png">

When user returns to edit a draft, the completed sections are shown as blue ticks, otherwise empty:
<img width="472" alt="Screen Shot 2020-03-10 at 13 22 43" src="https://user-images.githubusercontent.com/1064982/76319609-258aa780-62e8-11ea-8113-8fd2aab881a0.png">

When user clicks "Publish" and there are incomplete sections:
<img width="454" alt="Screen Shot 2020-03-10 at 13 22 48" src="https://user-images.githubusercontent.com/1064982/76319765-5b2f9080-62e8-11ea-801f-a9564f11e877.png">

When editing a published product, the update icon is shown:
<img width="437" alt="Screen Shot 2020-03-10 at 13 53 18" src="https://user-images.githubusercontent.com/1064982/76319795-64b8f880-62e8-11ea-89ea-52d7380a0688.png">

Other notes:
- Inline errors shown only after publish clicked
- Added unit tests for validation context and product nav component

@mattatgit I left it so that the errors are also triggered when deploying a data union which happens before publish. What do you think, should we show error only when publishing?