### PR TITLE
[PLATFORM-1332] Cover image republish fix

### DIFF
--- a/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
+++ b/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
@@ -154,11 +154,19 @@ function useValidationContext(): ContextProps {
             clearStatus('pricePerSecond')
         }
 
-        // Set pending fields
+        // Set pending fields, a change is marked pending if there was a saved pending change or
+        // we made a change that is different from the loaded product
         const changes = getPendingChanges(product)
         const isPublic = isPublished(product)
         PENDING_CHANGE_FIELDS.forEach((field) => {
-            setPendingChange(field, (field in changes) || (isPublic && isTouched(field) && !isEqual(product[field], originalProduct[field])))
+            let fieldsAreEqual = isEqual(product[field], originalProduct[field])
+
+            // special case, imageUrl will be updated if there is a new image uploaded
+            if (field === 'imageUrl') {
+                fieldsAreEqual = fieldsAreEqual && !product.newImageToUpload
+            }
+
+            setPendingChange(field, (field in changes) || (isPublic && isTouched(field) && !fieldsAreEqual))
         })
     }, [setStatus, clearStatus, isMounted, setPendingChange, isTouched, originalProduct])
 

--- a/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
+++ b/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
@@ -159,14 +159,7 @@ function useValidationContext(): ContextProps {
         const changes = getPendingChanges(product)
         const isPublic = isPublished(product)
         PENDING_CHANGE_FIELDS.forEach((field) => {
-            let fieldsAreEqual = isEqual(product[field], originalProduct[field])
-
-            // special case, imageUrl will be updated if there is a new image uploaded
-            if (field === 'imageUrl') {
-                fieldsAreEqual = fieldsAreEqual && !product.newImageToUpload
-            }
-
-            setPendingChange(field, (field in changes) || (isPublic && isTouched(field) && !fieldsAreEqual))
+            setPendingChange(field, (field in changes) || (isPublic && isTouched(field) && !isEqual(product[field], originalProduct[field])))
         })
     }, [setStatus, clearStatus, isMounted, setPendingChange, isTouched, originalProduct])
 

--- a/app/src/marketplace/containers/ProductController/tests/ValidationContextProvider.test.jsx
+++ b/app/src/marketplace/containers/ProductController/tests/ValidationContextProvider.test.jsx
@@ -834,7 +834,6 @@ describe('validation context', () => {
                     description: 'New Description',
                     category: 'category',
                     streams: ['2', '3', '4'],
-                    imageUrl: 'http://...',
                     newImageToUpload: new File([''], 'filename'),
                     state: 'DEPLOYED',
                 })

--- a/app/src/marketplace/containers/ProductController/tests/useEditableProductActions.test.jsx
+++ b/app/src/marketplace/containers/ProductController/tests/useEditableProductActions.test.jsx
@@ -184,13 +184,14 @@ describe('useEditableProductActions', () => {
     describe('updateImageFile', () => {
         it('updates the product image upload', () => {
             let updater
+            let undoContext
             let product
             let validation
             function Test() {
                 updater = useEditableProductActions()
                 validation = useContext(ValidationContext)
-                const { state } = useContext(UndoContext.Context)
-                product = state
+                undoContext = useContext(UndoContext.Context)
+                product = undoContext.state
                 return null
             }
 
@@ -205,12 +206,20 @@ describe('useEditableProductActions', () => {
             expect(product).toBeFalsy()
             expect(validation.isTouched('imageUrl')).toBe(false)
 
+            act(() => {
+                undoContext.replace(() => ({
+                    name: 'Test product',
+                    imageUrl: 'http://...',
+                }))
+            })
+
             const file = new File([''], 'filename')
             act(() => {
                 updater.updateImageFile(file)
             })
 
             expect(product).toStrictEqual({
+                name: 'Test product',
                 newImageToUpload: file,
             })
             expect(validation.isTouched('imageUrl')).toBe(true)

--- a/app/src/marketplace/containers/ProductController/useEditableProductActions.js
+++ b/app/src/marketplace/containers/ProductController/useEditableProductActions.js
@@ -62,7 +62,7 @@ export function useEditableProductActions() {
         touch('imageUrl')
     }, [commit, touch])
     const updateImageFile = useCallback((image: File) => {
-        commit('Update image file', (p) => ({
+        commit('Update image file', ({ imageUrl, ...p }) => ({
             ...p,
             newImageToUpload: image,
         }))

--- a/app/test/unit/utils/product.test.js
+++ b/app/test/unit/utils/product.test.js
@@ -365,8 +365,8 @@ describe('product utils', () => {
                 assert.equal(all.getValidId('1234', true), '0x1234')
             })
             it('throws with an invalid id', () => {
-                assert.throws(() => all.getValidId('test'), /is not valid hex/)
-                assert.throws(() => all.getValidId('test', true), /is not valid hex/)
+                assert.throws(() => all.getValidId('test'), /is not a valid hex/)
+                assert.throws(() => all.getValidId('test', true), /is not a valid hex/)
             })
         })
         describe('when prefix = false', () => {
@@ -377,7 +377,7 @@ describe('product utils', () => {
                 assert.equal(all.getValidId('1234', false), '1234')
             })
             it('throws with an invalid id', () => {
-                assert.throws(() => all.getValidId('test', false), /is not valid hex/)
+                assert.throws(() => all.getValidId('test', false), /is not a valid hex/)
             })
         })
     })


### PR DESCRIPTION
Fixes a bug when uploading a new cover image to a published product did not mark it as republishable.

To test:

1) Edit a published product
2) Upload a new cover image

Navigation icon should change to "update" icon and toolbar button to “Republish”.