### PR TITLE
[PLATFORM-1306] Ignore error from individual stream status query and continue

### DIFF
--- a/app/src/userpages/modules/userPageStreams/actions.js
+++ b/app/src/userpages/modules/userPageStreams/actions.js
@@ -290,8 +290,12 @@ export const updateStreamStatuses = (ids: StreamIdList) => (dispatch: Function) 
 
     const fetchStatuses = async () => {
         for (let index = 0; index < ids.length && !cancelled; index += 1) {
-            // eslint-disable-next-line no-await-in-loop
-            await dispatch(updateStreamStatus(ids[index]))
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await dispatch(updateStreamStatus(ids[index]))
+            } catch (e) {
+                // ignore error and continue, updateStreamStatus() already logs the issue
+            }
         }
     }
 


### PR DESCRIPTION
> On the stream list page, if one status query fails, the whole process of fetching statuses will be interrupted and no further queries are made. Is this a bug or a feature? IMO it would be better to continue fetching the statuses despite the failure, as the results for different streams are independent.

Similar to #925, continue if a stream status query fails in stream list.