### PR TITLE
[FRONT-96] Add separate label for KeyField name input

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/SharedSecretEditor.jsx
+++ b/app/src/marketplace/containers/EditProductPage/SharedSecretEditor.jsx
@@ -69,7 +69,7 @@ const SharedSecretEditor = ({ className, disabled }: Props) => {
                         })
                         setSecrets((currentSecrets) => currentSecrets.filter((secret) => secret.id !== s.id))
                     }}
-                    valueLabel="sharedSecret"
+                    labelType="sharedSecret"
                     className={styles.keyField}
                 />
             ))}
@@ -77,6 +77,7 @@ const SharedSecretEditor = ({ className, disabled }: Props) => {
                 <AddKeyField
                     label={I18n.t('editProductPage.sharedSecrets.addSecret')}
                     addKeyFieldAllowed={!disabled}
+                    labelType="sharedSecret"
                     onSave={async (name, value) => {
                         const result = await postSecret({
                             dataUnionId,

--- a/app/src/userpages/components/KeyField/AddKeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/AddKeyField/index.jsx
@@ -3,14 +3,14 @@
 import React from 'react'
 
 import Button from '$shared/components/Button'
-import KeyFieldEditor, { type ValueLabel } from '../KeyFieldEditor'
+import KeyFieldEditor, { type LabelType } from '../KeyFieldEditor'
 
 type Props = {
     label: string,
     createWithValue?: boolean,
     onSave: (keyName: string, value: string) => Promise<void>,
     addKeyFieldAllowed: boolean,
-    valueLabel?: ValueLabel,
+    labelType?: LabelType,
 }
 
 type State = {
@@ -73,7 +73,7 @@ class AddKeyField extends React.Component<Props, State> {
 
     render = () => {
         const { editing, waiting, error } = this.state
-        const { label, createWithValue, addKeyFieldAllowed, valueLabel } = this.props
+        const { label, createWithValue, addKeyFieldAllowed, labelType } = this.props
         return !editing ? (
             <Button
                 kind="secondary"
@@ -90,7 +90,7 @@ class AddKeyField extends React.Component<Props, State> {
                 editValue={createWithValue}
                 waiting={waiting}
                 error={error}
-                valueLabel={valueLabel}
+                labelType={labelType}
             />
         )
     }

--- a/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
+++ b/app/src/userpages/components/KeyField/KeyFieldEditor/index.jsx
@@ -10,7 +10,7 @@ import Errors from '$ui/Errors'
 
 import styles from './keyFieldEditor.pcss'
 
-export type ValueLabel = 'apiKey' | 'privateKey' | 'address' | 'sharedSecret'
+export type LabelType = 'apiKey' | 'address' | 'sharedSecret'
 
 type Props = {
     keyName?: string,
@@ -21,7 +21,7 @@ type Props = {
     onSave: (keyName: string, value: string) => void | Promise<void>,
     waiting?: boolean,
     error?: ?string,
-    valueLabel: ValueLabel,
+    labelType: LabelType,
 }
 
 type State = {
@@ -31,7 +31,7 @@ type State = {
 
 class KeyFieldEditor extends React.Component<Props, State> {
     static defaultProps = {
-        valueLabel: 'apiKey',
+        labelType: 'apiKey',
     }
 
     state = {
@@ -66,7 +66,7 @@ class KeyFieldEditor extends React.Component<Props, State> {
             editValue,
             waiting,
             error,
-            valueLabel,
+            labelType,
         } = this.props
         const filled = !!keyName && (createNew || !!keyId)
 
@@ -77,7 +77,7 @@ class KeyFieldEditor extends React.Component<Props, State> {
                         htmlFor="keyName"
                         state={createNew && !editValue && error && 'ERROR'}
                     >
-                        {I18n.t('userpages.keyFieldEditor.keyName')}
+                        {I18n.t(`userpages.keyFieldEditor.keyName.${labelType}`)}
                     </Label>
                     <Text
                         value={keyName}
@@ -95,7 +95,7 @@ class KeyFieldEditor extends React.Component<Props, State> {
                             htmlFor="keyValue"
                             state={error && 'ERROR'}
                         >
-                            {I18n.t(`userpages.keyFieldEditor.keyValue.${valueLabel}`)}
+                            {I18n.t(`userpages.keyFieldEditor.keyValue.${labelType}`)}
                         </Label>
                         <Text
                             id="keyValue"

--- a/app/src/userpages/components/KeyField/KeyFieldEditor/keyFieldEditor.stories.jsx
+++ b/app/src/userpages/components/KeyField/KeyFieldEditor/keyFieldEditor.stories.jsx
@@ -34,17 +34,17 @@ stories.add('default (address)', () => (
         value="value"
         onCancel={action('onCancel')}
         onSave={action('onSave')}
-        valueLabel="address"
+        labelType="address"
     />
 ))
 
-stories.add('default (private key)', () => (
+stories.add('default (shared secret)', () => (
     <KeyFieldEditor
         keyName="key"
         value="value"
         onCancel={action('onCancel')}
         onSave={action('onSave')}
-        valueLabel="privateKey"
+        labelType="sharedSecret"
     />
 ))
 

--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -6,7 +6,7 @@ import { Translate, I18n } from 'react-redux-i18n'
 
 import Popover from '$shared/components/Popover'
 import { truncate } from '$shared/utils/text'
-import KeyFieldEditor, { type ValueLabel } from './KeyFieldEditor'
+import KeyFieldEditor, { type LabelType } from './KeyFieldEditor'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
 import useIsMounted from '$shared/hooks/useIsMounted'
@@ -28,7 +28,7 @@ type Props = {
     allowDelete?: boolean,
     disableDelete?: boolean,
     onDelete?: () => Promise<void>,
-    valueLabel: ValueLabel,
+    labelType: LabelType,
     onToggleEditor?: (boolean) => void,
     labelComponent?: any,
 }
@@ -46,7 +46,7 @@ const KeyField = ({
     allowDelete,
     disableDelete,
     onDelete: onDeleteProp,
-    valueLabel,
+    labelType,
     onToggleEditor: onToggleEditorProp,
     labelComponent,
 }: Props) => {
@@ -71,11 +71,11 @@ const KeyField = ({
     const notify = useCallback(() => {
         Notification.push({
             title: I18n.t('notifications.valueCopied', {
-                value: I18n.t(`userpages.keyFieldEditor.keyValue.${valueLabel}`),
+                value: I18n.t(`userpages.keyFieldEditor.keyValue.${labelType}`),
             }),
             icon: NotificationIcon.CHECKMARK,
         })
-    }, [valueLabel])
+    }, [labelType])
 
     const onCopy = useCallback(() => {
         copy(value || '')
@@ -187,7 +187,7 @@ const KeyField = ({
                     onSave={onSave}
                     waiting={waiting}
                     error={error}
-                    valueLabel={valueLabel}
+                    labelType={labelType}
                 />
             )}
         </div>
@@ -195,7 +195,7 @@ const KeyField = ({
 }
 
 KeyField.defaultProps = {
-    valueLabel: 'apiKey',
+    labelType: 'apiKey',
 }
 
 export default KeyField

--- a/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/index.jsx
@@ -71,7 +71,7 @@ const IntegrationKeyItem = ({
                 onDelete={() => onDelete(item.id)}
                 onSave={(keyName) => onEdit(item.id, keyName || '')}
                 onToggleEditor={setEditing}
-                valueLabel="address"
+                labelType="address"
                 labelComponent={!editing && (
                     <Label as="div">
                         <StyledBalance>

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -948,14 +948,17 @@ msgstr "Edit"
 msgid "userpages.keyField.delete"
 msgstr "Delete"
 
-msgid "userpages.keyFieldEditor.keyName"
+msgid "userpages.keyFieldEditor.keyName.apiKey"
 msgstr "Key name"
+
+msgid "userpages.keyFieldEditor.keyName.address"
+msgstr "Account name"
+
+msgid "userpages.keyFieldEditor.keyName.sharedSecret"
+msgstr "Secret name"
 
 msgid "userpages.keyFieldEditor.keyValue.apiKey"
 msgstr "API key"
-
-msgid "userpages.keyFieldEditor.keyValue.privateKey"
-msgstr "Private key"
 
 msgid "userpages.keyFieldEditor.keyValue.address"
 msgstr "Address"

--- a/app/src/userpages/tests/components/KeyField/KeyFieldEditor/KeyFieldEditor.test.jsx
+++ b/app/src/userpages/tests/components/KeyField/KeyFieldEditor/KeyFieldEditor.test.jsx
@@ -20,7 +20,7 @@ describe('KeyFieldEditor', () => {
 
             assert(el.exists('.keyName Text'))
             assert(el.exists('.keyValue Text'))
-            assert(el.find('Label').at(0).text() === 'keyName')
+            assert(el.find('Label').at(0).text() === 'apiKey')
             assert(el.find('Label').at(1).text() === 'apiKey')
         })
 
@@ -99,7 +99,7 @@ describe('KeyFieldEditor', () => {
             />)
 
             assert(el.find('Text').length === 1)
-            assert(el.find('Label').text() === 'keyName')
+            assert(el.find('Label').text() === 'apiKey')
         })
 
         it('shows correct text for save button', () => {


### PR DESCRIPTION
> When user goes to edit the eth account details via the meatball menu, the first field is labelled "Key name" which is incorrect.

![image](https://user-images.githubusercontent.com/1064982/94528479-2281e500-0241-11eb-8ed7-c93ea2a7c13c.png)
