### PR TITLE
[PLATFORM-1324] Add loading state to stream list

### DIFF
--- a/app/src/marketplace/components/StreamSelector/index.jsx
+++ b/app/src/marketplace/components/StreamSelector/index.jsx
@@ -97,16 +97,17 @@ export const StreamSelector = (props: Props) => {
 
     const { hasError, error } = useLastError(rest)
 
+    const isDisabled = disabled || fetchingStreams
+
     return (
         <React.Fragment>
             <div className={className}>
                 <div
                     className={classNames(styles.root, {
                         [styles.withError]: !!hasError,
-                        [styles.disabled]: !!disabled,
+                        [styles.disabled]: !!isDisabled,
                     })}
                 >
-                    {!!fetchingStreams && <Translate value="streamSelector.loading" />}
                     <div className={styles.inputContainer}>
                         <SvgIcon name="search" className={styles.SearchIcon} />
                         <Input
@@ -114,7 +115,7 @@ export const StreamSelector = (props: Props) => {
                             onChange={onSearchChange}
                             value={search}
                             placeholder={I18n.t('streamSelector.typeToSearch')}
-                            disabled={!!disabled}
+                            disabled={!!isDisabled}
                         />
                         <DropdownActions
                             className={classNames(styles.sortDropdown, styles.dropdown)}
@@ -125,7 +126,7 @@ export const StreamSelector = (props: Props) => {
                                     {sort}
                                 </span>
                             }
-                            disabled={!!disabled}
+                            disabled={!!isDisabled}
                         >
                             <DropdownActions.Item onClick={() => setSort(SORT_BY_NAME)}>
                                 <Translate value="streamSelector.sortByName" />
@@ -139,7 +140,12 @@ export const StreamSelector = (props: Props) => {
                         </DropdownActions>
                     </div>
                     <div className={styles.streams}>
-                        {!availableStreams.length && (
+                        {!!fetchingStreams && (
+                            <div className={styles.noAvailableStreams}>
+                                <Translate value="streamSelector.loading" />
+                            </div>
+                        )}
+                        {!fetchingStreams && !availableStreams.length && (
                             <div className={styles.noAvailableStreams}>
                                 <p><Translate value="streamSelector.noStreams" /></p>
                                 <a href={links.userpages.streamCreate} className={styles.streamCreateButton}>
@@ -147,7 +153,7 @@ export const StreamSelector = (props: Props) => {
                                 </a>
                             </div>
                         )}
-                        {sortedStreams.map((stream: Stream) => (
+                        {!fetchingStreams && sortedStreams.map((stream: Stream) => (
                             <div
                                 key={stream.id}
                                 className={classNames(styles.stream, {
@@ -161,7 +167,7 @@ export const StreamSelector = (props: Props) => {
                                     onClick={() => {
                                         onToggle(stream.id)
                                     }}
-                                    disabled={!!disabled}
+                                    disabled={!!isDisabled}
                                 >
                                     {stream.name}
                                 </button>
@@ -186,7 +192,7 @@ export const StreamSelector = (props: Props) => {
                                     onSelectAll(toSelect)
                                 }
                             }}
-                            disabled={!!disabled}
+                            disabled={!!isDisabled}
                         >
                             {!allVisibleStreamsSelected
                                 ? <Translate value="streamSelector.selectAll" />

--- a/app/src/marketplace/components/StreamSelector/index.jsx
+++ b/app/src/marketplace/components/StreamSelector/index.jsx
@@ -12,6 +12,8 @@ import Button from '$shared/components/Button'
 import DropdownActions from '$shared/components/DropdownActions'
 import SvgIcon from '$shared/components/SvgIcon'
 import Errors from '$ui/Errors'
+import LoadingIndicator from '$userpages/components/LoadingIndicator'
+
 import links from '$mp/../links'
 import { useLastError, type LastErrorProps } from '$shared/hooks/useLastError'
 
@@ -140,11 +142,6 @@ export const StreamSelector = (props: Props) => {
                         </DropdownActions>
                     </div>
                     <div className={styles.streams}>
-                        {!!fetchingStreams && (
-                            <div className={styles.noAvailableStreams}>
-                                <Translate value="streamSelector.loading" />
-                            </div>
-                        )}
                         {!fetchingStreams && !availableStreams.length && (
                             <div className={styles.noAvailableStreams}>
                                 <p><Translate value="streamSelector.noStreams" /></p>
@@ -153,7 +150,7 @@ export const StreamSelector = (props: Props) => {
                                 </a>
                             </div>
                         )}
-                        {!fetchingStreams && sortedStreams.map((stream: Stream) => (
+                        {sortedStreams.map((stream: Stream) => (
                             <div
                                 key={stream.id}
                                 className={classNames(styles.stream, {
@@ -173,6 +170,7 @@ export const StreamSelector = (props: Props) => {
                                 </button>
                             </div>
                         ))}
+                        <LoadingIndicator className={styles.loadingIndicator} loading={!!fetchingStreams} />
                     </div>
                     <div className={styles.footer}>
                         <div className={styles.selectedCount}>

--- a/app/src/marketplace/components/StreamSelector/streamSelector.pcss
+++ b/app/src/marketplace/components/StreamSelector/streamSelector.pcss
@@ -66,6 +66,16 @@
   background: white;
   height: 315px;
   overflow: auto;
+  position: relative;
+}
+
+.loadingIndicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  opacity: 0.5 !important;
 }
 
 .stream {

--- a/app/src/marketplace/components/StreamSelector/streamSelector.stories.jsx
+++ b/app/src/marketplace/components/StreamSelector/streamSelector.stories.jsx
@@ -97,7 +97,7 @@ stories.add('disabled', () => (
 ))
 
 stories.add('loading', () => (
-    <StreamController loading />
+    <StreamController availableStreams={streamList} loading />
 ))
 
 stories.add('empty', () => (

--- a/app/src/marketplace/components/StreamSelector/streamSelector.stories.jsx
+++ b/app/src/marketplace/components/StreamSelector/streamSelector.stories.jsx
@@ -3,7 +3,6 @@
 import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs'
-import { action } from '@storybook/addon-actions'
 import styles from '@sambego/storybook-styles'
 
 import StreamSelector from '.'
@@ -17,7 +16,7 @@ const stories =
         }))
         .addDecorator(withKnobs)
 
-const availableStreams = [{
+const streamList = [{
     id: '1',
     name: 'First',
     description: '',
@@ -64,9 +63,11 @@ const availableStreams = [{
 type StreamControllerProps = {
     error?: string,
     disabled?: boolean,
+    availableStreams?: Array<Object>,
+    loading?: boolean,
 }
 
-const StreamController = ({ error, disabled }: StreamControllerProps) => {
+const StreamController = ({ error, disabled, availableStreams = [], loading = false }: StreamControllerProps) => {
     const [streams, setStreams] = useState([])
 
     return (
@@ -78,26 +79,51 @@ const StreamController = ({ error, disabled }: StreamControllerProps) => {
             availableStreams={availableStreams}
             error={error}
             disabled={disabled}
+            fetchingStreams={loading}
         />
     )
 }
 
 stories.add('basic', () => (
-    <StreamController />
+    <StreamController availableStreams={streamList} />
 ))
 
 stories.add('with error', () => (
-    <StreamController error="Something went wrong" />
+    <StreamController error="Something went wrong" availableStreams={streamList} />
 ))
 
 stories.add('disabled', () => (
-    <StreamController disabled />
+    <StreamController disabled availableStreams={streamList} />
+))
+
+stories.add('loading', () => (
+    <StreamController loading />
 ))
 
 stories.add('empty', () => (
-    <StreamSelector
-        streams={[]}
-        onEdit={action('update')}
-        availableStreams={[]}
-    />
+    <StreamController />
 ))
+
+stories.add('1500 streams', () => {
+    const longList = Array.from({
+        length: 1500,
+    }, (v, i) => ({
+        id: i + 1,
+        name: `stream ${i + 1}`,
+        description: '',
+        autoConfigure: false,
+        lastUpdated: 0,
+        inactivityThresholdHours: 0,
+        requireEncryptedData: false,
+        requireSignedData: false,
+        uiChannel: false,
+        storageDays: 0,
+        partitions: 0,
+        ownPermissions: [],
+        config: {},
+    }))
+
+    return (
+        <StreamController availableStreams={longList} />
+    )
+})


### PR DESCRIPTION
While investigating https://streamr.atlassian.net/browse/PLATFORM-1324 I noticed there is no styling for Stream selector load state. I added one like this (disabled & center text replaced):

<img width="911" alt="Screen Shot 2020-04-09 at 13 41 24" src="https://user-images.githubusercontent.com/1064982/78887293-43bf0100-7a68-11ea-86d6-74bf515f54b8.png">

The actual problem itself seems to be backend related (`/streams` endpoint doesn't return more than 1000 results).