### PR TITLE
Refactor LogoutPage “convey” component

### DIFF
--- a/app/src/auth/components/LogoutPage/index.jsx
+++ b/app/src/auth/components/LogoutPage/index.jsx
@@ -1,53 +1,34 @@
 // @flow
 
-import React, { useState } from 'react'
-import { connect } from 'react-redux'
-
+import { useDispatch } from 'react-redux'
 import { post } from '$shared/utils/api'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import useOnMount from '$shared/hooks/useOnMount'
 import { logout as logoutAction } from '$shared/modules/user/actions'
-import GenericErrorPage from '$shared/components/GenericErrorPage'
 import routes from '$routes'
+import useFailure from '$shared/hooks/useFailure'
 
-export type DispatchProps = {
-    logout: () => void,
-}
-
-type Props = DispatchProps & {}
-
-const LogoutPage = ({ logout }: Props) => {
-    const [error, setError] = useState(null)
-
+const LogoutPage = () => {
     const isMounted = useIsMounted()
 
-    useOnMount(() => {
-        post({
-            url: routes.externalLogout(),
-        })
-            .then(
-                () => {
-                    if (isMounted()) {
-                        logout()
-                    }
-                },
-                (e) => {
-                    if (isMounted()) {
-                        setError(e)
-                    }
-                },
-            )
+    const fail = useFailure()
+
+    const dispatch = useDispatch()
+
+    useOnMount(async () => {
+        try {
+            await post({
+                url: routes.externalLogout(),
+            })
+            if (isMounted()) {
+                dispatch(logoutAction())
+            }
+        } catch (e) {
+            fail(e)
+        }
     })
 
-    return !!error && (
-        <GenericErrorPage />
-    )
+    return null
 }
 
-export { LogoutPage }
-
-const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
-    logout: () => dispatch(logoutAction()),
-})
-
-export default connect(null, mapDispatchToProps)(LogoutPage)
+export default LogoutPage

--- a/app/src/shared/hooks/useFailure.js
+++ b/app/src/shared/hooks/useFailure.js
@@ -1,0 +1,23 @@
+// @flow
+
+import { useState, useEffect, useCallback } from 'react'
+import { type UseStateTuple } from '$shared/flowtype/common-types'
+import useIsMounted from '$shared/hooks/useIsMounted'
+
+export default () => {
+    const [failure, setFailure]: UseStateTuple<any> = useState()
+
+    const isMounted = useIsMounted()
+
+    useEffect(() => {
+        if (failure) {
+            throw failure
+        }
+    }, [failure])
+
+    return useCallback((value: any) => {
+        if (isMounted()) {
+            setFailure(value)
+        }
+    }, [isMounted])
+}

--- a/app/src/shared/hooks/useOnMount.js
+++ b/app/src/shared/hooks/useOnMount.js
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react'
 import { type Ref } from '$shared/flowtype/common-types'
 
-export default (onMount: () => void) => {
+export default (onMount: () => void | Promise<void>) => {
     const ref: Ref<Function> = useRef(onMount)
 
     useEffect(() => {


### PR DESCRIPTION
`LogoutPage` doesn’t render anything. It either throws an error or logs out and our auth stuff takes care of the redirecting. ✨ 

In this PR I introduce `useFailure` hook. It's a shortcut for going from a promise rejection to an exception catchable by error boundary. I use it in #943 so this one goes live first, ideally.

@fonty1 @tumppi it's a small PR. The smallest I could arrange. Trying to move fast with small puzzles. Should be easy to look through.

Cheers!