### PR TITLE
Refactor session token storage

### DIFF
--- a/app/src/auth/components/SessionProvider/index.jsx
+++ b/app/src/auth/components/SessionProvider/index.jsx
@@ -3,72 +3,21 @@
 /* eslint-disable react/no-unused-state */
 
 import React, { type Node, useEffect, useState, useMemo } from 'react'
-
 import Context from '$auth/contexts/Session'
-import { isLocalStorageAvailable } from '$shared/utils/storage'
-
-export const SESSION_TOKEN_KEY = 'session.token'
-export const SESSION_LOGIN_TIME = 'session.loginTime'
-export const EXPIRES_AT_VALID_HOURS = 6
+import { store, retrieve } from '$shared/utils/sessionToken'
 
 type Props = {
     children: Node,
 }
 
-const storage = isLocalStorageAvailable() ? window.localStorage : null
-
-let cachedToken // fallback if no webstorage
-let cachedDate
-
-function getStoredToken(): ?string {
-    let date
-    let token
-    if (!storage) {
-        token = cachedToken || null
-        date = cachedDate || null
-    } else {
-        token = storage.getItem(SESSION_TOKEN_KEY) || null
-        date = storage.getItem(SESSION_LOGIN_TIME) || null
-        date = date ? new Date(date) : null
-    }
-
-    if (date) {
-        // token expires after login time + interval
-        date.setHours(date.getHours() + EXPIRES_AT_VALID_HOURS)
-
-        return ((date.getTime() - Date.now()) > 0) ? token : null
-    }
-
-    return null
-}
-
-function storeToken(value?: ?string) {
-    const loginTime = new Date()
-
-    if (!storage) {
-        cachedToken = value || null
-        cachedDate = loginTime
-        return
-    }
-
-    if (value) {
-        storage.setItem(SESSION_TOKEN_KEY, value)
-        storage.setItem(SESSION_LOGIN_TIME, loginTime)
-    } else {
-        // remove entire key if not set
-        storage.removeItem(SESSION_TOKEN_KEY)
-        storage.removeItem(SESSION_LOGIN_TIME)
-    }
-}
-
 function SessionProvider(props: Props) {
     const { children } = props
 
-    const [token, setSessionToken] = useState(getStoredToken())
+    const [token, setSessionToken] = useState(retrieve())
 
     useEffect(() => {
         // update storage when token changes
-        storeToken(token)
+        store(token)
     }, [token])
 
     const sessionProvider = useMemo(() => ({
@@ -82,8 +31,5 @@ function SessionProvider(props: Props) {
         </Context.Provider>
     )
 }
-
-SessionProvider.token = (): ?string => getStoredToken()
-SessionProvider.storeToken = storeToken
 
 export default SessionProvider

--- a/app/src/auth/components/SessionProvider/index.jsx
+++ b/app/src/auth/components/SessionProvider/index.jsx
@@ -4,7 +4,7 @@
 
 import React, { type Node, useEffect, useState, useMemo } from 'react'
 import Context from '$auth/contexts/Session'
-import { store, retrieve } from '$shared/utils/sessionToken'
+import { setToken, getToken } from '$shared/utils/sessionToken'
 
 type Props = {
     children: Node,
@@ -13,11 +13,11 @@ type Props = {
 function SessionProvider(props: Props) {
     const { children } = props
 
-    const [token, setSessionToken] = useState(retrieve())
+    const [token, setSessionToken] = useState(getToken())
 
     useEffect(() => {
         // update storage when token changes
-        store(token)
+        setToken(token)
     }, [token])
 
     const sessionProvider = useMemo(() => ({

--- a/app/src/auth/tests/SessionProvider.test.jsx
+++ b/app/src/auth/tests/SessionProvider.test.jsx
@@ -4,7 +4,8 @@ import { act } from 'react-dom/test-utils'
 
 import Context from '$auth/contexts/Session'
 
-import SessionProvider, { SESSION_TOKEN_KEY, SESSION_LOGIN_TIME } from '$auth/components/SessionProvider'
+import SessionProvider from '$auth/components/SessionProvider'
+import { SESSION_TOKEN_KEY, SESSION_LOGIN_TIME } from '$shared/utils/sessionToken'
 
 describe('SessionProvider', () => {
     let realDate

--- a/app/src/editor/shared/tests/Client.test.jsx
+++ b/app/src/editor/shared/tests/Client.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme'
 import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
 import { act } from 'react-dom/test-utils'
 import { ClientProviderComponent, Context as ClientContext } from '$shared/contexts/StreamrClient'
-import SessionProvider from '$auth/components/SessionProvider'
+import { retrieve } from '$shared/utils/sessionToken'
 
 describe('Client', () => {
     let teardown
@@ -18,7 +18,7 @@ describe('Client', () => {
     })
 
     beforeAll(async () => {
-        sessionToken = SessionProvider.token()
+        sessionToken = retrieve()
     })
 
     it('creates client on mount, can unmount', (done) => {

--- a/app/src/editor/shared/tests/Client.test.jsx
+++ b/app/src/editor/shared/tests/Client.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme'
 import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
 import { act } from 'react-dom/test-utils'
 import { ClientProviderComponent, Context as ClientContext } from '$shared/contexts/StreamrClient'
-import { retrieve } from '$shared/utils/sessionToken'
+import { getToken } from '$shared/utils/sessionToken'
 
 describe('Client', () => {
     let teardown
@@ -18,7 +18,7 @@ describe('Client', () => {
     })
 
     beforeAll(async () => {
-        sessionToken = retrieve()
+        sessionToken = getToken()
     })
 
     it('creates client on mount, can unmount', (done) => {

--- a/app/src/editor/shared/tests/ModuleSubscription.test.jsx
+++ b/app/src/editor/shared/tests/ModuleSubscription.test.jsx
@@ -6,7 +6,7 @@ import { ClientProviderComponent, createClient } from '$shared/contexts/StreamrC
 import ModuleSubscription from '$editor/shared/components/ModuleSubscription'
 import * as State from '$editor/canvas/state'
 import * as Services from '$editor/canvas/services'
-import { retrieve } from '$shared/utils/sessionToken'
+import { getToken } from '$shared/utils/sessionToken'
 
 function throwError(err) {
     throw err
@@ -29,7 +29,7 @@ describe('Canvas Subscriptions', () => {
     })
 
     beforeAll(async () => {
-        sessionToken = retrieve()
+        sessionToken = getToken()
     })
 
     describe('create subscription', () => {

--- a/app/src/editor/shared/tests/ModuleSubscription.test.jsx
+++ b/app/src/editor/shared/tests/ModuleSubscription.test.jsx
@@ -4,9 +4,9 @@ import { mount } from 'enzyme'
 import { setupAuthorizationHeader, loadModuleDefinition } from '$editor/shared/tests/utils'
 import { ClientProviderComponent, createClient } from '$shared/contexts/StreamrClient'
 import ModuleSubscription from '$editor/shared/components/ModuleSubscription'
-import SessionProvider from '$auth/components/SessionProvider'
 import * as State from '$editor/canvas/state'
 import * as Services from '$editor/canvas/services'
+import { retrieve } from '$shared/utils/sessionToken'
 
 function throwError(err) {
     throw err
@@ -29,7 +29,7 @@ describe('Canvas Subscriptions', () => {
     })
 
     beforeAll(async () => {
-        sessionToken = SessionProvider.token()
+        sessionToken = retrieve()
     })
 
     describe('create subscription', () => {

--- a/app/src/editor/shared/tests/Subscription.test.jsx
+++ b/app/src/editor/shared/tests/Subscription.test.jsx
@@ -6,7 +6,7 @@ import uniqueId from 'lodash/uniqueId'
 
 import { ClientProviderComponent, createClient } from '$shared/contexts/StreamrClient'
 import Subscription from '$shared/components/Subscription'
-import { retrieve } from '$shared/utils/sessionToken'
+import { getToken } from '$shared/utils/sessionToken'
 
 function throwError(err) {
     throw err
@@ -29,7 +29,7 @@ describe('Subscription', () => {
     })
 
     beforeAll(async () => {
-        sessionToken = retrieve()
+        sessionToken = getToken()
     })
 
     describe('create subscription', () => {

--- a/app/src/editor/shared/tests/Subscription.test.jsx
+++ b/app/src/editor/shared/tests/Subscription.test.jsx
@@ -6,7 +6,7 @@ import uniqueId from 'lodash/uniqueId'
 
 import { ClientProviderComponent, createClient } from '$shared/contexts/StreamrClient'
 import Subscription from '$shared/components/Subscription'
-import SessionProvider from '$auth/components/SessionProvider'
+import { retrieve } from '$shared/utils/sessionToken'
 
 function throwError(err) {
     throw err
@@ -29,7 +29,7 @@ describe('Subscription', () => {
     })
 
     beforeAll(async () => {
-        sessionToken = SessionProvider.token()
+        sessionToken = retrieve()
     })
 
     describe('create subscription', () => {

--- a/app/src/editor/shared/tests/utils.js
+++ b/app/src/editor/shared/tests/utils.js
@@ -1,7 +1,7 @@
 import keythereum from 'keythereum'
 import StreamrClient from 'streamr-client'
 import * as Services from '../services'
-import SessionProvider from '$auth/components/SessionProvider'
+import { store } from '$shared/utils/sessionToken'
 
 /**
  * Creates a client for a new, generated user.
@@ -33,10 +33,10 @@ export async function setupAuthorizationHeader() {
     await client.connect()
     const sessionToken = await client.session.getSessionToken() // returns a Promise that resolves with session token
 
-    SessionProvider.storeToken(sessionToken)
+    store(sessionToken)
 
     return async () => {
-        SessionProvider.storeToken(null)
+        store(null)
 
         if (client && client.connection) {
             await client.disconnect()

--- a/app/src/editor/shared/tests/utils.js
+++ b/app/src/editor/shared/tests/utils.js
@@ -1,7 +1,7 @@
 import keythereum from 'keythereum'
 import StreamrClient from 'streamr-client'
 import * as Services from '../services'
-import { store } from '$shared/utils/sessionToken'
+import { setToken } from '$shared/utils/sessionToken'
 
 /**
  * Creates a client for a new, generated user.
@@ -33,10 +33,10 @@ export async function setupAuthorizationHeader() {
     await client.connect()
     const sessionToken = await client.session.getSessionToken() // returns a Promise that resolves with session token
 
-    store(sessionToken)
+    setToken(sessionToken)
 
     return async () => {
-        store(null)
+        setToken(null)
 
         if (client && client.connection) {
             await client.disconnect()

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -18,7 +18,7 @@ import LoadingIndicator from '$shared/components/LoadingIndicator'
 import PurchaseModal from './PurchaseModal'
 import useProduct from '$mp/containers/ProductController/useProduct'
 import { selectUserData } from '$shared/modules/user/selectors'
-import { retrieve } from '$shared/utils/sessionToken'
+import { getToken } from '$shared/utils/sessionToken'
 
 import Page from './Page'
 import styles from './page.pcss'
@@ -34,7 +34,7 @@ const ProductPage = () => {
     } = useController()
     const product = useProduct()
     const userData = useSelector(selectUserData)
-    const isLoggedIn = userData !== null && !!retrieve()
+    const isLoggedIn = userData !== null && !!getToken()
 
     const { match } = useContext(RouterContext.Context)
 

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -18,7 +18,7 @@ import LoadingIndicator from '$shared/components/LoadingIndicator'
 import PurchaseModal from './PurchaseModal'
 import useProduct from '$mp/containers/ProductController/useProduct'
 import { selectUserData } from '$shared/modules/user/selectors'
-import SessionProvider from '$auth/components/SessionProvider'
+import { retrieve } from '$shared/utils/sessionToken'
 
 import Page from './Page'
 import styles from './page.pcss'
@@ -34,7 +34,7 @@ const ProductPage = () => {
     } = useController()
     const product = useProduct()
     const userData = useSelector(selectUserData)
-    const isLoggedIn = userData !== null && SessionProvider.token() !== null
+    const isLoggedIn = userData !== null && !!retrieve()
 
     const { match } = useContext(RouterContext.Context)
 

--- a/app/src/shared/contexts/StreamrClient/index.jsx
+++ b/app/src/shared/contexts/StreamrClient/index.jsx
@@ -9,7 +9,7 @@
 import React, { type Node, type Context, useState, useEffect, useLayoutEffect, useCallback, useMemo } from 'react'
 import { connect } from 'react-redux'
 import StreamrClient from 'streamr-client'
-import SessionProvider from '$auth/components/SessionProvider'
+import { retrieve } from '$shared/utils/sessionToken'
 
 import { selectAuthState } from '$shared/modules/user/selectors'
 import useIsMountedRef from '$shared/hooks/useIsMountedRef'
@@ -17,7 +17,6 @@ import useIsMountedRef from '$shared/hooks/useIsMountedRef'
 export type ContextProps = {
     hasLoaded: boolean,
     client: any,
-    sessionToken: ?string,
 }
 
 export const ClientContext: Context<ContextProps> = React.createContext({
@@ -44,10 +43,11 @@ type ClientProviderProps = {
     authenticationFailed: boolean,
 }
 
-function useClientProvider({ sessionToken, isAuthenticating, authenticationFailed }: ClientProviderProps) {
+function useClientProvider({ isAuthenticating, authenticationFailed }: ClientProviderProps) {
     const [client, setClient] = useState()
     const isMountedRef = useIsMountedRef()
     const hasClient = !!client
+    const sessionToken = retrieve()
     const hasLoaded = !!sessionToken || !!(!isAuthenticating && authenticationFailed)
 
     const reset = useCallback(() => {
@@ -109,7 +109,6 @@ export function ClientProviderComponent({ children, ...props }: Props) {
 
 const mapStateToProps = (state) => ({
     ...selectAuthState(state),
-    sessionToken: SessionProvider.token(),
 })
 
 export const ClientProvider = connect(mapStateToProps)(ClientProviderComponent)

--- a/app/src/shared/contexts/StreamrClient/index.jsx
+++ b/app/src/shared/contexts/StreamrClient/index.jsx
@@ -9,7 +9,7 @@
 import React, { type Node, type Context, useState, useEffect, useLayoutEffect, useCallback, useMemo } from 'react'
 import { connect } from 'react-redux'
 import StreamrClient from 'streamr-client'
-import { retrieve } from '$shared/utils/sessionToken'
+import { getToken } from '$shared/utils/sessionToken'
 
 import { selectAuthState } from '$shared/modules/user/selectors'
 import useIsMountedRef from '$shared/hooks/useIsMountedRef'
@@ -47,7 +47,7 @@ function useClientProvider({ isAuthenticating, authenticationFailed }: ClientPro
     const [client, setClient] = useState()
     const isMountedRef = useIsMountedRef()
     const hasClient = !!client
-    const sessionToken = retrieve()
+    const sessionToken = getToken()
     const hasLoaded = !!sessionToken || !!(!isAuthenticating && authenticationFailed)
 
     const reset = useCallback(() => {

--- a/app/src/shared/utils/getAuthorizationHeader.js
+++ b/app/src/shared/utils/getAuthorizationHeader.js
@@ -1,12 +1,11 @@
 // @flow
 
-import SessionProvider from '$auth/components/SessionProvider'
+import { retrieve } from '$shared/utils/sessionToken'
 
 export default () => {
-    const token: ?string = SessionProvider.token()
-    // no auth header if no token
-    if (!token) { return {} }
-    return {
-        Authorization: `Bearer ${token || 0}`,
-    }
+    const token: ?string = retrieve()
+
+    return token ? {
+        Authorization: `Bearer ${token}`,
+    } : {}
 }

--- a/app/src/shared/utils/getAuthorizationHeader.js
+++ b/app/src/shared/utils/getAuthorizationHeader.js
@@ -1,9 +1,9 @@
 // @flow
 
-import { retrieve } from '$shared/utils/sessionToken'
+import { getToken } from '$shared/utils/sessionToken'
 
 export default () => {
-    const token: ?string = retrieve()
+    const token: ?string = getToken()
 
     return token ? {
         Authorization: `Bearer ${token}`,

--- a/app/src/shared/utils/sessionToken.js
+++ b/app/src/shared/utils/sessionToken.js
@@ -11,7 +11,7 @@ const cache = {
 
 const storage = isLocalStorageAvailable() ? window.localStorage : {
     setItem: (key, value) => {
-        cache[key] = value
+        cache[key] = value || null
     },
     getItem: (key) => cache[key] || null,
     removeItem: (key) => storage.setItem(key, null),
@@ -32,5 +32,5 @@ const expired = (date) => (
 )
 
 export const retrieve = () => (
-    expired(storage.getItem(SESSION_LOGIN_TIME)) ? null : storage.getItem(SESSION_TOKEN_KEY)
+    (!expired(storage.getItem(SESSION_LOGIN_TIME)) && storage.getItem(SESSION_TOKEN_KEY)) || null
 )

--- a/app/src/shared/utils/sessionToken.js
+++ b/app/src/shared/utils/sessionToken.js
@@ -17,7 +17,7 @@ const storage = isLocalStorageAvailable() ? window.localStorage : {
     removeItem: (key) => storage.setItem(key, null),
 }
 
-export const store = (token) => {
+export const setToken = (token) => {
     if (token) {
         storage.setItem(SESSION_TOKEN_KEY, token)
         storage.setItem(SESSION_LOGIN_TIME, new Date())
@@ -31,6 +31,6 @@ const expired = (date) => (
     Date.now() > new Date(date || 0).getTime() + (EXPIRES_AT_VALID_HOURS * 1000 * 3600)
 )
 
-export const retrieve = () => (
+export const getToken = () => (
     (!expired(storage.getItem(SESSION_LOGIN_TIME)) && storage.getItem(SESSION_TOKEN_KEY)) || null
 )

--- a/app/src/shared/utils/sessionToken.js
+++ b/app/src/shared/utils/sessionToken.js
@@ -1,0 +1,36 @@
+import { isLocalStorageAvailable } from '$shared/utils/storage'
+
+export const SESSION_TOKEN_KEY = 'session.token'
+export const SESSION_LOGIN_TIME = 'session.loginTime'
+export const EXPIRES_AT_VALID_HOURS = 6
+
+const cache = {
+    [SESSION_TOKEN_KEY]: null,
+    [SESSION_LOGIN_TIME]: null,
+}
+
+const storage = isLocalStorageAvailable() ? window.localStorage : {
+    setItem: (key, value) => {
+        cache[key] = value
+    },
+    getItem: (key) => cache[key] || null,
+    removeItem: (key) => storage.setItem(key, null),
+}
+
+export const store = (token) => {
+    if (token) {
+        storage.setItem(SESSION_TOKEN_KEY, token)
+        storage.setItem(SESSION_LOGIN_TIME, new Date())
+    } else {
+        storage.removeItem(SESSION_TOKEN_KEY)
+        storage.removeItem(SESSION_LOGIN_TIME)
+    }
+}
+
+const expired = (date) => (
+    Date.now() > new Date(date || 0).getTime() + (EXPIRES_AT_VALID_HOURS * 1000 * 3600)
+)
+
+export const retrieve = () => (
+    expired(storage.getItem(SESSION_LOGIN_TIME)) ? null : storage.getItem(SESSION_TOKEN_KEY)
+)

--- a/app/src/shared/utils/sessionToken.test.js
+++ b/app/src/shared/utils/sessionToken.test.js
@@ -72,11 +72,11 @@ describe('session token utility', () => {
             expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(null)
         })
 
-        it('retrieves null by default', () => {
+        it('stores null by default', () => {
             expect(retrieve2()).toBe(null)
         })
 
-        it('retrieves the stored value before its expiration', () => {
+        it('stores and expires a token', () => {
             store2('token')
             expect(retrieve2()).toBe('token')
             clock.tick(((EXPIRES_AT_VALID_HOURS * 3600) - 60) * 1000) // 60s before expiration
@@ -85,7 +85,7 @@ describe('session token utility', () => {
             expect(retrieve2()).toBe(null)
         })
 
-        it('retrieves null if stored token is an empty string', () => {
+        it('stores null when token is a falsy value', () => {
             store2('')
             expect(retrieve2()).toBe(null)
             store2(null)

--- a/app/src/shared/utils/sessionToken.test.js
+++ b/app/src/shared/utils/sessionToken.test.js
@@ -57,22 +57,15 @@ describe('session token utility', () => {
     })
 
     describe('fallback storage', () => {
-        let store2
-        let retrieve2
+        jest.resetModules()
 
-        beforeEach(() => {
-            jest.resetModules()
+        jest.mock('$shared/utils/storage', () => ({
+            __esModule: true,
+            isLocalStorageAvailable: () => false,
+        }))
 
-            jest.mock('$shared/utils/storage', () => ({
-                __esModule: true,
-                isLocalStorageAvailable: () => false,
-            }))
-
-            // eslint-disable-next-line global-require
-            const sessionToken = require('$shared/utils/sessionToken')
-            store2 = sessionToken.store
-            retrieve2 = sessionToken.retrieve
-        })
+        // eslint-disable-next-line global-require
+        const { store: store2, retrieve: retrieve2 } = require('$shared/utils/sessionToken')
 
         afterEach(() => {
             expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)

--- a/app/src/shared/utils/sessionToken.test.js
+++ b/app/src/shared/utils/sessionToken.test.js
@@ -1,4 +1,4 @@
-import { store, retrieve, SESSION_TOKEN_KEY, SESSION_LOGIN_TIME, EXPIRES_AT_VALID_HOURS } from '$shared/utils/sessionToken'
+import { setToken, getToken, SESSION_TOKEN_KEY, SESSION_LOGIN_TIME, EXPIRES_AT_VALID_HOURS } from '$shared/utils/sessionToken'
 import sinon from 'sinon'
 
 describe('session token utility', () => {
@@ -16,41 +16,41 @@ describe('session token utility', () => {
         sandbox.restore()
     })
 
-    describe('retrieve', () => {
+    describe('getToken', () => {
         it('gives null by default', () => {
-            expect(retrieve()).toBe(null)
+            expect(getToken()).toBe(null)
         })
 
         it('gives the stored value before its expiration', () => {
             global.localStorage.setItem(SESSION_TOKEN_KEY, 'token')
             global.localStorage.setItem(SESSION_LOGIN_TIME, new Date())
-            expect(retrieve()).toBe('token')
+            expect(getToken()).toBe('token')
             clock.tick(((EXPIRES_AT_VALID_HOURS * 3600) - 60) * 1000) // 60s before expiration
-            expect(retrieve()).toBe('token')
+            expect(getToken()).toBe('token')
             clock.tick(120 * 1000) // 60s after expiration
-            expect(retrieve()).toBe(null)
+            expect(getToken()).toBe(null)
         })
 
         it('gives null if stored token is an empty string', () => {
             global.localStorage.setItem(SESSION_TOKEN_KEY, '')
             global.localStorage.setItem(SESSION_LOGIN_TIME, new Date())
 
-            expect(retrieve()).toBe(null)
+            expect(getToken()).toBe(null)
         })
     })
 
-    describe('store', () => {
+    describe('setToken', () => {
         it('puts non-empty value into local storage', () => {
-            store('')
+            setToken('')
             expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)
             expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(null)
-            store(null)
+            setToken(null)
             expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)
             expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(null)
-            store(undefined)
+            setToken(undefined)
             expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)
             expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(null)
-            store('token')
+            setToken('token')
             expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe('token')
             expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(new Date().toString())
         })
@@ -65,7 +65,7 @@ describe('session token utility', () => {
         }))
 
         // eslint-disable-next-line global-require
-        const { store: store2, retrieve: retrieve2 } = require('$shared/utils/sessionToken')
+        const { setToken: setToken2, getToken: getToken2 } = require('$shared/utils/sessionToken')
 
         afterEach(() => {
             expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)
@@ -73,25 +73,25 @@ describe('session token utility', () => {
         })
 
         it('stores null by default', () => {
-            expect(retrieve2()).toBe(null)
+            expect(getToken2()).toBe(null)
         })
 
         it('stores and expires a token', () => {
-            store2('token')
-            expect(retrieve2()).toBe('token')
+            setToken2('token')
+            expect(getToken2()).toBe('token')
             clock.tick(((EXPIRES_AT_VALID_HOURS * 3600) - 60) * 1000) // 60s before expiration
-            expect(retrieve2()).toBe('token')
+            expect(getToken2()).toBe('token')
             clock.tick(120 * 1000) // 60s after expiration
-            expect(retrieve2()).toBe(null)
+            expect(getToken2()).toBe(null)
         })
 
         it('stores null when token is a falsy value', () => {
-            store2('')
-            expect(retrieve2()).toBe(null)
-            store2(null)
-            expect(retrieve2()).toBe(null)
-            store2(undefined)
-            expect(retrieve2()).toBe(null)
+            setToken2('')
+            expect(getToken2()).toBe(null)
+            setToken2(null)
+            expect(getToken2()).toBe(null)
+            setToken2(undefined)
+            expect(getToken2()).toBe(null)
         })
     })
 })

--- a/app/src/shared/utils/sessionToken.test.js
+++ b/app/src/shared/utils/sessionToken.test.js
@@ -88,6 +88,10 @@ describe('session token utility', () => {
         it('retrieves null if stored token is an empty string', () => {
             store2('')
             expect(retrieve2()).toBe(null)
+            store2(null)
+            expect(retrieve2()).toBe(null)
+            store2(undefined)
+            expect(retrieve2()).toBe(null)
         })
     })
 })

--- a/app/src/shared/utils/sessionToken.test.js
+++ b/app/src/shared/utils/sessionToken.test.js
@@ -1,0 +1,100 @@
+import { store, retrieve, SESSION_TOKEN_KEY, SESSION_LOGIN_TIME, EXPIRES_AT_VALID_HOURS } from '$shared/utils/sessionToken'
+import sinon from 'sinon'
+
+describe('session token utility', () => {
+    let clock
+    let sandbox
+
+    beforeEach(() => {
+        global.localStorage.clear()
+        clock = sinon.useFakeTimers(new Date())
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        clock.restore()
+        sandbox.restore()
+    })
+
+    describe('retrieve', () => {
+        it('gives null by default', () => {
+            expect(retrieve()).toBe(null)
+        })
+
+        it('gives the stored value before its expiration', () => {
+            global.localStorage.setItem(SESSION_TOKEN_KEY, 'token')
+            global.localStorage.setItem(SESSION_LOGIN_TIME, new Date())
+            expect(retrieve()).toBe('token')
+            clock.tick(((EXPIRES_AT_VALID_HOURS * 3600) - 60) * 1000) // 60s before expiration
+            expect(retrieve()).toBe('token')
+            clock.tick(120 * 1000) // 60s after expiration
+            expect(retrieve()).toBe(null)
+        })
+
+        it('gives null if stored token is an empty string', () => {
+            global.localStorage.setItem(SESSION_TOKEN_KEY, '')
+            global.localStorage.setItem(SESSION_LOGIN_TIME, new Date())
+
+            expect(retrieve()).toBe(null)
+        })
+    })
+
+    describe('store', () => {
+        it('puts non-empty value into local storage', () => {
+            store('')
+            expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)
+            expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(null)
+            store(null)
+            expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)
+            expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(null)
+            store(undefined)
+            expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)
+            expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(null)
+            store('token')
+            expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe('token')
+            expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(new Date().toString())
+        })
+    })
+
+    describe('fallback storage', () => {
+        let store2
+        let retrieve2
+
+        beforeEach(() => {
+            jest.resetModules()
+
+            jest.mock('$shared/utils/storage', () => ({
+                __esModule: true,
+                isLocalStorageAvailable: () => false,
+            }))
+
+            // eslint-disable-next-line global-require
+            const sessionToken = require('$shared/utils/sessionToken')
+            store2 = sessionToken.store
+            retrieve2 = sessionToken.retrieve
+        })
+
+        afterEach(() => {
+            expect(global.localStorage.getItem(SESSION_TOKEN_KEY)).toBe(null)
+            expect(global.localStorage.getItem(SESSION_LOGIN_TIME)).toBe(null)
+        })
+
+        it('retrieves null by default', () => {
+            expect(retrieve2()).toBe(null)
+        })
+
+        it('retrieves the stored value before its expiration', () => {
+            store2('token')
+            expect(retrieve2()).toBe('token')
+            clock.tick(((EXPIRES_AT_VALID_HOURS * 3600) - 60) * 1000) // 60s before expiration
+            expect(retrieve2()).toBe('token')
+            clock.tick(120 * 1000) // 60s after expiration
+            expect(retrieve2()).toBe(null)
+        })
+
+        it('retrieves null if stored token is an empty string', () => {
+            store2('')
+            expect(retrieve2()).toBe(null)
+        })
+    })
+})


### PR DESCRIPTION
I took a stab at refactoring our session token storage feature. Extracted `getStoredToken` and `storeToken` from `SessionProvider`, simplified them and put them in the `sessionToken` utility.

Main reason for it is that I want to be able to interact with the token directly from the e2e tests and don't wanna fight its config and import too much.

Hope you guys like it.