### PR TITLE
Fix content type for auth endpoints

### DIFF
--- a/app/src/auth/components/ForgotPasswordPage/index.jsx
+++ b/app/src/auth/components/ForgotPasswordPage/index.jsx
@@ -58,7 +58,7 @@ const ForgotPasswordPage = ({ from }: Props) => {
 
         return post(routes.auth.external.forgotPassword(), {
             username,
-        }, false, true)
+        }, false)
     }, [form])
 
     const onBack = useCallback(() => {

--- a/app/src/auth/components/RegisterPage/index.jsx
+++ b/app/src/auth/components/RegisterPage/index.jsx
@@ -117,7 +117,7 @@ const RegisterPage = ({ location: { search, pathname }, history: { replace } }: 
             password2,
             tosConfirmed,
             invite,
-        }, false, true).then(({ username }) => mountedRef.current && (
+        }, false).then(({ username }) => mountedRef.current && (
             getSessionToken({
                 username,
                 password,

--- a/app/src/auth/components/ResetPasswordPage/index.jsx
+++ b/app/src/auth/components/ResetPasswordPage/index.jsx
@@ -75,7 +75,7 @@ const ResetPasswordPage = ({ location: { search, pathname }, history: { replace 
             password,
             password2,
             t,
-        }, false, true)
+        }, false)
     }, [form])
 
     const mountedRef = useIsMountedRef()

--- a/app/src/auth/components/SignupPage/index.jsx
+++ b/app/src/auth/components/SignupPage/index.jsx
@@ -47,7 +47,7 @@ const SignupPage = () => {
     const submit = useCallback(() => (
         post(routes.auth.external.signUp(), {
             username,
-        }, false, true)
+        }, false)
     ), [username])
 
     return (

--- a/app/src/auth/utils/post.js
+++ b/app/src/auth/utils/post.js
@@ -8,7 +8,7 @@ export default (url: string, form: FormFields, successWithError: boolean): Promi
     url,
     data: form,
 })
-    .then(({ data }) => {
+    .then((data) => {
         if (successWithError && data.error) {
             throw new Error(data.error)
         }

--- a/app/src/auth/utils/post.js
+++ b/app/src/auth/utils/post.js
@@ -1,33 +1,26 @@
 // @flow
 
-import axios from 'axios'
-import qs from 'query-string'
+import { post } from '$shared/utils/api'
 
 import type { FormFields } from '$shared/flowtype/auth-types'
 
-export default (url: string, form: FormFields, successWithError: boolean, xhr?: boolean): Promise<*> => (
-    axios
-        .post(url, qs.stringify(form), {
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                ...(xhr ? {
-                    'X-Requested-With': 'XMLHttpRequest',
-                } : {}),
-            },
-        })
-        .then(({ data }) => {
-            if (successWithError && data.error) {
-                throw new Error(data.error)
+export default (url: string, form: FormFields, successWithError: boolean): Promise<*> => post({
+    url,
+    data: form,
+})
+    .then(({ data }) => {
+        if (successWithError && data.error) {
+            throw new Error(data.error)
+        }
+        return data
+    }, (error) => {
+        const message = (() => {
+            try {
+                return error.response.data.error
+            } catch (e) {
+                return ''
             }
-            return data
-        }, (error) => {
-            const message = (() => {
-                try {
-                    return error.response.data.error
-                } catch (e) {
-                    return ''
-                }
-            })()
-            throw new Error(message || 'Something went wrong')
-        })
-)
+        })()
+        throw new Error(message || 'Something went wrong')
+    })
+

--- a/app/src/shared/modules/user/services.js
+++ b/app/src/shared/modules/user/services.js
@@ -16,24 +16,15 @@ export const putUser = (user: User): ApiResult<User> => put({
     data: user,
 })
 
-export const postPasswordUpdate = (passwordUpdate: PasswordUpdate, username: string): ApiResult<null> => {
-    const form = new FormData()
-    form.append('username', username)
-    form.append('currentpassword', passwordUpdate.currentPassword)
-    form.append('password', passwordUpdate.newPassword)
-    form.append('password2', passwordUpdate.confirmNewPassword)
-
-    return post({
-        url: routes.api.currentUser.changePassword(),
-        data: form,
-        options: {
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'X-Requested-With': 'XMLHttpRequest',
-            },
-        },
-    })
-}
+export const postPasswordUpdate = (passwordUpdate: PasswordUpdate, username: string): ApiResult<null> => post({
+    url: routes.api.currentUser.changePassword(),
+    data: {
+        username,
+        currentpassword: passwordUpdate.currentPassword,
+        password: passwordUpdate.newPassword,
+        password2: passwordUpdate.confirmNewPassword,
+    },
+})
 
 export const uploadProfileAvatar = (image: File): Promise<void> => {
     const options = {

--- a/app/src/shared/test/modules/user/services.test.js
+++ b/app/src/shared/test/modules/user/services.test.js
@@ -103,10 +103,9 @@ describe('user - services', () => {
     describe('postPasswordUpdate', () => {
         it('should POST password update to the api', async (done) => {
             const passwordUpdate = {
-                confirmNewPassword: 'Testtesttest234!',
+                newPassword: 'newPassword',
+                confirmNewPassword: 'newPassword',
                 currentPassword: 'Testtesttest123!',
-                strongEnoughPassword: true,
-                updating: false,
             }
 
             moxios.wait(() => {
@@ -118,8 +117,12 @@ describe('user - services', () => {
 
                 assert.equal(request.config.method, 'post')
                 assert.equal(request.config.url, '/users/me/changePassword')
-                assert.equal(request.headers['Content-Type'], 'application/x-www-form-urlencoded')
-                assert.equal(request.headers['X-Requested-With'], 'XMLHttpRequest')
+                assert.deepStrictEqual(request.config.data, JSON.stringify({
+                    username: 'tester2@streamr.com',
+                    currentpassword: 'Testtesttest123!',
+                    password: 'newPassword',
+                    password2: 'newPassword',
+                }))
                 done()
             })
 

--- a/app/test/unit/components/AuthPage/utils/post.test.js
+++ b/app/test/unit/components/AuthPage/utils/post.test.js
@@ -17,26 +17,8 @@ describe('post', () => {
         await moxios.promiseWait()
         const request = moxios.requests.mostRecent()
 
-        expect(request.headers['Content-Type']).toEqual('application/x-www-form-urlencoded')
+        expect(request.headers['Content-Type']).toEqual('application/json')
         expect(request.config.method).toEqual('post')
-    })
-
-    describe('xhr requests', () => {
-        it('posts without X-Requested-With header when xhr flag is NOT set', async () => {
-            post('url', {}, false)
-            await moxios.promiseWait()
-            const request = moxios.requests.mostRecent()
-
-            expect(request.headers['X-Requested-With']).toBeUndefined()
-        })
-
-        it('posts WITH correct X-Requested-With header when xhr flag IS set', async () => {
-            post('url', {}, false, true)
-            await moxios.promiseWait()
-            const request = moxios.requests.mostRecent()
-
-            expect(request.headers['X-Requested-With']).toEqual('XMLHttpRequest')
-        })
     })
 
     it('posts with given params', async () => {
@@ -46,7 +28,9 @@ describe('post', () => {
         await moxios.promiseWait()
         const request = moxios.requests.mostRecent()
 
-        expect(request.config.data).toEqual('param=value')
+        expect(request.config.data).toEqual(JSON.stringify({
+            param: 'value',
+        }))
     })
 
     it('resolves on success with response body', async () => {


### PR DESCRIPTION
Changes content type for endpoints from `application/x-www-form-urlencoded` to `application/json`, using the same parameters as before.

Affected pages:
- sign up
- forgot password
- register
- change password in profile

Tested locally and seemed to fix the issue.