### PR TITLE
[PLATFORM-1290] Terms of use

### DIFF
--- a/app/src/marketplace/components/ProductPage/Terms/index.jsx
+++ b/app/src/marketplace/components/ProductPage/Terms/index.jsx
@@ -1,0 +1,104 @@
+// @flow
+
+import React from 'react'
+import styled from 'styled-components'
+import { I18n } from 'react-redux-i18n'
+
+import ProductContainer from '$shared/components/Container/Product'
+import type { Product } from '$mp/flowtype/product-types'
+
+const Container = styled(ProductContainer)`
+    background-color: #f8f8f8;
+    margin-top: 48px !important;
+`
+
+const Header = styled.div`
+    display: flex;
+    background-color: #efefef;
+    color: #525252;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16px;
+    letter-spacing: 1.17px;
+    text-transform: uppercase;
+    height: 4.5rem;
+    align-items: center;
+    padding: 2em;
+`
+
+const Content = styled.div`
+    padding: 1.5em 2em;
+`
+
+const Text = styled.span`
+    font-size: 14px;
+    line-height: 28px;
+    font-weight: ${(props) => (props.bold ? '500' : '400')};
+`
+
+type Props = {
+    className?: string,
+    product: Product,
+}
+
+const getTermStrings = (ids: Array<string>) => (
+    ids.map((id, index) => {
+        const term = I18n.t(`editProductPage.terms.${id}`)
+        if (index !== 0) {
+            const separator = (index === ids.length - 1) ? ' & ' : ', '
+            return `${separator}${term.toLowerCase()}`
+        }
+        return term
+    })
+)
+
+const Terms = ({ className, product }: Props) => {
+    if (product == null) {
+        return null
+    }
+
+    const terms = product.termsOfUse
+    const entries = Object.entries(terms)
+    const permitted = entries.filter((e) => e[1] === true).map((e) => e[0])
+    const notPermitted = entries.filter((e) => e[1] === false).map((e) => e[0])
+
+    return (
+        <Container className={className}>
+            <Header>
+                Terms and conditions
+            </Header>
+            <Content>
+                <Text bold>Basic terms</Text>
+                {' '}
+                <Text>
+                    {getTermStrings(permitted)}
+                    {' '}
+                    {permitted.length > 0 && `${I18n.t('productPage.termsOfUse.permitted', {
+                        count: permitted.length,
+                    })}. `}
+                    {getTermStrings(notPermitted)}
+                    {' '}
+                    {notPermitted.length > 0 && I18n.t('productPage.termsOfUse.notPermitted', {
+                        count: notPermitted.length,
+                    })}
+                    {permitted.length === 0 && ` ${I18n.t('productPage.termsOfUse.postfix')}`}
+                    {notPermitted.length > 0 && '.'}
+                </Text>
+                {terms.termsUrl && (
+                    <React.Fragment>
+                        <br />
+                        <Text bold>Detailed terms</Text>
+                        {' '}
+                        <Text bold>
+                            <a href={terms.termsUrl} target="_blank" rel="noopener noreferrer">
+                                {terms.termsName != null && terms.termsName.length > 0 ? terms.termsName : terms.termsUrl}
+                            </a>
+                        </Text>
+                    </React.Fragment>
+                )}
+            </Content>
+        </Container>
+    )
+}
+
+export default Terms

--- a/app/src/marketplace/components/ProductPage/Terms/index.jsx
+++ b/app/src/marketplace/components/ProductPage/Terms/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import { Translate, I18n } from 'react-redux-i18n'
 
@@ -39,7 +39,7 @@ const Content = styled.div`
 const Text = styled.span`
     font-size: 14px;
     line-height: 28px;
-    font-weight: ${(props) => (props.bold ? '500' : '400')};
+    font-weight: ${(props) => (props.bold ? 'var(--medium)' : 'var(--normal)')};
 `
 
 type Props = {
@@ -55,18 +55,20 @@ const getTermStrings = (ids: Array<string>) => (
             return `${separator}${term.toLowerCase()}`
         }
         return term
-    })
+    }).join('')
 )
 
 const Terms = ({ className, product }: Props) => {
-    if (product == null) {
-        return null
-    }
-
-    const terms = product.termsOfUse
+    const terms = product.termsOfUse || {}
     const entries = Object.entries(terms)
     const permitted = entries.filter((e) => e[1] === true).map((e) => e[0])
     const notPermitted = entries.filter((e) => e[1] === false).map((e) => e[0])
+    const permittedStr = useMemo(() => getTermStrings(permitted), [permitted])
+    const notPermittedStr = useMemo(() => getTermStrings(notPermitted), [notPermitted])
+
+    if (product == null) {
+        return null
+    }
 
     return (
         <Container className={className}>
@@ -79,15 +81,14 @@ const Terms = ({ className, product }: Props) => {
                 </Text>
                 {' '}
                 <Text>
-                    {getTermStrings(permitted)}
-                    {' '}
-                    {permitted.length > 0 && `${I18n.t('productPage.termsOfUse.permitted', {
+                    {permitted.length > 0 && I18n.t('productPage.termsOfUse.permitted', {
                         count: permitted.length,
-                    })}. `}
-                    {getTermStrings(notPermitted)}
+                        permissions: permittedStr,
+                    })}
                     {' '}
                     {notPermitted.length > 0 && I18n.t('productPage.termsOfUse.notPermitted', {
                         count: notPermitted.length,
+                        permissions: notPermittedStr,
                     })}
                     {permitted.length === 0 && ` ${I18n.t('productPage.termsOfUse.postfix')}`}
                     {notPermitted.length > 0 && '.'}

--- a/app/src/marketplace/components/ProductPage/Terms/index.jsx
+++ b/app/src/marketplace/components/ProductPage/Terms/index.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import styled from 'styled-components'
-import { I18n } from 'react-redux-i18n'
+import { Translate, I18n } from 'react-redux-i18n'
 
 import ProductContainer from '$shared/components/Container/Product'
 import type { Product } from '$mp/flowtype/product-types'
@@ -71,10 +71,12 @@ const Terms = ({ className, product }: Props) => {
     return (
         <Container className={className}>
             <Header>
-                Terms and conditions
+                <Translate value="productPage.termsOfUse.title" />
             </Header>
             <Content>
-                <Text bold>Basic terms</Text>
+                <Text bold>
+                    <Translate value="productPage.termsOfUse.basic" />
+                </Text>
                 {' '}
                 <Text>
                     {getTermStrings(permitted)}
@@ -93,7 +95,9 @@ const Terms = ({ className, product }: Props) => {
                 {terms.termsUrl && (
                     <React.Fragment>
                         <br />
-                        <Text bold>Detailed terms</Text>
+                        <Text bold>
+                            <Translate value="productPage.termsOfUse.detailed" />
+                        </Text>
                         {' '}
                         <Text bold>
                             <a href={terms.termsUrl} target="_blank" rel="noopener noreferrer">

--- a/app/src/marketplace/components/ProductPage/Terms/index.jsx
+++ b/app/src/marketplace/components/ProductPage/Terms/index.jsx
@@ -6,10 +6,16 @@ import { I18n } from 'react-redux-i18n'
 
 import ProductContainer from '$shared/components/Container/Product'
 import type { Product } from '$mp/flowtype/product-types'
+import { MD } from '$shared/utils/styled'
 
 const Container = styled(ProductContainer)`
     background-color: #f8f8f8;
     margin-top: 48px !important;
+    
+    @media (max-width: ${MD}px) {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
 `
 
 const Header = styled.div`

--- a/app/src/marketplace/containers/EditProductPage/Editor.jsx
+++ b/app/src/marketplace/containers/EditProductPage/Editor.jsx
@@ -16,6 +16,7 @@ import PriceSelector from './PriceSelector'
 import ProductDetails from './ProductDetails'
 import ConnectEthIdentity from './ConnectEthIdentity'
 import SharedSecrets from './SharedSecrets'
+import TermsOfUse from './TermsOfUse'
 
 import styles from './editor.pcss'
 
@@ -42,6 +43,7 @@ const Editor = ({ disabled }: Props) => {
                         <PriceSelector disabled={disabled} />
                         <ProductDetails disabled={disabled} />
                         <ConnectEthIdentity disabled={disabled} />
+                        <TermsOfUse disabled={disabled} />
                         {!!isDataUnion && (
                             <SharedSecrets disabled={disabled} />
                         )}

--- a/app/src/marketplace/containers/EditProductPage/EditorNav.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditorNav.jsx
@@ -144,6 +144,10 @@ const EditorNav = () => {
             id: 'details',
             heading: I18n.t('editProductPage.navigation.details'),
             status: detailsStatus,
+        }, {
+            id: 'terms',
+            heading: I18n.t('editProductPage.navigation.terms'),
+            status: getStatus('termsOfUse'),
         }]
 
         if (isDataUnion) {

--- a/app/src/marketplace/containers/EditProductPage/Preview.jsx
+++ b/app/src/marketplace/containers/EditProductPage/Preview.jsx
@@ -18,6 +18,7 @@ import HeroComponent from '$mp/components/Hero'
 import { ImageTile } from '$shared/components/Tile'
 import ProductDetails from '$mp/components/ProductPage/ProductDetails'
 import StreamListing from '$mp/components/ProductPage/StreamListing'
+import Terms from '$mp/components/ProductPage/Terms'
 import ProductContainer from '$shared/components/Container/Product'
 import StatsValues from '$shared/components/DataUnionStats/Values'
 import StatsHeader from '$shared/components/DataUnionStats/Header'
@@ -216,6 +217,16 @@ const Streams = () => {
     )
 }
 
+const TermsOfUse = () => {
+    const product = useEditableProduct()
+
+    return (
+        <Terms
+            product={product}
+        />
+    )
+}
+
 const Preview = () => {
     const product = useEditableProduct()
 
@@ -236,6 +247,7 @@ const Preview = () => {
                 <DataUnionStats />
             )}
             <Streams />
+            <TermsOfUse />
         </div>
     )
 }

--- a/app/src/marketplace/containers/EditProductPage/TermsOfUse.jsx
+++ b/app/src/marketplace/containers/EditProductPage/TermsOfUse.jsx
@@ -44,7 +44,7 @@ const StyledCheckbox = styled(Checkbox)`
     height: 24px !important;
 `
 
-const TermCheckbox = ({ id, product, updateTermsOfUse }: { id: string, product: any, updateTermsOfUse: any }) => (
+const TermCheckbox = ({ id, product, updateTermsOfUse, disabled }: { id: string, product: any, updateTermsOfUse: any, disabled: boolean }) => (
     <CheckboxLabel htmlFor={id}>
         <StyledCheckbox
             id={id}
@@ -56,7 +56,7 @@ const TermCheckbox = ({ id, product, updateTermsOfUse }: { id: string, product: 
                     [id]: e.target.checked,
                 })
             }}
-            autoFocus
+            disabled={disabled}
         />&nbsp;
         <Translate
             value={`editProductPage.terms.${id}`}
@@ -79,10 +79,10 @@ const TermsOfUse = ({ className, disabled }: Props) => {
                 dangerousHTML
             />
             <CheckboxContainer>
-                <TermCheckbox id="redistribution" product={product} updateTermsOfUse={updateTermsOfUse} />
-                <TermCheckbox id="commercialUse" product={product} updateTermsOfUse={updateTermsOfUse} />
-                <TermCheckbox id="reselling" product={product} updateTermsOfUse={updateTermsOfUse} />
-                <TermCheckbox id="storage" product={product} updateTermsOfUse={updateTermsOfUse} />
+                <TermCheckbox id="redistribution" product={product} updateTermsOfUse={updateTermsOfUse} disabled={!!disabled} />
+                <TermCheckbox id="commercialUse" product={product} updateTermsOfUse={updateTermsOfUse} disabled={!!disabled} />
+                <TermCheckbox id="reselling" product={product} updateTermsOfUse={updateTermsOfUse} disabled={!!disabled} />
+                <TermCheckbox id="storage" product={product} updateTermsOfUse={updateTermsOfUse} disabled={!!disabled} />
             </CheckboxContainer>
             <DetailsContainer>
                 <div>

--- a/app/src/marketplace/containers/EditProductPage/TermsOfUse.jsx
+++ b/app/src/marketplace/containers/EditProductPage/TermsOfUse.jsx
@@ -1,0 +1,138 @@
+// @flow
+
+import React from 'react'
+import { Translate, I18n } from 'react-redux-i18n'
+import styled from 'styled-components'
+
+import Checkbox from '$shared/components/Checkbox'
+import Text from '$ui/Text'
+import Label from '$ui/Label'
+import Errors, { MarketplaceTheme } from '$ui/Errors'
+import useEditableProduct from '../ProductController/useEditableProduct'
+import useEditableProductActions from '../ProductController/useEditableProductActions'
+import useValidation from '../ProductController/useValidation'
+
+type Props = {
+    className?: string,
+    disabled?: boolean,
+}
+
+const Section = styled.section`
+    background: none;
+`
+
+const CheckboxContainer = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    margin: 40px 0;
+`
+
+const CheckboxLabel = styled.label`
+    display: flex;
+    margin: 0;
+`
+
+const DetailsContainer = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 24px;
+`
+
+const StyledCheckbox = styled(Checkbox)`
+    width: 24px !important;
+    height: 24px !important;
+`
+
+const TermCheckbox = ({ id, product, updateTermsOfUse }: { id: string, product: any, updateTermsOfUse: any }) => (
+    <CheckboxLabel htmlFor={id}>
+        <StyledCheckbox
+            id={id}
+            name={id}
+            value={product.termsOfUse[id]}
+            onChange={(e) => {
+                updateTermsOfUse({
+                    ...product.termsOfUse,
+                    [id]: e.target.checked,
+                })
+            }}
+            autoFocus
+        />&nbsp;
+        <Translate
+            value={`editProductPage.terms.${id}`}
+            dangerousHTML
+        />
+    </CheckboxLabel>
+)
+
+const TermsOfUse = ({ className, disabled }: Props) => {
+    const product = useEditableProduct()
+    const { updateTermsOfUse } = useEditableProductActions()
+    const { isValid, message } = useValidation('termsOfUse')
+
+    return (
+        <Section id="terms" className={className}>
+            <Translate tag="h1" value="editProductPage.terms.title" />
+            <Translate
+                value="editProductPage.terms.description"
+                tag="p"
+                dangerousHTML
+            />
+            <CheckboxContainer>
+                <TermCheckbox id="redistribution" product={product} updateTermsOfUse={updateTermsOfUse} />
+                <TermCheckbox id="commercialUse" product={product} updateTermsOfUse={updateTermsOfUse} />
+                <TermCheckbox id="reselling" product={product} updateTermsOfUse={updateTermsOfUse} />
+                <TermCheckbox id="storage" product={product} updateTermsOfUse={updateTermsOfUse} />
+            </CheckboxContainer>
+            <DetailsContainer>
+                <div>
+                    <Label
+                        as={Translate}
+                        value="editProductPage.terms.link.title"
+                        tag="div"
+                    />
+                    <Text
+                        defaultValue={product.termsOfUse.termsUrl}
+                        onCommit={(text) => {
+                            updateTermsOfUse({
+                                ...product.termsOfUse,
+                                termsUrl: text,
+                            })
+                        }}
+                        placeholder={I18n.t('editProductPage.terms.link.placeholder')}
+                        disabled={!!disabled}
+                        selectAllOnFocus
+                        smartCommit
+                        invalid={!isValid}
+                    />
+                    {!isValid && (
+                        <Errors theme={MarketplaceTheme}>
+                            {message}
+                        </Errors>
+                    )}
+                </div>
+                <div>
+                    <Label
+                        as={Translate}
+                        value="editProductPage.terms.displayName.title"
+                        tag="div"
+                    />
+                    <Text
+                        defaultValue={product.termsOfUse.termsName}
+                        onCommit={(text) => {
+                            updateTermsOfUse({
+                                ...product.termsOfUse,
+                                termsName: text,
+                            })
+                        }}
+                        placeholder={I18n.t('editProductPage.terms.displayName.placeholder')}
+                        disabled={!!disabled}
+                        selectAllOnFocus
+                        smartCommit
+                    />
+                </div>
+            </DetailsContainer>
+        </Section>
+    )
+}
+
+export default TermsOfUse

--- a/app/src/marketplace/containers/EditProductPage/TermsOfUse.jsx
+++ b/app/src/marketplace/containers/EditProductPage/TermsOfUse.jsx
@@ -24,6 +24,7 @@ const Section = styled.section`
 const CheckboxContainer = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-gap: 16px;
     margin: 40px 0;
 `
 

--- a/app/src/marketplace/containers/EditProductPage/state.js
+++ b/app/src/marketplace/containers/EditProductPage/state.js
@@ -18,6 +18,7 @@ export const PENDING_CHANGE_FIELDS = [
     'adminFee',
     'timeUnit',
     'price',
+    'termsOfUse',
 ]
 
 export function isPublished(product: Product) {

--- a/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
+++ b/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { useMemo, useCallback, useState, type Node, type Context } from 'react'
+import * as yup from 'yup'
 import useIsMounted from '$shared/hooks/useIsMounted'
 
 import { isEthereumAddress } from '$mp/utils/validate'
@@ -123,6 +124,18 @@ function useValidationContext(): ContextProps {
             setStatus('streams', ERROR, 'No streams selected')
         } else {
             clearStatus('streams')
+        }
+
+        if (product.termsOfUse != null && product.termsOfUse.termsUrl) {
+            const validator = yup.string()
+                .trim()
+                .url()
+            const result = validator.isValidSync(product.termsOfUse.termsUrl)
+            if (!result) {
+                setStatus('termsOfUse', ERROR, 'Invalid URL for detailed terms')
+            } else {
+                clearStatus('termsOfUse')
+            }
         }
 
         const isPaid = isPaidProduct(product)

--- a/app/src/marketplace/containers/ProductController/useEditableProductActions.js
+++ b/app/src/marketplace/containers/ProductController/useEditableProductActions.js
@@ -122,6 +122,13 @@ export function useEditableProductActions() {
         }))
         touch('type')
     }, [commit, touch])
+    const updateTermsOfUse = useCallback((termsOfUse: $ElementType<Product, 'termsOfUse'>) => {
+        commit('Update terms of use', (p) => ({
+            ...p,
+            termsOfUse,
+        }))
+        touch('termsOfUse')
+    }, [commit, touch])
 
     return useMemo(() => ({
         undo,
@@ -137,6 +144,7 @@ export function useEditableProductActions() {
         updatePrice,
         updateBeneficiaryAddress,
         updateType,
+        updateTermsOfUse,
     }), [
         undo,
         updateProduct,
@@ -151,6 +159,7 @@ export function useEditableProductActions() {
         updatePrice,
         updateBeneficiaryAddress,
         updateType,
+        updateTermsOfUse,
     ])
 }
 

--- a/app/src/marketplace/containers/ProductPage/Page.jsx
+++ b/app/src/marketplace/containers/ProductPage/Page.jsx
@@ -9,6 +9,7 @@ import Hero from './Hero'
 import Description from './Description'
 import DataUnionStats from './DataUnionStats'
 import Streams from './Streams'
+import Terms from './Terms'
 import RelatedProducts from './RelatedProducts'
 
 import styles from './page.pcss'
@@ -26,6 +27,7 @@ const ProductDetailsPage = () => {
                 <DataUnionStats />
             )}
             <Streams />
+            <Terms />
             <RelatedProducts />
         </div>
     )

--- a/app/src/marketplace/containers/ProductPage/Terms.jsx
+++ b/app/src/marketplace/containers/ProductPage/Terms.jsx
@@ -1,0 +1,18 @@
+// @flow
+
+import React from 'react'
+
+import useProduct from '$mp/containers/ProductController/useProduct'
+import TermsComponent from '$mp/components/ProductPage/Terms'
+
+const Terms = () => {
+    const product = useProduct()
+
+    return (
+        <TermsComponent
+            product={product}
+        />
+    )
+}
+
+export default Terms

--- a/app/src/marketplace/flowtype/product-types.js
+++ b/app/src/marketplace/flowtype/product-types.js
@@ -22,6 +22,15 @@ export type PendingChanges = {
     adminFee?: number
 }
 
+export type TermsOfUse = {
+    commercialUse: boolean,
+    redistribution: boolean,
+    reselling: boolean,
+    storage: boolean,
+    termsName: ?string,
+    termsUrl: ?string,
+}
+
 export type Product = {
     adminFee?: number,
     key?: string,
@@ -49,6 +58,7 @@ export type Product = {
     isFree?: boolean,
     type?: ProductType,
     pendingChanges?: PendingChanges,
+    termsOfUse: TermsOfUse,
 }
 
 export type ProductSubscriptionId = string

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -1176,13 +1176,13 @@ msgstr "Detailed terms"
 
 msgid "productPage##termsOfUse##permitted"
 msgid_plural "productPage##termsOfUse##permitted"
-msgstr[1] "is permitted"
-msgstr[2] "are permitted"
+msgstr[1] "%{permissions} is permitted."
+msgstr[2] "%{permissions} are permitted."
 
 msgid "productPage##termsOfUse##notPermitted"
 msgid_plural "productPage##termsOfUse##notPermitted"
-msgstr[1] "is not"
-msgstr[2] "are not"
+msgstr[1] "%{permissions} is not"
+msgstr[2] "%{permissions} are not"
 
 msgid "productPage##termsOfUse##postfix"
 msgstr "permitted"

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -1165,6 +1165,15 @@ msgstr "Streams"
 msgid "productPage##streamListing##view"
 msgstr "View live data"
 
+msgid "productPage##termsOfUse##title"
+msgstr "Terms and conditions"
+
+msgid "productPage##termsOfUse##basic"
+msgstr "Basic terms"
+
+msgid "productPage##termsOfUse##detailed"
+msgstr "Detailed terms"
+
 msgid "productPage##termsOfUse##permitted"
 msgid_plural "productPage##termsOfUse##permitted"
 msgstr[1] "is permitted"

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -201,6 +201,9 @@ msgstr "Ethereum identity"
 msgid "editProductPage##navigation##sharedSecrets"
 msgstr "Shared secrets"
 
+msgid "editProductPage##navigation##terms"
+msgstr "Terms"
+
 msgid "editProductPage##sidebar##category"
 msgstr "Product category"
 
@@ -209,6 +212,39 @@ msgstr "Active subscribers"
 
 msgid "editProductPage##sidebar##mostRecentPurchase"
 msgstr "Most recent purchase"
+
+msgid "editProductPage##terms##title"
+msgstr "Set terms of use"
+
+msgid "editProductPage##terms##description"
+msgstr ""
+"You can indicate the terms of use you prefer for data purchasers, either by checking boxes "
+"below to show permitted usage types, or give more detail by providing a link to your own terms "
+"of use document."
+
+msgid "editProductPage##terms##redistribution"
+msgstr "Redistribution"
+
+msgid "editProductPage##terms##commercialUse"
+msgstr "Commercial use"
+
+msgid "editProductPage##terms##reselling"
+msgstr "Reselling"
+
+msgid "editProductPage##terms##storage"
+msgstr "Storage"
+
+msgid "editProductPage##terms##link##title"
+msgstr "Link to detailed terms"
+
+msgid "editProductPage##terms##link##placeholder"
+msgstr "Add a URL here"
+
+msgid "editProductPage##terms##displayName##title"
+msgstr "Display name for link"
+
+msgid "editProductPage##terms##displayName##placeholder"
+msgstr "Add a display name"
 
 msgid "error##general"
 msgstr "Oops. Something has broken down here."
@@ -1128,6 +1164,19 @@ msgstr "Streams"
 
 msgid "productPage##streamListing##view"
 msgstr "View live data"
+
+msgid "productPage##termsOfUse##permitted"
+msgid_plural "productPage##termsOfUse##permitted"
+msgstr[1] "is permitted"
+msgstr[2] "are permitted"
+
+msgid "productPage##termsOfUse##notPermitted"
+msgid_plural "productPage##termsOfUse##notPermitted"
+msgstr[1] "is not"
+msgstr[2] "are not"
+
+msgid "productPage##termsOfUse##postfix"
+msgstr "permitted"
 
 msgid "productTile##active"
 msgstr "Active"

--- a/app/src/shared/assets/images/checkbox-checked.svg
+++ b/app/src/shared/assets/images/checkbox-checked.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
   <g fill="none" fill-rule="evenodd">
     <g stroke-width="1.5">
       <rect stroke="#0324FF" fill="#0324FF" x=".75" y=".75" width="14.5" height="14.5" rx="2"/>

--- a/app/src/shared/assets/images/checkbox.svg
+++ b/app/src/shared/assets/images/checkbox.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
     <g fill="#FFF" fill-rule="evenodd">
         <rect x=".75" y=".75" width="14.5" height="14.5" rx="2" stroke-width="1.5" stroke="#CDCDCD"/>
     </g>


### PR DESCRIPTION
Adds terms of use section to product editor and also to product page (& preview).

Related designs:
- https://share.goabstract.com/1e34f51b-97f2-4310-a0c2-26ff6c6995b6?mode=design&sha=22fda9a67b422eb66e3a86d23687ca30a90593e5
- https://share.goabstract.com/5e6cff3f-703b-41fc-9f8a-a78630a1498c?mode=design&sha=2143b193b923e9df49dcb8dc32897fdc204a1a01

PS. I noticed that somehow after adding the terms of use section to product editor, it seems that editor always scrolls to that section when opening a product. I couldn't figure out why this is happening. Could it be related to the ScrollSpy?