### PR TITLE
[PLATFORM-1304] Fix stream page load when stream status query fails

### DIFF
--- a/app/src/userpages/components/StreamPage/Show/index.jsx
+++ b/app/src/userpages/components/StreamPage/Show/index.jsx
@@ -296,7 +296,13 @@ function StreamLoader(props: Props) {
             currentProps.getStream(id).then(async () => {
                 if (!isMounted()) { return }
                 // get stream status before copying state to edit stream object
-                await currentProps.refreshStreamStatus(id)
+                try {
+                    // the status query might fail due to cassandra problems.
+                    // Ignore error to prevent the stream page from getting stuck while loading
+                    await currentProps.refreshStreamStatus(id)
+                } catch (e) {
+                    console.warn(e)
+                }
                 currentProps.openStream(id)
                 currentProps.initEditStream()
             }),


### PR DESCRIPTION
> Currently the status query fails often due to cassandra problems. I noticed that when that happens, the stream page does not display, instead it stays white with only the spinner showing.

This fixes the issue when stream status query fails, stream page does not display at all.

You can test this by blocking the stream status request or temporarily replacing the `getStreamStatus` method with:

```js
export const getStreamStatus = (id: StreamId): ApiResult<StreamStatus> => new Promise((resolve, reject) => {
    reject(new Error('fail'))
})
```

I will hotfix this separately to production once approved.