### PR TITLE
Relax ModuleSubscription Tests

### DIFF
--- a/app/src/editor/shared/tests/ModuleSubscription.test.jsx
+++ b/app/src/editor/shared/tests/ModuleSubscription.test.jsx
@@ -86,8 +86,7 @@ describe('Canvas Subscriptions', () => {
             const newRowMessages = receivedMessages.filter(({ nr }) => nr)
             // should have roughly 10 new row messages
             expect(newRowMessages.length).toBeTruthy()
-            expect(newRowMessages.length).toBeGreaterThanOrEqual(8)
-            expect(newRowMessages.length).toBeLessThanOrEqual(13)
+            expect(newRowMessages.length).toBeGreaterThanOrEqual(7)
             done()
         }, 15000)
 
@@ -125,8 +124,7 @@ describe('Canvas Subscriptions', () => {
             const newRowMessages = receivedMessages.filter(({ nr }) => nr)
             // should have roughly 10 new row messages
             expect(newRowMessages.length).toBeTruthy()
-            expect(newRowMessages.length).toBeGreaterThanOrEqual(8)
-            expect(newRowMessages.length).toBeLessThanOrEqual(13)
+            expect(newRowMessages.length).toBeGreaterThanOrEqual(7)
             done()
         }, 20000)
     })


### PR DESCRIPTION
Makes ModuleSubscription tests less likely to fail if backend is feeling sluggish.