### PR TITLE
Hide data union creation under DATA_UNIONS flag

### DIFF
--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -322,8 +322,6 @@ const UserpagesRouter = () => ([
     <Route exact path={userpages.products} component={ProductsPageAuth} key="ProductsPage" />,
     ...(process.env.NEW_MP_CONTRACT ? [
         <Route exact path={routes.editProduct()} component={EditProductAuth2} key="EditProduct" />,
-    ] : []),
-    ...(process.env.DATA_UNIONS ? [
         <Route exact path={routes.productStats()} component={StatsPageAuth} key="StatsPage" />,
         <Route exact path={routes.productMembers()} component={MembersPageAuth} key="MembersPage" />,
     ] : []),

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -156,13 +156,13 @@ const ProductsPage = () => {
                                         {!!process.env.NEW_MP_CONTRACT && (
                                             <MenuItems.View id={id} disabled={!deployed} />
                                         )}
-                                        {!!process.env.DATA_UNIONS && isDataUnion && (
+                                        {!!process.env.NEW_MP_CONTRACT && isDataUnion && !!beneficiaryAddress && (
                                             <MenuItems.ViewStats id={id} />
                                         )}
-                                        {!!process.env.DATA_UNIONS && isDataUnion && (
+                                        {!!process.env.NEW_MP_CONTRACT && isDataUnion && !!beneficiaryAddress && (
                                             <MenuItems.ViewDataUnion id={id} />
                                         )}
-                                        {!!process.env.DATA_UNIONS && contractAddress && (
+                                        {!!process.env.NEW_MP_CONTRACT && contractAddress && (
                                             <MenuItems.CopyContractAddress address={contractAddress} />
                                         )}
                                         <MenuItems.Copy id={id} disabled={!deployed} />


### PR DESCRIPTION
This changes the features hidden under `DATA_UNIONS` flag so that only the data union creation is disabled if flag is not present. Otherwise they are enabled with `NEW_MP_CONTRACT` flag. 

This way we can test the existing data union products in staging but not enable users to create them themselves.