### PR TITLE
[PLATFORM-1436] Show unpublished & deployed DU status in product tile

### DIFF
--- a/app/src/shared/components/Tile/index.jsx
+++ b/app/src/shared/components/Tile/index.jsx
@@ -223,6 +223,7 @@ const PurchaseTile = ({
 type ProductTileProps = {
     actions?: any,
     deployed?: boolean,
+    published?: boolean,
     numMembers?: number,
     product: any,
     showDataUnionBadge?: boolean,
@@ -232,6 +233,7 @@ type ProductTileProps = {
 const ProductTile = ({
     actions,
     deployed,
+    published,
     numMembers,
     product,
     showDataUnionBadge,
@@ -266,10 +268,14 @@ const ProductTile = ({
                 name={product.name}
                 description={touchedAgo(product)}
                 label={(
-                    <Label mood={deployed && HAPPY}>
-                        {deployed ? (
+                    <Label mood={published && HAPPY}>
+                        {!!published && (
                             <Translate value="userpages.products.published" />
-                        ) : (
+                        )}
+                        {!published && !!deployed && (
+                            <Translate value="userpages.products.deployed" />
+                        )}
+                        {!published && !deployed && (
                             <Translate value="userpages.products.draft" />
                         )}
                     </Label>

--- a/app/src/userpages/components/ProductsPage/index.jsx
+++ b/app/src/userpages/components/ProductsPage/index.jsx
@@ -113,7 +113,8 @@ const ProductsPage = () => {
                         const memberCount = isDataUnion ? members[(beneficiaryAddress || '').toLowerCase()] : undefined
                         const isDeploying = isDataUnion && !fetchingDataUnionStats && !!beneficiaryAddress && typeof memberCount === 'undefined'
                         const contractAddress = isDataUnion ? beneficiaryAddress : null
-                        const deployed = state === productStates.DEPLOYED
+                        const published = state === productStates.DEPLOYED
+                        const deployed = !!(isDataUnion && !!beneficiaryAddress)
 
                         return (
                             <ProductTile
@@ -121,19 +122,20 @@ const ProductsPage = () => {
                                 actions={
                                     <Fragment>
                                         <MenuItems.Edit id={id} />
-                                        <MenuItems.View id={id} disabled={!deployed} />
-                                        {isDataUnion && !!beneficiaryAddress && (
+                                        <MenuItems.View id={id} disabled={!published} />
+                                        {deployed && (
                                             <MenuItems.ViewStats id={id} />
                                         )}
-                                        {isDataUnion && !!beneficiaryAddress && (
+                                        {deployed && (
                                             <MenuItems.ViewDataUnion id={id} />
                                         )}
                                         {contractAddress && (
                                             <MenuItems.CopyContractAddress address={contractAddress} />
                                         )}
-                                        <MenuItems.Copy id={id} disabled={!deployed} />
+                                        <MenuItems.Copy id={id} disabled={!published} />
                                     </Fragment>
                                 }
+                                published={published}
                                 deployed={deployed}
                                 numMembers={memberCount}
                                 product={product}

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -184,6 +184,9 @@ msgstr "Clear filters"
 msgid "userpages##products##draft"
 msgstr "Draft"
 
+msgid "userpages##products##deployed"
+msgstr "Deployed"
+
 msgid "userpages##products##published"
 msgstr "Published"
 


### PR DESCRIPTION
When a Data Union is deployed but not published, the product tile shows 'Deployed'.