### PR TITLE
[FRONT-15] Fix overflowing button in product editor nav

### DIFF
--- a/app/src/marketplace/components/ProductPage/EditorNav/editorNav.pcss
+++ b/app/src/marketplace/components/ProductPage/EditorNav/editorNav.pcss
@@ -40,6 +40,9 @@
   text-align: right;
   white-space: nowrap;
   transition: color 0.3s;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 1rem;
 
   a,
   a:visited,
@@ -58,6 +61,9 @@
     outline: none;
     cursor: pointer;
     text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
All ellipsis to overflowing text

<img width="771" alt="Screen Shot 2020-08-21 at 14 14 53" src="https://user-images.githubusercontent.com/1064982/90884810-180a3b00-e3b9-11ea-848e-8489c6f51cd7.png">
