### PR TITLE
[FRONT-48] Truncate product owner name

### DIFF
--- a/app/src/shared/components/Tile/Summary.jsx
+++ b/app/src/shared/components/Tile/Summary.jsx
@@ -15,6 +15,8 @@ const Secondary = styled.div`
 
 const Description = styled(Secondary)`
     color: #a3a3a3;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
 `
 
 const Label = styled(Secondary)`


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1064982/92931829-55a43600-f444-11ea-9eaa-0d98a4357107.png)

Fixes long product owner name overflowing.