### PR TITLE
[PLATFORM-1434] Add validation rule for ethereum identity

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/ConnectEthIdentity.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ConnectEthIdentity.jsx
@@ -2,6 +2,7 @@
 
 import React, { Fragment, useState, useCallback, useContext } from 'react'
 import cx from 'classnames'
+import styled from 'styled-components'
 import { Translate } from 'react-redux-i18n'
 
 import useModal from '$shared/hooks/useModal'
@@ -14,6 +15,16 @@ import useIsEthIdentityNeeded from './useIsEthIdentityNeeded'
 import { Context as EditControllerContext } from './EditControllerProvider'
 
 import styles from './productStreams.pcss'
+
+const H1 = styled.h1`
+    display: flex;
+`
+
+const ValidationError = styled(Errors)`
+    display: inline-flex;
+    justify-content: flex-end;
+    flex-grow: 1;
+`
 
 type Props = {
     className?: string,
@@ -48,7 +59,14 @@ const ConnectEthIdentity = ({ className, disabled }: Props) => {
 
     return (
         <section id="connect-eth-identity" className={cx(styles.root, className)}>
-            <Translate tag="h1" value="editProductPage.connectEthIdentity.title" />
+            <H1>
+                <Translate value="editProductPage.connectEthIdentity.title" />
+                {!isValid && publishAttempted && (
+                    <ValidationError theme={MarketplaceTheme}>
+                        {message}
+                    </ValidationError>
+                )}
+            </H1>
             {walletLocked && (
                 <Translate
                     value="editProductPage.connectEthIdentity.web3Locked"
@@ -73,11 +91,6 @@ const ConnectEthIdentity = ({ className, disabled }: Props) => {
                     >
                         <Translate value="editProductPage.connectEthIdentity.addNewAddress" />
                     </Button>
-                    {!isValid && publishAttempted && (
-                        <Errors theme={MarketplaceTheme}>
-                            {message}
-                        </Errors>
-                    )}
                 </Fragment>
             )}
             <AddIdentityDialog />

--- a/app/src/marketplace/containers/EditProductPage/ConnectEthIdentity.jsx
+++ b/app/src/marketplace/containers/EditProductPage/ConnectEthIdentity.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Fragment, useState, useCallback } from 'react'
+import React, { Fragment, useState, useCallback, useContext } from 'react'
 import cx from 'classnames'
 import { Translate } from 'react-redux-i18n'
 
@@ -8,7 +8,10 @@ import useModal from '$shared/hooks/useModal'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import Button from '$shared/components/Button'
 import AddIdentityDialog from '$userpages/components/ProfilePage/IdentityHandler/AddIdentityDialog'
+import Errors, { MarketplaceTheme } from '$ui/Errors'
+import useValidation from '../ProductController/useValidation'
 import useIsEthIdentityNeeded from './useIsEthIdentityNeeded'
+import { Context as EditControllerContext } from './EditControllerProvider'
 
 import styles from './productStreams.pcss'
 
@@ -19,6 +22,8 @@ type Props = {
 
 const ConnectEthIdentity = ({ className, disabled }: Props) => {
     const { isRequired, requiredAddress, walletLocked } = useIsEthIdentityNeeded()
+    const { isValid, message } = useValidation('ethIdentity')
+    const { publishAttempted } = useContext(EditControllerContext)
 
     const [waiting, setWaiting] = useState(false)
     const { api: addIdentityDialog, isOpen } = useModal('userpages.addIdentity')
@@ -68,6 +73,11 @@ const ConnectEthIdentity = ({ className, disabled }: Props) => {
                     >
                         <Translate value="editProductPage.connectEthIdentity.addNewAddress" />
                     </Button>
+                    {!isValid && publishAttempted && (
+                        <Errors theme={MarketplaceTheme}>
+                            {message}
+                        </Errors>
+                    )}
                 </Fragment>
             )}
             <AddIdentityDialog />

--- a/app/src/marketplace/containers/EditProductPage/EditorNav.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditorNav.jsx
@@ -19,6 +19,8 @@ import styles from './editorNav.pcss'
 const SCROLLSPY_OFFSET = -40
 const CLICK_OFFSET = -130
 
+const includeIf = (condition: boolean, elements: Array<any>) => (condition ? elements : [])
+
 const EditorNav = () => {
     const product = useEditableProduct()
     const productRef = useRef()
@@ -152,26 +154,21 @@ const EditorNav = () => {
             id: 'details',
             heading: I18n.t('editProductPage.navigation.details'),
             status: detailsStatus,
-        }, {
+        },
+        ...includeIf(!!showConnectEthIdentity, [{
+            id: 'connect-eth-identity',
+            heading: I18n.t('editProductPage.navigation.connectEthIdentity'),
+            status: ethIdentityStatus,
+        }]), {
             id: 'terms',
             heading: I18n.t('editProductPage.navigation.terms'),
             status: getStatus('termsOfUse'),
-        }]
-
-        if (isDataUnion) {
-            if (showConnectEthIdentity) {
-                nextSections.push({
-                    id: 'connect-eth-identity',
-                    heading: I18n.t('editProductPage.navigation.connectEthIdentity'),
-                    status: ethIdentityStatus,
-                })
-            }
-            nextSections.push({
-                id: 'shared-secrets',
-                heading: I18n.t('editProductPage.navigation.sharedSecrets'),
-                status: sharedSecretStatus,
-            })
-        }
+        },
+        ...includeIf(!!isDataUnion, [{
+            id: 'shared-secrets',
+            heading: I18n.t('editProductPage.navigation.sharedSecrets'),
+            status: sharedSecretStatus,
+        }])]
 
         return nextSections
     }, [

--- a/app/src/marketplace/containers/EditProductPage/EditorNav.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditorNav.jsx
@@ -113,11 +113,12 @@ const EditorNav = () => {
     }, [scrollTo])
 
     const ethIdentityStatus = useMemo(() => {
+        const status = getStatus('ethIdentity')
         if (!publishAttempted) {
             return statuses.EMPTY
         }
-        return statuses.VALID
-    }, [publishAttempted])
+        return status
+    }, [publishAttempted, getStatus])
 
     const sharedSecretStatus = useMemo(() => {
         if (!publishAttempted) {

--- a/app/src/marketplace/containers/EditProductPage/PriceSelector.test.jsx
+++ b/app/src/marketplace/containers/EditProductPage/PriceSelector.test.jsx
@@ -17,7 +17,9 @@ const mockState = {
     contractProduct: {
         id: '1',
     },
-    dataUnion: {},
+    dataUnion: {
+        id: 'dataUnionId',
+    },
     global: {
         dataPerUsd: 10,
     },
@@ -32,11 +34,26 @@ const mockState = {
                 id: '1',
             },
         },
+        dataUnions: {
+            dataUnionId: {
+                id: 'dataUnionId',
+                memberCount: {
+                    active: 0,
+                },
+            },
+        },
+        integrationKeys: {
+            test: '12345',
+        },
+    },
+    integrationKey: {
+        ethereumIdentities: ['test'],
     },
 }
 
 jest.mock('react-redux', () => ({
     useSelector: jest.fn().mockImplementation((selectorFn) => selectorFn(mockState)),
+    useDispatch: jest.fn(),
 }))
 
 describe('PriceSelector', () => {

--- a/app/src/marketplace/containers/EditProductPage/tests/EditControllerProvider.test.jsx
+++ b/app/src/marketplace/containers/EditProductPage/tests/EditControllerProvider.test.jsx
@@ -40,11 +40,18 @@ const mockState = {
                 },
             },
         },
+        integrationKeys: {
+            test: '12345',
+        },
+    },
+    integrationKey: {
+        ethereumIdentities: ['test'],
     },
 }
 
 jest.mock('react-redux', () => ({
     useSelector: jest.fn().mockImplementation((selectorFn) => selectorFn(mockState)),
+    useDispatch: jest.fn(),
 }))
 
 describe('EditControllerProvider', () => {

--- a/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
+++ b/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
@@ -163,7 +163,7 @@ function useValidationContext(): ContextProps {
             clearStatus('beneficiaryAddress')
 
             if (isEthIdentityRequired) {
-                setStatus('ethIdentity', ERROR, 'Ethereum address not connected')
+                setStatus('ethIdentity', ERROR, 'Please connect an Ethereum address')
             } else {
                 clearStatus('ethIdentity')
             }

--- a/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
+++ b/app/src/marketplace/containers/ProductController/ValidationContextProvider.jsx
@@ -11,6 +11,7 @@ import { isEthereumAddress } from '$mp/utils/validate'
 import { isPaidProduct, isDataUnionProduct } from '$mp/utils/product'
 import { isPriceValid } from '$mp/utils/price'
 import { isPublished, getPendingChanges, PENDING_CHANGE_FIELDS } from '../EditProductPage/state'
+import useIsEthIdentityNeeded from '../EditProductPage/useIsEthIdentityNeeded'
 import useProduct from '../ProductController/useProduct'
 
 export const INFO = 'info'
@@ -47,6 +48,7 @@ function useValidationContext(): ContextProps {
     const [pendingChanges, setPendingChanges] = useState({})
     const [touched, setTouched] = useState({})
     const originalProduct = useProduct()
+    const { isRequired: isEthIdentityRequired } = useIsEthIdentityNeeded()
 
     const touch = useCallback((name: string) => {
         setTouched((existing) => ({
@@ -159,6 +161,12 @@ function useValidationContext(): ContextProps {
                 clearStatus('adminFee')
             }
             clearStatus('beneficiaryAddress')
+
+            if (isEthIdentityRequired) {
+                setStatus('ethIdentity', ERROR, 'Ethereum address not connected')
+            } else {
+                clearStatus('ethIdentity')
+            }
         } else {
             if (isPaid && (!product.beneficiaryAddress || !isEthereumAddress(product.beneficiaryAddress))) {
                 setStatus('beneficiaryAddress', ERROR, 'A valid ethereum address is needed')
@@ -214,7 +222,7 @@ function useValidationContext(): ContextProps {
                 get(changes, field) || (isPublic && isTouched(field) && !isEqual(get(product, field), get(originalProduct, field))),
             )
         })
-    }, [setStatus, clearStatus, isMounted, setPendingChange, isTouched, originalProduct])
+    }, [setStatus, clearStatus, isMounted, setPendingChange, isTouched, originalProduct, isEthIdentityRequired])
 
     return useMemo(() => ({
         setStatus,

--- a/app/src/marketplace/containers/ProductController/tests/ValidationContextProvider.test.jsx
+++ b/app/src/marketplace/containers/ProductController/tests/ValidationContextProvider.test.jsx
@@ -7,6 +7,33 @@ import * as useProduct from '../useProduct'
 
 import { Provider as ValidationContextProvider, Context as ValidationContext } from '../ValidationContextProvider'
 
+const mockState = {
+    dataUnion: {
+        id: 'dataUnionId',
+    },
+    entities: {
+        dataUnions: {
+            dataUnionId: {
+                id: 'dataUnionId',
+                memberCount: {
+                    active: 0,
+                },
+            },
+        },
+        integrationKeys: {
+            test: '12345',
+        },
+    },
+    integrationKey: {
+        ethereumIdentities: ['test'],
+    },
+}
+
+jest.mock('react-redux', () => ({
+    useSelector: jest.fn().mockImplementation((selectorFn) => selectorFn(mockState)),
+    useDispatch: jest.fn(),
+}))
+
 describe('validation context', () => {
     let sandbox
 

--- a/app/src/marketplace/containers/ProductController/tests/useEditableProductActions.test.jsx
+++ b/app/src/marketplace/containers/ProductController/tests/useEditableProductActions.test.jsx
@@ -12,10 +12,30 @@ const mockState = {
     global: {
         dataPerUsd: 10,
     },
+    dataUnion: {
+        id: 'dataUnionId',
+    },
+    entities: {
+        dataUnions: {
+            dataUnionId: {
+                id: 'dataUnionId',
+                memberCount: {
+                    active: 0,
+                },
+            },
+        },
+        integrationKeys: {
+            test: '12345',
+        },
+    },
+    integrationKey: {
+        ethereumIdentities: ['test'],
+    },
 }
 
 jest.mock('react-redux', () => ({
     useSelector: jest.fn().mockImplementation((selectorFn) => selectorFn(mockState)),
+    useDispatch: jest.fn(),
 }))
 jest.mock('../useNewProductMode', () => (
     jest.fn().mockImplementation(() => ({


### PR DESCRIPTION
Now product editor shows a validation error when user tries to deploy a data union but has no ethereum identity connected.

<img width="1094" alt="Screenshot 2020-07-01 at 15 36 15" src="https://user-images.githubusercontent.com/432588/86244784-27d38300-bbb1-11ea-8f46-8d32b68327c2.png">
