### PR TITLE
[PLATFORM-1312] When an image is uploaded that is too large, it silently fails

### DIFF
--- a/app/src/marketplace/components/Modal/CropImageModal/cropImageModal.test.jsx
+++ b/app/src/marketplace/components/Modal/CropImageModal/cropImageModal.test.jsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+
+jest.mock('$shared/components/ModalPortal', () => ({
+    __esModule: true,
+    default: ({ children }) => children || null,
+}))
+
+const mockGetImage = jest.fn(() => ({
+    width: 100,
+    height: 100,
+    toBlob: (resolve) => resolve('image'),
+}))
+
+jest.doMock('react-avatar-editor', () => ({
+    __esModule: true,
+    default: React.forwardRef((props, ref) => {
+        // eslint-disable-next-line no-param-reassign
+        ref.current = {
+            getImage: mockGetImage,
+        }
+        return (
+            <div id="AvatarEditor" />
+        )
+    }),
+}))
+
+/* eslint-disable object-curly-newline */
+describe('CropImageModal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        jest.restoreAllMocks()
+    })
+
+    afterEach(() => {
+    })
+
+    describe('getResizedBlob', () => {
+        it('returns the same canvas if smaller than max width', async () => {
+            const { getResizedBlob, MAX_WIDTH } = await import('.')
+
+            const originalCanvas = {
+                width: 100,
+                height: 100,
+                toBlob: (resolve) => resolve('image'),
+            }
+            expect(originalCanvas.width).toBeLessThanOrEqual(MAX_WIDTH)
+            const result = await getResizedBlob(originalCanvas)
+            expect(result).toBe('image')
+        })
+
+        it('returns a resized canvas if smaller than max width', async () => {
+            const { getResizedBlob, MAX_WIDTH } = await import('.')
+
+            const nextCanvas = {
+                width: undefined,
+                height: undefined,
+                getContext: () => ({
+                    drawImage: jest.fn(),
+                }),
+                toBlob: (resolve) => resolve('nextImage'),
+            }
+
+            jest.spyOn(document, 'createElement').mockImplementation(() => nextCanvas)
+            const originalCanvas = {
+                width: 2000,
+                height: 2000,
+            }
+            expect(originalCanvas.width).toBeGreaterThan(MAX_WIDTH)
+
+            const result = await getResizedBlob(originalCanvas)
+            expect(result).toBe('nextImage')
+            expect(nextCanvas.width).toBe(MAX_WIDTH)
+        })
+    })
+
+    it('renders the avatar editor', async () => {
+        const { default: CropImageModal } = await import('.')
+        let el
+
+        await act(async () => {
+            el = await mount((
+                <CropImageModal
+                    imageUrl="http://"
+                    onClose={jest.fn()}
+                    onSave={jest.fn()}
+                />
+            ))
+        })
+        expect(el.find({ id: 'AvatarEditor' }).exists()).toBe(true)
+    })
+
+    it('closes the modal', async () => {
+        const { default: CropImageModal } = await import('.')
+        const closeStub = jest.fn()
+        const el = mount((
+            <CropImageModal
+                imageUrl="http://"
+                onClose={closeStub}
+                onSave={jest.fn()}
+            />
+        ))
+
+        await act(async () => {
+            await el.find('button').at(0).simulate('click')
+        })
+
+        expect(closeStub).toHaveBeenCalled()
+    })
+
+    it('calls the save prop with edited image', async () => {
+        const { default: CropImageModal } = await import('.')
+        const saveStub = jest.fn()
+        let el
+        await act(async () => {
+            el = await mount((
+                <CropImageModal
+                    imageUrl="http://"
+                    onClose={jest.fn()}
+                    onSave={saveStub}
+                />
+            ))
+        })
+
+        await act(async () => {
+            await el.find('button').at(1).simulate('click')
+        })
+        expect(saveStub).toHaveBeenCalled()
+    })
+})
+/* eslint-enable object-curly-newline */

--- a/app/src/marketplace/components/Modal/CropImageModal/index.jsx
+++ b/app/src/marketplace/components/Modal/CropImageModal/index.jsx
@@ -33,7 +33,7 @@ export function getResizedBlob(originalCanvas: HTMLCanvasElement): Promise<Blob>
         // Draw the original image on the (temp) resizing canvas
         resizedCanvasContext.drawImage(originalCanvas, 0, 0)
 
-        // Quickly reduce the dize by 50% each time in few iterations until the size is less then
+        // Quickly reduce the size by 50% each time in few iterations until the size is less then
         // 2x time the target size - the motivation for it, is to reduce the aliasing that would have been
         // created with direct reduction of very big image to small image
         while (resizedCanvas.width * 0.5 > MAX_WIDTH) {

--- a/app/src/marketplace/components/Modal/CropImageModal/index.jsx
+++ b/app/src/marketplace/components/Modal/CropImageModal/index.jsx
@@ -16,10 +16,10 @@ type Props = {
     onSave: (File) => void,
 }
 
-const MAX_WIDTH = 1080
+export const MAX_WIDTH = 1024
 
 // only width is considered because images returned from the cropper will always be wider than taller
-function getResizedBlob(originalCanvas: HTMLCanvasElement) {
+export function getResizedBlob(originalCanvas: HTMLCanvasElement): Promise<Blob> {
     let canvas = originalCanvas
 
     if (originalCanvas.width > MAX_WIDTH) {

--- a/app/src/marketplace/components/Modal/CropImageModal/index.jsx
+++ b/app/src/marketplace/components/Modal/CropImageModal/index.jsx
@@ -16,17 +16,51 @@ type Props = {
     onSave: (File) => void,
 }
 
+const MAX_WIDTH = 1080
+
+// only width is considered because images returned from the cropper will always be wider than taller
+function getResizedBlob(originalCanvas: HTMLCanvasElement) {
+    let canvas = originalCanvas
+
+    if (originalCanvas.width > MAX_WIDTH) {
+        const resizedCanvas = document.createElement('canvas')
+        const resizedCanvasContext = resizedCanvas.getContext('2d')
+
+        // Start with original image size
+        resizedCanvas.width = originalCanvas.width
+        resizedCanvas.height = originalCanvas.height
+
+        // Draw the original image on the (temp) resizing canvas
+        resizedCanvasContext.drawImage(originalCanvas, 0, 0)
+
+        // Quickly reduce the dize by 50% each time in few iterations until the size is less then
+        // 2x time the target size - the motivation for it, is to reduce the aliasing that would have been
+        // created with direct reduction of very big image to small image
+        while (resizedCanvas.width * 0.5 > MAX_WIDTH) {
+            resizedCanvas.width *= 0.5
+            resizedCanvas.height *= 0.5
+            resizedCanvasContext.drawImage(resizedCanvas, 0, 0, resizedCanvas.width, resizedCanvas.height)
+        }
+
+        // Now do final resize for the resizingCanvas to meet the dimension requirments
+        // directly to the output canvas, that will output the final image
+        resizedCanvas.width = MAX_WIDTH
+        resizedCanvas.height = (resizedCanvas.width * originalCanvas.height) / originalCanvas.width
+        resizedCanvasContext.drawImage(originalCanvas, 0, 0, resizedCanvas.width, resizedCanvas.height)
+
+        canvas = resizedCanvas
+    }
+
+    return new Promise((resolve) => canvas.toBlob(resolve))
+}
+
 const CropImageModal = ({ imageUrl, onClose, onSave: onSaveProp }: Props) => {
     const editorRef = useRef()
     const [sliderValue, setSliderValue] = useState(1)
 
     const onSave = useCallback(async () => {
         if (editorRef.current) {
-            const canvas = editorRef.current.getImage()
-            const dataURL = canvas.toDataURL()
-
-            const res = await fetch(dataURL)
-            const blob = await res.blob()
+            const blob = await getResizedBlob(editorRef.current.getImage())
             const file = new File([blob], 'coverImage.png')
 
             onSaveProp(file)


### PR DESCRIPTION
From issue description:

> Surprisingly this seems ok in the old product editor (perhaps we are compressing) before sending? In the new editor, when I uploaded an image 4.2mb large, the server returns 413 but no UI warnings:

After investigating this issue, it seems to happen in the new editor because we use the cropping tool to create a new image whose file size is not necessarily dependant on the original image. Also there are differences between browsers, see: https://stackoverflow.com/questions/9773154/canvas-todataurl-increases-file-size-of-image

So the old editor works because we submit the original image. The new editor will also give an error if you try to give it an image that is over 5MB.

I changed the crop tool to use `canvas.toBlob` instead of `canvas.toDataUrl` and introduced a method to reduce the dimensions of the given image down to 1024 pixels which should be enough for product images. There is an option in `toBlob` also to convert images to JPG which would reduce the size even more but seeing as there are more graphical product images than photos maybe PNG is better to avoid image quality loss.

Another issue that I noticed is that the backend forces the images to crop. I think it's trying to fit them into a set width/height ratio:

**Original image**
![Helsinki_tram_20170130](https://user-images.githubusercontent.com/1064982/78773980-aea30600-799c-11ea-88ab-8a686a6c25fd.jpg)

**In crop tool**
<img width="540" alt="Screen Shot 2020-04-08 at 13 08 54" src="https://user-images.githubusercontent.com/1064982/78773998-b5317d80-799c-11ea-8dff-af07067d4523.png">

**In editor immediately after**
<img width="677" alt="Screen Shot 2020-04-08 at 13 09 01" src="https://user-images.githubusercontent.com/1064982/78774016-ba8ec800-799c-11ea-9544-1542ecbedc45.png">

**After saving and coming back to edit again**
<img width="677" alt="Screen Shot 2020-04-08 at 13 09 23" src="https://user-images.githubusercontent.com/1064982/78774058-c8444d80-799c-11ea-894f-beea92b405b0.png">

I will add a backend issue about it (https://streamr.atlassian.net/browse/CORE-1898)
