### PR TITLE
[PLATFORM-1316] Workaround for Marketplace expired token

### DIFF
--- a/app/src/auth/components/SessionProvider/index.jsx
+++ b/app/src/auth/components/SessionProvider/index.jsx
@@ -20,12 +20,12 @@ const storage = isLocalStorageAvailable() ? window.localStorage : null
 let cachedToken // fallback if no webstorage
 let cachedDate
 
-function hasExpired(date: Date) {
+function isValid(date: Date) {
     if (!date) { return true }
 
-    const diff = Math.abs(Date.now() - date.getTime())
+    const diff = date.getTime() - Date.now()
 
-    return (diff > EXPIRES_AT_VALID_HOURS * 60 * 60 * 1000)
+    return (diff > 0 && diff < EXPIRES_AT_VALID_HOURS * 60 * 60 * 1000)
 }
 
 function getStoredToken(): ?string {
@@ -40,7 +40,7 @@ function getStoredToken(): ?string {
         date = date ? new Date(date) : null
     }
 
-    return date && !hasExpired(date) ? token : null
+    return date && isValid(date) ? token : null
 }
 
 function storeToken(value?: ?string) {

--- a/app/src/auth/components/SessionProvider/index.jsx
+++ b/app/src/auth/components/SessionProvider/index.jsx
@@ -7,7 +7,9 @@ import React, { type Node, useEffect, useState, useMemo } from 'react'
 import Context from '$auth/contexts/Session'
 import { isLocalStorageAvailable } from '$shared/utils/storage'
 
-const SESSION_TOKEN_KEY = 'session.token'
+export const SESSION_TOKEN_KEY = 'session.token'
+export const SESSION_EXPIRES_AT = 'session.expiresAt'
+export const EXPIRES_AT_VALID_HOURS = 6
 
 type Props = {
     children: Node,
@@ -16,23 +18,48 @@ type Props = {
 const storage = isLocalStorageAvailable() ? window.localStorage : null
 
 let cachedToken // fallback if no webstorage
+let cachedDate
+
+function hasExpired(date: Date) {
+    if (!date) { return true }
+
+    const diff = Math.abs(Date.now() - date.getTime())
+
+    return (diff > EXPIRES_AT_VALID_HOURS * 60 * 60 * 1000)
+}
 
 function getStoredToken(): ?string {
-    if (!storage) { return cachedToken || null }
-    return storage.getItem(SESSION_TOKEN_KEY) || null
+    let date
+    let token
+    if (!storage) {
+        token = cachedToken || null
+        date = cachedDate || null
+    } else {
+        token = storage.getItem(SESSION_TOKEN_KEY) || null
+        date = storage.getItem(SESSION_EXPIRES_AT) || null
+        date = date ? new Date(date) : null
+    }
+
+    return date && !hasExpired(date) ? token : null
 }
 
 function storeToken(value?: ?string) {
+    const expiresAt = new Date()
+    expiresAt.setHours(expiresAt.getHours() + EXPIRES_AT_VALID_HOURS)
+
     if (!storage) {
         cachedToken = value || null
+        cachedDate = expiresAt
         return
     }
 
     if (value) {
         storage.setItem(SESSION_TOKEN_KEY, value)
+        storage.setItem(SESSION_EXPIRES_AT, expiresAt)
     } else {
         // remove entire key if not set
         storage.removeItem(SESSION_TOKEN_KEY)
+        storage.removeItem(SESSION_EXPIRES_AT)
     }
 }
 

--- a/app/src/auth/components/SessionProvider/index.jsx
+++ b/app/src/auth/components/SessionProvider/index.jsx
@@ -20,14 +20,6 @@ const storage = isLocalStorageAvailable() ? window.localStorage : null
 let cachedToken // fallback if no webstorage
 let cachedDate
 
-function isValid(date: Date) {
-    if (!date) { return true }
-
-    const diff = date.getTime() - Date.now()
-
-    return (diff > 0 && diff < EXPIRES_AT_VALID_HOURS * 60 * 60 * 1000)
-}
-
 function getStoredToken(): ?string {
     let date
     let token
@@ -40,7 +32,7 @@ function getStoredToken(): ?string {
         date = date ? new Date(date) : null
     }
 
-    return date && isValid(date) ? token : null
+    return (!!date && (date.getTime() - Date.now()) > 0) ? token : null
 }
 
 function storeToken(value?: ?string) {

--- a/app/src/auth/tests/SessionProvider.test.jsx
+++ b/app/src/auth/tests/SessionProvider.test.jsx
@@ -64,7 +64,7 @@ describe('SessionProvider', () => {
         }
 
         const date = new Date()
-        date.setHours(date.getHours() - 2)
+        date.setHours(date.getHours() + 2)
         global.localStorage.setItem(SESSION_TOKEN_KEY, 'myToken')
         global.localStorage.setItem(SESSION_EXPIRES_AT, date)
 
@@ -87,7 +87,7 @@ describe('SessionProvider', () => {
         }
 
         const date = new Date()
-        date.setHours(date.getHours() - 8)
+        date.setHours(date.getHours() + 8)
         global.localStorage.setItem(SESSION_TOKEN_KEY, 'myToken')
         global.localStorage.setItem(SESSION_EXPIRES_AT, date)
 
@@ -98,6 +98,59 @@ describe('SessionProvider', () => {
         ))
 
         expect(currentContext.token).toBeFalsy()
+    })
+
+    it('returns token if now = 5am and date = 10am', () => {
+        const realDate = Date.now
+        global.Date.now = jest.fn(() => new Date('2020-01-01T05:00:00.000Z').getTime())
+
+        const date = new Date('2020-01-01T10:00:00.000Z')
+        global.localStorage.setItem(SESSION_TOKEN_KEY, 'myToken')
+        global.localStorage.setItem(SESSION_EXPIRES_AT, date)
+
+        let currentContext
+
+        const Test = () => {
+            currentContext = useContext(Context)
+
+            return null
+        }
+
+        mount((
+            <SessionProvider>
+                <Test />
+            </SessionProvider>
+        ))
+
+        expect(currentContext.token).toBe('myToken')
+        global.Date.now = realDate
+    })
+
+    it('returns token if now = 10am and date = 5am', () => {
+        const realDate = Date.now
+        global.Date.now = jest.fn(() => new Date('2020-01-01T10:00:00.000Z').getTime())
+
+        const date = new Date('2020-01-01T05:00:00.000Z')
+        global.localStorage.setItem(SESSION_TOKEN_KEY, 'myToken')
+        global.localStorage.setItem(SESSION_EXPIRES_AT, date)
+
+        let currentContext
+
+        const Test = () => {
+            currentContext = useContext(Context)
+
+            return null
+        }
+
+        mount((
+            <SessionProvider>
+                <Test />
+            </SessionProvider>
+        ))
+
+        expect(currentContext.token).toBeFalsy()
+
+        global.Date.now = realDate
     })
 
     it('sets session token', () => {

--- a/app/src/auth/tests/SessionProvider.test.jsx
+++ b/app/src/auth/tests/SessionProvider.test.jsx
@@ -1,0 +1,127 @@
+import React, { useContext } from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+
+import Context from '$auth/contexts/Session'
+
+import SessionProvider, { SESSION_TOKEN_KEY, SESSION_EXPIRES_AT } from '$auth/components/SessionProvider'
+
+describe('SessionProvider', () => {
+    beforeEach(() => {
+        global.localStorage.clear()
+    })
+
+    afterAll(() => {
+        global.localStorage.clear()
+    })
+
+    it('returns no token by default', () => {
+        let currentContext
+
+        const Test = () => {
+            currentContext = useContext(Context)
+
+            return null
+        }
+
+        mount((
+            <SessionProvider>
+                <Test />
+            </SessionProvider>
+        ))
+
+        expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBeFalsy()
+        expect(currentContext.token).toBeFalsy()
+    })
+
+    it('returns empty token if no expires date set', () => {
+        let currentContext
+
+        const Test = () => {
+            currentContext = useContext(Context)
+
+            return null
+        }
+
+        global.localStorage.setItem(SESSION_TOKEN_KEY, 'myToken')
+
+        mount((
+            <SessionProvider>
+                <Test />
+            </SessionProvider>
+        ))
+
+        expect(currentContext.token).toBeFalsy()
+    })
+
+    it('returns stored token if not expired', () => {
+        let currentContext
+
+        const Test = () => {
+            currentContext = useContext(Context)
+
+            return null
+        }
+
+        const date = new Date()
+        date.setHours(date.getHours() - 2)
+        global.localStorage.setItem(SESSION_TOKEN_KEY, 'myToken')
+        global.localStorage.setItem(SESSION_EXPIRES_AT, date)
+
+        mount((
+            <SessionProvider>
+                <Test />
+            </SessionProvider>
+        ))
+
+        expect(currentContext.token).toBe('myToken')
+    })
+
+    it('does not return token if expired', () => {
+        let currentContext
+
+        const Test = () => {
+            currentContext = useContext(Context)
+
+            return null
+        }
+
+        const date = new Date()
+        date.setHours(date.getHours() - 8)
+        global.localStorage.setItem(SESSION_TOKEN_KEY, 'myToken')
+        global.localStorage.setItem(SESSION_EXPIRES_AT, date)
+
+        mount((
+            <SessionProvider>
+                <Test />
+            </SessionProvider>
+        ))
+
+        expect(currentContext.token).toBeFalsy()
+    })
+
+    it('sets session token', () => {
+        let currentContext
+
+        const Test = () => {
+            currentContext = useContext(Context)
+
+            return null
+        }
+
+        mount((
+            <SessionProvider>
+                <Test />
+            </SessionProvider>
+        ))
+
+        expect(currentContext.token).toBeFalsy()
+
+        act(() => {
+            currentContext.setSessionToken('myToken')
+        })
+
+        expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe('myToken')
+        expect(currentContext.token).toBe('myToken')
+    })
+})

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -34,7 +34,7 @@ const ProductPage = () => {
     } = useController()
     const product = useProduct()
     const userData = useSelector(selectUserData)
-    const isLoggedIn = userData !== null && SessionProvider.token()
+    const isLoggedIn = userData !== null && SessionProvider.token() !== null
 
     const { match } = useContext(RouterContext.Context)
 

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -18,6 +18,7 @@ import LoadingIndicator from '$userpages/components/LoadingIndicator'
 import PurchaseModal from './PurchaseModal'
 import useProduct from '$mp/containers/ProductController/useProduct'
 import { selectUserData } from '$shared/modules/user/selectors'
+import SessionProvider from '$auth/components/SessionProvider'
 
 import Page from './Page'
 import styles from './page.pcss'
@@ -33,7 +34,7 @@ const ProductPage = () => {
     } = useController()
     const product = useProduct()
     const userData = useSelector(selectUserData)
-    const isLoggedIn = userData !== null
+    const isLoggedIn = userData !== null && SessionProvider.token()
 
     const { match } = useContext(RouterContext.Context)
 

--- a/app/src/marketplace/containers/deprecated/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/deprecated/ProductPage/index.jsx
@@ -22,6 +22,7 @@ import { getProductById, getProductSubscription, purchaseProduct, getUserProduct
 import { getRelatedProducts } from '$mp/modules/relatedProducts/actions'
 import { isPaidProduct } from '$mp/utils/product'
 import BackToProductsButton from '$shared/components/BackToProductsButton'
+import SessionProvider from '$auth/components/SessionProvider'
 
 import {
     selectFetchingProduct,
@@ -235,7 +236,7 @@ export const mapStateToProps = (state: StoreState): StateProps => ({
     relatedProducts: selectRelatedProductList(state),
     fetchingProduct: selectFetchingProduct(state),
     fetchingStreams: selectFetchingStreams(state),
-    isLoggedIn: selectUserData(state) !== null,
+    isLoggedIn: selectUserData(state) !== null && SessionProvider.token() !== null,
     editPermission: selectProductEditPermission(state),
     publishPermission: selectProductPublishPermission(state),
     isProductSubscriptionValid: selectSubscriptionIsValid(state),

--- a/app/src/shared/modules/user/reducer.js
+++ b/app/src/shared/modules/user/reducer.js
@@ -46,6 +46,7 @@ const reducer: (UserState) => UserState = handleActions({
 
     [USER_DATA_FAILURE]: (state: UserState, action: UserErrorAction) => ({
         ...state,
+        user: null,
         fetchingUserData: false,
         userDataError: action.payload.error,
     }),

--- a/app/src/shared/test/modules/user/reducer.test.js
+++ b/app/src/shared/test/modules/user/reducer.test.js
@@ -61,6 +61,41 @@ describe('user - reducer', () => {
                 },
             }), expectedState)
         })
+
+        it('resets current user when fetch fails', () => {
+            const user = {
+                name: 'Tester1',
+                username: 'tester1@streamr.com',
+            }
+
+            const expectedState1 = {
+                ...initialState,
+                user,
+                fetchingUserData: false,
+            }
+
+            assert.deepStrictEqual(reducer(undefined, {
+                type: constants.USER_DATA_SUCCESS,
+                payload: {
+                    user,
+                },
+            }), expectedState1)
+
+            const error = new Error('Test')
+            const expectedState2 = {
+                ...initialState,
+                user: null,
+                fetchingUserData: false,
+                userDataError: error,
+            }
+
+            assert.deepStrictEqual(reducer(undefined, {
+                type: constants.USER_DATA_FAILURE,
+                payload: {
+                    error,
+                },
+            }), expectedState2)
+        })
     })
 
     describe('UPDATE_CURRENT_USER', () => {

--- a/app/test/unit/containers/ProductPage/ProductPage.test.jsx
+++ b/app/test/unit/containers/ProductPage/ProductPage.test.jsx
@@ -12,6 +12,7 @@ import * as productActions from '$mp/modules/product/actions'
 import * as relatedProductsActions from '$mp/modules/relatedProducts/actions'
 import * as urlUtils from '$shared/utils/url'
 import links from '$shared/../links'
+import SessionProvider from '$auth/components/SessionProvider'
 
 import ProductPageComponent from '$mp/components/deprecated/ProductPage'
 import NotFoundPage from '$mp/components/NotFoundPage'
@@ -144,6 +145,105 @@ describe('ProductPage', () => {
         }
 
         assert.deepStrictEqual(mapStateToProps(state), expectedProps)
+    })
+
+    it('maps login state to props', () => {
+        const state = {
+            categories: {
+                ids: [1, 2],
+            },
+            relatedProducts: {
+                ids: [],
+                fetching: false,
+                error: null,
+            },
+            product: {
+                id: product.id,
+                fetchingProduct: false,
+                productError: null,
+                streams: [],
+                fetchingStreams: false,
+                streamsError: null,
+                fetchingContractProduct: false,
+                contractProductError: null,
+                fetchingContractSubscription: false,
+                contractSubscriptionError: null,
+                contractSubscription: null,
+                productPermissions: {
+                    read: false,
+                    write: false,
+                    share: false,
+                    fetchingPermissions: false,
+                    permissionsError: null,
+                },
+            },
+            myPurchaseList: {
+                products: [],
+                subscriptions: [],
+                fetching: false,
+                error: null,
+            },
+            user: {
+                user: null,
+                fetchingUserData: false,
+                userDataError: null,
+                ethereumIdentities: null,
+                privateKeys: null,
+                fetchingIntegrationKeys: false,
+                integrationKeysError: null,
+            },
+            web3: {
+                accountId: null,
+                error: null,
+                enabled: false,
+            },
+            entities: {
+                products: {
+                    'product-1': product,
+                },
+                categories: {
+                    '1': categories[0],
+                    '2': categories[1],
+                },
+            },
+        }
+
+        const expectedProps = {
+            product,
+            productError: null,
+            streams: [],
+            relatedProducts: [],
+            fetchingProduct: false,
+            fetchingStreams: false,
+            isLoggedIn: false,
+            editPermission: false,
+            publishPermission: false,
+            isProductSubscriptionValid: false,
+            fetchingSharePermission: false,
+        }
+
+        assert.deepStrictEqual(mapStateToProps(state), expectedProps)
+
+        // maps login status
+        const sessionStub = sandbox.stub(SessionProvider, 'token').callsFake(() => null)
+        const nextState = {
+            ...state,
+            user: {
+                ...state.user,
+                user: {
+                    id: '1',
+                },
+            },
+        }
+        assert.deepStrictEqual(mapStateToProps(nextState), expectedProps)
+
+        sessionStub.restore()
+        sandbox.stub(SessionProvider, 'token').callsFake(() => 'myToken')
+        const nextExpectedProps = {
+            ...expectedProps,
+            isLoggedIn: true,
+        }
+        assert.deepStrictEqual(mapStateToProps(nextState), nextExpectedProps)
     })
 
     it('maps actions to props', () => {


### PR DESCRIPTION
Adds a date to localstorage variable whenever the login token is set. Token is not sent if the date is not set or **more** than 6 hours old (typo edited, was: ~less~). This value should be the same as returned from the login enpoint. This value is not exposed by the StreamrClient API, though, so I set it in the frontend. It will still redirect to login if the sent token is bad but that can't be really helped.