### PR TITLE
Refactor transaction list, fix transaction fetching

### DIFF
--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -53,6 +53,7 @@
     "giveFeedback": "https://github.com/streamr-dev/streamr-platform/issues",
     "publisherTerms": "https://s3.amazonaws.com/streamr-public/streamr-data-provider-agreement.pdf",
     "resetAllowanceInfo": "https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729",
+    "etherscanTransaction": "https://etherscan.io/tx/:tx",
     "allowanceInfo": "https://tokenallowance.io",
     "marketplace": {
         "index": "/marketplace",

--- a/app/src/userpages/components/TransactionPage/List/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/index.jsx
@@ -1,24 +1,24 @@
 // @flow
 
-import React, { Component } from 'react'
-import { connect } from 'react-redux'
+import React, { useCallback, useEffect, useMemo } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { Translate, I18n } from 'react-redux-i18n'
 import cx from 'classnames'
-import copy from 'copy-to-clipboard'
 import BN from 'bignumber.js'
 import Helmet from 'react-helmet'
 
 import NoTransactionsView from './NoTransactions'
 import Layout from '$userpages/components/Layout'
-import { selectEthereumIdentities } from '$shared/modules/integrationKey/selectors'
-import type { StoreState } from '$shared/flowtype/store-state'
-import type { TransactionEntityList, Address } from '$shared/flowtype/web3-types'
-import type { IntegrationKeyList } from '$shared/flowtype/integration-key-types'
-import type { ProductEntities } from '$mp/flowtype/product-types'
-import { fetchIntegrationKeys } from '$shared/modules/integrationKey/actions'
-import { getTransactionEvents, showEvents, clearTransactionList, noTransactionResults } from '$userpages/modules/transactionHistory/actions'
-import { selectVisibleTransactions, selectTransactionEvents, selectOffset, selectFetching } from '$userpages/modules/transactionHistory/selectors'
+import * as transactionActions from '$userpages/modules/transactionHistory/actions'
+import {
+    selectVisibleTransactions,
+    selectTransactionEvents,
+    selectOffset,
+    selectFetching as selectFetchingTransactions,
+} from '$userpages/modules/transactionHistory/selectors'
+import { selectFetching as selectFetchingProducts } from '$mp/modules/myProductList/selectors'
 import { selectEntities } from '$shared/modules/entities/selectors'
+import { getMyProducts } from '$mp/modules/myProductList/actions'
 import { mapPriceFromContract } from '$mp/utils/product'
 import Table from '$shared/components/Table'
 import DropdownActions from '$shared/components/DropdownActions'
@@ -26,188 +26,151 @@ import Meatball from '$shared/components/Meatball'
 import LoadMore from '$mp/components/LoadMore'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import ListContainer from '$shared/components/Container/List'
-import { selectAccountId } from '$mp/modules/web3/selectors'
-import { areAddressesEqual } from '$mp/utils/smartContract'
 import { ago } from '$shared/utils/time'
+import useAccountAddress from '$shared/hooks/useAccountAddress'
+import useCopy from '$shared/hooks/useCopy'
+import useEthereumIdentities from '$shared/modules/integrationKey/hooks/useEthereumIdentities'
+import routes from '$routes'
 
 import styles from './list.pcss'
 
-type StateProps = {
-    fetching: boolean,
-    web3Accounts: ?IntegrationKeyList,
-    transactions: ?TransactionEntityList,
-    products: ProductEntities,
-    hasMoreResults: boolean,
-    accountId: ?Address,
-}
+const TransactionList = () => {
+    const dispatch = useDispatch()
 
-type DispatchProps = {
-    clearTransactionList: () => void,
-    noTransactionResults: () => void,
-    getWeb3Accounts: () => void,
-    getTransactionEvents: () => void,
-    showEvents: () => void,
-    copyToClipboard: (text: string) => void,
-    openInEtherscan: (url: string) => void,
-}
+    const accountId = useAccountAddress()
+    const { copy: copyToClipboard } = useCopy()
+    const { load: loadEthIdentities, isLinked, ethereumIdentities } = useEthereumIdentities()
 
-type Props = StateProps & DispatchProps
+    const offset = useSelector(selectOffset)
+    const events = useSelector(selectTransactionEvents) || []
+    const transactions = useSelector(selectVisibleTransactions)
+    const fetchingTransactions = useSelector(selectFetchingTransactions)
+    const fetchingProducs = useSelector(selectFetchingProducts)
+    const { contractProducts: products } = useSelector(selectEntities)
+    const hasMoreResults = events.length > 0 && events.length > (offset + 10)
 
-class TransactionList extends Component<Props> {
-    async componentDidMount() {
-        this.props.clearTransactionList()
-        await this.props.getWeb3Accounts()
-        await this.startSubscription()
-    }
+    const clearTransactionList = useCallback(() => dispatch(transactionActions.clearTransactionList()), [dispatch])
+    const getTransactionEvents = useCallback(() => dispatch(transactionActions.getTransactionEvents()), [dispatch])
+    const showEvents = useCallback(() => dispatch(transactionActions.showEvents()), [dispatch])
+    const openInEtherscan = useCallback((tx: string) => {
+        window.open(routes.etherscanTransaction({
+            tx,
+        }), '_blank')
+    }, [])
 
-    startSubscription = () => {
-        const { web3Accounts, getTransactionEvents, noTransactionResults } = this.props
-        if (web3Accounts) {
-            if (web3Accounts.length > 0) {
-                getTransactionEvents()
-            } else {
-                noTransactionResults()
+    const loadProducts = useCallback(() => dispatch(getMyProducts({
+        id: '',
+    })), [dispatch])
+
+    useEffect(() => {
+        clearTransactionList()
+
+        Promise.all([
+            loadEthIdentities(),
+            loadProducts(),
+        ])
+            .then(getTransactionEvents)
+    }, [clearTransactionList, loadEthIdentities, loadProducts, getTransactionEvents])
+
+    const accountsExist = useMemo(() => !!(ethereumIdentities && ethereumIdentities.length), [ethereumIdentities])
+    const accountLinked = useMemo(() => !!(accountId && isLinked(accountId)), [isLinked, accountId])
+
+    const isLoading = !!(fetchingTransactions || fetchingProducs)
+    return (
+        <Layout
+            loading={isLoading}
+            headerSearchComponent={
+                <div className={styles.searchPlaceholder} />
             }
-        }
-    }
+        >
+            <Helmet title={`Streamr Core | ${I18n.t('userpages.title.transactions')}`} />
+            <ListContainer className={styles.transactionList}>
+                {!isLoading && transactions && transactions.length <= 0 && (
+                    <NoTransactionsView
+                        accountsExist={accountsExist}
+                        accountLinked={accountLinked}
+                    />
+                )}
+                {transactions && transactions.length > 0 && (
+                    <Table className={cx({
+                        [styles.loadingMore]: !!(hasMoreResults && fetchingTransactions),
+                    })}
+                    >
+                        <thead>
+                            <tr>
+                                <th><Translate value="userpages.transactions.list.name" /></th>
+                                <th><Translate value="userpages.transactions.list.type" /></th>
+                                <th><Translate value="userpages.transactions.list.transaction" /></th>
+                                <th><Translate value="userpages.transactions.list.when" /></th>
+                                <th><Translate value="userpages.transactions.list.value" /></th>
+                                <th><Translate value="userpages.transactions.list.gas" /></th>
+                                <th><Translate value="userpages.transactions.list.status" /></th>
+                                <th className={styles.menuColumn} />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {transactions.map((transaction) => {
+                                const productTitle = (transaction && transaction.productId && products[transaction.productId]) ?
+                                    products[transaction.productId].name : '-'
+                                const price = BN(transaction.value)
 
-    render() {
-        const {
-            fetching,
-            transactions,
-            hasMoreResults,
-            web3Accounts,
-            accountId,
-        } = this.props
-        const accountsExist = !!(web3Accounts && web3Accounts.length)
-        const accountLinked = !!(web3Accounts &&
-            accountId &&
-            web3Accounts.find((account) =>
-                account.json && account.json.address && areAddressesEqual(account.json.address, accountId))
-        )
-
-        return (
-            <Layout
-                loading={fetching}
-                headerSearchComponent={
-                    <div className={styles.searchPlaceholder} />
-                }
-            >
-                <Helmet title={`Streamr Core | ${I18n.t('userpages.title.transactions')}`} />
-                <ListContainer className={styles.transactionList}>
-                    {!fetching && transactions && transactions.length <= 0 && (
-                        <NoTransactionsView
-                            accountsExist={accountsExist}
-                            accountLinked={accountLinked}
-                        />
-                    )}
-                    {transactions && transactions.length > 0 && (
-                        <Table className={cx({
-                            [styles.loadingMore]: !!(hasMoreResults && fetching),
-                        })}
-                        >
-                            <thead>
-                                <tr>
-                                    <th><Translate value="userpages.transactions.list.name" /></th>
-                                    <th><Translate value="userpages.transactions.list.type" /></th>
-                                    <th><Translate value="userpages.transactions.list.transaction" /></th>
-                                    <th><Translate value="userpages.transactions.list.when" /></th>
-                                    <th><Translate value="userpages.transactions.list.value" /></th>
-                                    <th><Translate value="userpages.transactions.list.gas" /></th>
-                                    <th><Translate value="userpages.transactions.list.status" /></th>
-                                    <th className={styles.menuColumn} />
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {transactions.map((transaction) => {
-                                    const productTitle = (transaction && transaction.productId && this.props.products[transaction.productId]) ?
-                                        this.props.products[transaction.productId].name : '-'
-                                    const price = BN(transaction.value)
-
-                                    return (
-                                        <tr key={transaction.id}>
-                                            <Table.Th title={productTitle} noWrap>{productTitle}</Table.Th>
-                                            <Table.Td title={transaction.type} noWrap>
-                                                {!!transaction.type && (
-                                                    <Translate value={`userpages.transactions.type.${transaction.type}`} />
-                                                )}
-                                            </Table.Td>
-                                            <Table.Td title={transaction.hash} noWrap>{transaction.hash}</Table.Td>
-                                            <Table.Td noWrap>{transaction.timestamp ? ago(new Date(transaction.timestamp)) : '-'}</Table.Td>
-                                            <Table.Td noWrap>
-                                                {price.isGreaterThanOrEqualTo(0) ? '+' : ''}{mapPriceFromContract(price)} DATA
-                                            </Table.Td>
-                                            <Table.Td noWrap>{transaction.gasUsed} / {transaction.gasPrice}</Table.Td>
-                                            <Table.Td noWrap>
-                                                {!!transaction.state && (
-                                                    <Translate value={`userpages.transactions.status.${transaction.state}`} />
-                                                )}
-                                            </Table.Td>
-                                            <Table.Td className={styles.menuColumn}>
-                                                <DropdownActions
-                                                    title={<Meatball alt={I18n.t('userpages.transactions.actions.title')} />}
-                                                    noCaret
-                                                    menuProps={{
-                                                        modifiers: {
-                                                            offset: {
-                                                                // Make menu aligned to the right.
-                                                                // See https://popper.js.org/popper-documentation.html#modifiers..offset
-                                                                offset: '-100%p + 100%',
-                                                            },
+                                return (
+                                    <tr key={transaction.id}>
+                                        <Table.Th title={productTitle} noWrap>{productTitle}</Table.Th>
+                                        <Table.Td title={transaction.type} noWrap>
+                                            {!!transaction.type && (
+                                                <Translate value={`userpages.transactions.type.${transaction.type}`} />
+                                            )}
+                                        </Table.Td>
+                                        <Table.Td title={transaction.hash} noWrap>{transaction.hash}</Table.Td>
+                                        <Table.Td noWrap>{transaction.timestamp ? ago(new Date(transaction.timestamp)) : '-'}</Table.Td>
+                                        <Table.Td noWrap>
+                                            {price.isGreaterThanOrEqualTo(0) ? '+' : ''}{mapPriceFromContract(price)} DATA
+                                        </Table.Td>
+                                        <Table.Td noWrap>{transaction.gasUsed} / {transaction.gasPrice}</Table.Td>
+                                        <Table.Td noWrap>
+                                            {!!transaction.state && (
+                                                <Translate value={`userpages.transactions.status.${transaction.state}`} />
+                                            )}
+                                        </Table.Td>
+                                        <Table.Td className={styles.menuColumn}>
+                                            <DropdownActions
+                                                title={<Meatball alt={I18n.t('userpages.transactions.actions.title')} />}
+                                                noCaret
+                                                menuProps={{
+                                                    modifiers: {
+                                                        offset: {
+                                                            // Make menu aligned to the right.
+                                                            // See https://popper.js.org/popper-documentation.html#modifiers..offset
+                                                            offset: '-100%p + 100%',
                                                         },
-                                                    }}
-                                                >
-                                                    <DropdownActions.Item onClick={() => this.props.openInEtherscan(transaction.hash)}>
-                                                        <Translate value="userpages.transactions.actions.viewOnEtherscan" />
-                                                    </DropdownActions.Item>
-                                                    <DropdownActions.Item onClick={() => this.props.copyToClipboard(transaction.hash)}>
-                                                        <Translate value="userpages.transactions.actions.copyTxHash" />
-                                                    </DropdownActions.Item>
-                                                </DropdownActions>
-                                            </Table.Td>
-                                        </tr>
-                                    )
-                                })}
-                            </tbody>
-                        </Table>
-                    )}
-                    {!fetching && (
-                        <LoadMore
-                            hasMoreSearchResults={hasMoreResults}
-                            onClick={this.props.showEvents}
-                        />
-                    )}
-                </ListContainer>
-                <DocsShortcuts />
-            </Layout>
-        )
-    }
+                                                    },
+                                                }}
+                                            >
+                                                <DropdownActions.Item onClick={() => openInEtherscan(transaction.hash)}>
+                                                    <Translate value="userpages.transactions.actions.viewOnEtherscan" />
+                                                </DropdownActions.Item>
+                                                <DropdownActions.Item onClick={() => copyToClipboard(transaction.hash)}>
+                                                    <Translate value="userpages.transactions.actions.copyTxHash" />
+                                                </DropdownActions.Item>
+                                            </DropdownActions>
+                                        </Table.Td>
+                                    </tr>
+                                )
+                            })}
+                        </tbody>
+                    </Table>
+                )}
+                {!fetchingTransactions && (
+                    <LoadMore
+                        hasMoreSearchResults={hasMoreResults}
+                        onClick={showEvents}
+                    />
+                )}
+            </ListContainer>
+            <DocsShortcuts />
+        </Layout>
+    )
 }
 
-const mapStateToProps = (state: StoreState) => {
-    const offset = selectOffset(state)
-    const events = selectTransactionEvents(state) || []
-
-    return {
-        accountId: selectAccountId(state),
-        transactions: selectVisibleTransactions(state),
-        fetching: selectFetching(state),
-        web3Accounts: selectEthereumIdentities(state),
-        products: selectEntities(state).contractProducts,
-        hasMoreResults: events.length > 0 && events.length > (offset + 10),
-    }
-}
-
-const mapDispatchToProps = (dispatch: Function) => ({
-    noTransactionResults: () => dispatch(noTransactionResults()),
-    clearTransactionList: () => dispatch(clearTransactionList()),
-    getWeb3Accounts: () => dispatch(fetchIntegrationKeys()),
-    getTransactionEvents: () => dispatch(getTransactionEvents()),
-    showEvents: () => dispatch(showEvents()),
-    copyToClipboard: (text) => copy(text),
-    openInEtherscan: (url: string) => {
-        window.open(`https://rinkeby.etherscan.io/tx/${url}`, '_blank')
-    },
-})
-
-export default connect(mapStateToProps, mapDispatchToProps)(TransactionList)
+export default TransactionList

--- a/app/src/userpages/components/TransactionPage/List/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/index.jsx
@@ -58,7 +58,7 @@ const TransactionList = () => {
     const events = useSelector(selectTransactionEvents) || []
     const transactions = useSelector(selectVisibleTransactions)
     const fetchingTransactions = useSelector(selectFetchingTransactions)
-    const fetchingProducs = useSelector(selectFetchingProducts)
+    const fetchingProducts = useSelector(selectFetchingProducts)
     const { contractProducts: products } = useSelector(selectEntities)
     const hasMoreResults = events.length > 0 && events.length > (offset + 10)
 
@@ -88,7 +88,7 @@ const TransactionList = () => {
     const accountsExist = useMemo(() => !!(ethereumIdentities && ethereumIdentities.length), [ethereumIdentities])
     const accountLinked = useMemo(() => !!(accountId && isLinked(accountId)), [isLinked, accountId])
 
-    const isLoading = !!(fetchingTransactions || fetchingProducs)
+    const isLoading = !!(fetchingTransactions || fetchingProducts)
     return (
         <Layout
             loading={isLoading}

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -725,6 +725,9 @@ msgstr "View on Etherscan"
 msgid "userpages##transactions##actions##copyTxHash"
 msgstr "Copy TX hash"
 
+msgid "userpages##transactions##actions##txHashCopied"
+msgstr "TX hash copied"
+
 msgid "userpages##transactions##type##createContractProduct"
 msgstr "Publish"
 

--- a/app/src/userpages/modules/transactionHistory/services.js
+++ b/app/src/userpages/modules/transactionHistory/services.js
@@ -36,8 +36,10 @@ const getPurchaseTokens = (logValues) => {
 
         // ETH
         case 2: {
-            paymentCurrency = paymentCurrencies.ETH;
-            [currencyEvent, dataEvent] = transferEvents
+            // TODO: approximate ETH from currencyEvent token amount
+            // paymentCurrency = paymentCurrencies.ETH;
+            // [currencyEvent, dataEvent] = transferEvents
+            [, dataEvent] = transferEvents
 
             break
         }

--- a/app/src/userpages/modules/transactionHistory/services.js
+++ b/app/src/userpages/modules/transactionHistory/services.js
@@ -9,98 +9,93 @@ import { getPublicWeb3 } from '$shared/web3/web3Provider'
 import getConfig from '$shared/web3/config'
 import type { HashList, TransactionEntityList, TransactionEntity, EventLog, EventLogList } from '$shared/flowtype/web3-types'
 import TransactionError from '$shared/errors/TransactionError'
-// import { getUnprefixedHexString } from '$mp/utils/smartContract'
+import type { ProductIdList } from '$mp/flowtype/product-types'
+
+const eventTypeToTransactionType = {
+    ProductCreated: transactionTypes.CREATE_CONTRACT_PRODUCT,
+    ProductUpdated: transactionTypes.UPDATE_CONTRACT_PRODUCT,
+    ProductDeleted: transactionTypes.UNDEPLOY_PRODUCT,
+    ProductRedeployed: transactionTypes.REDEPLOY_PRODUCT,
+}
 
 const getInputValues = (type, logs) => {
-    const logValues = abiDecoder.decodeLogs(logs)
+    const logValues = (abiDecoder.decodeLogs(logs) || []).filter(Boolean)
 
     switch (type) {
-        case 'PaymentReceived':
-            // hack to handle minting coins to account (also a transfer event)
-            if (logValues[1].name === 'Minted') {
-                return {
-                    productId: '0x0',
-                    type: transactionTypes.PAYMENT,
-                    value: logValues[1].events[0].value,
-                }
-            }
+        case 'PaymentReceived': {
+            const { events: subscribedEvents } = logValues.find(({ name }) => name === 'Subscribed') || {}
+            const { events: transferEvents } = logValues.find(({ name }) => name === 'Transfer') || {}
+            const { value: productId } = (subscribedEvents && subscribedEvents.find(({ name }) => name === 'productId')) || {}
+            const { value: tokens } = (transferEvents && transferEvents.find(({ name }) => name === 'tokens')) || {}
 
             return {
-                productId: logValues[1].events[0].value,
+                productId,
                 type: transactionTypes.PAYMENT,
-                value: logValues[2].events[2].value,
+                value: tokens,
             }
+        }
 
-        case 'PaymentSent':
+        case 'PaymentSent': {
+            const { events: subscribedEvents } = logValues.find(({ name }) => name === 'Subscribed') || {}
+            const { events: transferEvents } = logValues.find(({ name }) => name === 'Transfer') || {}
+            const { value: productId } = (subscribedEvents && subscribedEvents.find(({ name }) => name === 'productId')) || {}
+            const { value: tokens } = (transferEvents && transferEvents.find(({ name }) => name === 'tokens')) || {}
+
             return {
-                productId: logValues[1].events[0].value,
+                productId,
                 type: transactionTypes.PURCHASE,
-                value: BN(logValues[2].events[2].value).negated(),
+                value: BN(tokens).negated(),
             }
+        }
 
         case 'ProductCreated':
-            return {
-                productId: logValues[0].events[1].value,
-                type: transactionTypes.CREATE_CONTRACT_PRODUCT,
-                value: '0',
-            }
-
         case 'ProductUpdated':
-            return {
-                productId: logValues[0].events[1].value,
-                type: transactionTypes.UPDATE_CONTRACT_PRODUCT,
-                value: '0',
-            }
-
         case 'ProductDeleted':
-            return {
-                productId: logValues[0].events[1].value,
-                type: transactionTypes.UNDEPLOY_PRODUCT,
-                value: '0',
-            }
+        case 'ProductRedeployed': {
+            const { events } = logValues.find(({ name }) => name === type) || {}
+            const { value: productId } = (events && events.find(({ name }) => name === 'id')) || {}
 
-        case 'ProductRedeployed':
             return {
-                productId: logValues[0].events[1].value,
-                type: transactionTypes.REDEPLOY_PRODUCT,
+                productId,
+                type: eventTypeToTransactionType[type],
                 value: '0',
             }
+        }
 
         default:
             return {}
     }
 }
 
-export const getTransactionEvents = (addresses: HashList): Promise<EventLogList> => {
+export const getTransactionEvents = (addresses: HashList, products: ProductIdList): Promise<EventLogList> => {
     const web3 = getPublicWeb3()
     const { marketplace, dataToken } = getConfig()
-    const marketPlaceContract = new web3.eth.Contract(marketplace.abi, marketplace.address)
-    const tokenContract = new web3.eth.Contract(dataToken.abi, dataToken.address)
+
+    // these are needed to decode log values
     abiDecoder.addABI(marketplace.abi)
     abiDecoder.addABI(dataToken.abi)
 
+    const marketPlaceContract = new web3.eth.Contract(marketplace.abi, marketplace.address)
     const rawEvents = []
 
     // Get past events by filtering with the indexed address parameter.
     const eventNames = [{
-        contract: tokenContract, name: 'Transfer', filter: 'to', type: 'PaymentReceived',
+        contract: marketPlaceContract, name: 'Subscribed', filter: { productId: products }, type: 'PaymentReceived',
     }, {
-        contract: tokenContract, name: 'Transfer', filter: 'from', type: 'PaymentSent',
+        contract: marketPlaceContract, name: 'Subscribed', filter: { subscriber: addresses }, type: 'PaymentSent',
     }, {
-        contract: marketPlaceContract, name: 'ProductCreated', filter: 'owner', type: 'ProductCreated',
+        contract: marketPlaceContract, name: 'ProductCreated', filter: { owner: addresses }, type: 'ProductCreated',
     }, {
-        contract: marketPlaceContract, name: 'ProductUpdated', filter: 'owner', type: 'ProductUpdated',
+        contract: marketPlaceContract, name: 'ProductUpdated', filter: { owner: addresses }, type: 'ProductUpdated',
     }, {
-        contract: marketPlaceContract, name: 'ProductDeleted', filter: 'owner', type: 'ProductDeleted',
+        contract: marketPlaceContract, name: 'ProductDeleted', filter: { owner: addresses }, type: 'ProductDeleted',
     }, {
-        contract: marketPlaceContract, name: 'ProductRedeployed', filter: 'owner', type: 'ProductRedeployed',
+        contract: marketPlaceContract, name: 'ProductRedeployed', filter: { owner: addresses }, type: 'ProductRedeployed',
     }]
     const eventTypes = eventNames.map(({ type }) => type)
     const eventPromises = eventNames.map(({ contract, name, filter }) => contract.getPastEvents(name, {
         fromBlock: 1,
-        filter: {
-            [(filter: string)]: addresses,
-        },
+        filter,
     }))
     const transactionCounts = {}
 
@@ -138,25 +133,31 @@ export const getTransactionsFromEvents = (events: EventLogList): Promise<Transac
         web3.eth.getTransactionReceipt(event.transactionHash),
         web3.eth.getBlock(event.blockHash),
     ])))
-        .then(([...transactions]) =>
-            transactions.map(([event, tx, receipt, block]): TransactionEntity => {
-                const rest = {}
+        .then(([...transactions]) => transactions.map(([event, tx, receipt, block]): TransactionEntity => {
+            const rest = {}
 
-                if (receipt.status === true) {
-                    rest.receipt = receipt
-                } else {
-                    rest.error = new TransactionError(I18n.t('error.txFailed'), receipt)
-                }
+            if (receipt.status === true) {
+                rest.receipt = receipt
+            } else {
+                rest.error = new TransactionError(I18n.t('error.txFailed'), receipt)
+            }
 
-                return {
-                    id: event.id,
-                    hash: tx.hash,
-                    state: 'completed',
-                    gasUsed: receipt.gasUsed,
-                    gasPrice: tx.gas,
-                    timestamp: block.timestamp,
-                    ...getInputValues(event.type, receipt.logs),
-                    ...rest,
-                }
-            }))
+            let inputValues
+            try {
+                inputValues = getInputValues(event.type, receipt.logs)
+            } catch (e) {
+                console.warn(e)
+            }
+
+            return {
+                id: event.id,
+                hash: tx.hash,
+                state: 'completed',
+                gasUsed: receipt.gasUsed,
+                gasPrice: tx.gas,
+                timestamp: block.timestamp,
+                ...(inputValues || {}),
+                ...rest,
+            }
+        }))
 }


### PR DESCRIPTION
Fixes the transaction list so that it can fetch purchases (using the new contract) and at least not crash 🙄 The trickiest part is fetching the payments coming to the user, Uniswap purchases don't show when searching with the `to` address filter. In the end I wound up using a list of the products owned by the current user to do that filtering.

The timestamp is off (showing "50 years ago") but that is the timestamp returned for the block, I suspect this is due to Parity). It's not exactly the Unix epoch but in fact sometime after, ie. timestamp is not being returned as `0`.

<img width="1366" alt="Screen Shot 2020-06-09 at 21 29 04" src="https://user-images.githubusercontent.com/1064982/84186088-a64c7180-aa98-11ea-9fb3-4d629db9e276.png">

Buying your own product will show the money spent and received:
<img width="1356" alt="Screen Shot 2020-06-09 at 21 29 52" src="https://user-images.githubusercontent.com/1064982/84186137-be23f580-aa98-11ea-9640-0d982f85fdda.png">

PR test url: http://streamr-marketplace-pr-32daf1076b2dc7e992872f2cd5919c7296efa039.s3-website-eu-west-1.amazonaws.com/core/transactions