### PR TITLE
[FRONT-94] Live data Inspector doesn't scroll

### DIFF
--- a/app/src/marketplace/components/StreamPreview/index.jsx
+++ b/app/src/marketplace/components/StreamPreview/index.jsx
@@ -253,11 +253,13 @@ const StreamData = styled.div`
     transition:opacity 300ms linear;
     margin-bottom: 80px;
 
-    ${({ inspectorFocused }) => (inspectorFocused ? css`
-        opacity: 0;
-    ` : `
-        opacity: 1;
-    `)}
+    @media (max-width: ${SM}px) {
+        ${({ inspectorFocused }) => (inspectorFocused ? css`
+            opacity: 0;
+        ` : `
+            opacity: 1;
+        `)}
+    }
 
     @media (min-width: ${SM}px) {
         width: calc(100% - 504px);
@@ -274,6 +276,8 @@ const Inspector = styled.div`
     border-left: 1px solid #EFEFEF;
     width: 504px;
     transition: left 300ms ease-out;
+    overflow-y: scroll;
+    margin-bottom: 80px;
 
     @media (max-width: ${SM}px) {
         left: calc(100% - 130px);
@@ -284,6 +288,10 @@ const Inspector = styled.div`
             left: 0;
             transform: none;
         `}
+    }
+
+    @media (min-width: ${SM}px) {
+        margin-bottom: 0;
     }
 `
 


### PR DESCRIPTION
> Live data Inspector needs to be vertically scrollable, but currently users are unable to scroll on all device breakpoints.

Add vertical scrolling to live data inspector in stream preview. To test, have some data in a stream with multiple fields and select a data point to view. The data points should all be scrollable into view (and not hidden by the toolbar in mobile).