### PR TITLE
[PLATFORM-1385] Fix read-only stream title

### DIFF
--- a/app/src/shared/components/TOCPage/TOCNav.jsx
+++ b/app/src/shared/components/TOCPage/TOCNav.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import styled from 'styled-components'
+import { LG } from '$shared/utils/styled'
 
 export const Link = styled.a`
     color: #${({ active }) => (active ? '0324ff' : '323232')} !important;
@@ -9,7 +10,7 @@ export const Link = styled.a`
 const TOCNav = styled.div`
     font-size: 16px;
     line-height: 2em;
-    margin-top: 72px; /* Line up with TOCSection's title. */
+    margin-top: 0px; /* Line up with TOCSection's title. */
     position: sticky;
     text-align: right;
     top: 164px;

--- a/app/src/shared/components/TOCPage/index.jsx
+++ b/app/src/shared/components/TOCPage/index.jsx
@@ -15,7 +15,7 @@ type Props = {
 
 const SectionWrapper = styled.div`
     > div {
-        padding-top: 72px;
+        padding-top: 0px;
     }
 
     > div + div {
@@ -37,8 +37,12 @@ export const Title = styled.h1`
     font-size: 24px;
     font-weight: ${REGULAR};
     letter-spacing: 0;
-    line-height: 1.5rem;
     margin: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    margin-bottom: 24px;
+    line-height: 24px;
 
     @media (min-width: ${MD}px) {
         font-size: 18px;
@@ -47,6 +51,8 @@ export const Title = styled.h1`
     @media (min-width: ${LG}px) {
         display: block;
         font-size: 36px;
+        margin-bottom: 64px;
+        line-height: 40px;
     }
 `
 
@@ -59,7 +65,7 @@ const UnstyledTOCPage = ({ children, title, ...props }: Props) => {
                 {!!title && (
                     <React.Fragment>
                         <Wing />
-                        <Title>{title}</Title>
+                        <Title title={title}>{title}</Title>
                         <div />
                     </React.Fragment>
                 )}
@@ -98,7 +104,7 @@ const StyledTOCPage = styled(UnstyledTOCPage)`
 
     @media (min-width: ${LG}px) {
         max-width: none;
-        padding: 88px 0 128px;
+        padding: 80px 0 128px;
         width: 928px;
 
         > div {

--- a/app/src/userpages/components/StreamPage/View.jsx
+++ b/app/src/userpages/components/StreamPage/View.jsx
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux'
 import Layout from '$shared/components/Layout/Core'
 import Label from '$ui/Label'
 import UnstyledText from '$ui/Text'
-import { SM, MD, LG, XL, MEDIUM } from '$shared/utils/styled'
+import { SM, MD, XL, MEDIUM } from '$shared/utils/styled'
 import TOCPage, { Title } from '$shared/components/TOCPage'
 import TOCSection from '$shared/components/TOCPage/TOCSection'
 import BackButton from '$shared/components/BackButton'
@@ -358,14 +358,6 @@ const View = styled(UnstyledView)`
 
     ${Title} {
         display: block;
-    }
-
-    ${TOCSection}:first-child {
-        padding-top: 24px;
-
-        @media (min-width: ${LG}px) {
-            padding-top: 72px;
-        }
     }
 `
 


### PR DESCRIPTION
Add truncation for read-only stream title:
<img width="1017" alt="Screen Shot 2020-06-08 at 11 33 55" src="https://user-images.githubusercontent.com/1064982/84009691-524c6a80-a97c-11ea-9726-df241ce87012.png">
<img width="769" alt="Screen Shot 2020-06-08 at 11 34 04" src="https://user-images.githubusercontent.com/1064982/84009702-57111e80-a97c-11ea-9e46-e5d4d9d4e96f.png">

Editable stream:
<img width="1057" alt="Screen Shot 2020-06-08 at 11 34 43" src="https://user-images.githubusercontent.com/1064982/84009744-67c19480-a97c-11ea-8037-f64949e69c7a.png">
<img width="919" alt="Screen Shot 2020-06-08 at 11 34 50" src="https://user-images.githubusercontent.com/1064982/84009773-6f813900-a97c-11ea-80e5-969de7a76f73.png">

Profile page:
<img width="1036" alt="Screen Shot 2020-06-08 at 11 34 34" src="https://user-images.githubusercontent.com/1064982/84009794-77d97400-a97c-11ea-8ed5-a472e4c79860.png">
<img width="921" alt="Screen Shot 2020-06-08 at 11 34 21" src="https://user-images.githubusercontent.com/1064982/84009812-7d36be80-a97c-11ea-813e-34a3b74ed6dd.png">
