### PR TITLE
[PLATFORM-1428] Use icons instead of text for ETH address copy

### DIFF
--- a/app/src/shared/components/HoverCopy/hoverCopy.stories.jsx
+++ b/app/src/shared/components/HoverCopy/hoverCopy.stories.jsx
@@ -1,0 +1,19 @@
+// @flow
+
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import styles from '@sambego/storybook-styles'
+
+import HoverCopy from '.'
+
+const stories = storiesOf('Shared/HoverCopy', module)
+    .addDecorator(styles({
+        color: '#323232',
+        fontSize: '16px',
+    }))
+
+stories.add('default', () => (
+    <HoverCopy value="something">
+        Hover over me to show copy icon
+    </HoverCopy>
+))

--- a/app/src/shared/components/HoverCopy/index.jsx
+++ b/app/src/shared/components/HoverCopy/index.jsx
@@ -16,7 +16,7 @@ export type Props = {
 const Container = styled.div``
 
 const Icon = styled(SvgIcon)`
-    display: none;
+    display: ${(props) => (props.forceVisible ? 'inline-flex' : 'none')};
     height: 12px;
     color: #525252;
     margin-bottom: 2px;
@@ -52,7 +52,7 @@ const HoverCopy = ({ value, children }: Props) => {
                     <CopyIcon name="clipboardPlus" onClick={() => copy(value)} />
                 )}
                 {isCopied && (
-                    <CopiedIcon name="clipboardCheck" />
+                    <CopiedIcon name="clipboardCheck" forceVisible={isCopied} />
                 )}
             </Tooltip>
         </Container>

--- a/app/src/shared/components/HoverCopy/index.jsx
+++ b/app/src/shared/components/HoverCopy/index.jsx
@@ -5,6 +5,8 @@ import styled from 'styled-components'
 import { I18n } from 'react-redux-i18n'
 
 import useCopy from '$shared/hooks/useCopy'
+import SvgIcon from '$shared/components/SvgIcon'
+import Tooltip from '$shared/components/Tooltip'
 
 export type Props = {
     value: string,
@@ -13,43 +15,46 @@ export type Props = {
 
 const Container = styled.div``
 
-const Content = styled.span`
-    display: inline-flex;
-    margin-left: 10px;
-    width: ${(props) => props.width}px;
-    color: #13013d;
-`
-
-const Button = styled(Content)`
+const Icon = styled(SvgIcon)`
     display: none;
-    color: #0324ff;
-    cursor: pointer;
+    height: 12px;
+    color: #525252;
+    margin-bottom: 2px;
+    margin-left: 8px;
 
     ${Container}:hover & {
         display: inline-flex;
     }
 `
 
+const CopyIcon = styled(Icon)`
+    cursor: pointer;
+
+    :hover {
+        color: #0324FF;
+    }
+`
+
+const CopiedIcon = styled(Icon)`
+    color: #0324FF;
+`
+
 const HoverCopy = ({ value, children }: Props) => {
     const { copy, isCopied } = useCopy()
-    const copyText = I18n.t('general.copy')
+    const copyText = I18n.t('general.copyToClipboard')
     const copiedText = I18n.t('general.copied')
-    // Determine 'Content' element width by longest text so that we
-    // will have static size and not change between copy and copied states.
-    const maxLength = Math.max(copyText.length, copiedText.length)
-    const width = maxLength * 6
 
     return (
         <Container>
             {children}
-            {!isCopied && (
-                <Button onClick={() => copy(value)} width={width}>
-                    {copyText}
-                </Button>
-            )}
-            {isCopied && (
-                <Content width={width}>{copiedText}</Content>
-            )}
+            <Tooltip value={isCopied ? copiedText : copyText}>
+                {!isCopied && (
+                    <CopyIcon name="clipboardPlus" onClick={() => copy(value)} />
+                )}
+                {isCopied && (
+                    <CopiedIcon name="clipboardCheck" />
+                )}
+            </Tooltip>
         </Container>
     )
 }

--- a/app/src/shared/components/SvgIcon/index.jsx
+++ b/app/src/shared/components/SvgIcon/index.jsx
@@ -604,6 +604,23 @@ const sources = {
             </g>
         </svg>
     ),
+    clipboardPlus: (
+        <svg viewBox="0 0 11 13" xmlns="http://www.w3.org/2000/svg">
+            <g stroke="currentColor" fill="none" fillRule="evenodd" strokeLinecap="round">
+                <path d="M7.375 2.875H9.25a.75.75 0 01.75.75V11.5a.75.75 0 01-.75.75h-7.5A.75.75 0 011 11.5V3.625a.75.75 0 01.75-.75h1.875a1.875 1.875 0 113.75 0z" strokeLinejoin="round" />
+                <path d="M5.529 2.883a.187.187 0 11-.058.37.187.187 0 01.058-.37" strokeLinejoin="round" />
+                <path d="M3.5 7.5h4M5.5 5.5v4" />
+            </g>
+        </svg>
+    ),
+    clipboardCheck: (
+        <svg viewBox="0 0 11 13" xmlns="http://www.w3.org/2000/svg">
+            <g stroke="currentColor" fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M7.375 2.875H9.25a.75.75 0 01.75.75V11.5a.75.75 0 01-.75.75h-7.5A.75.75 0 011 11.5V3.625a.75.75 0 01.75-.75h1.875a1.875 1.875 0 113.75 0z" />
+                <path d="M5.529 2.883a.187.187 0 11-.058.37.187.187 0 01.058-.37M7.612 6L4.816 8.796a.409.409 0 01-.579 0L3.3 7.858" />
+            </g>
+        </svg>
+    ),
 }
 
 export type IconName = $Keys<typeof sources>

--- a/app/src/shared/i18n/en.po
+++ b/app/src/shared/i18n/en.po
@@ -185,6 +185,9 @@ msgstr "Docs"
 msgid "general##copy"
 msgstr "Copy"
 
+msgid "general##copyToClipboard"
+msgstr "Copy to clipboard"
+
 msgid "general##copied"
 msgstr "Copied"
 


### PR DESCRIPTION
Improved ETH address copy to use icons instead of text.

https://streamr.atlassian.net/browse/PLATFORM-1428