### PR TITLE
[PLATFORM-1409] Keep header visible while loading DU data

### DIFF
--- a/app/src/userpages/components/ProductsPage/Header/index.jsx
+++ b/app/src/userpages/components/ProductsPage/Header/index.jsx
@@ -44,6 +44,14 @@ const Header = ({ className, searchComponent, filterComponent }: Props) => {
         dispatch,
     ])
 
+    const {
+        id,
+        imageUrl,
+        name,
+        beneficiaryAddress,
+        state,
+    } = product || {}
+
     return (
         <React.Fragment>
             <BodyClass className="core" />
@@ -55,21 +63,25 @@ const Header = ({ className, searchComponent, filterComponent }: Props) => {
             <ListContainer className={cx(styles.listTemp, className)}>
                 <div className={styles.profile}>
                     <div className={cx(avatarStyles.container, styles.avatar)}>
-                        <FallbackImage
-                            className={cx(avatarCircleStyles.accountCircle, avatarStyles.avatarCircle)}
-                            src={product.imageUrl || ''}
-                            alt={product.name || ''}
-                        />
-                        <NameAndUsername name={product.name} username={product.beneficiaryAddress} />
+                        {!imageUrl ? (
+                            <div className={avatarStyles.avatarCircle} />
+                        ) : (
+                            <FallbackImage
+                                className={cx(avatarCircleStyles.accountCircle, avatarStyles.avatarCircle)}
+                                src={imageUrl || ''}
+                                alt={name || ''}
+                            />
+                        )}
+                        <NameAndUsername name={name} username={beneficiaryAddress} />
                     </div>
                     <div className={styles.additionalComponent}>
                         <Button
                             className={styles.viewProductButton}
                             outline
-                            {...(product.state === productStates.DEPLOYED ? {
+                            {...(state === productStates.DEPLOYED ? {
                                 tag: Link,
                                 to: routes.marketplace.product({
-                                    id: product.id,
+                                    id,
                                 }),
                             } : {
                                 type: 'button',
@@ -81,10 +93,16 @@ const Header = ({ className, searchComponent, filterComponent }: Props) => {
                         </Button>
                         <Button
                             className={styles.editProductButton}
-                            tag={Link}
                             outline
-                            to={routes.products.edit({
-                                id: product.id,
+                            {...(id ? {
+                                tag: Link,
+                                to: routes.products.edit({
+                                    id,
+                                }),
+                            } : {
+                                type: 'button',
+                                onClick: () => {},
+                                disabled: true,
                             })}
                         >
                             <Translate value="userpages.products.settings" />
@@ -98,16 +116,16 @@ const Header = ({ className, searchComponent, filterComponent }: Props) => {
                         </div>
                         <div className={styles.tabs}>
                             <Tab
-                                to={routes.products.stats({
-                                    id: product.id,
-                                })}
+                                to={id ? routes.products.stats({
+                                    id,
+                                }) : ''}
                             >
                                 Overview
                             </Tab>
                             <Tab
-                                to={routes.products.members({
-                                    id: product.id,
-                                })}
+                                to={id ? routes.products.members({
+                                    id,
+                                }) : ''}
                             >
                                 Members
                             </Tab>

--- a/app/src/userpages/components/ProductsPage/Members/index.jsx
+++ b/app/src/userpages/components/ProductsPage/Members/index.jsx
@@ -10,8 +10,6 @@ import CoreLayout from '$shared/components/Layout/Core'
 import coreLayoutStyles from '$shared/components/Layout/core.pcss'
 import Header from '../Header'
 import ListContainer from '$shared/components/Container/List'
-import LoadingIndicator from '$shared/components/LoadingIndicator'
-import Layout from '$shared/components/Layout'
 import Dropdown from '$shared/components/Dropdown'
 import { getFilters } from '$userpages/utils/constants'
 import ProductController, { useController } from '$mp/containers/ProductController'
@@ -222,29 +220,29 @@ const Members = () => {
             hideNavOnDesktop
             navComponent={(
                 <Header
-                    {...(dataUnionDeployed ? {
-                        searchComponent: (
-                            <Search
-                                placeholder={I18n.t('userpages.members.filterMembers')}
-                                value={search || ''}
-                                onChange={setSearch}
-                            />
-                        ),
-                        filterComponent: (
-                            <Dropdown
-                                title={I18n.t('userpages.filter.sortBy')}
-                                onChange={onSortChange}
-                                selectedItem={selectedFilterId}
-                                disabled={!dataUnionDeployed}
-                            >
-                                {sortOptions.map((s) => (
-                                    <Dropdown.Item key={s.filter.id} value={s.filter.id}>
-                                        {s.displayName}
-                                    </Dropdown.Item>
-                                ))}
-                            </Dropdown>
-                        ),
-                    } : {})}
+                    searchComponent={dataUnionDeployed ? (
+                        <Search
+                            placeholder={I18n.t('userpages.members.filterMembers')}
+                            value={search || ''}
+                            onChange={setSearch}
+                        />
+                    ) : (
+                        <div className={styles.searchPlaceholder} />
+                    )}
+                    filterComponent={!!dataUnionDeployed && (
+                        <Dropdown
+                            title={I18n.t('userpages.filter.sortBy')}
+                            onChange={onSortChange}
+                            selectedItem={selectedFilterId}
+                            disabled={!dataUnionDeployed}
+                        >
+                            {sortOptions.map((s) => (
+                                <Dropdown.Item key={s.filter.id} value={s.filter.id}>
+                                    {s.displayName}
+                                </Dropdown.Item>
+                            ))}
+                        </Dropdown>
+                    )}
                 />
             )}
             loading={fetchingMembers}
@@ -387,9 +385,19 @@ const Members = () => {
 }
 
 const LoadingView = () => (
-    <Layout nav={false}>
-        <LoadingIndicator loading className={styles.loadingIndicator} />
-    </Layout>
+    <CoreLayout
+        footer={false}
+        hideNavOnDesktop
+        navComponent={(
+            <Header
+                searchComponent={
+                    <div className={styles.searchPlaceholder} />
+                }
+            />
+        )}
+        contentClassname={cx(styles.contentArea, coreLayoutStyles.pad)}
+        loading
+    />
 )
 
 const MembersWrap = () => {

--- a/app/src/userpages/components/ProductsPage/Members/members.pcss
+++ b/app/src/userpages/components/ProductsPage/Members/members.pcss
@@ -143,3 +143,7 @@
     transform: translate(0, -45%);
   }
 }
+
+.searchPlaceholder {
+  width: var(--um);
+}

--- a/app/src/userpages/components/ProductsPage/Stats/index.jsx
+++ b/app/src/userpages/components/ProductsPage/Stats/index.jsx
@@ -10,8 +10,6 @@ import CoreLayout from '$shared/components/Layout/Core'
 import coreLayoutStyles from '$shared/components/Layout/core.pcss'
 import Header from '../Header'
 import ListContainer from '$shared/components/Container/List'
-import LoadingIndicator from '$shared/components/LoadingIndicator'
-import Layout from '$shared/components/Layout'
 import { isEthereumAddress } from '$mp/utils/validate'
 import ProductController, { useController } from '$mp/containers/ProductController'
 import usePending from '$shared/hooks/usePending'
@@ -46,7 +44,11 @@ const Stats = () => {
             footer={false}
             hideNavOnDesktop
             navComponent={(
-                <Header />
+                <Header
+                    searchComponent={
+                        <div className={styles.searchPlaceholder} />
+                    }
+                />
             )}
             contentClassname={cx(styles.contentArea, coreLayoutStyles.pad)}
         >
@@ -88,9 +90,19 @@ const Stats = () => {
 }
 
 const LoadingView = () => (
-    <Layout nav={false}>
-        <LoadingIndicator loading className={styles.loadingIndicator} />
-    </Layout>
+    <CoreLayout
+        footer={false}
+        hideNavOnDesktop
+        navComponent={(
+            <Header
+                searchComponent={
+                    <div className={styles.searchPlaceholder} />
+                }
+            />
+        )}
+        contentClassname={cx(styles.contentArea, coreLayoutStyles.pad)}
+        loading
+    />
 )
 
 const StatsWrap = () => {

--- a/app/src/userpages/components/ProductsPage/Stats/stats.pcss
+++ b/app/src/userpages/components/ProductsPage/Stats/stats.pcss
@@ -24,3 +24,7 @@
   border-radius: 4px;
   padding: 1.5rem 2.5rem;
 }
+
+.searchPlaceholder {
+  width: var(--um);
+}


### PR DESCRIPTION
Fix Stats & Members views to keep header visible while switching between them.

![ezgif-2-8f657addfc58](https://user-images.githubusercontent.com/1064982/84893312-b3282100-b0a7-11ea-8230-119b29031fba.gif)
