### PR TITLE
[FRONT-102] Stream traffic indicator broken

### DIFF
--- a/app/src/shared/components/List/list.stories.jsx
+++ b/app/src/shared/components/List/list.stories.jsx
@@ -42,21 +42,21 @@ const defaultList = [{
     description: 'Short description',
     updated: '4 days ago',
     lastData: '1 second ago',
-    status: 'error',
+    status: StatusIcon.ERROR,
 }, {
     id: '2',
     title: 'Just the title',
     description: '',
     updated: '',
     lastData: '',
-    status: 'ok',
+    status: StatusIcon.OK,
 }, {
     id: '3',
     title: 'Title for the item that is really long and will break the layout if it goes long enough over the screen',
     description: 'Description that is really long and will break the layout if it goes long enough over the screen',
     updated: 'a week ago',
     lastData: '1 weeek ago',
-    status: 'inactive',
+    status: StatusIcon.INACTIVE,
 }]
 
 const DefaultList = () => (
@@ -330,14 +330,14 @@ const streamList = [{
     description: 'Live updates from my coffee machine',
     updated: '',
     lastData: '4 days ago',
-    status: 'ok',
+    status: StatusIcon.OK,
 }, {
     id: '2',
     title: 'JoinPart stream for data union 21aec220f1c0460798828211aa3070f265e261dd9e474405824f6379af7849df',
     description: 'Automatically created JoinPart stream for data union',
     updated: '1 week ago',
     lastData: '2 minutes ago',
-    status: 'error',
+    status: StatusIcon.ERROR,
 }]
 
 const StreamList = () => (
@@ -406,19 +406,19 @@ const memberList = [{
     address: '0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1',
     joined: 'An hour ago',
     lastUpdated: 'An hour ago',
-    status: 'pending',
+    status: StatusIcon.PENDING,
 }, {
     id: '2',
     address: '0x538a2Fa87E03B280e10C83AA8dD7E5B15B868BD9',
     joined: '2 hours ago',
     lastUpdated: 'An hour ago',
-    status: 'pending',
+    status: StatusIcon.PENDING,
 }, {
     id: '3',
     address: '0x13581255eE2D20e780B0cD3D07fac018241B5E03',
     joined: '1 day ago',
     lastUpdated: '1 day ago',
-    status: 'ok',
+    status: StatusIcon.OK,
 }]
 
 const MemberList = () => {
@@ -504,7 +504,7 @@ const transactions = [{
     when: '2 months ago',
     value: '+1.05 DATA',
     gas: '186347 / 500000',
-    status: 'ok',
+    status: StatusIcon.OK,
 }]
 
 const TransactionList = () => (

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -25,6 +25,7 @@ import ShareSidebar from '$userpages/components/ShareSidebar'
 import BackButton from '$shared/components/BackButton'
 import Nav from '$shared/components/Layout/Nav'
 import { resetResourcePermission } from '$userpages/modules/permission/actions'
+import { mapStatus } from '../List'
 
 import InfoView from './InfoView'
 import KeyView from './KeyView'
@@ -215,7 +216,10 @@ const Edit = ({ stream: streamProp, canShare, disabled }: any) => {
                 <TOCPage.Section
                     id="status"
                     title={I18n.t('userpages.streams.edit.details.nav.status')}
-                    status={<StatusIcon tooltip status={stream.streamStatus} />}
+                    status={<StatusIcon
+                        tooltip
+                        status={mapStatus(stream.streamStatus)}
+                    />}
                     onlyDesktop
                 >
                     <StatusView disabled={disabled} />

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -93,6 +93,19 @@ const TabletPopover = styled(Popover)`
     }
 `
 
+export const mapStatus = (state: string) => {
+    switch (state) {
+        case 'ok':
+            return StatusIcon.OK
+        case 'error':
+            return StatusIcon.ERROR
+        case 'pending':
+            return StatusIcon.PENDING
+        default:
+            return StatusIcon.INACTIVE
+    }
+}
+
 type TargetStream = ?Stream
 
 type TargetStreamSetter = [TargetStream, ((TargetStream => TargetStream) | TargetStream) => void]
@@ -435,7 +448,10 @@ const StreamList = () => {
                                         {stream.lastData && titleize(ago(new Date(stream.lastData)))}
                                     </StreamListComponent.Item>
                                     <StreamListComponent.Item>
-                                        <StatusIcon status={stream.streamStatus} tooltip />
+                                        <StatusIcon
+                                            status={mapStatus(stream.streamStatus)}
+                                            tooltip
+                                        />
                                     </StreamListComponent.Item>
                                     <StreamListComponent.Actions>
                                         {getActions(stream)}

--- a/app/src/userpages/components/TransactionPage/List/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/index.jsx
@@ -62,6 +62,17 @@ const SearchPlaceholder = styled.div`
     width: var(--um);
 `
 
+const mapState = (state) => {
+    switch (state) {
+        case 'ok':
+            return StatusIcon.OK
+        case 'error':
+            return StatusIcon.ERROR
+        default:
+            return StatusIcon.INACTIVE
+    }
+}
+
 const TransactionList = () => {
     const dispatch = useDispatch()
 
@@ -215,7 +226,7 @@ const TransactionList = () => {
                                     </TransactionListComponent.Item>
                                     <TransactionListComponent.Item>
                                         <StatusIcon
-                                            status={state}
+                                            status={mapState(state)}
                                             tooltip={I18n.t(`userpages.transactions.status.${state}`)}
                                         />
                                     </TransactionListComponent.Item>


### PR DESCRIPTION
> is it possible that such a bug could slip in during your recent table refactoring?

Fixes status icon mapping on list views, it was indeed broken when I refactored the list views 😰 