### PR TITLE
[DOCS-129] Add missing DU docs links

### DIFF
--- a/app/src/docs/content/dataUnions/dataUnionsCore.mdx
+++ b/app/src/docs/content/dataUnions/dataUnionsCore.mdx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import docsLinks from '$shared/../docsLinks'
+import docsStyles from '$docs/components/DocsLayout/docsLayout.pcss'
 
 import Build from './images/data_unions_in_core_01_build.jpg'
 import Build2x from './images/data_unions_in_core_01_build@2x.jpg'
@@ -9,7 +10,7 @@ import Managing from './videos/data_unions_in_core_03_managing.mp4'
 
 # Build a Data Union with Core
 
-To create a Data Union in Core, go to Core > Products, click Create and choose Data Union as the product type. Other than the sections below, the process is similar to creating a Data Product. If you haven’t made one before, please check out <Link to={docsLinks.products}>Creating a Data Product</Link> before proceeding with this article.
+To create a Data Union in Core, go to Core > Products, click <span className={docsStyles.streamrHighlight}>Create</span> and choose Data Union as the product type. Other than the sections below, the process is similar to creating a Data Product. If you haven’t made one before, please check out <Link to={docsLinks.products}>Creating a Data Product</Link> before proceeding with this article.
 
 <figure>
     <picture>

--- a/app/src/docs/content/dataUnions/introToDataUnions.mdx
+++ b/app/src/docs/content/dataUnions/introToDataUnions.mdx
@@ -15,7 +15,7 @@ As a general concept, a Data Union is a structure that allows separate entities 
 
 Streamr implements this idea with its Data Unions Framework, which allows admins to create crowdsourced data products that combine real-time data from many members into a single, more valuable dataset. 
 
-A Data Union Product is an Ethereum smart contract, created and deployed via the Core app and published on the Marketplace. Most revenue from a Data Union flows to its members, but the admin can set a percentage fee they receive in return for creating and managing the union. For more information on structure, see Data Union Framework Roles.
+A Data Union Product is an Ethereum smart contract, created and deployed via the Core app and published on the Marketplace. Most revenue from a Data Union flows to its members, but the admin can set a percentage fee they receive in return for creating and managing the union. For more information on structure, see <Link to={docsLinks.frameworkRoles}>Data Union Framework Roles</Link>.
 
 <figure>
     <picture>

--- a/app/src/docs/content/dataUnions/joinAndWithdraw.mdx
+++ b/app/src/docs/content/dataUnions/joinAndWithdraw.mdx
@@ -1,10 +1,13 @@
+import { Link } from 'react-router-dom'
+
+import docsLinks from '$shared/../docsLinks'
 import CodeSnippet from '$shared/components/CodeSnippet'
 
 # Join and withdraw funds from Data Unions
 
 ### Joining Data Unions
 
-Joining the Data Union requires no transaction. The request must be authenticated with their Ethereum address, see Data Unions Auth & Identity.
+Joining the Data Union requires no transaction. The request must be authenticated with their Ethereum address, see <Link to={docsLinks.authAndIdentity}>Data Unions Auth & Identity</Link>.
 
 ```
 await streamr.joinDataunion(dataunionAddress, secret)


### PR DESCRIPTION
Introduction to Data Unions
- add missing linking to Framework roles page
- added highlight for the create button

Join & Withdraw page
- add missing linking to Auth & Identity page 