### PR TITLE
[FRONT-50] "View product" button in post-publish modal takes users to the Not Found page

### DIFF
--- a/app/src/marketplace/containers/ProductController/index.jsx
+++ b/app/src/marketplace/containers/ProductController/index.jsx
@@ -39,9 +39,10 @@ const ProductControllerContext: Context<ContextProps> = React.createContext({})
 
 type EffectProps = {
     ignoreUnauthorized?: boolean,
+    requirePublished?: boolean,
 }
 
-function useProductLoadEffect({ ignoreUnauthorized }: EffectProps) {
+function useProductLoadEffect({ ignoreUnauthorized, requirePublished }: EffectProps) {
     const [loadedOnce, setLoadedOnce] = useState(false)
     const loadProduct = useProductLoadCallback()
     const loadContractProduct = useContractProductLoadCallback()
@@ -56,16 +57,18 @@ function useProductLoadEffect({ ignoreUnauthorized }: EffectProps) {
             loadProduct({
                 productId: urlId,
                 ignoreUnauthorized,
+                requirePublished,
             })
             loadContractProduct(urlId)
             setLoadedOnce(true)
         }
-    }, [urlId, loadedOnce, loadProduct, loadContractProduct, isPending, ignoreUnauthorized])
+    }, [urlId, loadedOnce, loadProduct, loadContractProduct, isPending, ignoreUnauthorized, requirePublished])
 }
 
-function ProductEffects({ ignoreUnauthorized }: EffectProps) {
+function ProductEffects({ ignoreUnauthorized, requirePublished }: EffectProps) {
     useProductLoadEffect({
         ignoreUnauthorized,
+        requirePublished,
     })
     useProductValidationEffect()
 
@@ -131,13 +134,13 @@ function ControllerProvider({ children }: ControllerProviderProps) {
 
 type ControllerProps = ControllerProviderProps & EffectProps
 
-const ProductController = ({ children, ignoreUnauthorized = false }: ControllerProps) => (
+const ProductController = ({ children, ignoreUnauthorized = false, requirePublished = false }: ControllerProps) => (
     <RouterContext.Provider>
         <PendingProvider name="product">
             <ValidationContextProvider>
                 <PermissionsProvider>
                     <ControllerProvider>
-                        <ProductEffects ignoreUnauthorized={ignoreUnauthorized} />
+                        <ProductEffects ignoreUnauthorized={ignoreUnauthorized} requirePublished={requirePublished} />
                         {children || null}
                     </ControllerProvider>
                 </PermissionsProvider>

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -21,8 +21,6 @@ import PurchaseModal from './PurchaseModal'
 import useProduct from '$mp/containers/ProductController/useProduct'
 import { selectUserData } from '$shared/modules/user/selectors'
 import { getToken } from '$shared/utils/sessionToken'
-import ResourceNotFoundError, { ResourceType } from '$shared/errors/ResourceNotFoundError'
-import { productStates } from '$shared/utils/constants'
 
 import Page from './Page'
 
@@ -105,13 +103,6 @@ const EditWrap = () => {
         return <LoadingView />
     }
 
-    // bail if the product is not actually published - this is an edge case
-    // because this should only happen with user's own products, otherwise
-    // the product load will fail due to permissions
-    if (product.state !== productStates.DEPLOYED) {
-        throw new ResourceNotFoundError(ResourceType.PRODUCT, product.id)
-    }
-
     const key = (!!product && product.id) || ''
 
     return (
@@ -123,7 +114,7 @@ const EditWrap = () => {
 }
 
 const ProductContainer = withRouter((props) => (
-    <ProductController key={props.match.params.id} ignoreUnauthorized>
+    <ProductController key={props.match.params.id} ignoreUnauthorized requirePublished>
         <EditWrap />
     </ProductController>
 ))


### PR DESCRIPTION
> Once a product got published users end up seeing a confirmation dialog with "Copy link" link and "View product" button. While the copied link works just fine when opened in a new tab the "View product" button takes the user to a 404 page (despite correctly linking to the product).

This bug was caused by the old product state being fetched from redux which didn't have time to clear before reloading the product and triggering that error. I moved the check to happen after reloading and only done on the product page.