### PR TITLE
[PLATFORM-1351] Fix field list layering bug

### DIFF
--- a/app/src/shared/components/SortableList/index.jsx
+++ b/app/src/shared/components/SortableList/index.jsx
@@ -3,6 +3,7 @@
 import React, { type Node, useState, useCallback } from 'react'
 import { SortableContainer, type SortableContainerProps } from 'react-sortable-hoc'
 import cx from 'classnames'
+import styled from 'styled-components'
 import BodyClass from '$shared/components/BodyClass'
 import SortableItem from './SortableItem'
 import styles from './SortableList.pcss'
@@ -17,7 +18,7 @@ type Props = {
     disabled?: boolean,
 }
 
-const SortableList = ({ children, disabled, ...props }: Props) => {
+const UnstyledSortableList = ({ children, disabled, ...props }: Props) => {
     const len = React.Children.count(children)
 
     return (
@@ -36,6 +37,11 @@ const SortableList = ({ children, disabled, ...props }: Props) => {
         </div>
     )
 }
+
+const SortableList = styled(UnstyledSortableList)`
+    position: relative;
+    z-index: 0;
+`
 
 const Sortable = SortableContainer(SortableList)
 


### PR DESCRIPTION
`SortableList` uses dynamic `z-index` to keep proper order of items (for dropdown menus, IIRC). See:

<img width="607" alt="Screenshot 2020-07-29 10 59 37" src="https://user-images.githubusercontent.com/320066/88780497-5d0cca00-d18b-11ea-8c45-42a36cfbe5e2.png">

Toolbars are at `z-index: 5` so 5-6th field would render above the toolbar.

**Solution**: I give sortable list's outer element `z-index: 0` which scopes layering produced by individual sortable items.

