### PR TITLE
Use Node 10 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '8'
+- '10'
 sudo: true
 branches:
   only:
@@ -12,7 +12,7 @@ before_install:
 - sudo apt-get -y install expect
 - pip install awscli --upgrade --user
 - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-- npm i -g npm@^6.9.0
+- npm i -g npm@^6.14.4
 - cd app
 install:
 - npm ci

--- a/app/src/editor/shared/tests/ModuleSubscription.test.jsx
+++ b/app/src/editor/shared/tests/ModuleSubscription.test.jsx
@@ -88,7 +88,7 @@ describe('Canvas Subscriptions', () => {
             expect(newRowMessages.length).toBeTruthy()
             expect(newRowMessages.length).toBeGreaterThanOrEqual(7)
             done()
-        }, 15000)
+        }, 20000)
 
         it('should get canvas module subscription messages in restarted canvas', async (done) => {
             let canvas = await Services.create()
@@ -126,6 +126,6 @@ describe('Canvas Subscriptions', () => {
             expect(newRowMessages.length).toBeTruthy()
             expect(newRowMessages.length).toBeGreaterThanOrEqual(7)
             done()
-        }, 20000)
+        }, 30000)
     })
 })

--- a/app/test/test-utils/setupTests.js
+++ b/app/test/test-utils/setupTests.js
@@ -5,7 +5,7 @@ import dotenv from '../../scripts/dotenv'
 
 dotenv()
 
-jest.setTimeout(15000) // remove when we get --timeout jest 24.9.0
+jest.setTimeout(30000) // remove when we get --timeout jest 24.9.0
 
 moxios.promiseWait = () => new Promise((resolve) => moxios.wait(resolve))
 

--- a/app/test/test-utils/setupTests.js
+++ b/app/test/test-utils/setupTests.js
@@ -5,7 +5,7 @@ import dotenv from '../../scripts/dotenv'
 
 dotenv()
 
-jest.setTimeout(10000) // remove when we get --timeout jest 24.9.0
+jest.setTimeout(15000) // remove when we get --timeout jest 24.9.0
 
 moxios.promiseWait = () => new Promise((resolve) => moxios.wait(resolve))
 


### PR DESCRIPTION
Minor change but Node 8 is very old and no longer maintained:

![image](https://user-images.githubusercontent.com/43438/78580691-c2196a00-7800-11ea-95e9-09ff35560020.png)

Node 10 should be faster too so CI install/builds/tests might be a little faster?