### PR TITLE
Fix streams with API keys in share sidebar

### DIFF
--- a/app/src/userpages/components/ShareSidebar/ShareSidebar.test.jsx
+++ b/app/src/userpages/components/ShareSidebar/ShareSidebar.test.jsx
@@ -1,240 +1,288 @@
 import { setupAuthorizationHeader } from '$editor/shared/tests/utils'
 import * as Services from '$editor/canvas/services'
+import * as StreamServices from '$userpages/modules/userPageStreams/services'
+import { addStreamResourceKey } from '$shared/modules/resourceKey/services'
+import { getResourcePermissionsAPI } from '$userpages/modules/permission/actions'
+
 import { getUserData } from '$shared/modules/user/services'
+import uid from 'lodash/uniqueId'
 
 import * as State from './state'
 
 describe('ShareSidebar Permission Handling', () => {
-    // TODO: make these tests ignorant of particular permission names
     let teardown
     let user
-    let canvas
-    let permissions
-    const resourceType = 'CANVAS'
 
     beforeAll(async () => {
         teardown = await setupAuthorizationHeader()
+        user = await getUserData()
     }, 60000)
 
     afterAll(async () => {
         await teardown()
     })
 
-    beforeAll(async () => {
-        user = await getUserData()
-        canvas = await Services.create()
-        permissions = await Services.getCanvasPermissions(canvas)
-    })
+    describe('use with canvas', () => {
+        // TODO: make these tests ignorant of particular permission names
+        let canvas
+        let permissions
+        const resourceType = 'CANVAS'
 
-    afterAll(async () => {
-        if (!canvas) { return }
-        await Services.deleteCanvas(canvas)
-    })
-
-    describe('usersFromPermissions', () => {
-        it('creates dictionary of users + permissions', () => {
-            const users = State.usersFromPermissions(resourceType, permissions)
-            expect(users.anonymous).toBeTruthy() // anonymous user should be added
-            expect(users[user.username]).toBeTruthy()
+        beforeAll(async () => {
+            canvas = await Services.create()
+            permissions = await Services.getCanvasPermissions(canvas)
         })
-    })
 
-    it('can add/remove users', () => {
-        const newUserId = 'test@test.com'
-        let users = State.usersFromPermissions(resourceType, permissions)
-        users = State.addUser(users, newUserId, {})
-        expect(newUserId in users).toBeTruthy()
-        users = State.removeUser(users, newUserId)
-        expect(newUserId in users).not.toBeTruthy() // new user gone
-        expect(user.username in users).toBeTruthy() // original user still around
-    })
-
-    it('can update permissions', () => {
-        const newUserId = 'test@test.com'
-        let users = State.usersFromPermissions(resourceType, permissions)
-        users = State.addUser(users, newUserId)
-        users = State.updatePermission(resourceType, users, newUserId, { get: true })
-        expect(users[newUserId].get).toBeTruthy()
-        users = State.updatePermission(resourceType, users, newUserId, { get: false })
-        expect(users[newUserId].get).not.toBeTruthy() // read perm gone
-        expect(users[user.username]).toBeTruthy() // original user still around
-    })
-
-    it('keeps order of keys', () => {
-        let users = State.usersFromPermissions(resourceType, permissions)
-        const expectedOrder = Object.keys(State.getEmptyPermissions(resourceType))
-        users = State.updatePermission(resourceType, users, user.username, { get: true })
-        expect(Object.keys(users[user.username])).toEqual(expectedOrder)
-        users = State.updatePermission(resourceType, users, user.username, { get: false })
-        expect(Object.keys(users[user.username])).toEqual(expectedOrder)
-    })
-
-    it('errors with bad userId', () => {
-        const users = State.usersFromPermissions(resourceType, permissions)
-        const badUserIds = [
-            null,
-            undefined,
-            {},
-            2,
-            0,
-            /asdasd/,
-            false,
-            true,
-        ]
-
-        badUserIds.forEach((badUserId) => {
-            expect(() => State.addUser(users, badUserId)).toThrow(/Invalid/g)
-            expect(() => State.removeUser(users, badUserId)).toThrow(/Invalid/g)
-            expect(() => State.updatePermission(resourceType, users, badUserId, { get: false })).toThrow(/Invalid/g)
+        afterAll(async () => {
+            if (!canvas) { return }
+            await Services.deleteCanvas(canvas)
         })
-    })
 
-    describe('diff/hasPermissionsChanges', () => {
-        const newUserId = 'test@test.com'
-
-        it('handles no changes', () => {
-            const users = State.usersFromPermissions(resourceType, permissions)
-            const diff = State.diffUsersPermissions({
-                newUsers: users,
-                oldPermissions: permissions,
-                resourceType,
+        describe('usersFromPermissions', () => {
+            it('creates dictionary of users + permissions', () => {
+                const users = State.usersFromPermissions(resourceType, permissions)
+                expect(users.anonymous).toBeTruthy() // anonymous user should be added
+                expect(users[user.username]).toBeTruthy()
             })
-
-            expect(diff.added).toEqual([])
-            expect(diff.removed).toEqual([])
-
-            expect(State.hasPermissionsChanges({
-                newUsers: users,
-                oldPermissions: permissions,
-                resourceType,
-            })).toBe(false)
         })
 
-        it('can detect added', () => {
-            const users = State.usersFromPermissions(resourceType, permissions)
-            const diff = State.diffUsersPermissions({
-                newUsers: users,
-                oldPermissions: [],
-                resourceType,
-            })
-            expect(diff.added).toEqual(permissions.map(({ user, operation }) => ({
-                // ignore id in permissions
-                user,
-                operation,
-            })))
-            expect(diff.removed).toEqual([])
-            expect(State.hasPermissionsChanges({
-                newUsers: users,
-                oldPermissions: [],
-                resourceType,
-            })).toBeTruthy()
-        })
-
-        it('can detect removed', () => {
-            const diff = State.diffUsersPermissions({
-                newUsers: {},
-                oldPermissions: permissions,
-                resourceType,
-            })
-            expect(diff.added).toEqual([])
-            expect(diff.removed).toEqual(permissions)
-            expect(State.hasPermissionsChanges({
-                newUsers: {},
-                oldPermissions: permissions,
-                resourceType,
-            })).toBeTruthy()
-        })
-
-        it('can detect changed', () => {
+        it('can add/remove users', () => {
+            const newUserId = 'test@test.com'
             let users = State.usersFromPermissions(resourceType, permissions)
-            users = State.addUser(users, newUserId, { get: true })
-            const updatedPermissions = State.permissionsFromUsers(resourceType, users)
-            const oldReadPerm = updatedPermissions.find(({ user, operation }) => user === newUserId && operation === 'canvas_get')
-            expect(oldReadPerm).toBeTruthy()
-
-            users = State.updatePermission(resourceType, users, newUserId, { get: false })
-            const diff = State.diffUsersPermissions({
-                newUsers: users,
-                oldPermissions: updatedPermissions,
-                resourceType,
-            })
-            expect(diff.added).toEqual([])
-            expect(diff.removed).toEqual([oldReadPerm])
-
-            expect(State.hasPermissionsChanges({
-                newUsers: users,
-                oldPermissions: updatedPermissions,
-                resourceType,
-            })).toBeTruthy()
+            users = State.addUser(users, newUserId, {})
+            expect(newUserId in users).toBeTruthy()
+            users = State.removeUser(users, newUserId)
+            expect(newUserId in users).not.toBeTruthy() // new user gone
+            expect(user.username in users).toBeTruthy() // original user still around
         })
 
-        it('can detect changed when multiple identical permissions', () => {
+        it('can update permissions', () => {
+            const newUserId = 'test@test.com'
             let users = State.usersFromPermissions(resourceType, permissions)
-            users = State.addUser(users, newUserId, { get: true })
-            const updatedPermissions = State.permissionsFromUsers(resourceType, users)
-            const oldReadPerm = updatedPermissions.find(({ user, operation }) => user === newUserId && operation === 'canvas_get')
-            expect(oldReadPerm).toBeTruthy()
-            const duplicateOldReadPermision = {
-                ...oldReadPerm,
-                id: Math.random(),
-            }
-            updatedPermissions.push(duplicateOldReadPermision)
-
+            users = State.addUser(users, newUserId)
+            users = State.updatePermission(resourceType, users, newUserId, { get: true })
+            expect(users[newUserId].get).toBeTruthy()
             users = State.updatePermission(resourceType, users, newUserId, { get: false })
-            const diff = State.diffUsersPermissions({
-                newUsers: users,
-                oldPermissions: updatedPermissions,
-                resourceType,
-            })
-            expect(diff.added).toEqual([])
-            expect(diff.removed).toEqual([oldReadPerm, duplicateOldReadPermision])
-
-            expect(State.hasPermissionsChanges({
-                newUsers: users,
-                oldPermissions: updatedPermissions,
-                resourceType,
-            })).toBeTruthy()
+            expect(users[newUserId].get).not.toBeTruthy() // read perm gone
+            expect(users[user.username]).toBeTruthy() // original user still around
         })
-    })
 
-    describe('permission group name detection', () => {
-        State.getResourceTypes().slice(0, 1).forEach((resourceType) => {
-            describe(`using ${resourceType}`, () => {
-                it('defaults to default', () => {
-                    const groups = State.getPermissionGroups(resourceType)
-                    const p = State.getPermissionsForGroupName(resourceType, 'default')
-                    const p1 = State.getPermissionsForGroupName(resourceType)
-                    const p2 = State.getPermissionsForGroupName(resourceType, groups.default)
-                    expect(p).toEqual(p1)
-                    expect(p).toEqual(p2)
+        it('keeps order of keys', () => {
+            let users = State.usersFromPermissions(resourceType, permissions)
+            const expectedOrder = Object.keys(State.getEmptyPermissions(resourceType))
+            users = State.updatePermission(resourceType, users, user.username, { get: true })
+            expect(Object.keys(users[user.username])).toEqual(expectedOrder)
+            users = State.updatePermission(resourceType, users, user.username, { get: false })
+            expect(Object.keys(users[user.username])).toEqual(expectedOrder)
+        })
+
+        it('errors with bad userId', () => {
+            const users = State.usersFromPermissions(resourceType, permissions)
+            const badUserIds = [
+                null,
+                undefined,
+                {},
+                2,
+                0,
+                /asdasd/,
+                false,
+                true,
+            ]
+
+            badUserIds.forEach((badUserId) => {
+                expect(() => State.addUser(users, badUserId)).toThrow(/Invalid/g)
+                expect(() => State.removeUser(users, badUserId)).toThrow(/Invalid/g)
+                expect(() => State.updatePermission(resourceType, users, badUserId, { get: false })).toThrow(/Invalid/g)
+            })
+        })
+
+        describe('diff/hasPermissionsChanges', () => {
+            const newUserId = 'test@test.com'
+
+            it('handles no changes', () => {
+                const users = State.usersFromPermissions(resourceType, permissions)
+                const diff = State.diffUsersPermissions({
+                    newUsers: users,
+                    oldPermissions: permissions,
+                    resourceType,
                 })
 
-                it('detects correct name from exact matching permissions', () => {
-                    const groups = State.getPermissionGroups(resourceType)
-                    Object.keys(groups).filter((name) => name !== 'default').forEach((expectedGroupName) => {
-                        const p = State.getPermissionsForGroupName(resourceType, expectedGroupName)
-                        expect(State.findPermissionGroupName(resourceType, p)).toEqual(expectedGroupName)
+                expect(diff.added).toEqual([])
+                expect(diff.removed).toEqual([])
+
+                expect(State.hasPermissionsChanges({
+                    newUsers: users,
+                    oldPermissions: permissions,
+                    resourceType,
+                })).toBe(false)
+            })
+
+            it('can detect added', () => {
+                const users = State.usersFromPermissions(resourceType, permissions)
+                const diff = State.diffUsersPermissions({
+                    newUsers: users,
+                    oldPermissions: [],
+                    resourceType,
+                })
+                expect(diff.added).toEqual(permissions.map(({ user, operation }) => ({
+                    // ignore id in permissions
+                    user,
+                    operation,
+                })))
+                expect(diff.removed).toEqual([])
+                expect(State.hasPermissionsChanges({
+                    newUsers: users,
+                    oldPermissions: [],
+                    resourceType,
+                })).toBeTruthy()
+            })
+
+            it('can detect removed', () => {
+                const diff = State.diffUsersPermissions({
+                    newUsers: {},
+                    oldPermissions: permissions,
+                    resourceType,
+                })
+                expect(diff.added).toEqual([])
+                expect(diff.removed).toEqual(permissions)
+                expect(State.hasPermissionsChanges({
+                    newUsers: {},
+                    oldPermissions: permissions,
+                    resourceType,
+                })).toBeTruthy()
+            })
+
+            it('can detect changed', () => {
+                let users = State.usersFromPermissions(resourceType, permissions)
+                users = State.addUser(users, newUserId, { get: true })
+                const updatedPermissions = State.permissionsFromUsers(resourceType, users)
+                const oldReadPerm = updatedPermissions.find(({ user, operation }) => user === newUserId && operation === 'canvas_get')
+                expect(oldReadPerm).toBeTruthy()
+
+                users = State.updatePermission(resourceType, users, newUserId, { get: false })
+                const diff = State.diffUsersPermissions({
+                    newUsers: users,
+                    oldPermissions: updatedPermissions,
+                    resourceType,
+                })
+                expect(diff.added).toEqual([])
+                expect(diff.removed).toEqual([oldReadPerm])
+
+                expect(State.hasPermissionsChanges({
+                    newUsers: users,
+                    oldPermissions: updatedPermissions,
+                    resourceType,
+                })).toBeTruthy()
+            })
+
+            it('can detect changed when multiple identical permissions', () => {
+                let users = State.usersFromPermissions(resourceType, permissions)
+                users = State.addUser(users, newUserId, { get: true })
+                const updatedPermissions = State.permissionsFromUsers(resourceType, users)
+                const oldReadPerm = updatedPermissions.find(({ user, operation }) => user === newUserId && operation === 'canvas_get')
+                expect(oldReadPerm).toBeTruthy()
+                const duplicateOldReadPermision = {
+                    ...oldReadPerm,
+                    id: Math.random(),
+                }
+                updatedPermissions.push(duplicateOldReadPermision)
+
+                users = State.updatePermission(resourceType, users, newUserId, { get: false })
+                const diff = State.diffUsersPermissions({
+                    newUsers: users,
+                    oldPermissions: updatedPermissions,
+                    resourceType,
+                })
+                expect(diff.added).toEqual([])
+                expect(diff.removed).toEqual([oldReadPerm, duplicateOldReadPermision])
+
+                expect(State.hasPermissionsChanges({
+                    newUsers: users,
+                    oldPermissions: updatedPermissions,
+                    resourceType,
+                })).toBeTruthy()
+            })
+        })
+
+        describe('permission group name detection', () => {
+            State.getResourceTypes().slice(0, 1).forEach((resourceType) => {
+                describe(`using ${resourceType}`, () => {
+                    it('defaults to default', () => {
+                        const groups = State.getPermissionGroups(resourceType)
+                        const p = State.getPermissionsForGroupName(resourceType, 'default')
+                        const p1 = State.getPermissionsForGroupName(resourceType)
+                        const p2 = State.getPermissionsForGroupName(resourceType, groups.default)
+                        expect(p).toEqual(p1)
+                        expect(p).toEqual(p2)
+                    })
+
+                    it('detects correct name from exact matching permissions', () => {
+                        const groups = State.getPermissionGroups(resourceType)
+                        Object.keys(groups).filter((name) => name !== 'default').forEach((expectedGroupName) => {
+                            const p = State.getPermissionsForGroupName(resourceType, expectedGroupName)
+                            expect(State.findPermissionGroupName(resourceType, p)).toEqual(expectedGroupName)
+                        })
+                    })
+
+                    it('detects default group name correctly', () => {
+                        const groups = State.getPermissionGroups(resourceType)
+                        const defaultPermissions = State.getPermissionsForGroupName(resourceType, 'default')
+                        expect(State.findPermissionGroupName(resourceType, defaultPermissions)).toEqual(groups.default) // i.e. not default
                     })
                 })
+            })
 
-                it('detects default group name correctly', () => {
-                    const groups = State.getPermissionGroups(resourceType)
-                    const defaultPermissions = State.getPermissionsForGroupName(resourceType, 'default')
-                    expect(State.findPermissionGroupName(resourceType, defaultPermissions)).toEqual(groups.default) // i.e. not default
+            it('detects correct name + isCustom from similar matching permissions', () => {
+                // for CANVAS, user/editor are dissimilar
+                const GROUP_NAME = 'user'
+                const p = State.getPermissionsForGroupName(resourceType, GROUP_NAME)
+                expect(State.isCustom(resourceType, GROUP_NAME, p)).toBeFalsy()
+                const newPermissions = Object.assign({}, p, {
+                    edit: true,
                 })
+                expect(State.findPermissionGroupName(resourceType, newPermissions)).toEqual(GROUP_NAME)
+                expect(State.isCustom(resourceType, GROUP_NAME, newPermissions)).toBeTruthy()
             })
         })
+    })
 
-        it('detects correct name + isCustom from similar matching permissions', () => {
-            // for CANVAS, user/editor are dissimilar
-            const GROUP_NAME = 'user'
-            const p = State.getPermissionsForGroupName(resourceType, GROUP_NAME)
-            expect(State.isCustom(resourceType, GROUP_NAME, p)).toBeFalsy()
-            const newPermissions = Object.assign({}, p, {
-                edit: true,
+    describe('stream with api key', () => {
+        const resourceType = 'STREAM'
+        let stream
+        let permissions
+
+        beforeAll(async () => {
+            const name = uid('test-stream')
+            stream = await StreamServices.postStream({
+                name,
             })
-            expect(State.findPermissionGroupName(resourceType, newPermissions)).toEqual(GROUP_NAME)
-            expect(State.isCustom(resourceType, GROUP_NAME, newPermissions)).toBeTruthy()
+
+            // add resource key (this shows up in permissions response)
+            await addStreamResourceKey(stream.id, uid(`${name}-stream-api-key`), 'stream_subscribe')
+            permissions = await getResourcePermissionsAPI(resourceType, stream.id)
+        })
+
+        afterAll(async () => {
+            if (!stream) { return }
+            await StreamServices.deleteStream(stream.id)
+        })
+
+        it('ignores api key entries', () => {
+            const users = State.usersFromPermissions(resourceType, permissions)
+
+            // should not have 'undefined' users
+            expect(Object.keys(users)).toEqual([user.username, 'anonymous'])
+
+            const diff = State.diffUsersPermissions({
+                oldPermissions: permissions,
+                newUsers: users,
+                resourceType,
+            })
+            // ensure api key entries don't mess with diffing
+            expect(diff).toStrictEqual({
+                added: [],
+                removed: [],
+            })
         })
     })
 })

--- a/app/src/userpages/components/ShareSidebar/state.js
+++ b/app/src/userpages/components/ShareSidebar/state.js
@@ -227,6 +227,7 @@ export function updatePermission(resourceType, users, userId, permissions = {}) 
 
 export function usersFromPermissions(resourceType, permissions) {
     if (!resourceType) { throw new Error('resourceType required') }
+    permissions = permissions.filter((p) => !p.key) // ignore api keys
     const users = mapValues(groupBy(permissions, 'user'), (value) => {
         const r = Object.assign({}, getEmptyPermissions(resourceType))
         value.forEach((v) => {

--- a/app/src/userpages/modules/permission/actions.js
+++ b/app/src/userpages/modules/permission/actions.js
@@ -60,11 +60,15 @@ const getResourcePermissionsFailure = (error: ErrorInUi) => ({
     error,
 })
 
-export const getResourcePermissions = (resourceType: ResourceType, resourceId: ResourceId, notify: boolean = true) => async (dispatch: Function) => {
-    dispatch(getResourcePermissionsRequest())
-    const resourcePermissions = await api.get({
+export const getResourcePermissionsAPI = (resourceType: ResourceType, resourceId: ResourceId) => (
+    api.get({
         url: `${getApiUrl(resourceType, resourceId)}/permissions`,
     })
+)
+
+export const getResourcePermissions = (resourceType: ResourceType, resourceId: ResourceId, notify: boolean = true) => async (dispatch: Function) => {
+    dispatch(getResourcePermissionsRequest())
+    const resourcePermissions = await getResourcePermissionsAPI(resourceType, resourceId)
         .catch((error) => {
             dispatch(getResourcePermissionsFailure(error))
             if (notify) {


### PR DESCRIPTION
Fixes `Invalid userId: undefined` issue reported by @fonty1 via Sentry: https://sentry.io/organizations/streamr/issues/1732638237/?project=1203154 

![image](https://user-images.githubusercontent.com/43438/85063365-0b2e5880-b178-11ea-89b0-54c6ba56c4ea.png)

#### To Test

1. Create a stream via UI
2. Add an API Access key in stream edit
3. Save
4. Open share sidebar
5. Note no `undefined` user listed, no errors when saving