### PR TITLE
Add tests around NEW_MP_CONTRACT dependent routes

### DIFF
--- a/app/src/app/Marketplace.jsx
+++ b/app/src/app/Marketplace.jsx
@@ -1,0 +1,47 @@
+// @flow
+
+import React from 'react'
+import { Route as RouterRoute } from 'react-router-dom'
+
+import { userIsAuthenticated } from '$auth/utils/userAuthenticated'
+import withErrorBoundary from '$shared/utils/withErrorBoundary'
+import routes from '$routes'
+import links from '../links'
+import { formatPath } from '$shared/utils/url'
+
+import ErrorPageView from '$mp/components/ErrorPageView'
+
+import ProductPage from '$mp/containers/deprecated/ProductPage'
+import ProductPage2 from '$mp/containers/ProductPage'
+import StreamPreviewPage from '$mp/containers/StreamPreviewPage'
+import EditProductPage from '$mp/containers/deprecated/EditProductPage'
+import Products from '$mp/containers/Products'
+import NewProductPage from '$mp/components/NewProductPage'
+
+const Route = withErrorBoundary(ErrorPageView)(RouterRoute)
+
+const CreateProductAuth = userIsAuthenticated(EditProductPage)
+const EditProductAuth = userIsAuthenticated(EditProductPage)
+
+// Other components
+const ProductPurchasePage = (props) => <ProductPage overlayPurchaseDialog {...props} />
+const ProductPublishPage = (props) => <ProductPage overlayPublishDialog {...props} />
+
+const { marketplace } = links
+
+const MarketplaceRouter = () => (process.env.NEW_MP_CONTRACT ? [
+    <Route exact path={marketplace.main} component={Products} key="Products" />,
+    <Route exact path={formatPath(marketplace.products, ':id', 'streamPreview', ':streamId')} component={StreamPreviewPage} key="StreamPreview" />,
+    <Route exact path={formatPath(marketplace.products, ':id')} component={ProductPage2} key="ProductPage2" />,
+    <Route exact path={routes.newProduct()} component={NewProductPage} key="NewProductPage" />,
+] : [
+    <Route exact path={marketplace.main} component={Products} key="Products" />,
+    <Route exact path={links.marketplace.createProduct} component={CreateProductAuth} key="CreateProduct" />,
+    <Route exact path={formatPath(marketplace.products, ':id', 'purchase')} component={ProductPurchasePage} key="ProductPurchasePage" />,
+    <Route exact path={formatPath(marketplace.products, ':id', 'publish')} component={ProductPublishPage} key="ProductPublishPage" />,
+    <Route exact path={formatPath(marketplace.products, ':id', 'streamPreview', ':streamId')} component={StreamPreviewPage} key="StreamPreview" />,
+    <Route exact path={formatPath(marketplace.products, ':id')} component={ProductPage} key="ProductPage" />,
+    <Route exact path={formatPath(marketplace.products, ':id', 'edit')} component={EditProductAuth} key="EditProduct" />,
+])
+
+export default MarketplaceRouter

--- a/app/src/app/Userpages.jsx
+++ b/app/src/app/Userpages.jsx
@@ -1,0 +1,64 @@
+// @flow
+
+import React from 'react'
+import { Route as RouterRoute, Redirect } from 'react-router-dom'
+
+import { userIsAuthenticated } from '$auth/utils/userAuthenticated'
+import withErrorBoundary from '$shared/utils/withErrorBoundary'
+import { formatPath } from '$shared/utils/url'
+import routes from '$routes'
+import links from '../links'
+
+import ErrorPageView from '$mp/components/ErrorPageView'
+
+// Userpages
+import DashboardList from '$userpages/components/DashboardPage/List'
+import CanvasList from '$userpages/components/CanvasPage/List'
+import StreamShowView from '$userpages/components/StreamPage/Show'
+import StreamListView from '$userpages/components/StreamPage/List'
+import StreamLivePreview from '$userpages/components/StreamLivePreview'
+import TransactionList from '$userpages/components/TransactionPage/List'
+import ProfilePage from '$userpages/components/ProfilePage'
+import PurchasesPage from '$userpages/components/PurchasesPage'
+import ProductsPage from '$userpages/components/ProductsPage'
+import StatsPage from '$userpages/components/ProductsPage/Stats'
+import MembersPage from '$userpages/components/ProductsPage/Members'
+import EditProductPage2 from '$mp/containers/EditProductPage'
+
+const Route = withErrorBoundary(ErrorPageView)(RouterRoute)
+
+// Userpages Auth
+const CanvasListAuth = userIsAuthenticated(CanvasList)
+const ProfilePageAuth = userIsAuthenticated(ProfilePage)
+const DashboardListAuth = userIsAuthenticated(DashboardList)
+const StreamShowViewAuth = userIsAuthenticated(StreamShowView)
+const StreamListViewAuth = userIsAuthenticated(StreamListView)
+const StreamLivePreviewAuth = userIsAuthenticated(StreamLivePreview)
+const TransactionListAuth = userIsAuthenticated(TransactionList)
+const PurchasesPageAuth = userIsAuthenticated(PurchasesPage)
+const ProductsPageAuth = userIsAuthenticated(ProductsPage)
+const StatsPageAuth = userIsAuthenticated(StatsPage)
+const MembersPageAuth = userIsAuthenticated(MembersPage)
+const EditProductAuth2 = userIsAuthenticated(EditProductPage2)
+
+const { userpages } = links
+
+const UserpagesRouter = () => ([
+    <Route exact path={userpages.canvases} component={CanvasListAuth} key="CanvasesCanvasList" />,
+    <Route exact path={userpages.profile} component={ProfilePageAuth} key="ProfilePage" />,
+    <Route exact path={userpages.dashboards} component={DashboardListAuth} key="DashboardList" />,
+    <Route exact path={formatPath(userpages.streamShow, ':id?')} component={StreamShowViewAuth} key="streamShow" />,
+    <Route exact path={userpages.streams} component={StreamListViewAuth} key="StreamListView" />,
+    <Route exact path={formatPath(userpages.streamPreview, ':streamId')} component={StreamLivePreviewAuth} key="StreamLivePreview" />,
+    <Route exact path={userpages.transactions} component={TransactionListAuth} key="TransactionList" />,
+    <Route exact path={userpages.purchases} component={PurchasesPageAuth} key="PurchasesPage" />,
+    <Route exact path={userpages.products} component={ProductsPageAuth} key="ProductsPage" />,
+    ...(process.env.NEW_MP_CONTRACT ? [
+        <Route exact path={routes.editProduct()} component={EditProductAuth2} key="EditProduct" />,
+        <Route exact path={routes.productStats()} component={StatsPageAuth} key="StatsPage" />,
+        <Route exact path={routes.productMembers()} component={MembersPageAuth} key="MembersPage" />,
+    ] : []),
+    <Redirect from={userpages.main} to={userpages.streams} component={StreamListViewAuth} key="StreamListViewRedirect" />,
+])
+
+export default UserpagesRouter

--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -9,13 +9,8 @@ import { ConnectedRouter } from 'connected-react-router'
 import qs from 'query-string'
 
 // Marketplace
-import ProductPage from '$mp/containers/deprecated/ProductPage'
-import ProductPage2 from '$mp/containers/ProductPage'
-import StreamPreviewPage from '$mp/containers/StreamPreviewPage'
-import EditProductPage from '$mp/containers/deprecated/EditProductPage'
-import EditProductPage2 from '$mp/containers/EditProductPage'
+import MarketplaceRouter from './Marketplace'
 import Products from '$mp/containers/Products'
-import NewProductPage from '$mp/components/NewProductPage'
 
 // Auth
 import SessionProvider from '$auth/components/SessionProvider'
@@ -27,17 +22,7 @@ import ResetPasswordPage from '$auth/components/ResetPasswordPage'
 import RegisterPage from '$auth/components/RegisterPage'
 
 // Userpages
-import DashboardList from '$userpages/components/DashboardPage/List'
-import CanvasList from '$userpages/components/CanvasPage/List'
-import StreamShowView from '$userpages/components/StreamPage/Show'
-import StreamListView from '$userpages/components/StreamPage/List'
-import StreamLivePreview from '$userpages/components/StreamLivePreview'
-import TransactionList from '$userpages/components/TransactionPage/List'
-import ProfilePage from '$userpages/components/ProfilePage'
-import PurchasesPage from '$userpages/components/PurchasesPage'
-import ProductsPage from '$userpages/components/ProductsPage'
-import StatsPage from '$userpages/components/ProductsPage/Stats'
-import MembersPage from '$userpages/components/ProductsPage/Members'
+import UserpagesRouter from './Userpages'
 
 // Docs Pages
 import IntroductionDocsPage from '$docs/components/DocsPages/Introduction'
@@ -113,35 +98,14 @@ import Analytics from '$shared/utils/Analytics'
 import routes from '$routes'
 
 // Wrap authenticated components here instead of render() method
-// Marketplace Auth
-const CreateProductAuth = userIsAuthenticated(EditProductPage)
-const EditProductAuth = userIsAuthenticated(EditProductPage)
-const EditProductAuth2 = userIsAuthenticated(EditProductPage2)
-
-// Userpages Auth
-const CanvasListAuth = userIsAuthenticated(CanvasList)
-const ProfilePageAuth = userIsAuthenticated(ProfilePage)
-const DashboardListAuth = userIsAuthenticated(DashboardList)
-const StreamShowViewAuth = userIsAuthenticated(StreamShowView)
-const StreamListViewAuth = userIsAuthenticated(StreamListView)
-const StreamLivePreviewAuth = userIsAuthenticated(StreamLivePreview)
-const TransactionListAuth = userIsAuthenticated(TransactionList)
-const PurchasesPageAuth = userIsAuthenticated(PurchasesPage)
-const ProductsPageAuth = userIsAuthenticated(ProductsPage)
-const StatsPageAuth = userIsAuthenticated(StatsPage)
-const MembersPageAuth = userIsAuthenticated(MembersPage)
 
 // Editor Auth
 const DashboardEditorAuth = userIsAuthenticated(DashboardEditor)
 
-// Other components
-const ProductPurchasePage = (props) => <ProductPage overlayPurchaseDialog {...props} />
-const ProductPublishPage = (props) => <ProductPage overlayPublishDialog {...props} />
-
 // Wrap each Route to an ErrorBoundary
 const Route = withErrorBoundary(ErrorPageView)(RouterRoute)
 
-const { marketplace, userpages, docs, editor } = links
+const { docs, editor } = links
 
 const forwardTo = (routeFn: Function) => ({ location: { search } }: Location) => (
     <Redirect to={routeFn(qs.parse(search))} />
@@ -158,21 +122,6 @@ const AuthenticationRouter = () => ([
     <Route exact path="/register/register" key="RegisterRedirect" render={forwardTo(routes.register)} />,
     <Route exact path="/register/resetPassword" key="ResetPasswordRedirect" render={forwardTo(routes.resetPassword)} />,
     <Redirect from="/register/forgotPassword" to={routes.forgotPassword()} key="ForgotPasswordRedirect" />,
-])
-
-const MarketplaceRouter = () => (process.env.NEW_MP_CONTRACT ? [
-    <Route exact path={marketplace.main} component={Products} key="Products" />,
-    <Route exact path={formatPath(marketplace.products, ':id', 'streamPreview', ':streamId')} component={StreamPreviewPage} key="StreamPreview" />,
-    <Route exact path={formatPath(marketplace.products, ':id')} component={ProductPage2} key="ProductPage2" />,
-    <Route exact path={routes.newProduct()} component={NewProductPage} key="NewProductPage" />,
-] : [
-    <Route exact path={marketplace.main} component={Products} key="Products" />,
-    <Route exact path={links.marketplace.createProduct} component={CreateProductAuth} key="CreateProduct" />,
-    <Route exact path={formatPath(marketplace.products, ':id', 'purchase')} component={ProductPurchasePage} key="ProductPurchasePage" />,
-    <Route exact path={formatPath(marketplace.products, ':id', 'publish')} component={ProductPublishPage} key="ProductPublishPage" />,
-    <Route exact path={formatPath(marketplace.products, ':id', 'streamPreview', ':streamId')} component={StreamPreviewPage} key="StreamPreview" />,
-    <Route exact path={formatPath(marketplace.products, ':id')} component={ProductPage} key="ProductPage" />,
-    <Route exact path={formatPath(marketplace.products, ':id', 'edit')} component={EditProductAuth} key="EditProduct" />,
 ])
 
 const DocsRouter = () => ([
@@ -308,24 +257,6 @@ const DocsRouter = () => ([
     <Route exact path={docs.technicalNotes.root} component={TechnicalNotesDocsPage} key="technicalNotes" />,
     // Docs Root
     <Redirect exact from={docs.main} to={docs.introduction} key="DocsRoot" />,
-])
-
-const UserpagesRouter = () => ([
-    <Route exact path={userpages.canvases} component={CanvasListAuth} key="CanvasesCanvasList" />,
-    <Route exact path={userpages.profile} component={ProfilePageAuth} key="ProfilePage" />,
-    <Route exact path={userpages.dashboards} component={DashboardListAuth} key="DashboardList" />,
-    <Route exact path={formatPath(userpages.streamShow, ':id?')} component={StreamShowViewAuth} key="streamShow" />,
-    <Route exact path={userpages.streams} component={StreamListViewAuth} key="StreamListView" />,
-    <Route exact path={formatPath(userpages.streamPreview, ':streamId')} component={StreamLivePreviewAuth} key="StreamLivePreview" />,
-    <Route exact path={userpages.transactions} component={TransactionListAuth} key="TransactionList" />,
-    <Route exact path={userpages.purchases} component={PurchasesPageAuth} key="PurchasesPage" />,
-    <Route exact path={userpages.products} component={ProductsPageAuth} key="ProductsPage" />,
-    ...(process.env.NEW_MP_CONTRACT ? [
-        <Route exact path={routes.editProduct()} component={EditProductAuth2} key="EditProduct" />,
-        <Route exact path={routes.productStats()} component={StatsPageAuth} key="StatsPage" />,
-        <Route exact path={routes.productMembers()} component={MembersPageAuth} key="MembersPage" />,
-    ] : []),
-    <Redirect from={userpages.main} to={userpages.streams} component={StreamListViewAuth} key="StreamListViewRedirect" />,
 ])
 
 const EditorRouter = () => ([

--- a/app/src/marketplace/components/ActionBar/index.jsx
+++ b/app/src/marketplace/components/ActionBar/index.jsx
@@ -20,14 +20,49 @@ import FilterSelector from './FilterSelector'
 import FilterDropdownItem from './FilterDropdownItem'
 import styles from './actionBar.pcss'
 
+export type CreateProductButtonProps = {
+    onCreateProduct: () => void,
+}
+
+export const CreateProductButton = ({ onCreateProduct }: CreateProductButtonProps) => {
+    if (!process.env.NEW_MP_CONTRACT) {
+        return (
+            <Button kind="secondary" tag={Link} to={links.marketplace.createProduct}>
+                <Translate value="actionBar.create" />
+            </Button>
+        )
+    } else if (process.env.DATA_UNIONS) {
+        return (
+            <Button
+                kind="secondary"
+                type="button"
+                onClick={() => onCreateProduct()}
+            >
+                <Translate value="actionBar.create" />
+            </Button>
+        )
+    }
+
+    return (
+        <Button
+            kind="secondary"
+            tag={Link}
+            to={routes.newProduct({
+                type: productTypes.NORMAL,
+            })}
+        >
+            <Translate value="actionBar.create" />
+        </Button>
+    )
+}
+
 export type Props = {
     filter: Filter,
     categories: ?Array<Category>,
     onCategoryChange: (filter: Filter) => void,
     onSortChange: (filter: Filter) => void,
     onSearchChange: (filter: Filter) => void,
-    onCreateProduct: () => void,
-}
+} & CreateProductButtonProps
 
 class ActionBar extends Component<Props> {
     static sortByOptions = ['pricePerSecond', 'free']
@@ -137,31 +172,7 @@ class ActionBar extends Component<Props> {
                                 </FilterSelector>
                             </li>
                             <li className={classNames('d-none d-md-block', styles.createProduct)}>
-                                {!!process.env.DATA_UNIONS && (
-                                    <Button
-                                        kind="secondary"
-                                        type="button"
-                                        onClick={() => onCreateProduct()}
-                                    >
-                                        <Translate value="actionBar.create" />
-                                    </Button>
-                                )}
-                                {!!process.env.NEW_MP_CONTRACT && !process.env.DATA_UNIONS && (
-                                    <Button
-                                        kind="secondary"
-                                        tag={Link}
-                                        to={routes.newProduct({
-                                            type: productTypes.NORMAL,
-                                        })}
-                                    >
-                                        <Translate value="actionBar.create" />
-                                    </Button>
-                                )}
-                                {!process.env.NEW_MP_CONTRACT && !process.env.DATA_UNIONS && (
-                                    <Button kind="secondary" tag={Link} to={links.marketplace.createProduct}>
-                                        <Translate value="actionBar.create" />
-                                    </Button>
-                                )}
+                                <CreateProductButton onCreateProduct={onCreateProduct} />
                             </li>
                         </ul>
                     </Container>

--- a/app/src/shared/components/Tile/index.jsx
+++ b/app/src/shared/components/Tile/index.jsx
@@ -218,7 +218,7 @@ type ProductTileProps = {
     showDeployingBadge?: boolean,
 }
 
-const getProductLink = (id: string) => (process.env.NEW_MP_CONTRACT ? (
+export const getProductLink = (id: string) => (process.env.NEW_MP_CONTRACT ? (
     formatPath(links.userpages.products, id, 'edit')
 ) : (
     formatPath(links.marketplace.products, id)

--- a/app/src/shared/test/components/ProductTile/ProductTile.test.jsx
+++ b/app/src/shared/test/components/ProductTile/ProductTile.test.jsx
@@ -1,0 +1,23 @@
+import { getProductLink } from '$shared/components/Tile'
+
+describe('getProductLink', () => {
+    let oldMpContractFlag
+
+    beforeEach(() => {
+        oldMpContractFlag = process.env.NEW_MP_CONTRACT
+    })
+
+    afterEach(() => {
+        process.env.NEW_MP_CONTRACT = oldMpContractFlag
+    })
+
+    it('returns new editor link when NEW_MP_CONTRACT is defined', () => {
+        process.env.NEW_MP_CONTRACT = 'on'
+        expect(getProductLink('product123')).toBe('/core/products/product123/edit')
+    })
+
+    it('returns deprecated editor link when NEW_MP_CONTRACT is not defined', () => {
+        process.env.NEW_MP_CONTRACT = ''
+        expect(getProductLink('product123')).toBe('/marketplace/products/product123')
+    })
+})

--- a/app/src/shared/test/components/ProductTile/ProductTile.test.jsx
+++ b/app/src/shared/test/components/ProductTile/ProductTile.test.jsx
@@ -17,7 +17,7 @@ describe('getProductLink', () => {
     })
 
     it('returns deprecated editor link when NEW_MP_CONTRACT is not defined', () => {
-        process.env.NEW_MP_CONTRACT = ''
+        delete process.env.NEW_MP_CONTRACT
         expect(getProductLink('product123')).toBe('/marketplace/products/product123')
     })
 })

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -31,7 +31,7 @@ import * as MenuItems from './MenuItems'
 
 import styles from './products.pcss'
 
-const CreateProductButton = () => {
+export const CreateProductButton = () => {
     const { api: createProductDialog } = useModal('marketplace.createProduct')
 
     if (!process.env.NEW_MP_CONTRACT) {

--- a/app/src/userpages/tests/components/ProductsPage/CreateProductButton.test.jsx
+++ b/app/src/userpages/tests/components/ProductsPage/CreateProductButton.test.jsx
@@ -31,8 +31,8 @@ describe('CreateProductButton', () => {
 
     describe('NEW_MP_CONTRACT=off, DATA_UNIONS=off', () => {
         it('creates a product with the deprecated editor', () => {
-            process.env.NEW_MP_CONTRACT = ''
-            process.env.DATA_UNIONS = ''
+            delete process.env.NEW_MP_CONTRACT
+            delete process.env.DATA_UNIONS
 
             let nextProps
             const Test = withRouter((props) => {
@@ -54,7 +54,7 @@ describe('CreateProductButton', () => {
     describe('NEW_MP_CONTRACT=on, DATA_UNIONS=off', () => {
         it('creates a product with the new product page', () => {
             process.env.NEW_MP_CONTRACT = 'on'
-            process.env.DATA_UNIONS = ''
+            delete process.env.DATA_UNIONS
 
             let nextProps
             const Test = withRouter((props) => {

--- a/app/src/userpages/tests/components/ProductsPage/CreateProductButton.test.jsx
+++ b/app/src/userpages/tests/components/ProductsPage/CreateProductButton.test.jsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { MemoryRouter, withRouter } from 'react-router-dom'
+import { mount } from 'enzyme'
+
+import { CreateProductButton } from '$userpages/components/ProductsPage'
+
+const mockModalApiOpen = jest.fn()
+jest.mock('$shared/hooks/useModal', () => ({
+    __esModule: true,
+    default: () => ({
+        api: {
+            open: mockModalApiOpen,
+        },
+    }),
+}))
+
+describe('CreateProductButton', () => {
+    let oldMpContractFlag
+    let oldDataUnionsFlag
+
+    beforeEach(() => {
+        oldMpContractFlag = process.env.NEW_MP_CONTRACT
+        oldDataUnionsFlag = process.env.DATA_UNIONS
+    })
+
+    afterEach(() => {
+        process.env.NEW_MP_CONTRACT = oldMpContractFlag
+        process.env.DATA_UNIONS = oldDataUnionsFlag
+        mockModalApiOpen.mockRestore()
+    })
+
+    describe('NEW_MP_CONTRACT=off, DATA_UNIONS=off', () => {
+        it('creates a product with the deprecated editor', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            process.env.DATA_UNIONS = ''
+
+            let nextProps
+            const Test = withRouter((props) => {
+                nextProps = props
+
+                return <CreateProductButton />
+            })
+            const el = mount((
+                <MemoryRouter initialEntries={['/']}>
+                    <Test />
+                </MemoryRouter>
+            ))
+            expect(nextProps.location.pathname).toBe('/')
+            el.find('a').simulate('click', { button: 0 })
+            expect(nextProps.location.pathname).toBe('/marketplace/products/create')
+        })
+    })
+
+    describe('NEW_MP_CONTRACT=on, DATA_UNIONS=off', () => {
+        it('creates a product with the new product page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            process.env.DATA_UNIONS = ''
+
+            let nextProps
+            const Test = withRouter((props) => {
+                nextProps = props
+
+                return <CreateProductButton />
+            })
+            const el = mount((
+                <MemoryRouter initialEntries={['/']}>
+                    <Test />
+                </MemoryRouter>
+            ))
+            expect(nextProps.location.pathname).toBe('/')
+            el.find('a').simulate('click', { button: 0 })
+            expect(nextProps.location.pathname).toBe('/core/products/new')
+            expect(nextProps.location.search).toBe('?type=NORMAL')
+        })
+    })
+
+    describe('NEW_MP_CONTRACT=on, DATA_UNIONS=on', () => {
+        it('creates a product with the new product page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            process.env.DATA_UNIONS = 'on'
+
+            let nextProps
+            const Test = withRouter((props) => {
+                nextProps = props
+
+                return <CreateProductButton />
+            })
+            const el = mount((
+                <MemoryRouter initialEntries={['/']}>
+                    <Test />
+                </MemoryRouter>
+            ))
+            expect(nextProps.location.pathname).toBe('/')
+            el.find('button').simulate('click')
+            expect(nextProps.location.pathname).toBe('/')
+            expect(mockModalApiOpen).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/app/src/userpages/tests/components/ProductsPage/MenuItems.test.jsx
+++ b/app/src/userpages/tests/components/ProductsPage/MenuItems.test.jsx
@@ -28,7 +28,7 @@ describe('MenuItems', () => {
         })
 
         it('creates a link to new product editor when NEW_MP_CONTRACT=off', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
 
             const el = mount((
                 <MemoryRouter>

--- a/app/src/userpages/tests/components/ProductsPage/MenuItems.test.jsx
+++ b/app/src/userpages/tests/components/ProductsPage/MenuItems.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { mount } from 'enzyme'
+
+import { Edit } from '$userpages/components/ProductsPage/MenuItems'
+
+describe('MenuItems', () => {
+    let oldMpContractFlag
+
+    beforeEach(() => {
+        oldMpContractFlag = process.env.NEW_MP_CONTRACT
+    })
+
+    afterEach(() => {
+        process.env.NEW_MP_CONTRACT = oldMpContractFlag
+    })
+
+    describe('Edit', () => {
+        it('creates a link to new product editor when NEW_MP_CONTRACT=on', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+
+            const el = mount((
+                <MemoryRouter>
+                    <Edit id="123" />
+                </MemoryRouter>
+            ))
+            expect(el.find('Link').prop('to')).toBe('/core/products/123/edit')
+        })
+
+        it('creates a link to new product editor when NEW_MP_CONTRACT=off', () => {
+            process.env.NEW_MP_CONTRACT = ''
+
+            const el = mount((
+                <MemoryRouter>
+                    <Edit id="123" />
+                </MemoryRouter>
+            ))
+            expect(el.find('Link').prop('to')).toBe('/marketplace/products/123/edit')
+        })
+    })
+})

--- a/app/test/unit/app/Marketplace.test.jsx
+++ b/app/test/unit/app/Marketplace.test.jsx
@@ -1,0 +1,322 @@
+import React from 'react'
+import { MemoryRouter, Route, Switch } from 'react-router-dom'
+import { mount } from 'enzyme'
+
+import ErrorPageView from '$mp/components/ErrorPageView'
+import MarketplaceRouter from '$mp/../app/Marketplace'
+
+/* eslint-disable react/prop-types */
+jest.mock('$mp/containers/Products', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Main page</div>
+    ),
+}))
+jest.mock('$mp/containers/ProductPage', () => ({
+    __esModule: true,
+    default: ({ match }) => (
+        <div>Product {match.params.id} page</div>
+    ),
+}))
+jest.mock('$mp/containers/deprecated/ProductPage', () => ({
+    __esModule: true,
+    default: ({ match, overlayPublishDialog, overlayPurchaseDialog }) => (
+        <div>
+            Deprecated product {match.params.id} page
+            {overlayPublishDialog && (' (publish)')}
+            {overlayPurchaseDialog && (' (purchase)')}
+        </div>
+    ),
+}))
+jest.mock('$mp/containers/StreamPreviewPage', () => ({
+    __esModule: true,
+    default: ({ match }) => (
+        <div>Product {match.params.id} preview</div>
+    ),
+}))
+jest.mock('$mp/components/NewProductPage', () => ({
+    __esModule: true,
+    default: () => (
+        <div>New product</div>
+    ),
+}))
+jest.mock('$mp/components/ErrorPageView', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Error page</div>
+    ),
+}))
+jest.mock('$mp/containers/deprecated/EditProductPage', () => ({
+    __esModule: true,
+    default: ({ match }) => (
+        <div>Edit product {match.params.id} page</div>
+    ),
+}))
+jest.mock('$auth/utils/userAuthenticated', () => ({
+    __esModule: true,
+    userIsAuthenticated: (component) => component,
+}))
+/* eslint-enable react/prop-types */
+
+describe('Marketplace Routes', () => {
+    let oldMpContractFlag
+
+    beforeEach(() => {
+        oldMpContractFlag = process.env.NEW_MP_CONTRACT
+    })
+
+    afterEach(() => {
+        process.env.NEW_MP_CONTRACT = oldMpContractFlag
+    })
+
+    describe('With community product (NEW_MP_CONTRACT=on)', () => {
+        it('shows main page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Main page')
+        })
+
+        it('shows product page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Product 123 page')
+        })
+
+        it('shows stream preview', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123/streamPreview/stream456']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Product 123 preview')
+        })
+
+        it('shows new product page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/core/products/new']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('New product')
+        })
+
+        it('does not show previous new product page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/create']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            // "create" is treated as an id
+            expect(el.text()).toBe('Product create page')
+        })
+
+        it('does not show edit product page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123/edit']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                        <Route component={ErrorPageView} key="NotFoundPage" />
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Error page')
+        })
+
+        it('does not show publish route', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123/publish']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                        <Route component={ErrorPageView} key="NotFoundPage" />
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Error page')
+        })
+
+        it('does not show purchase route', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123/purchase']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                        <Route component={ErrorPageView} key="NotFoundPage" />
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Error page')
+        })
+    })
+
+    describe('With community product (NEW_MP_CONTRACT="")', () => {
+        it('shows main page', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Main page')
+        })
+
+        it('shows deprecated product page', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Deprecated product 123 page')
+        })
+
+        it('shows stream preview', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123/streamPreview/stream456']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Product 123 preview')
+        })
+
+        it('shows previous new product page', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/create']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Edit product  page')
+        })
+
+        it('shows edit product page', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123/edit']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Edit product 123 page')
+        })
+
+        it('shows publish route', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123/publish']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            // publish dialog is overlaid on top of the product page
+            expect(el.text()).toBe('Deprecated product 123 page (publish)')
+        })
+
+        it('shows purchase route', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/marketplace/products/123/purchase']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            // purchase dialog is overlaid on top of the product page
+            expect(el.text()).toBe('Deprecated product 123 page (purchase)')
+        })
+
+        it('does not show new product page', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/core/products/new']}
+                >
+                    <Switch>
+                        {MarketplaceRouter()}
+                        <Route component={ErrorPageView} key="NotFoundPage" />
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Error page')
+        })
+    })
+})

--- a/app/test/unit/app/Marketplace.test.jsx
+++ b/app/test/unit/app/Marketplace.test.jsx
@@ -197,7 +197,7 @@ describe('Marketplace Routes', () => {
 
     describe('With community product (NEW_MP_CONTRACT="")', () => {
         it('shows main page', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/marketplace']}
@@ -212,7 +212,7 @@ describe('Marketplace Routes', () => {
         })
 
         it('shows deprecated product page', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/marketplace/products/123']}
@@ -227,7 +227,7 @@ describe('Marketplace Routes', () => {
         })
 
         it('shows stream preview', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/marketplace/products/123/streamPreview/stream456']}
@@ -242,7 +242,7 @@ describe('Marketplace Routes', () => {
         })
 
         it('shows previous new product page', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/marketplace/products/create']}
@@ -257,7 +257,7 @@ describe('Marketplace Routes', () => {
         })
 
         it('shows edit product page', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/marketplace/products/123/edit']}
@@ -272,7 +272,7 @@ describe('Marketplace Routes', () => {
         })
 
         it('shows publish route', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/marketplace/products/123/publish']}
@@ -288,7 +288,7 @@ describe('Marketplace Routes', () => {
         })
 
         it('shows purchase route', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/marketplace/products/123/purchase']}
@@ -304,7 +304,7 @@ describe('Marketplace Routes', () => {
         })
 
         it('does not show new product page', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/core/products/new']}

--- a/app/test/unit/app/Userpages.test.jsx
+++ b/app/test/unit/app/Userpages.test.jsx
@@ -149,7 +149,7 @@ describe('Userpages Routes', () => {
 
     describe('With community product (NEW_MP_CONTRACT="")', () => {
         it('does not show the product editor', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/core/products/123/edit']}
@@ -164,7 +164,7 @@ describe('Userpages Routes', () => {
         })
 
         it('shows the data union stats page', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/core/products/123/stats']}
@@ -179,7 +179,7 @@ describe('Userpages Routes', () => {
         })
 
         it('shows the data union members page', () => {
-            process.env.NEW_MP_CONTRACT = ''
+            delete process.env.NEW_MP_CONTRACT
             const el = mount((
                 <MemoryRouter
                     initialEntries={['/core/products/123/members']}

--- a/app/test/unit/app/Userpages.test.jsx
+++ b/app/test/unit/app/Userpages.test.jsx
@@ -1,0 +1,196 @@
+import React from 'react'
+import { MemoryRouter, Switch } from 'react-router-dom'
+import { mount } from 'enzyme'
+
+import UserpagesRouter from '$mp/../app/Userpages'
+
+/* eslint-disable react/prop-types */
+jest.mock('$userpages/components/DashboardPage/List', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Dashboard list</div>
+    ),
+}))
+jest.mock('$userpages/components/CanvasPage/List', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Canvas list</div>
+    ),
+}))
+jest.mock('$userpages/components/StreamPage/Show', () => ({
+    __esModule: true,
+    default: ({ match }) => (
+        <div>Stream {match.params.id} page</div>
+    ),
+}))
+jest.mock('$userpages/components/StreamPage/List', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Stream list</div>
+    ),
+}))
+jest.mock('$userpages/components/StreamLivePreview', () => ({
+    __esModule: true,
+    default: ({ match }) => (
+        <div>Stream {match.params.id} preview</div>
+    ),
+}))
+jest.mock('$userpages/components/TransactionPage/List', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Transaction list</div>
+    ),
+}))
+jest.mock('$userpages/components/ProfilePage', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Profile page</div>
+    ),
+}))
+jest.mock('$userpages/components/PurchasesPage', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Purchases page</div>
+    ),
+}))
+jest.mock('$userpages/components/ProductsPage', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Products page</div>
+    ),
+}))
+jest.mock('$userpages/components/ProductsPage/Stats', () => ({
+    __esModule: true,
+    default: ({ match }) => (
+        <div>Product {match.params.id} stats</div>
+    ),
+}))
+jest.mock('$userpages/components/ProductsPage/Members', () => ({
+    __esModule: true,
+    default: ({ match }) => (
+        <div>Product {match.params.id} members</div>
+    ),
+}))
+jest.mock('$mp/containers/EditProductPage', () => ({
+    __esModule: true,
+    default: ({ match }) => (
+        <div>Product {match.params.id} editor</div>
+    ),
+}))
+jest.mock('$mp/components/ErrorPageView', () => ({
+    __esModule: true,
+    default: () => (
+        <div>Error page</div>
+    ),
+}))
+jest.mock('$auth/utils/userAuthenticated', () => ({
+    __esModule: true,
+    userIsAuthenticated: (component) => component,
+}))
+/* eslint-enable react/prop-types */
+
+describe('Userpages Routes', () => {
+    let oldMpContractFlag
+
+    beforeEach(() => {
+        oldMpContractFlag = process.env.NEW_MP_CONTRACT
+    })
+
+    afterEach(() => {
+        process.env.NEW_MP_CONTRACT = oldMpContractFlag
+    })
+
+    describe('With community product (NEW_MP_CONTRACT=on)', () => {
+        it('shows product editor', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/core/products/123/edit']}
+                >
+                    <Switch>
+                        {UserpagesRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Product 123 editor')
+        })
+
+        it('shows the data union stats page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/core/products/123/stats']}
+                >
+                    <Switch>
+                        {UserpagesRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Product 123 stats')
+        })
+
+        it('shows the data union members page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/core/products/123/members']}
+                >
+                    <Switch>
+                        {UserpagesRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Product 123 members')
+        })
+    })
+
+    describe('With community product (NEW_MP_CONTRACT="")', () => {
+        it('does not show the product editor', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/core/products/123/edit']}
+                >
+                    <Switch>
+                        {UserpagesRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Stream list')
+        })
+
+        it('shows the data union stats page', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/core/products/123/stats']}
+                >
+                    <Switch>
+                        {UserpagesRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Stream list')
+        })
+
+        it('shows the data union members page', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            const el = mount((
+                <MemoryRouter
+                    initialEntries={['/core/products/123/members']}
+                >
+                    <Switch>
+                        {UserpagesRouter()}
+                    </Switch>
+                </MemoryRouter>
+            ))
+
+            expect(el.text()).toBe('Stream list')
+        })
+    })
+})

--- a/app/test/unit/components/ActionBar/CreateProductButton.test.jsx
+++ b/app/test/unit/components/ActionBar/CreateProductButton.test.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { MemoryRouter, withRouter } from 'react-router-dom'
+import { mount } from 'enzyme'
+
+import { CreateProductButton } from '$mp/components/ActionBar'
+
+describe('CreateProductButton', () => {
+    let oldMpContractFlag
+    let oldDataUnionsFlag
+
+    beforeEach(() => {
+        oldMpContractFlag = process.env.NEW_MP_CONTRACT
+        oldDataUnionsFlag = process.env.DATA_UNIONS
+    })
+
+    afterEach(() => {
+        process.env.NEW_MP_CONTRACT = oldMpContractFlag
+        process.env.DATA_UNIONS = oldDataUnionsFlag
+    })
+
+    describe('NEW_MP_CONTRACT=off, DATA_UNIONS=off', () => {
+        it('creates a product with the deprecated editor', () => {
+            process.env.NEW_MP_CONTRACT = ''
+            process.env.DATA_UNIONS = ''
+
+            const createStub = jest.fn()
+            let nextProps
+            const Test = withRouter((props) => {
+                nextProps = props
+
+                return <CreateProductButton onCreateProduct={createStub} />
+            })
+            const el = mount((
+                <MemoryRouter initialEntries={['/']}>
+                    <Test />
+                </MemoryRouter>
+            ))
+            expect(nextProps.location.pathname).toBe('/')
+            el.find('a').simulate('click', {
+                button: 0,
+            })
+            expect(nextProps.location.pathname).toBe('/marketplace/products/create')
+            expect(createStub).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('NEW_MP_CONTRACT=on, DATA_UNIONS=off', () => {
+        it('creates a product with the new product page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            process.env.DATA_UNIONS = ''
+
+            const createStub = jest.fn()
+            let nextProps
+            const Test = withRouter((props) => {
+                nextProps = props
+
+                return <CreateProductButton onCreateProduct={createStub} />
+            })
+            const el = mount((
+                <MemoryRouter initialEntries={['/']}>
+                    <Test />
+                </MemoryRouter>
+            ))
+            expect(nextProps.location.pathname).toBe('/')
+            el.find('a').simulate('click', {
+                button: 0,
+            })
+            expect(nextProps.location.pathname).toBe('/core/products/new')
+            expect(nextProps.location.search).toBe('?type=NORMAL')
+            expect(createStub).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('NEW_MP_CONTRACT=on, DATA_UNIONS=on', () => {
+        it('creates a product with the new product page', () => {
+            process.env.NEW_MP_CONTRACT = 'on'
+            process.env.DATA_UNIONS = 'on'
+
+            const createStub = jest.fn()
+            let nextProps
+            const Test = withRouter((props) => {
+                nextProps = props
+
+                return <CreateProductButton onCreateProduct={createStub} />
+            })
+            const el = mount((
+                <MemoryRouter initialEntries={['/']}>
+                    <Test />
+                </MemoryRouter>
+            ))
+            expect(nextProps.location.pathname).toBe('/')
+            el.find('button').simulate('click')
+            expect(nextProps.location.pathname).toBe('/')
+            expect(createStub).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/app/test/unit/components/ActionBar/CreateProductButton.test.jsx
+++ b/app/test/unit/components/ActionBar/CreateProductButton.test.jsx
@@ -20,8 +20,8 @@ describe('CreateProductButton', () => {
 
     describe('NEW_MP_CONTRACT=off, DATA_UNIONS=off', () => {
         it('creates a product with the deprecated editor', () => {
-            process.env.NEW_MP_CONTRACT = ''
-            process.env.DATA_UNIONS = ''
+            delete process.env.NEW_MP_CONTRACT
+            delete process.env.DATA_UNIONS
 
             const createStub = jest.fn()
             let nextProps
@@ -47,7 +47,7 @@ describe('CreateProductButton', () => {
     describe('NEW_MP_CONTRACT=on, DATA_UNIONS=off', () => {
         it('creates a product with the new product page', () => {
             process.env.NEW_MP_CONTRACT = 'on'
-            process.env.DATA_UNIONS = ''
+            delete process.env.DATA_UNIONS
 
             const createStub = jest.fn()
             let nextProps


### PR DESCRIPTION
I separated the `UserpagesRouter` and `MarketplaceRouter` for easier testability and added some tests around components that depend on the `NEW_MP_CONTRACT` flag. Hopefully this will prevent some bugs from leaking in to production before we get rid of the flags.