### PR TITLE
Fetch API Key for Client if it doesn't have it already.

### DIFF
--- a/app/src/shared/contexts/StreamrClient/index.jsx
+++ b/app/src/shared/contexts/StreamrClient/index.jsx
@@ -59,7 +59,7 @@ function useClientProvider({
     const [client, setClient] = useState()
     const isMountedRef = useIsMountedRef()
     const hasClient = !!client
-    const hasLoaded = !!apiKey || !!(!isAuthenticating && (isAuthenticated || authenticationFailed))
+    const hasLoaded = !!apiKey || !!(!isAuthenticating && authenticationFailed)
     const loadKeyPending = usePending('client.key')
 
     useEffect(() => {


### PR DESCRIPTION
Always fetch apiKey if we don't currently have it. Should fix missing auth credentials issues on login.

A bug exists where client tries to subscribe without sending auth keys.

To reproduce bug reliably:

1. Create a stopped Clock->Table canvas.
2. Log out.
3. Log in.
4. Open Canvas
5. Click Run

Canvas won't appear to start and you will see an error saying something like "user doesn't have permission to subscribe to stream X"

Issue seemed to be that the apiKey is fetched automatically by some other component in the app if the user was already logged in when the app started. On the initial login however, the apiKey is not there, and the client doesn't go fetch it.  This is why a refresh fixes it and why we don't see it all the time, because we're usually developing on a page after already logging in. This PR fixes the client component to go fetch the credentials if it doesn't have them and it isn't currently fetching them.
 
To Test:

1. Run steps above and it should now work.