### PR TITLE
[PLATFORM-1425] Fix Stream Preview

### DIFF
--- a/app/src/marketplace/components/StreamPreviewPage/index.jsx
+++ b/app/src/marketplace/components/StreamPreviewPage/index.jsx
@@ -112,7 +112,7 @@ const StreamPreviewPage = ({
         return null
     }
 
-    if (!productId && !(permissions || []).includes('read')) {
+    if (!productId && !(permissions || []).includes('stream_get')) {
         throw new ResourceNotFoundError(ResourceType.STREAM, urlId)
     }
 


### PR DESCRIPTION
A permissions check seemed to trip up the Stream Editor Live Preview - reproducible in local & prod. 