### PR TITLE
[PLATFORM-1457] Tweak joinPartStream permissions

### DIFF
--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -85,23 +85,15 @@ export const createJoinPartStream = async (productId: ?ProductId = undefined): P
                     resourceType: 'STREAM',
                     resourceId: stream.id,
                     data: {
+                        operation: 'stream_get',
+                        user: address,
+                    },
+                }),
+                addResourcePermission({
+                    resourceType: 'STREAM',
+                    resourceId: stream.id,
+                    data: {
                         operation: 'stream_publish',
-                        user: address,
-                    },
-                }),
-                addResourcePermission({
-                    resourceType: 'STREAM',
-                    resourceId: stream.id,
-                    data: {
-                        operation: 'stream_share',
-                        user: address,
-                    },
-                }),
-                addResourcePermission({
-                    resourceType: 'STREAM',
-                    resourceId: stream.id,
-                    data: {
-                        operation: 'stream_edit',
                         user: address,
                     },
                 }),
@@ -118,7 +110,7 @@ export const createJoinPartStream = async (productId: ?ProductId = undefined): P
             resourceType: 'STREAM',
             resourceId: stream.id,
         })
-        const deletedTypes = new Set(['stream_edit', 'stream_delete', 'stream_share'])
+        const deletedTypes = new Set(['stream_edit', 'stream_delete'])
         const deletedPermissions = myPermissions.filter((p) => deletedTypes.has(p.operation))
 
         if (deletedPermissions && deletedPermissions.length > 0) {


### PR DESCRIPTION
Change `joinPartStream` permissions:

- Leave `stream_share` to the user
- Don't add `stream_edit` to E&E

@hpihkala Original intention in the issue was to revoke `stream_share` from E&E but looks like `stream_share` is needed to revoke `stream_edit` and `stream_delete` from the user. Otherwise those revoke calls fail with `Cannot revoke only SHARE permission of JoinPart stream for data union 0x...`.