### PR TITLE
Don't do a whitelist check on free products

### DIFF
--- a/app/src/marketplace/containers/ProductPage/Hero.jsx
+++ b/app/src/marketplace/containers/ProductPage/Hero.jsx
@@ -46,13 +46,13 @@ const Hero = () => {
     const isProductSubscriptionValid = useSelector(selectSubscriptionIsValid)
     const subscription = useSelector(selectContractSubscription)
     const { account } = useWeb3Status()
-    const [isWhitelisted, setIsWhitelisted] = useState(null)
 
     const productId = product.id
     const contactEmail = product && product.contact && product.contact.email
     const productName = product && product.name
     const isPaid = isPaidProduct(product)
-    const isWhitelistEnabled = product.requiresWhitelist
+    const isWhitelistEnabled = !!(isPaid && product.requiresWhitelist)
+    const [isWhitelisted, setIsWhitelisted] = useState(isWhitelistEnabled ? null : false)
 
     const onPurchase = useCallback(async () => (
         wrap(async () => {


### PR DESCRIPTION
Add a check for whitelist loading so that it is only done for paid products. Otherwise it never gets loaded if Metamask is not active or account is not present. 