### PR TITLE
[PLATFORM-1344] Use session token to initiate the `StreamrClient` instead of API key

### DIFF
--- a/app/src/editor/shared/tests/Client.test.jsx
+++ b/app/src/editor/shared/tests/Client.test.jsx
@@ -2,14 +2,12 @@ import React, { useContext } from 'react'
 import { mount } from 'enzyme'
 import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
 import { act } from 'react-dom/test-utils'
-import api from '../utils/api'
-
-import * as Services from '../services'
 import { ClientProviderComponent, Context as ClientContext } from '$shared/contexts/StreamrClient'
+import SessionProvider from '$auth/components/SessionProvider'
 
 describe('Client', () => {
     let teardown
-    let apiKey
+    let sessionToken
 
     beforeAll(async () => {
         teardown = await setupAuthorizationHeader()
@@ -20,8 +18,7 @@ describe('Client', () => {
     })
 
     beforeAll(async () => {
-        const [key] = await api().get(`${process.env.STREAMR_API_URL}/users/me/keys`).then(Services.getData)
-        apiKey = key.id
+        sessionToken = SessionProvider.token()
     })
 
     it('creates client on mount, can unmount', (done) => {
@@ -32,7 +29,7 @@ describe('Client', () => {
         }
 
         const result = mount((
-            <ClientProviderComponent apiKey={apiKey}>
+            <ClientProviderComponent sessionToken={sessionToken}>
                 <Test />
             </ClientProviderComponent>
         ))
@@ -54,7 +51,7 @@ describe('Client', () => {
         }
 
         const result = mount((
-            <ClientProviderComponent apiKey={apiKey}>
+            <ClientProviderComponent sessionToken={sessionToken}>
                 <Test />
             </ClientProviderComponent>
         ))
@@ -85,7 +82,7 @@ describe('Client', () => {
         }
 
         const result = mount((
-            <ClientProviderComponent apiKey={apiKey}>
+            <ClientProviderComponent sessionToken={sessionToken}>
                 <Test />
             </ClientProviderComponent>
         ))
@@ -110,7 +107,7 @@ describe('Client', () => {
         }
 
         const result = mount((
-            <ClientProviderComponent apiKey={apiKey}>
+            <ClientProviderComponent sessionToken={sessionToken}>
                 <Test />
             </ClientProviderComponent>
         ))

--- a/app/src/editor/shared/tests/ModuleSubscription.test.jsx
+++ b/app/src/editor/shared/tests/ModuleSubscription.test.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { mount } from 'enzyme'
 
 import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/tests/utils'
-import api from '$editor/shared/utils/api'
 import { ClientProviderComponent, createClient } from '$shared/contexts/StreamrClient'
 import ModuleSubscription from '$editor/shared/components/ModuleSubscription'
+import SessionProvider from '$auth/components/SessionProvider'
 import * as State from '$editor/canvas/state'
 import * as Services from '$editor/canvas/services'
 
@@ -18,7 +18,7 @@ function wait(delay) {
 
 describe('Canvas Subscriptions', () => {
     let teardown
-    let apiKey
+    let sessionToken
 
     beforeAll(async () => {
         teardown = await setupAuthorizationHeader()
@@ -29,15 +29,14 @@ describe('Canvas Subscriptions', () => {
     })
 
     beforeAll(async () => {
-        const [key] = await api().get(`${process.env.STREAMR_API_URL}/users/me/keys`).then(({ data }) => data)
-        apiKey = key.id
+        sessionToken = SessionProvider.token()
     })
 
     describe('create subscription', () => {
         let client
 
         async function setup() {
-            client = await createClient(apiKey)
+            client = await createClient(sessionToken)
             client.on('error', throwError)
         }
 
@@ -68,7 +67,7 @@ describe('Canvas Subscriptions', () => {
             const messages = []
 
             const result = mount((
-                <ClientProviderComponent apiKey={apiKey}>
+                <ClientProviderComponent sessionToken={sessionToken}>
                     <ModuleSubscription
                         module={runningTable}
                         onMessage={(message) => {
@@ -103,7 +102,7 @@ describe('Canvas Subscriptions', () => {
             const messages = []
 
             const result = mount((
-                <ClientProviderComponent apiKey={apiKey}>
+                <ClientProviderComponent sessionToken={sessionToken}>
                     <ModuleSubscription
                         module={canvas.modules.find((m) => m.name === 'Table')}
                         onMessage={(message) => {

--- a/app/src/editor/shared/tests/Subscription.test.jsx
+++ b/app/src/editor/shared/tests/Subscription.test.jsx
@@ -4,10 +4,9 @@ import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
 import { act } from 'react-dom/test-utils'
 import uniqueId from 'lodash/uniqueId'
 
-import api from '../utils/api'
-import * as Services from '../services'
 import { ClientProviderComponent, createClient } from '$shared/contexts/StreamrClient'
 import Subscription from '$shared/components/Subscription'
+import SessionProvider from '$auth/components/SessionProvider'
 
 function throwError(err) {
     throw err
@@ -19,7 +18,7 @@ function wait(delay) {
 
 describe('Subscription', () => {
     let teardown
-    let apiKey
+    let sessionToken
 
     beforeAll(async () => {
         teardown = await setupAuthorizationHeader()
@@ -30,8 +29,7 @@ describe('Subscription', () => {
     })
 
     beforeAll(async () => {
-        const [key] = await api().get(`${process.env.STREAMR_API_URL}/users/me/keys`).then(Services.getData)
-        apiKey = key.id
+        sessionToken = SessionProvider.token()
     })
 
     describe('create subscription', () => {
@@ -39,7 +37,7 @@ describe('Subscription', () => {
         let stream
 
         async function setup() {
-            client = await createClient(apiKey)
+            client = await createClient(sessionToken)
             client.on('error', throwError)
             stream = await client.getOrCreateStream({
                 name: uniqueId(),
@@ -67,7 +65,7 @@ describe('Subscription', () => {
             const Test = () => {
                 const [isActive, setIsActive] = useState(true)
                 return (
-                    <ClientProviderComponent apiKey={apiKey}>
+                    <ClientProviderComponent sessionToken={sessionToken}>
                         <Subscription
                             uiChannel={stream}
                             onSubscribed={() => {
@@ -90,7 +88,7 @@ describe('Subscription', () => {
         it('can create subscription', async (done) => {
             const msg = { test: uniqueId() }
             const result = mount((
-                <ClientProviderComponent apiKey={apiKey}>
+                <ClientProviderComponent sessionToken={sessionToken}>
                     <Subscription
                         uiChannel={stream}
                         onSubscribed={() => {
@@ -110,7 +108,7 @@ describe('Subscription', () => {
         it('unsubscribes on unmount', async (done) => {
             const sub = React.createRef()
             const result = mount((
-                <ClientProviderComponent apiKey={apiKey}>
+                <ClientProviderComponent sessionToken={sessionToken}>
                     <Subscription
                         ref={sub}
                         uiChannel={stream}
@@ -137,7 +135,7 @@ describe('Subscription', () => {
             const messages = []
             const onResending = jest.fn()
             const result = mount((
-                <ClientProviderComponent apiKey={apiKey}>
+                <ClientProviderComponent sessionToken={sessionToken}>
                     <Subscription
                         uiChannel={stream}
                         resendLast={2}
@@ -170,7 +168,7 @@ describe('Subscription', () => {
             await wait(10000) // wait for above messages to flush
 
             const result = mount((
-                <ClientProviderComponent apiKey={apiKey}>
+                <ClientProviderComponent sessionToken={sessionToken}>
                     <Subscription
                         uiChannel={stream}
                         resendLast={2}
@@ -209,7 +207,7 @@ describe('Subscription', () => {
             await wait(10000) // wait for above messages to flush
 
             const result = mount((
-                <ClientProviderComponent apiKey={apiKey}>
+                <ClientProviderComponent sessionToken={sessionToken}>
                     <Subscription
                         uiChannel={stream}
                         resendLast={0}

--- a/app/src/shared/contexts/StreamrClient/index.jsx
+++ b/app/src/shared/contexts/StreamrClient/index.jsx
@@ -9,32 +9,29 @@
 import React, { type Node, type Context, useState, useEffect, useLayoutEffect, useCallback, useMemo } from 'react'
 import { connect } from 'react-redux'
 import StreamrClient from 'streamr-client'
+import SessionProvider from '$auth/components/SessionProvider'
 
-import { selectAuthApiKeyId } from '$shared/modules/resourceKey/selectors'
-import { getMyResourceKeys } from '$shared/modules/resourceKey/actions'
 import { selectAuthState } from '$shared/modules/user/selectors'
 import useIsMountedRef from '$shared/hooks/useIsMountedRef'
-import { usePending } from '$shared/hooks/usePending'
-import type { ResourceKeyId } from '$shared/flowtype/resource-key-types'
 
 export type ContextProps = {
     hasLoaded: boolean,
     client: any,
-    apiKey: ?ResourceKeyId,
+    sessionToken: ?string,
 }
 
 export const ClientContext: Context<ContextProps> = React.createContext({
     hasLoaded: false,
     client: undefined,
-    apiKey: undefined,
+    sessionToken: undefined,
 })
 
-export function createClient(apiKey: ?ResourceKeyId) {
+export function createClient(sessionToken: ?string) {
     return new StreamrClient({
         url: process.env.STREAMR_WS_URL,
         restUrl: process.env.STREAMR_API_URL,
-        auth: apiKey == null ? {} : {
-            apiKey,
+        auth: sessionToken == null ? {} : {
+            sessionToken,
         },
         autoConnect: true,
         autoDisconnect: false,
@@ -42,34 +39,16 @@ export function createClient(apiKey: ?ResourceKeyId) {
 }
 
 type ClientProviderProps = {
-    apiKey: ?ResourceKeyId,
-    loadKeys: Function,
+    sessionToken: ?string,
     isAuthenticating: boolean,
     authenticationFailed: boolean,
 }
 
-function useClientProvider({ apiKey, loadKeys, isAuthenticating, authenticationFailed }: ClientProviderProps) {
+function useClientProvider({ sessionToken, isAuthenticating, authenticationFailed }: ClientProviderProps) {
     const [client, setClient] = useState()
     const isMountedRef = useIsMountedRef()
     const hasClient = !!client
-    const hasLoaded = !!apiKey || !!(!isAuthenticating && authenticationFailed)
-    const loadKeyPending = usePending('client.key')
-
-    useEffect(() => {
-        // do nothing if waiting to auth
-        if (hasLoaded || loadKeyPending.isPending) { return }
-        loadKeyPending.wrap(() => (
-            loadKeys().catch((error) => {
-                if (!isMountedRef.current) { return }
-                if (error.statusCode === 401 || error.statusCode === 403) {
-                    // ignore 401/403
-                    return
-                }
-
-                throw error
-            })
-        ))
-    }, [loadKeys, loadKeyPending, isMountedRef, hasLoaded])
+    const hasLoaded = !!sessionToken || !!(!isAuthenticating && authenticationFailed)
 
     const reset = useCallback(() => {
         if (!client) { return }
@@ -92,13 +71,13 @@ function useClientProvider({ apiKey, loadKeys, isAuthenticating, authenticationF
         client.connection.once('disconnected', reset)
         client.once('error', reset)
         return reset // reset to cleanup
-    }, [reset, client, apiKey])
+    }, [reset, client, sessionToken])
 
     // (re)create client if none
     useLayoutEffect(() => {
         if (hasClient || !hasLoaded) { return }
-        setClient(createClient(apiKey))
-    }, [hasClient, setClient, apiKey, hasLoaded])
+        setClient(createClient(sessionToken))
+    }, [hasClient, setClient, sessionToken, hasLoaded])
 
     // disconnect on unmount/client change
     useEffect(() => {
@@ -111,8 +90,8 @@ function useClientProvider({ apiKey, loadKeys, isAuthenticating, authenticationF
     return useMemo(() => ({
         hasLoaded,
         client,
-        apiKey,
-    }), [client, apiKey, hasLoaded])
+        sessionToken,
+    }), [client, sessionToken, hasLoaded])
 }
 
 type Props = ClientProviderProps & {
@@ -128,13 +107,12 @@ export function ClientProviderComponent({ children, ...props }: Props) {
     )
 }
 
-const withAuthApiKey = connect((state) => ({
-    apiKey: selectAuthApiKeyId(state),
-}), {
-    loadKeys: getMyResourceKeys,
+const mapStateToProps = (state) => ({
+    ...selectAuthState(state),
+    sessionToken: SessionProvider.token(),
 })
 
-export const ClientProvider = withAuthApiKey(connect(selectAuthState)(ClientProviderComponent))
+export const ClientProvider = connect(mapStateToProps)(ClientProviderComponent)
 
 export {
     ClientProvider as Provider,


### PR DESCRIPTION
We should use the same session token that we are using for HTTP requests to init the StreamrClient instead of API key.

Note: There is another `StreamrClientProvider` under `userpages` which will be removed in #969.