### PR TITLE
[PLATFORM-1442] Data Unions docs link missing in Core shortcuts

### DIFF
--- a/app/src/userpages/components/DocsShortcuts/index.jsx
+++ b/app/src/userpages/components/DocsShortcuts/index.jsx
@@ -24,6 +24,9 @@ const DocsShortcuts = () => (
         <Link to={docsLinks.products} target="_blank" rel="noopener noreferrer">
             <Translate value="general.products" />
         </Link>
+        <Link to={docsLinks.dataUnions} target="_blank" rel="noopener noreferrer">
+            <Translate value="general.dataUnions" />
+        </Link>
         {null}
         <Link href={routes.community.telegram()} target="_blank" rel="noopener noreferrer">
             <Translate value="general.telegramGroup" />


### PR DESCRIPTION
Link to DU docs was missing from userpages shortcuts:

![Screen Shot 2020-07-02 at 17 02 41](https://user-images.githubusercontent.com/1064982/86368483-e2cd5080-bc85-11ea-9d5b-8dbf69ed4add.png)
