### PR TITLE
[PLATFORM-1254] Fix SetPrice's layout on Firefox

### DIFF
--- a/app/src/marketplace/components/PriceField/index.jsx
+++ b/app/src/marketplace/components/PriceField/index.jsx
@@ -60,7 +60,9 @@ const PriceField = ({
                     className={styles.input}
                     {...inputProps}
                 />
-                <span className={styles.currency}>{currency}</span>
+                <div>
+                    <span className={styles.currency}>{currency}</span>
+                </div>
             </div>
             {hasError && !!lastError && (
                 <Errors overlap theme={MarketplaceTheme}>

--- a/app/src/marketplace/components/PriceField/priceField.pcss
+++ b/app/src/marketplace/components/PriceField/priceField.pcss
@@ -37,11 +37,12 @@
 
 .currency {
   background-color: #F1F1F1;
+  display: block;
   font-size: 0.875rem;
   letter-spacing: 0;
   line-height: calc(2.5rem - 2px);
   text-align: center;
-  width: 7em;
+  width: 5em;
   outline: none;
   margin: 0;
   padding: 0;

--- a/app/src/marketplace/components/PriceField/priceField.pcss
+++ b/app/src/marketplace/components/PriceField/priceField.pcss
@@ -21,6 +21,7 @@
 }
 
 .input {
+  flex-grow: 1;
   font-size: 1rem;
   letter-spacing: 0;
   height: calc(2.5rem - 2px);
@@ -30,7 +31,7 @@
   outline: none;
   background-color: white;
   border: 0;
-  width: 100%;
+  width: 4rem; /* Mixed with `flex-grow` brings magic to Firefox! ✨ */
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
 }

--- a/app/src/marketplace/components/SetPrice/index.jsx
+++ b/app/src/marketplace/components/SetPrice/index.jsx
@@ -82,7 +82,9 @@ const SetPrice = ({
                         error={error}
                         className={styles.input}
                     />
-                    <SvgIcon name="transfer" className={styles.icon} onClick={onCurrencyChange} />
+                    <div>
+                        <SvgIcon name="transfer" className={styles.icon} onClick={onCurrencyChange} />
+                    </div>
                     <PriceField
                         currency={getQuoteCurrencyFor(currency)}
                         placeholder="Price"
@@ -90,7 +92,9 @@ const SetPrice = ({
                         disabled
                         className={styles.input}
                     />
-                    <span className={styles.per}>per</span>
+                    <div>
+                        <span className={styles.per}>per</span>
+                    </div>
                     <SelectField
                         placeholder="Select"
                         options={options}

--- a/app/src/marketplace/components/SetPrice/setPrice.pcss
+++ b/app/src/marketplace/components/SetPrice/setPrice.pcss
@@ -5,7 +5,7 @@
 .priceControls {
   display: flex;
   flex-direction: row;
-  align-items: baseline;
+  align-items: center;
 }
 
 .disabled {


### PR DESCRIPTION
Fixing [`PLATFORM-1254`](https://streamr.atlassian.net/browse/PLATFORM-1254) in here.

SetPrice component layout is consistent across browsers. 3000 words:

**Firefox**

<img width="1920" alt="Screenshot 2020-04-01 01 17 55" src="https://user-images.githubusercontent.com/320066/78084680-24b1d680-73b9-11ea-8fb6-1ab9464d3c40.png">

**Chrome**

<img width="1920" alt="Screenshot 2020-04-01 01 23 00" src="https://user-images.githubusercontent.com/320066/78084684-28455d80-73b9-11ea-82e0-77720afaccc7.png">

**Safari**

<img width="1920" alt="Screenshot 2020-04-01 01 25 26" src="https://user-images.githubusercontent.com/320066/78084685-28ddf400-73b9-11ea-9498-3378fa55e10f.png">
