### PR TITLE
[PLATFORM-1389] Disable publish while DU is being deployed

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
@@ -180,9 +180,11 @@ function useEditController(product: Product) {
             return false
         }
 
-        if (isDataUnionProduct(productRef.current) && dataUnion != null && dataUnion.memberCount != null) {
+        if (isDataUnionProduct(productRef.current)) {
+            const { active: activeMembers } = (dataUnion && dataUnion.memberCount) || {}
             const memberLimit = parseInt(process.env.DATA_UNION_PUBLISH_MEMBER_LIMIT, 10) || 0
-            if (dataUnion.memberCount.active < memberLimit) {
+
+            if (!dataUnion || (activeMembers || 0) < memberLimit) {
                 Notification.push({
                     title: I18n.t('notifications.notEnoughMembers', {
                         memberLimit,


### PR DESCRIPTION
Small fix to extend the member limit check to include the case when the stats are not ready, ie. when the DU is in "Deploying..." state.