### PR TITLE
[PLATFORM-1398] Update table header font

### DIFF
--- a/app/src/shared/components/Table/table.pcss
+++ b/app/src/shared/components/Table/table.pcss
@@ -29,11 +29,13 @@
   }
 
   thead {
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: normal;
-    letter-spacing: 0;
-    color: #A3A3A3;
+    th {
+      font-family: var(--sans);
+      font-size: 12px;
+      letter-spacing: 0;
+      color: #A3A3A3;
+      font-weight: var(--medium);
+    }
   }
 
   tbody tr th {

--- a/app/src/shared/components/Table/table.pcss
+++ b/app/src/shared/components/Table/table.pcss
@@ -25,7 +25,7 @@
   }
 
   tbody tr:--enter {
-    background-color: #E7E7E7 !important;
+    background-color: #EFEFEF !important;
   }
 
   thead {
@@ -35,6 +35,8 @@
       letter-spacing: 0;
       color: #A3A3A3;
       font-weight: var(--medium);
+      line-height: 2;
+      padding-bottom: 0.5rem;
     }
   }
 


### PR DESCRIPTION
Updated the shared table font:
<img width="1379" alt="Screen Shot 2020-06-15 at 11 45 14" src="https://user-images.githubusercontent.com/1064982/84636952-e2029380-aefd-11ea-88e4-42507000811c.png">
