### PR TITLE
[PLATFORM-1414] Add more steps to progress bars

### DIFF
--- a/app/src/marketplace/components/Modal/PublishTransactionProgress/index.jsx
+++ b/app/src/marketplace/components/Modal/PublishTransactionProgress/index.jsx
@@ -21,20 +21,12 @@ export type Props = {
     isPrompted?: boolean,
 }
 
-const StyledDialog = styled(Dialog)`
-    ${({ isPrompted }) => !!isPrompted && css`
-        .${Dialog.classNames.title} {
-            opacity: 0.5;
-        }
-    `}
-`
-
 const PublishProgress = styled.div`
     width: 100%;
 `
 
 const PendingTasks = styled.div`
-    color: #A3A3A3;
+    color: ${({ isPrompted }) => (isPrompted ? '#FF5C00' : '#A3A3A3')};
     font-size: 1rem;
     line-height: 1.5rem;
     width: 100%;
@@ -82,8 +74,7 @@ const PublishTransactionProgress = ({ publishMode, onCancel, status, isPrompted 
 
     return (
         <ModalPortal>
-            <StyledDialog
-                isPrompted={isPrompted}
+            <Dialog
                 onClose={onCancel}
                 title={I18n.t(`modal.publishProgress.${publishMode}.title`)}
                 actions={{
@@ -112,7 +103,7 @@ const PublishTransactionProgress = ({ publishMode, onCancel, status, isPrompted 
                     </PendingTasks>
                     <ProgressBar value={((progress + 1) / ((Object.keys(status).length * 2) + 1)) * 100} />
                 </PublishProgress>
-            </StyledDialog>
+            </Dialog>
         </ModalPortal>
     )
 }

--- a/app/src/marketplace/components/Modal/PublishTransactionProgress/index.jsx
+++ b/app/src/marketplace/components/Modal/PublishTransactionProgress/index.jsx
@@ -53,21 +53,31 @@ const PendingTasks = styled.div`
 `
 
 const PublishTransactionProgress = ({ publishMode, onCancel, status, isPrompted }: Props) => {
-    const { pending, complete } = useMemo(() => Object.keys(status).reduce((result, key) => {
+    const { pending, progress } = useMemo(() => Object.keys(status).reduce((result, key) => {
         const value = status[key]
 
         if (value === transactionStates.PENDING) {
-            result.pending.push(key)
+            return {
+                ...result,
+                pending: [
+                    ...result.pending,
+                    key,
+                ],
+                progress: result.progress + 1,
+            }
         }
 
         if (value === transactionStates.FAILED || value === transactionStates.CONFIRMED) {
-            result.complete.push(key)
+            return {
+                ...result,
+                progress: result.progress + 2,
+            }
         }
 
         return result
     }, {
         pending: [],
-        complete: [],
+        progress: 0,
     }), [status])
 
     return (
@@ -100,7 +110,7 @@ const PublishTransactionProgress = ({ publishMode, onCancel, status, isPrompted 
                             I18n.t(`modal.publishProgress.${key}.pending`)
                         )).join(', ')}
                     </PendingTasks>
-                    <ProgressBar value={(complete.length / Math.max(1, Object.keys(status).length)) * 100} />
+                    <ProgressBar value={((progress + 1) / ((Object.keys(status).length * 2) + 1)) * 100} />
                 </PublishProgress>
             </StyledDialog>
         </ModalPortal>

--- a/app/src/marketplace/components/Modal/PurchaseTransactionProgress/index.jsx
+++ b/app/src/marketplace/components/Modal/PurchaseTransactionProgress/index.jsx
@@ -152,21 +152,31 @@ const PurchasePrompt = ({ onCancel }: PromptProps) => (
 )
 
 const PurchaseTransactionProgress = ({ onCancel, status, prompt }: Props) => {
-    const { pending, complete } = useMemo(() => Object.keys(status).reduce((result, key) => {
+    const { pending, progress } = useMemo(() => Object.keys(status).reduce((result, key) => {
         const value = status[key]
 
         if (value === transactionStates.PENDING) {
-            result.pending.push(key)
+            return {
+                ...result,
+                pending: [
+                    ...result.pending,
+                    key,
+                ],
+                progress: result.progress + 1,
+            }
         }
 
         if (value === transactionStates.FAILED || value === transactionStates.CONFIRMED) {
-            result.complete.push(key)
+            return {
+                ...result,
+                progress: result.progress + 2,
+            }
         }
 
         return result
     }, {
         pending: [],
-        complete: [],
+        progress: 0,
     }), [status])
 
     switch (prompt) {
@@ -227,7 +237,7 @@ const PurchaseTransactionProgress = ({ onCancel, status, prompt }: Props) => {
                             I18n.t(`modal.purchaseProgress.${key}.pending`)
                         )).join(', ')}
                     </PendingTasks>
-                    <ProgressBar value={(complete.length / Math.max(1, Object.keys(status).length)) * 100} />
+                    <ProgressBar value={((progress + 1) / ((Object.keys(status).length * 2) + 1)) * 100} />
                 </PurchaseProgress>
             </Dialog>
         </ModalPortal>


### PR DESCRIPTION
Adds some comfort noise to purchase and publish modal progress bars by adding the number of steps and initial progress.