### PR TITLE
[PLATFORM-1348] Fix updating contract product price failure

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/usePublish.js
+++ b/app/src/marketplace/containers/EditProductPage/usePublish.js
@@ -89,21 +89,28 @@ export default function usePublish() {
                     id: actionsTypes.UPDATE_ADMIN_FEE,
                     requireWeb3: true,
                     requireOwner: dataUnionOwner,
-                    handler: (update, done) => (
-                        setAdminFee(product.beneficiaryAddress, adminFee)
-                            .onTransactionHash((hash) => {
-                                update(transactionStates.PENDING)
-                                dispatch(addTransaction(hash, transactionTypes.UPDATE_ADMIN_FEE))
-                                done()
-                            })
-                            .onTransactionComplete(() => {
-                                update(transactionStates.CONFIRMED)
-                            })
-                            .onError((error) => {
-                                done()
-                                update(transactionStates.FAILED, error)
-                            })
-                    ),
+                    handler: (update, done) => {
+                        try {
+                            return setAdminFee(product.beneficiaryAddress, adminFee)
+                                .onTransactionHash((hash) => {
+                                    update(transactionStates.PENDING)
+                                    dispatch(addTransaction(hash, transactionTypes.UPDATE_ADMIN_FEE))
+                                    done()
+                                })
+                                .onTransactionComplete(() => {
+                                    update(transactionStates.CONFIRMED)
+                                })
+                                .onError((error) => {
+                                    done()
+                                    update(transactionStates.FAILED, error)
+                                })
+                        } catch (e) {
+                            done()
+                            update(transactionStates.FAILED, e)
+                        }
+
+                        return null
+                    },
                 })
             }
         }
@@ -120,24 +127,31 @@ export default function usePublish() {
                             return null
                         }
 
-                        return updateContractProduct({
-                            ...contractProduct,
-                            pricePerSecond: pricePerSecond || product.pricePerSecond,
-                            beneficiaryAddress: beneficiaryAddress || product.beneficiaryAddress,
-                            priceCurrency: priceCurrency || product.priceCurrency,
-                        })
-                            .onTransactionHash((hash) => {
-                                update(transactionStates.PENDING)
-                                done()
-                                dispatch(addTransaction(hash, transactionTypes.UPDATE_CONTRACT_PRODUCT))
+                        try {
+                            return updateContractProduct({
+                                ...contractProduct,
+                                pricePerSecond: pricePerSecond || product.pricePerSecond,
+                                beneficiaryAddress: beneficiaryAddress || product.beneficiaryAddress,
+                                priceCurrency: priceCurrency || product.priceCurrency,
                             })
-                            .onTransactionComplete(() => {
-                                update(transactionStates.CONFIRMED)
-                            })
-                            .onError((error) => {
-                                done()
-                                update(transactionStates.FAILED, error)
-                            })
+                                .onTransactionHash((hash) => {
+                                    update(transactionStates.PENDING)
+                                    done()
+                                    dispatch(addTransaction(hash, transactionTypes.UPDATE_CONTRACT_PRODUCT))
+                                })
+                                .onTransactionComplete(() => {
+                                    update(transactionStates.CONFIRMED)
+                                })
+                                .onError((error) => {
+                                    done()
+                                    update(transactionStates.FAILED, error)
+                                })
+                        } catch (e) {
+                            done()
+                            update(transactionStates.FAILED, e)
+                        }
+
+                        return null
                     },
                 })
             }
@@ -152,44 +166,58 @@ export default function usePublish() {
                     id: actionsTypes.CREATE_CONTRACT_PRODUCT,
                     requireWeb3: true,
                     requireOwner: dataUnionOwner,
-                    handler: (update, done) => (
-                        createContractProduct({
-                            id: product.id || '',
-                            name: product.name,
-                            beneficiaryAddress: product.beneficiaryAddress,
-                            pricePerSecond: product.pricePerSecond,
-                            priceCurrency: product.priceCurrency,
-                            minimumSubscriptionInSeconds: product.minimumSubscriptionInSeconds,
-                            state: product.state,
-                            ownerAddress: '', // owner address is not needed when creating
-                        })
-                            .onTransactionHash((hash) => {
-                                update(transactionStates.PENDING)
-                                done()
-                                dispatch(addTransaction(hash, transactionTypes.CREATE_CONTRACT_PRODUCT))
-                                postSetDeploying(product.id || '', hash)
+                    handler: (update, done) => {
+                        try {
+                            return createContractProduct({
+                                id: product.id || '',
+                                name: product.name,
+                                beneficiaryAddress: product.beneficiaryAddress,
+                                pricePerSecond: product.pricePerSecond,
+                                priceCurrency: product.priceCurrency,
+                                minimumSubscriptionInSeconds: product.minimumSubscriptionInSeconds,
+                                state: product.state,
+                                ownerAddress: '', // owner address is not needed when creating
                             })
-                            .onTransactionComplete(() => {
-                                update(transactionStates.CONFIRMED)
-                            })
-                            .onError((error) => {
-                                update(transactionStates.FAILED, error)
-                                done()
-                            })
-                    ),
+                                .onTransactionHash((hash) => {
+                                    update(transactionStates.PENDING)
+                                    done()
+                                    dispatch(addTransaction(hash, transactionTypes.CREATE_CONTRACT_PRODUCT))
+                                    postSetDeploying(product.id || '', hash)
+                                })
+                                .onTransactionComplete(() => {
+                                    update(transactionStates.CONFIRMED)
+                                })
+                                .onError((error) => {
+                                    update(transactionStates.FAILED, error)
+                                    done()
+                                })
+                        } catch (e) {
+                            update(transactionStates.FAILED, e)
+                            done()
+                        }
+
+                        return null
+                    },
                 })
             } else {
                 queue.add({
                     id: actionsTypes.PUBLISH_FREE,
-                    handler: (update, done) => (
-                        postDeployFree(product.id || '').then(() => {
-                            update(transactionStates.CONFIRMED)
+                    handler: (update, done) => {
+                        try {
+                            return postDeployFree(product.id || '').then(() => {
+                                update(transactionStates.CONFIRMED)
+                                done()
+                            }, (error) => {
+                                update(transactionStates.FAILED, error)
+                                done()
+                            })
+                        } catch (e) {
+                            update(transactionStates.FAILED, e)
                             done()
-                        }, (error) => {
-                            update(transactionStates.FAILED, error)
-                            done()
-                        })
-                    ),
+                        }
+
+                        return null
+                    },
                 })
             }
         }
@@ -200,22 +228,29 @@ export default function usePublish() {
                 id: actionsTypes.REDEPLOY_PAID,
                 requireWeb3: true,
                 requireOwner: contractProduct.ownerAddress,
-                handler: (update, done) => (
-                    redeployProduct(product.id || '')
-                        .onTransactionHash((hash) => {
-                            update(transactionStates.PENDING)
-                            done()
-                            dispatch(addTransaction(hash, transactionTypes.REDEPLOY_PRODUCT))
-                            postSetDeploying(product.id || '', hash)
-                        })
-                        .onTransactionComplete(() => {
-                            update(transactionStates.CONFIRMED)
-                        })
-                        .onError((error) => {
-                            update(transactionStates.FAILED, error)
-                            done()
-                        })
-                ),
+                handler: (update, done) => {
+                    try {
+                        return redeployProduct(product.id || '')
+                            .onTransactionHash((hash) => {
+                                update(transactionStates.PENDING)
+                                done()
+                                dispatch(addTransaction(hash, transactionTypes.REDEPLOY_PRODUCT))
+                                postSetDeploying(product.id || '', hash)
+                            })
+                            .onTransactionComplete(() => {
+                                update(transactionStates.CONFIRMED)
+                            })
+                            .onError((error) => {
+                                update(transactionStates.FAILED, error)
+                                done()
+                            })
+                    } catch (e) {
+                        update(transactionStates.FAILED, e)
+                        done()
+                    }
+
+                    return null
+                },
             })
         }
 
@@ -226,35 +261,49 @@ export default function usePublish() {
                     id: actionsTypes.UNDEPLOY_CONTRACT_PRODUCT,
                     requireWeb3: true,
                     requireOwner: contractProduct.ownerAddress,
-                    handler: (update, done) => (
-                        deleteProduct(product.id || '')
-                            .onTransactionHash((hash) => {
-                                update(transactionStates.PENDING)
-                                done()
-                                dispatch(addTransaction(hash, transactionTypes.UNDEPLOY_PRODUCT))
-                                postSetUndeploying(product.id || '', hash)
-                            })
-                            .onTransactionComplete(() => {
-                                update(transactionStates.CONFIRMED)
-                            })
-                            .onError((error) => {
-                                update(transactionStates.FAILED, error)
-                                done()
-                            })
-                    ),
+                    handler: (update, done) => {
+                        try {
+                            return deleteProduct(product.id || '')
+                                .onTransactionHash((hash) => {
+                                    update(transactionStates.PENDING)
+                                    done()
+                                    dispatch(addTransaction(hash, transactionTypes.UNDEPLOY_PRODUCT))
+                                    postSetUndeploying(product.id || '', hash)
+                                })
+                                .onTransactionComplete(() => {
+                                    update(transactionStates.CONFIRMED)
+                                })
+                                .onError((error) => {
+                                    update(transactionStates.FAILED, error)
+                                    done()
+                                })
+                        } catch (e) {
+                            update(transactionStates.FAILED, e)
+                            done()
+                        }
+
+                        return null
+                    },
                 })
             } else {
                 queue.add({
                     id: actionsTypes.UNPUBLISH_FREE,
-                    handler: (update, done) => (
-                        postUndeployFree(product.id || '').then(() => {
-                            update(transactionStates.CONFIRMED)
+                    handler: (update, done) => {
+                        try {
+                            return postUndeployFree(product.id || '').then(() => {
+                                update(transactionStates.CONFIRMED)
+                                done()
+                            }, (error) => {
+                                update(transactionStates.FAILED, error)
+                                done()
+                            })
+                        } catch (e) {
+                            update(transactionStates.FAILED, e)
                             done()
-                        }, (error) => {
-                            update(transactionStates.FAILED, error)
-                            done()
-                        })
-                    ),
+                        }
+
+                        return null
+                    },
                 })
             }
         }
@@ -263,19 +312,26 @@ export default function usePublish() {
         if (nextMode === publishModes.REPUBLISH) {
             queue.add({
                 id: actionsTypes.PUBLISH_PENDING_CHANGES,
-                handler: (update, done) => (
-                    putProduct({
-                        ...product,
-                        ...productDataChanges,
-                        pendingChanges: undefined,
-                    }, product.id || '').then(() => {
-                        update(transactionStates.CONFIRMED)
+                handler: (update, done) => {
+                    try {
+                        return putProduct({
+                            ...product,
+                            ...productDataChanges,
+                            pendingChanges: undefined,
+                        }, product.id || '').then(() => {
+                            update(transactionStates.CONFIRMED)
+                            done()
+                        }, (error) => {
+                            update(transactionStates.FAILED, error)
+                            done()
+                        })
+                    } catch (e) {
+                        update(transactionStates.FAILED, e)
                         done()
-                    }, (error) => {
-                        update(transactionStates.FAILED, error)
-                        done()
-                    })
-                ),
+                    }
+
+                    return null
+                },
             })
         }
 

--- a/app/src/marketplace/modules/createContractProduct/services.js
+++ b/app/src/marketplace/modules/createContractProduct/services.js
@@ -6,7 +6,6 @@ import { contractCurrencies as currencies, gasLimits } from '$shared/utils/const
 
 import type { SmartContractProduct } from '$mp/flowtype/product-types'
 import type { SmartContractTransaction } from '$shared/flowtype/web3-types'
-import type { Sendable } from '$mp/utils/smartContract'
 import {
     mapPriceToContract, validateProductPriceCurrency,
     validateContractProductPricePerSecond, getValidId,
@@ -14,7 +13,7 @@ import {
 
 const contractMethods = () => getContract(getConfig().marketplace).methods
 
-const createOrUpdateContractProduct = (method: (...any) => Sendable, product: SmartContractProduct): SmartContractTransaction => {
+export const createContractProduct = (product: SmartContractProduct): SmartContractTransaction => {
     const {
         id,
         name,
@@ -27,17 +26,42 @@ const createOrUpdateContractProduct = (method: (...any) => Sendable, product: Sm
     validateContractProductPricePerSecond(pricePerSecond)
     validateProductPriceCurrency(priceCurrency)
     const transformedPricePerSecond = mapPriceToContract(pricePerSecond)
-    const methodToSend =
-        method(getValidId(id), name, beneficiaryAddress, transformedPricePerSecond, currencyIndex, minimumSubscriptionInSeconds, false)
+    const methodToSend = contractMethods().createProduct(
+        getValidId(id),
+        name,
+        beneficiaryAddress,
+        transformedPricePerSecond,
+        currencyIndex,
+        minimumSubscriptionInSeconds,
+    )
     return send(methodToSend, {
         gas: gasLimits.CREATE_PRODUCT,
     })
 }
 
-export const createContractProduct = (product: SmartContractProduct): SmartContractTransaction => (
-    createOrUpdateContractProduct(contractMethods().createProduct, product)
-)
-
-export const updateContractProduct = (product: SmartContractProduct): SmartContractTransaction => (
-    createOrUpdateContractProduct(contractMethods().updateProduct, product)
-)
+export const updateContractProduct = (product: SmartContractProduct): SmartContractTransaction => {
+    const {
+        id,
+        name,
+        beneficiaryAddress,
+        pricePerSecond,
+        priceCurrency,
+        minimumSubscriptionInSeconds,
+    } = product
+    const currencyIndex = Object.keys(currencies).indexOf(priceCurrency)
+    validateContractProductPricePerSecond(pricePerSecond)
+    validateProductPriceCurrency(priceCurrency)
+    const transformedPricePerSecond = mapPriceToContract(pricePerSecond)
+    const methodToSend = contractMethods().updateProduct(
+        getValidId(id),
+        name,
+        beneficiaryAddress,
+        transformedPricePerSecond,
+        currencyIndex,
+        minimumSubscriptionInSeconds,
+        false,
+    )
+    return send(methodToSend, {
+        gas: gasLimits.UPDATE_PRODUCT,
+    })
+}

--- a/app/src/marketplace/modules/createContractProduct/services.js
+++ b/app/src/marketplace/modules/createContractProduct/services.js
@@ -28,7 +28,7 @@ const createOrUpdateContractProduct = (method: (...any) => Sendable, product: Sm
     validateProductPriceCurrency(priceCurrency)
     const transformedPricePerSecond = mapPriceToContract(pricePerSecond)
     const methodToSend =
-        method(getValidId(id), name, beneficiaryAddress, transformedPricePerSecond, currencyIndex, minimumSubscriptionInSeconds)
+        method(getValidId(id), name, beneficiaryAddress, transformedPricePerSecond, currencyIndex, minimumSubscriptionInSeconds, false)
     return send(methodToSend, {
         gas: gasLimits.CREATE_PRODUCT,
     })

--- a/app/src/shared/utils/constants.js
+++ b/app/src/shared/utils/constants.js
@@ -73,7 +73,7 @@ export const transactionTypes = {
 export const gasLimits = {
     DEFAULT: 3e5,
     CREATE_PRODUCT: 4e5,
-    UPDATE_PRODUCT: 4e5,
+    UPDATE_PRODUCT: 3e5,
     BUY_PRODUCT: 3e5,
     BUY_PRODUCT_WITH_ETH: 5e5,
     BUY_PRODUCT_WITH_ERC20: 6e5,

--- a/app/src/shared/utils/constants.js
+++ b/app/src/shared/utils/constants.js
@@ -73,6 +73,7 @@ export const transactionTypes = {
 export const gasLimits = {
     DEFAULT: 3e5,
     CREATE_PRODUCT: 4e5,
+    UPDATE_PRODUCT: 4e5,
     BUY_PRODUCT: 3e5,
     BUY_PRODUCT_WITH_ETH: 5e5,
     BUY_PRODUCT_WITH_ERC20: 6e5,

--- a/app/test/unit/modules/createContractProduct/services.test.js
+++ b/app/test/unit/modules/createContractProduct/services.test.js
@@ -168,7 +168,7 @@ describe('Product services', () => {
             }))
             all.createContractProduct(exampleProduct)
             assert(createProductSpy.calledOnce)
-            assert(createProductSpy.calledWith(
+            assert(createProductSpy.calledWithExactly(
                 '0x1234abcdef',
                 'Awesome Granite Sausages',
                 '0xaf16ea680090e81af0acf5e2664a19a37f5a3c43',
@@ -190,7 +190,7 @@ describe('Product services', () => {
                 priceCurrency: 'USD',
             })
             assert(createProductSpy.calledOnce)
-            assert(createProductSpy.calledWith(
+            assert(createProductSpy.calledWithExactly(
                 '0x1234abcdef',
                 'Awesome Granite Sausages',
                 '0xaf16ea680090e81af0acf5e2664a19a37f5a3c43',
@@ -350,18 +350,19 @@ describe('Product services', () => {
             sandbox.stub(utils, 'send')
             sandbox.stub(utils, 'getContract').callsFake(() => ({
                 methods: {
-                    createProduct: updateProductSpy,
+                    updateProduct: updateProductSpy,
                 },
             }))
-            all.createContractProduct(exampleProduct)
+            all.updateContractProduct(exampleProduct)
             assert(updateProductSpy.calledOnce)
-            assert(updateProductSpy.calledWith(
+            assert(updateProductSpy.calledWithExactly(
                 '0x1234abcdef',
                 'Awesome Granite Sausages',
                 '0xaf16ea680090e81af0acf5e2664a19a37f5a3c43',
                 '63000000000000000000',
                 0,
                 0,
+                false,
             ))
         })
         it('must call updateProductSpy with correct params (when USD)', () => {
@@ -369,21 +370,22 @@ describe('Product services', () => {
             sandbox.stub(utils, 'send')
             sandbox.stub(utils, 'getContract').callsFake(() => ({
                 methods: {
-                    createProduct: updateProductSpy,
+                    updateProduct: updateProductSpy,
                 },
             }))
-            all.createContractProduct({
+            all.updateContractProduct({
                 ...exampleProduct,
                 priceCurrency: 'USD',
             })
             assert(updateProductSpy.calledOnce)
-            assert(updateProductSpy.calledWith(
+            assert(updateProductSpy.calledWithExactly(
                 '0x1234abcdef',
                 'Awesome Granite Sausages',
                 '0xaf16ea680090e81af0acf5e2664a19a37f5a3c43',
                 '63000000000000000000',
                 1,
                 0,
+                false,
             ))
         })
     })


### PR DESCRIPTION
Fixes failing `updateContractProduct` call when updating published product's price. Also added some checks to publish dialog so that it shows the error even when the transaction fails before it has started, before it just got stuck while waiting for progress.