### PR TITLE
getDataPerUsd, getBalance: don't use the public node

### DIFF
--- a/app/src/marketplace/modules/global/services.js
+++ b/app/src/marketplace/modules/global/services.js
@@ -10,7 +10,8 @@ import type { NumberString } from '$shared/flowtype/common-types'
 
 const marketplaceContract = (usePublicNode: boolean = false) => getContract(getConfig().marketplace, usePublicNode)
 
-export const getDataPerUsd = (): SmartContractCall<NumberString> => call(marketplaceContract(true).methods.dataPerUsd())
+export const getDataPerUsd = (): SmartContractCall<NumberString> => (call(marketplaceContract(false).methods.dataPerUsd())
     .then((value) => fromAtto(value).toString())
+)
 
 export const checkEthereumNetworkIsCorrect = (): Promise<void> => (checkEthereumNetworkIsCorrectUtil(getWeb3()))

--- a/app/src/shared/modules/integrationKey/actions.js
+++ b/app/src/shared/modules/integrationKey/actions.js
@@ -128,7 +128,7 @@ export const updateBalance = (account: Address) => async (dispatch: Function) =>
         accountEthBalance = await services.getBalance({
             address: account,
             type: BalanceType.ETH,
-            usePublicNode: true,
+            usePublicNode: false,
         })
     } catch (e) {
         console.warn(e)
@@ -138,7 +138,7 @@ export const updateBalance = (account: Address) => async (dispatch: Function) =>
         accountDataBalance = await services.getBalance({
             address: account,
             type: BalanceType.DATA,
-            usePublicNode: true,
+            usePublicNode: false,
         })
     } catch (e) {
         console.warn(e)


### PR DESCRIPTION
I'm curious to know if you can replicate this issue I'm having with the main net tests using this `.env`:

```
STREAMR_URL=http://localhost
PLATFORM_ORIGIN_URL=http://localhost
PLATFORM_PUBLIC_PATH=http://localhost
STREAMR_API_URL=https://streamr.network/api/v1
STREAMR_WS_URL=wss://streamr.network/api/v1/ws
NEW_MP_CONTRACT=on
DATA_UNION_PUBLISH_MEMBER_LIMIT=-1
MARKETPLACE_CONTRACT_ADDRESS=0xa756c844383d5eb88bc008820cb6c3e2b2b9a8db
MARKETPLACE_CONTRACT_ADDRESS_OLD=0xA10151D088f6f2705a05d6c83719e99E079A61C1
UNISWAP_ADAPTOR_CONTRACT_ADDRESS=0x2872e9e9bCf2D31E82275E7256DF3f77B4D59867
DATA_TOKEN_CONTRACT_ADDRESS=0x0Cf0Ee63788A0849fE5297F3407f701E122cC023
DAI_TOKEN_CONTRACT_ADDRESS=0x6B175474E89094C44Da98b954EedeAC495271d0F
WEB3_REQUIRED_NETWORK_ID=1
```

When using the public nodes I get null returns, when I set it to false, things work as expected:

<img width="135" alt="Screenshot 2020-04-06 at 21 38 16" src="https://user-images.githubusercontent.com/1593398/78594409-e866f600-7850-11ea-86b1-8ac5d783a9fd.png">

Not sure why that is!