### PR TITLE
[FRONT-6] Add editable email field for ETH users in profile

### DIFF
--- a/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx
+++ b/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx
@@ -107,9 +107,10 @@ export const GlobalInfoWatcher = ({ children }: Props) => {
         balanceTimeout.current = setTimeout(balancePoll, ACCOUNT_BALANCE_POLL_INTERVAL)
     }, [updateBalances])
     const user = useSelector(selectUserData)
+    const { username } = user || {}
 
     useEffect(() => {
-        if (!user) { return () => {} }
+        if (!username) { return () => {} }
 
         // fetch the integration keys first and then start polling for the balance
         dispatch(fetchIntegrationKeys())
@@ -120,7 +121,7 @@ export const GlobalInfoWatcher = ({ children }: Props) => {
         return () => {
             clearTimeout(balanceTimeout.current)
         }
-    }, [dispatch, balancePoll, user])
+    }, [dispatch, balancePoll, username])
 
     return children || null
 }

--- a/app/src/shared/modules/user/actions.js
+++ b/app/src/shared/modules/user/actions.js
@@ -2,6 +2,8 @@
 
 import { createAction } from 'redux-actions'
 import { push } from 'connected-react-router'
+import * as yup from 'yup'
+import { I18n } from 'react-redux-i18n'
 
 import type { ErrorInUi, ReduxActionCreator } from '$shared/flowtype/common-types'
 import type { User, PasswordUpdate } from '$shared/flowtype/user-types'
@@ -121,6 +123,16 @@ export const updateCurrentUserName = (name: string) => (dispatch: Function, getS
     }
 }
 
+export const updateCurrentUserEmail = (email: string) => (dispatch: Function, getState: Function) => {
+    const user = selectUserData(getState())
+    if (user) {
+        dispatch(updateCurrentUser({
+            ...user,
+            email,
+        }))
+    }
+}
+
 export const updateCurrentUserImage = (image: ?File) => (dispatch: Function, getState: Function) => {
     dispatch(updateAvatarRequest())
     const user = selectUserData(getState())
@@ -143,6 +155,8 @@ export const updateCurrentUserImage = (image: ?File) => (dispatch: Function, get
         })
 }
 
+const emailValidator = yup.string().trim().email()
+
 export const saveCurrentUser = () => async (dispatch: Function, getState: Function) => {
     dispatch(saveCurrentUserRequest())
 
@@ -150,6 +164,10 @@ export const saveCurrentUser = () => async (dispatch: Function, getState: Functi
 
     if (!user) {
         throw new Error('Invalid user data')
+    }
+
+    if (!!user.email && !emailValidator.isValidSync(user.email)) {
+        throw new Error(I18n.t('userpages.profilePage.profileSettings.userEmailError'))
     }
 
     return services.putUser(user)

--- a/app/src/userpages/components/ProfilePage/ProfileSettings/index.jsx
+++ b/app/src/userpages/components/ProfilePage/ProfileSettings/index.jsx
@@ -148,6 +148,8 @@ const ProfileSettings = () => {
 
     ), [wrapUploadAvatarDialog, uploadAvatarDialog, isMounted, originalImage])
 
+    const isEthereumUser = !!isEthereumAddress(user.username)
+
     return (
         <Root>
             <AvatarWrapper>
@@ -192,8 +194,8 @@ const ProfileSettings = () => {
                     id="userEmail"
                     value={user.email || ''}
                     onChange={onEmailChange}
-                    disabled={isPending}
-                    readOnly={!isEthereumAddress(user.username)}
+                    disabled={isPending || !isEthereumUser}
+                    readOnly={!isEthereumUser}
                     placeholder={I18n.t('userpages.profilePage.profileSettings.userEmailPlaceholder')}
                 />
             </InputRow>

--- a/app/src/userpages/components/ProfilePage/ProfileSettings/index.jsx
+++ b/app/src/userpages/components/ProfilePage/ProfileSettings/index.jsx
@@ -17,8 +17,9 @@ import useModal from '$shared/hooks/useModal'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
-import { updateCurrentUserName } from '$shared/modules/user/actions'
+import { updateCurrentUserName, updateCurrentUserEmail } from '$shared/modules/user/actions'
 import { MD, LG } from '$shared/utils/styled'
+import { isEthereumAddress } from '$mp/utils/validate'
 
 import ChangePasswordDialog from './ChangePasswordDialog'
 import EditAvatarDialog from './EditAvatarDialog'
@@ -90,9 +91,17 @@ const ProfileSettings = () => {
         dispatch(updateCurrentUserName(name))
     ), [dispatch])
 
+    const doUpdateUserEmail = useCallback((email: $ElementType<User, 'email'>) => (
+        dispatch(updateCurrentUserEmail(email))
+    ), [dispatch])
+
     const onNameChange = useCallback(({ target }: { target: { value: $ElementType<User, 'name'> } }) => {
         doUpdateUserName(target.value)
     }, [doUpdateUserName])
+
+    const onEmailChange = useCallback(({ target }: { target: { value: $ElementType<User, 'email'> } }) => {
+        doUpdateUserEmail(target.value)
+    }, [doUpdateUserEmail])
 
     const changePassword = useCallback(async () => (
         wrapChangePasswordDialog(async () => {
@@ -181,9 +190,11 @@ const ProfileSettings = () => {
                 </Label>
                 <Text
                     id="userEmail"
-                    value={user.username || ''}
-                    readOnly
+                    value={user.email || ''}
+                    onChange={onEmailChange}
                     disabled={isPending}
+                    readOnly={!isEthereumAddress(user.username)}
+                    placeholder={I18n.t('userpages.profilePage.profileSettings.userEmailPlaceholder')}
                 />
             </InputRow>
             <PasswordButton

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -797,6 +797,12 @@ msgstr "Your Name"
 msgid "userpages.profilePage.profileSettings.userEmail"
 msgstr "Email"
 
+msgid "userpages.profilePage.profileSettings.userEmailPlaceholder"
+msgstr "Your email address (optional)"
+
+msgid "userpages.profilePage.profileSettings.userEmailError"
+msgstr "Please enter a valid email address"
+
 msgid "userpages.profilePage.profileSettings.changePassword"
 msgstr "Change Password"
 


### PR DESCRIPTION
Changes email field to to be editable if user is logged in via Metamask. For normal users, email is read-only because of backend constraint.