### PR TITLE
[PLATFORM-1330] Fix price conversion in SetPrice component + specs

### DIFF
--- a/app/src/marketplace/components/SetPrice/index.jsx
+++ b/app/src/marketplace/components/SetPrice/index.jsx
@@ -49,8 +49,8 @@ const SetPrice = ({
 }: Props) => {
     const [quotePrice, setQuotePrice] = useState(BN(0))
 
-    const onPriceChange = useCallback((newPrice) => {
-        onPriceChangeProp(newPrice)
+    const onPriceChange = useCallback((e: SyntheticInputEvent<EventTarget>) => {
+        onPriceChangeProp(e.target.value)
     }, [onPriceChangeProp])
 
     const onCurrencyChange = useCallback(() => {
@@ -75,7 +75,7 @@ const SetPrice = ({
                 <div className={styles.priceControls}>
                     <PriceField
                         currency={currency}
-                        onCommit={onPriceChange}
+                        onChange={onPriceChange}
                         disabled={disabled}
                         placeholder="Price"
                         value={price.toString()}

--- a/app/src/marketplace/components/SetPrice/index.jsx
+++ b/app/src/marketplace/components/SetPrice/index.jsx
@@ -89,7 +89,8 @@ const SetPrice = ({
                         currency={getQuoteCurrencyFor(currency)}
                         placeholder="Price"
                         value={BN(quotePrice).isNaN() ? '0' : quotePrice.toString()}
-                        disabled
+                        readOnly
+                        disabled={disabled}
                         className={styles.input}
                     />
                     <div>

--- a/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
@@ -14,7 +14,7 @@ import { selectDataUnion } from '$mp/modules/dataUnion/selectors'
 import { selectProduct } from '$mp/modules/product/selectors'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import Notification from '$shared/utils/Notification'
-import { NotificationIcon, productStates } from '$shared/utils/constants'
+import { NotificationIcon, productStates, contractCurrencies as currencies, DEFAULT_CURRENCY } from '$shared/utils/constants'
 import routes from '$routes'
 import useEditableProductActions from '../ProductController/useEditableProductActions'
 import { isEthereumAddress } from '$mp/utils/validate'
@@ -34,6 +34,8 @@ type ContextProps = {
     deployDataUnion: () => void | Promise<void>,
     lastSectionRef: any,
     publishAttempted: boolean,
+    preferredCurrency: $Values<typeof currencies>,
+    setPreferredCurrency: ($Values<typeof currencies>) => void,
 }
 
 const EditControllerContext: Context<ContextProps> = React.createContext({})
@@ -52,6 +54,7 @@ function useEditController(product: Product) {
     const { replaceProduct } = useEditableProductUpdater()
     const dataUnion = useSelector(selectDataUnion)
     const [publishAttempted, setPublishAttempted] = useState(false)
+    const [preferredCurrency, setPreferredCurrency] = useState(product.priceCurrency || DEFAULT_CURRENCY)
 
     useEffect(() => {
         const handleBeforeunload = (event) => {
@@ -289,6 +292,8 @@ function useEditController(product: Product) {
         deployDataUnion,
         lastSectionRef,
         publishAttempted,
+        preferredCurrency,
+        setPreferredCurrency,
     }), [
         isPreview,
         setIsPreview,
@@ -299,6 +304,8 @@ function useEditController(product: Product) {
         deployDataUnion,
         lastSectionRef,
         publishAttempted,
+        preferredCurrency,
+        setPreferredCurrency,
     ])
 }
 

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
@@ -1,13 +1,13 @@
 // @flow
 
-import React, { useState, useCallback, useContext } from 'react'
+import React, { useCallback, useContext } from 'react'
 import { useSelector } from 'react-redux'
 import cx from 'classnames'
 import { Translate } from 'react-redux-i18n'
 
 import { isDataUnionProduct } from '$mp/utils/product'
 import { usePending } from '$shared/hooks/usePending'
-import { contractCurrencies as currencies, DEFAULT_CURRENCY } from '$shared/utils/constants'
+import { contractCurrencies as currencies } from '$shared/utils/constants'
 import { selectDataPerUsd } from '$mp/modules/global/selectors'
 import RadioButtonGroup from '$shared/components/RadioButtonGroup'
 import SetPrice from '$mp/components/SetPrice'
@@ -29,7 +29,7 @@ import styles from './PriceSelector.pcss'
 
 const PriceSelector = () => {
     const product = useEditableProduct()
-    const { publishAttempted } = useContext(EditControllerContext)
+    const { publishAttempted, preferredCurrency: currency, setPreferredCurrency: setCurrency } = useContext(EditControllerContext)
     const { updateIsFree, updatePrice, updateBeneficiaryAddress } = useEditableProductActions()
     const dataPerUsd = useSelector(selectDataPerUsd)
     const { isPending: savePending } = usePending('product.SAVE')
@@ -39,7 +39,7 @@ const PriceSelector = () => {
     const isLoadingOrSaving = !!(savePending || contractProductLoadPending)
     const isPriceTypeDisabled = !!(isLoadingOrSaving || isPublic || !!contractProduct)
 
-    const [currency, setCurrency] = useState(product.priceCurrency || DEFAULT_CURRENCY)
+    // const [currency, setCurrency] = useState(product.priceCurrency || DEFAULT_CURRENCY)
 
     const onPriceTypeChange = useCallback((type) => {
         updateIsFree(type === 'Free')

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.jsx
@@ -39,8 +39,6 @@ const PriceSelector = () => {
     const isLoadingOrSaving = !!(savePending || contractProductLoadPending)
     const isPriceTypeDisabled = !!(isLoadingOrSaving || isPublic || !!contractProduct)
 
-    // const [currency, setCurrency] = useState(product.priceCurrency || DEFAULT_CURRENCY)
-
     const onPriceTypeChange = useCallback((type) => {
         updateIsFree(type === 'Free')
     }, [updateIsFree])

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.test.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.test.jsx
@@ -1,0 +1,201 @@
+import React, { useContext } from 'react'
+import sinon from 'sinon'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import * as UndoContext from '$shared/contexts/Undo'
+import { Provider as ValidationContextProvider } from '../ProductController/ValidationContextProvider'
+import * as BeneficiaryAddress from './BeneficiaryAddress'
+import PriceSelector from './PriceSelector'
+import Select from '$ui/Select'
+import Toggle from '$shared/components/Toggle'
+import { timeUnits } from '$shared/utils/constants'
+
+const mockState = {
+    product: {
+        id: '1',
+    },
+    contractProduct: {
+        id: '1',
+    },
+    dataUnion: {},
+    global: {
+        dataPerUsd: 10,
+    },
+    entities: {
+        products: {
+            '1': {
+                id: '1',
+            },
+        },
+        contractProducts: {
+            '1': {
+                id: '1',
+            },
+        },
+    },
+}
+
+jest.mock('react-redux', () => ({
+    useSelector: jest.fn().mockImplementation((selectorFn) => selectorFn(mockState)),
+}))
+
+describe('PriceSelector', () => {
+    let sandbox
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+        sandbox.stub(BeneficiaryAddress, 'default').callsFake(() => null)
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    const setup = async (product, transform) => {
+        let undoContext
+
+        const WrappedPriceSelector = () => {
+            undoContext = useContext(UndoContext.Context)
+            const { state } = undoContext
+            return state && state.id ? <PriceSelector /> : null
+        }
+
+        const el = mount((
+            <UndoContext.Provider>
+                <ValidationContextProvider>
+                    <WrappedPriceSelector />
+                </ValidationContextProvider>
+            </UndoContext.Provider>
+        ))
+
+        await act(async () => {
+            await undoContext.replace(() => product)
+        })
+
+        el.update()
+
+        if (transform) {
+            transform(el)
+        }
+
+        return undoContext.state
+    }
+
+    it('sets DATA amount', async () => {
+        const { price, pricePerSecond, priceCurrency, timeUnit } = await setup({
+            id: '1',
+            price: '1',
+            priceCurrency: 'DATA',
+            timeUnit: 'second',
+        }, (el) => {
+            el
+                .find('.inputWrapper input')
+                .first()
+                .simulate('change', {
+                    target: {
+                        value: '10',
+                    },
+                })
+                .simulate('blur')
+        })
+
+        expect(price.toString()).toBe('10')
+        expect(pricePerSecond.toString()).toBe('10')
+        expect(priceCurrency.toString()).toBe('DATA')
+        expect(timeUnit).toBe('second')
+    })
+
+    it('sets USD amount', async () => {
+        const { price, pricePerSecond, priceCurrency, timeUnit } = await setup({
+            id: '1',
+            price: '1',
+            priceCurrency: 'DATA',
+            timeUnit: 'second',
+        }, (el) => {
+            expect(el.find('.currency').first().text()).toBe('DATA')
+
+            el
+                .find('.icon')
+                .first()
+                .simulate('click')
+
+            expect(el.find('.currency').first().text()).toBe('USD') /* It's USD now. */
+
+            el
+                .find('.inputWrapper input')
+                .first()
+                .simulate('change', {
+                    target: {
+                        value: '10',
+                    },
+                })
+                .simulate('blur')
+        })
+
+        expect(price.toString()).toBe('100')
+        expect(pricePerSecond.toString()).toBe('100')
+        expect(priceCurrency.toString()).toBe('DATA')
+        expect(timeUnit).toBe('second')
+    })
+
+    it('changes time unit + updates amounts', async () => {
+        const { price, pricePerSecond, priceCurrency, timeUnit } = await setup({
+            id: '1',
+            price: '7200',
+            priceCurrency: 'DATA',
+            pricePerSecond: '7200',
+            timeUnit: 'second',
+        }, (el) => {
+            act(() => {
+                el.find(Select).props().onChange({
+                    value: 'hour',
+                })
+            })
+        })
+
+        expect(price.toString()).toBe('7200')
+        expect(pricePerSecond.toString()).toBe('2')
+        expect(priceCurrency.toString()).toBe('DATA')
+        expect(timeUnit).toBe('hour')
+    })
+
+    describe('fixed fiat price', () => {
+        it('changes price currency to USD + converts', async () => {
+            const { price, pricePerSecond, priceCurrency, timeUnit } = await setup({
+                id: '1',
+                price: '1',
+                priceCurrency: 'DATA',
+                pricePerSecond: '1',
+                timeUnit: 'second',
+            }, (el) => {
+                act(() => {
+                    el.find(Toggle).props().onChange(true)
+                })
+            })
+
+            expect(price.toString()).toBe('0.1')
+            expect(pricePerSecond.toString()).toBe('0.1')
+            expect(priceCurrency.toString()).toBe('USD')
+            expect(timeUnit).toBe('second')
+        })
+
+        it('changes price currency to DATA + converts', async () => {
+            const { price, pricePerSecond, priceCurrency, timeUnit } = await setup({
+                id: '1',
+                price: '0.1',
+                priceCurrency: 'USD',
+                pricePerSecond: '0.1',
+                timeUnit: 'second',
+            }, (el) => {
+                act(() => {
+                    el.find(Toggle).props().onChange(false)
+                })
+            })
+
+            expect(price.toString()).toBe('1')
+            expect(pricePerSecond.toString()).toBe('1')
+            expect(priceCurrency.toString()).toBe('DATA')
+            expect(timeUnit).toBe('second')
+        })
+    })
+})

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.test.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.test.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useMemo, useState } from 'react'
 import sinon from 'sinon'
 import { mount } from 'enzyme'
 import { act } from 'react-dom/test-utils'
@@ -8,7 +8,7 @@ import * as BeneficiaryAddress from './BeneficiaryAddress'
 import PriceSelector from './PriceSelector'
 import Select from '$ui/Select'
 import Toggle from '$shared/components/Toggle'
-import { timeUnits } from '$shared/utils/constants'
+import { Context as EditControllerContext } from './EditControllerProvider'
 
 const mockState = {
     product: {
@@ -51,6 +51,25 @@ describe('PriceSelector', () => {
         sandbox.restore()
     })
 
+    // eslint-disable-next-line react/prop-types
+    const EditContextWrap = ({ children }) => {
+        const [preferredCurrency, setPreferredCurrency] = useState('DATA')
+
+        const value = useMemo(() => ({
+            preferredCurrency,
+            setPreferredCurrency,
+        }), [
+            preferredCurrency,
+            setPreferredCurrency,
+        ])
+
+        return (
+            <EditControllerContext.Provider value={value}>
+                {children}
+            </EditControllerContext.Provider>
+        )
+    }
+
     const setup = async (product, transform) => {
         let undoContext
 
@@ -61,11 +80,13 @@ describe('PriceSelector', () => {
         }
 
         const el = mount((
-            <UndoContext.Provider>
-                <ValidationContextProvider>
-                    <WrappedPriceSelector />
-                </ValidationContextProvider>
-            </UndoContext.Provider>
+            <EditContextWrap>
+                <UndoContext.Provider>
+                    <ValidationContextProvider>
+                        <WrappedPriceSelector />
+                    </ValidationContextProvider>
+                </UndoContext.Provider>
+            </EditContextWrap>
         ))
 
         await act(async () => {

--- a/app/src/marketplace/containers/ProductController/tests/useEditableProductActions.test.jsx
+++ b/app/src/marketplace/containers/ProductController/tests/useEditableProductActions.test.jsx
@@ -492,7 +492,7 @@ describe('useEditableProductActions', () => {
                     priceCurrency: contractCurrencies.DATA,
                     price: BN(0),
                 })
-                updater.updatePrice(new BN(8))
+                updater.updatePrice(new BN(8), contractCurrencies.DATA, timeUnits.second)
             })
 
             expect(product).toStrictEqual({
@@ -504,9 +504,7 @@ describe('useEditableProductActions', () => {
             })
             expect(validation.isTouched('pricePerSecond')).toBe(true)
         })
-    })
 
-    describe('updateTimeUnit', () => {
         it('updates the product price time unit', () => {
             let updater
             let product
@@ -538,7 +536,7 @@ describe('useEditableProductActions', () => {
                     priceCurrency: contractCurrencies.DATA,
                     price: BN(60),
                 })
-                updater.updateTimeUnit(timeUnits.minute)
+                updater.updatePrice(BN(60), contractCurrencies.DATA, timeUnits.minute)
             })
 
             expect(product).toStrictEqual({
@@ -550,9 +548,7 @@ describe('useEditableProductActions', () => {
             })
             expect(validation.isTouched('pricePerSecond')).toBe(true)
         })
-    })
 
-    describe('updatePriceCurrency', () => {
         it('updates the product price currency', () => {
             let updater
             let product
@@ -584,7 +580,7 @@ describe('useEditableProductActions', () => {
                     priceCurrency: contractCurrencies.DATA,
                     price: BN(10),
                 })
-                updater.updatePriceCurrency(contractCurrencies.USD)
+                updater.updatePrice(BN(10), contractCurrencies.USD, timeUnits.second)
             })
 
             expect(product).toStrictEqual({
@@ -592,7 +588,7 @@ describe('useEditableProductActions', () => {
                 timeUnit: timeUnits.second,
                 isFree: false,
                 price: new BN(10),
-                pricePerSecond: new BN(100),
+                pricePerSecond: new BN(10),
             })
             expect(validation.isTouched('pricePerSecond')).toBe(true)
         })

--- a/app/src/marketplace/containers/ProductController/useEditableProductActions.js
+++ b/app/src/marketplace/containers/ProductController/useEditableProductActions.js
@@ -1,38 +1,26 @@
 // @flow
 
 import { useMemo, useCallback, useContext } from 'react'
-import { useSelector } from 'react-redux'
 import BN from 'bignumber.js'
 
 import { Context as UndoContext } from '$shared/contexts/Undo'
 import { Context as ValidationContext } from './ValidationContextProvider'
 
 import useEditableProductUpdater from '../ProductController/useEditableProductUpdater'
-import { pricePerSecondFromTimeUnit, convert } from '$mp/utils/price'
-import { contractCurrencies as currencies, timeUnits } from '$shared/utils/constants'
-import { selectDataPerUsd } from '$mp/modules/global/selectors'
+import { pricePerSecondFromTimeUnit } from '$mp/utils/price'
+import { timeUnits } from '$shared/utils/constants'
 
 import type { Product } from '$mp/flowtype/product-types'
 import type { StreamIdList } from '$shared/flowtype/stream-types'
 
-const getPricePerSecond = (isFree, price, currency, timeUnit, dataPerUsd) => {
-    let pricePerSecond
-    if (isFree) {
-        pricePerSecond = BN(0)
-    } else {
-        const newPrice = (currency !== currencies.DATA) ?
-            convert(price || '0', dataPerUsd, currency, currencies.DATA) : price
-        pricePerSecond = pricePerSecondFromTimeUnit(newPrice || BN(0), timeUnit || timeUnits.hour)
-    }
-
-    return pricePerSecond
-}
+const getPricePerSecond = (isFree, price, timeUnit) => (
+    isFree ? BN(0) : pricePerSecondFromTimeUnit(BN(price || 0), timeUnit || timeUnits.hour)
+)
 
 export function useEditableProductActions() {
     const { updateProduct: commit } = useEditableProductUpdater()
     const { undo } = useContext(UndoContext)
     const { touch } = useContext(ValidationContext)
-    const dataPerUsd = useSelector(selectDataPerUsd)
 
     const updateProduct = useCallback((product: Object, msg: string = 'Update product') => {
         commit(msg, (p) => ({
@@ -101,35 +89,25 @@ export function useEditableProductActions() {
                 ...p,
                 isFree,
                 price,
-                pricePerSecond: getPricePerSecond(isFree, price, p.priceCurrency, p.timeUnit, dataPerUsd),
+                pricePerSecond: getPricePerSecond(isFree, price, p.timeUnit),
             }
         })
         touch('pricePerSecond')
-    }, [commit, touch, dataPerUsd])
-    const updatePrice = useCallback((price: $ElementType<Product, 'price'>) => {
+    }, [commit, touch])
+    const updatePrice = useCallback((
+        price: $ElementType<Product, 'price'>,
+        priceCurrency: $ElementType<Product, 'priceCurrency'>,
+        timeUnit: $ElementType<Product, 'timeUnit'>,
+    ) => {
         commit('Update price', (p) => ({
             ...p,
             price,
-            pricePerSecond: getPricePerSecond(p.isFree, price, p.priceCurrency, p.timeUnit, dataPerUsd),
-        }))
-        touch('pricePerSecond')
-    }, [commit, touch, dataPerUsd])
-    const updateTimeUnit = useCallback((timeUnit: $ElementType<Product, 'timeUnit'>) => {
-        commit('Update time unit', (p) => ({
-            ...p,
-            timeUnit,
-            pricePerSecond: getPricePerSecond(p.isFree, p.price, p.priceCurrency, timeUnit, dataPerUsd),
-        }))
-        touch('pricePerSecond')
-    }, [commit, touch, dataPerUsd])
-    const updatePriceCurrency = useCallback((priceCurrency: $ElementType<Product, 'priceCurrency'>) => {
-        commit('Update price currency', (p) => ({
-            ...p,
             priceCurrency,
-            pricePerSecond: getPricePerSecond(p.isFree, p.price, priceCurrency, p.timeUnit, dataPerUsd),
+            pricePerSecond: getPricePerSecond(p.isFree, price, timeUnit),
+            timeUnit,
         }))
         touch('pricePerSecond')
-    }, [commit, touch, dataPerUsd])
+    }, [commit, touch])
     const updateBeneficiaryAddress = useCallback((beneficiaryAddress: $ElementType<Product, 'beneficiaryAddress'>) => {
         commit('Update beneficiary address', (p) => ({
             ...p,
@@ -157,8 +135,6 @@ export function useEditableProductActions() {
         updateAdminFee,
         updateIsFree,
         updatePrice,
-        updateTimeUnit,
-        updatePriceCurrency,
         updateBeneficiaryAddress,
         updateType,
     }), [
@@ -173,8 +149,6 @@ export function useEditableProductActions() {
         updateAdminFee,
         updateIsFree,
         updatePrice,
-        updateTimeUnit,
-        updatePriceCurrency,
         updateBeneficiaryAddress,
         updateType,
     ])


### PR DESCRIPTION
In this PR when "Fix price in fiat" is enabled `priceCurrency` turns into $ and `pricePerSecond` represents $ not DATA. Previously it was \*always\* converted to DATA thus "fixed" was quite loose.

Wrote a buncha specs for it. Hope they're any good (lmk!)

—

_Post-feedback TODO_
- [x] Retain selected currency after switching back from the preview (← @juhah)
- [x] Update styling for the converted amount field (the read-only one) (← @fonty1)
- [x] Convert on change, not on blur (← @fonty1)