### PR TITLE
[FRONT-109] Fetch stream activity status through StreamrClient

### DIFF
--- a/app/cypress/integration/StreamPage.spec.js
+++ b/app/cypress/integration/StreamPage.spec.js
@@ -25,7 +25,7 @@ describe('Stream listing page', () => {
                 cy.visit('/core/streams')
                 cy.get(`[data-test-hook="Stream row for ${streamId}"]`).within(() => {
                     cy.get('[data-test-hook="Last message at"]').should('be.empty')
-                    cy.get('[data-test-hook="Status inactive"]').should('exist')
+                    cy.get('[data-test-hook="Status inactive"]')
                 })
             })
         })
@@ -50,7 +50,7 @@ describe('Stream listing page', () => {
                 cy.visit('/core/streams')
                 cy.get(`[data-test-hook="Stream row for ${streamId}"]`).within(() => {
                     cy.get('[data-test-hook="Last message at"]').should('be.empty')
-                    cy.get('[data-test-hook="Status inactive"]').should('exist')
+                    cy.get('[data-test-hook="Status inactive"]')
 
                     cy.sendToStream(streamId, {
                         key: 'value',

--- a/app/cypress/integration/StreamPage.spec.js
+++ b/app/cypress/integration/StreamPage.spec.js
@@ -464,7 +464,7 @@ describe('Stream edit page', () => {
         })
     })
 
-    describe.only('activity status', () => {
+    describe('activity status', () => {
         it('renders inactive color when no data is flowing', () => {
             cy.login()
             cy.createStream().then((streamId) => {

--- a/app/cypress/integration/StreamPage.spec.js
+++ b/app/cypress/integration/StreamPage.spec.js
@@ -36,6 +36,12 @@ describe('Stream listing page', () => {
                 cy.sendToStream(streamId, {
                     key: 'value',
                 })
+
+                // It looks like it takes a while for a message to get to the history storage.
+                // That's why we're waiting 3s below.
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
+                cy.wait(3000)
+
                 cy.visit('/core/streams')
                 cy.get(`[data-test-hook="Stream row for ${streamId}"]`).within(() => {
                     cy.get('[data-test-hook="Last message at"]').contains('Just now')
@@ -57,9 +63,9 @@ describe('Stream listing page', () => {
                     })
 
                     // It looks like it takes a while for a message to get to the history storage.
-                    // That's why we're waiting 5s below.
+                    // That's why we're waiting 3s below.
                     // eslint-disable-next-line cypress/no-unnecessary-waiting
-                    cy.wait(5000)
+                    cy.wait(3000)
 
                     cy.get('button').contains('Refresh').click({
                         force: true,
@@ -482,6 +488,12 @@ describe('Stream edit page', () => {
                 cy.sendToStream(streamId, {
                     key: 'value',
                 })
+
+                // It looks like it takes a while for a message to get to the history storage.
+                // That's why we're waiting 3s below.
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
+                cy.wait(3000)
+
                 cy.visit(`/core/streams/${streamId}`)
 
                 cy.get('[data-test-hook="TOCSection status"]').within(() => {

--- a/app/cypress/integration/StreamPage.spec.js
+++ b/app/cypress/integration/StreamPage.spec.js
@@ -30,6 +30,25 @@ describe('Stream listing page', () => {
             })
         })
 
+        it('renders error color when fetching fails', () => {
+            cy.login()
+            cy.createStream().then((streamId) => {
+                cy.server({
+                    method: 'GET',
+                    status: 404,
+                    response: {},
+                })
+                cy.route(`/api/v1/streams/${streamId}/data/partitions/0/last`).as('getLastMessage')
+
+                cy.visit('/core/streams')
+                cy.wait('@getLastMessage')
+                cy.get(`[data-test-hook="Stream row for ${streamId}"]`).within(() => {
+                    cy.get('[data-test-hook="Last message at"]').should('be.empty')
+                    cy.get('[data-test-hook="Status error"]')
+                })
+            })
+        })
+
         it('renders active color when data is flowing', () => {
             cy.login()
             cy.createStream().then((streamId) => {
@@ -478,6 +497,25 @@ describe('Stream edit page', () => {
 
                 cy.get('[data-test-hook="TOCSection status"]').within(() => {
                     cy.get('[data-test-hook="Status inactive"]')
+                })
+            })
+        })
+
+        it('renders error color when fetching fails', () => {
+            cy.login()
+            cy.createStream().then((streamId) => {
+                cy.server({
+                    method: 'GET',
+                    status: 404,
+                    response: {},
+                })
+                cy.route(`/api/v1/streams/${streamId}/data/partitions/0/last`).as('getLastMessage')
+
+                cy.visit(`/core/streams/${streamId}`)
+                cy.wait('@getLastMessage')
+
+                cy.get('[data-test-hook="TOCSection status"]').within(() => {
+                    cy.get('[data-test-hook="Status error"]')
                 })
             })
         })

--- a/app/cypress/integration/StreamPage.spec.js
+++ b/app/cypress/integration/StreamPage.spec.js
@@ -17,6 +17,33 @@ describe('Stream listing page', () => {
         cy.contains('Tester One')
         cy.location('pathname').should('eq', '/core/streams')
     })
+
+    describe('acivity badge', () => {
+        it('renders inactive streams (when no data is flowing)', () => {
+            cy.login()
+            cy.createStream().then((streamId) => {
+                cy.visit('/core/streams')
+                cy.get(`[data-test-hook="Stream row for ${streamId}"]`).within(() => {
+                    cy.get('[data-test-hook="Last message at"]').should('be.empty')
+                    cy.get('[data-test-hook="Status inactive"]').should('exist')
+                })
+            })
+        })
+
+        it('renders active streams (when data is flowing)', () => {
+            cy.login()
+            cy.createStream().then((streamId) => {
+                cy.sendToStream(streamId, {
+                    key: 'value',
+                })
+                cy.visit('/core/streams')
+                cy.get(`[data-test-hook="Stream row for ${streamId}"]`).within(() => {
+                    cy.get('[data-test-hook="Last message at"]').contains('Just now')
+                    cy.get('[data-test-hook="Status ok"]')
+                })
+            })
+        })
+    })
 })
 
 describe('New stream page', () => {

--- a/app/cypress/integration/StreamPage.spec.js
+++ b/app/cypress/integration/StreamPage.spec.js
@@ -38,7 +38,7 @@ describe('Stream listing page', () => {
                     status: 404,
                     response: {},
                 })
-                cy.route(`/api/v1/streams/${streamId}/data/partitions/0/last`).as('getLastMessage')
+                cy.route(`/api/v1/streams/${streamId}/data/partitions/0/last?count=1`).as('getLastMessage')
 
                 cy.visit('/core/streams')
                 cy.wait('@getLastMessage')
@@ -509,7 +509,7 @@ describe('Stream edit page', () => {
                     status: 404,
                     response: {},
                 })
-                cy.route(`/api/v1/streams/${streamId}/data/partitions/0/last`).as('getLastMessage')
+                cy.route(`/api/v1/streams/${streamId}/data/partitions/0/last?count=1`).as('getLastMessage')
 
                 cy.visit(`/core/streams/${streamId}`)
                 cy.wait('@getLastMessage')

--- a/app/cypress/integration/StreamPage.spec.js
+++ b/app/cypress/integration/StreamPage.spec.js
@@ -57,9 +57,9 @@ describe('Stream listing page', () => {
                     })
 
                     // It looks like it takes a while for a message to get to the history storage.
-                    // That's why we're waiting 1s below.
+                    // That's why we're waiting 5s below.
                     // eslint-disable-next-line cypress/no-unnecessary-waiting
-                    cy.wait(1000)
+                    cy.wait(5000)
 
                     cy.get('button').contains('Refresh').click({
                         force: true,

--- a/app/cypress/support/commands.js
+++ b/app/cypress/support/commands.js
@@ -116,13 +116,15 @@ Cypress.Commands.add('connectToClient', (options = {}) => {
 
 Cypress.Commands.add('sendToStream', (streamId, payload) => (
     cy.connectToClient().then(async (client) => {
-        client.publish(streamId, payload)
-
-        await new Promise((resolve) => {
+        const promise = new Promise((resolve) => {
             client.subscribe(streamId, () => {
                 resolve()
             })
         })
+
+        client.publish(streamId, payload)
+
+        await promise
 
         return client.ensureConnected()
     })

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10873,9 +10873,9 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
-      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg=="
     },
     "@types/sizzle": {
       "version": "2.3.2",
@@ -14567,6 +14567,11 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "blob-util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+      "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ=="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -20574,49 +20579,63 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
     "cypress": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.10.0.tgz",
-      "integrity": "sha512-eFv1WPp4zFrAgZ6mwherBGVsTpHvay/hEF5F7U7yfAkTxsUQn/ZG/LdX67fIi3bKDTQXYzFv/CvywlQSeug8Bg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.4.0.tgz",
+      "integrity": "sha512-BJR+u3DRSYMqaBS1a3l1rbh5AkMRHugbxcYYzkl+xYlO6dzcJVE8uAhghzVI/hxijCyBg1iuSe4TRp/g1PUg8Q==",
       "requires": {
-        "@cypress/listr-verbose-renderer": "0.4.1",
-        "@cypress/request": "2.88.5",
-        "@cypress/xvfb": "1.2.4",
-        "@types/sinonjs__fake-timers": "6.0.1",
-        "@types/sizzle": "2.3.2",
-        "arch": "2.1.2",
-        "bluebird": "3.7.2",
-        "cachedir": "2.3.0",
-        "chalk": "2.4.2",
-        "check-more-types": "2.24.0",
-        "cli-table3": "0.5.1",
-        "commander": "4.1.1",
-        "common-tags": "1.8.0",
-        "debug": "4.1.1",
-        "eventemitter2": "6.4.2",
-        "execa": "1.0.0",
-        "executable": "4.1.1",
-        "extract-zip": "1.7.0",
-        "fs-extra": "8.1.0",
-        "getos": "3.2.1",
-        "is-ci": "2.0.0",
-        "is-installed-globally": "0.3.2",
-        "lazy-ass": "1.6.0",
-        "listr": "0.14.3",
-        "lodash": "4.17.15",
-        "log-symbols": "3.0.0",
-        "minimist": "1.2.5",
-        "moment": "2.26.0",
-        "ospath": "1.2.2",
-        "pretty-bytes": "5.3.0",
-        "ramda": "0.26.1",
-        "request-progress": "3.0.0",
-        "supports-color": "7.1.0",
-        "tmp": "0.1.0",
-        "untildify": "4.0.0",
-        "url": "0.11.0",
-        "yauzl": "2.10.0"
+        "@cypress/listr-verbose-renderer": "^0.4.1",
+        "@cypress/request": "^2.88.5",
+        "@cypress/xvfb": "^1.2.4",
+        "@types/sinonjs__fake-timers": "^6.0.1",
+        "@types/sizzle": "^2.3.2",
+        "arch": "^2.1.2",
+        "blob-util": "2.0.2",
+        "bluebird": "^3.7.2",
+        "cachedir": "^2.3.0",
+        "chalk": "^4.1.0",
+        "check-more-types": "^2.24.0",
+        "cli-table3": "~0.6.0",
+        "commander": "^4.1.1",
+        "common-tags": "^1.8.0",
+        "debug": "^4.1.1",
+        "eventemitter2": "^6.4.2",
+        "execa": "^4.0.2",
+        "executable": "^4.1.1",
+        "extract-zip": "^1.7.0",
+        "fs-extra": "^9.0.1",
+        "getos": "^3.2.1",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.3.2",
+        "lazy-ass": "^1.6.0",
+        "listr": "^0.14.3",
+        "lodash": "^4.17.19",
+        "log-symbols": "^4.0.0",
+        "minimist": "^1.2.5",
+        "moment": "^2.27.0",
+        "ospath": "^1.2.2",
+        "pretty-bytes": "^5.3.0",
+        "ramda": "~0.26.1",
+        "request-progress": "^3.0.0",
+        "supports-color": "^7.1.0",
+        "tmp": "~0.2.1",
+        "untildify": "^4.0.0",
+        "url": "^0.11.0",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "arch": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
@@ -20628,23 +20647,12 @@
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
         },
         "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "ci-info": {
@@ -20652,43 +20660,71 @@
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
           "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
         },
+        "cli-table3": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+          "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^4.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "commander": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
           "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
         },
         "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
         "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "figures": {
@@ -20700,13 +20736,34 @@
             "object-assign": "^4.1.0"
           }
         },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
         "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
             "pump": "^3.0.0"
           }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "indent-string": {
           "version": "3.2.0",
@@ -20719,6 +20776,25 @@
           "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "requires": {
             "ci-info": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
           }
         },
         "listr": {
@@ -20735,6 +20811,13 @@
             "listr-verbose-renderer": "^0.5.0",
             "p-map": "^2.0.0",
             "rxjs": "^6.3.3"
+          },
+          "dependencies": {
+            "is-stream": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+            }
           }
         },
         "listr-update-renderer": {
@@ -20752,6 +20835,11 @@
             "strip-ansi": "^3.0.1"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
             "ansi-styles": {
               "version": "2.2.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -20777,6 +20865,14 @@
                 "chalk": "^1.0.0"
               }
             },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
             "supports-color": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -20795,6 +20891,37 @@
             "figures": "^2.0.0"
           },
           "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            },
             "figures": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -20802,21 +20929,39 @@
               "requires": {
                 "escape-string-regexp": "^1.0.5"
               }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
             }
           }
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
         "log-symbols": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
           "requires": {
-            "chalk": "^2.4.2"
+            "chalk": "^4.0.0"
           }
+        },
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
         "minimist": {
           "version": "1.2.5",
@@ -20824,19 +20969,40 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "moment": {
-          "version": "2.26.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-          "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
         "p-map": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "pump": {
           "version": "3.0.0",
@@ -20853,34 +21019,71 @@
           "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
         },
         "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "requires": {
             "glob": "^7.1.3"
           }
         },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-            }
           }
         },
         "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
           "requires": {
-            "rimraf": "^2.6.3"
+            "rimraf": "^3.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -22813,9 +23016,9 @@
       "integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q=="
     },
     "eventemitter2": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.2.tgz",
-      "integrity": "sha512-r/Pwupa5RIzxIHbEKCkNXqpEQIIT4uQDxmP4G/Lug/NokVUWj0joz/WzWl3OxRpC5kDrH/WdiUJoR+IrwvXJEw=="
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
+      "integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ=="
     },
     "eventemitter3": {
       "version": "3.1.0",
@@ -38048,9 +38251,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "pretty-bytes": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
+      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA=="
     },
     "pretty-error": {
       "version": "2.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -142,7 +142,7 @@
     "core-js": "^3.1.3",
     "css-loader": "^2.1.1",
     "css-mqpacker": "^6.0.2",
-    "cypress": "^4.10.0",
+    "cypress": "^5.4.0",
     "dotenv": "^6.0.0",
     "dotenv-safe": "^6.0.0",
     "enzyme": "^3.10.0",

--- a/app/src/marketplace/modules/streams/services.js
+++ b/app/src/marketplace/modules/streams/services.js
@@ -32,8 +32,9 @@ export const getStreams = (params: any): ApiResult<{
 }
 
 export const getStreamData = (streamId: StreamId, fromTimestamp: number): ApiResult<Object> => get({
-    url: routes.api.streams.data({
+    url: routes.api.streams.data.from({
         fromTimestamp,
+        partition: 0,
         streamId,
     }),
 })

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -143,7 +143,6 @@
             "data": "<api>/streams/:streamId/data/partitions/0/from",
             "index": "<api>/streams",
             "show": "<api>/streams/:id",
-            "status": "<api>/streams/:streamId/status",
             "detectFields": "<api>/streams/:streamId/detectFields",
             "keys": {
                 "index": "<api>/streams/:streamId/keys",

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -151,7 +151,8 @@
             "permissions": {
                 "index": "<api>/streams/:streamId/permissions",
                 "show": "<api>/streams/:streamId/permissions/:id"
-            }
+            },
+            "lastMessage": "<api>/streams/:streamId/data/partitions/:partition/last"
         },
         "dataunions": {
             "index": "<api>/dataunions",

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -140,7 +140,10 @@
             }
         },
         "streams": {
-            "data": "<api>/streams/:streamId/data/partitions/0/from",
+            "data": {
+                "from": "<api>/streams/:streamId/data/partitions/:partition/from",
+                "last": "<api>/streams/:streamId/data/partitions/:partition/last"
+            },
             "index": "<api>/streams",
             "show": "<api>/streams/:id",
             "detectFields": "<api>/streams/:streamId/detectFields",
@@ -151,8 +154,7 @@
             "permissions": {
                 "index": "<api>/streams/:streamId/permissions",
                 "show": "<api>/streams/:streamId/permissions/:id"
-            },
-            "lastMessage": "<api>/streams/:streamId/data/partitions/:partition/last"
+            }
         },
         "dataunions": {
             "index": "<api>/dataunions",

--- a/app/src/shared/components/Meatball/index.jsx
+++ b/app/src/shared/components/Meatball/index.jsx
@@ -30,6 +30,7 @@ const Meatball = ({
             [styles.white]: !!white,
             [styles.disabled]: !!disabled,
         })}
+        data-test-hook="meatball"
     >
         <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/app/src/shared/components/StatusIcon/index.jsx
+++ b/app/src/shared/components/StatusIcon/index.jsx
@@ -29,7 +29,9 @@ const PendingTheme = {
     background: '#FFBC00',
 }
 
-const Icon = styled.div`
+const Icon = styled.div.attrs(({ theme }) => ({
+    'data-test-hook': `Status ${theme.id}`,
+}))`
     position: relative;
     display: inline-block;
     width: 16px;

--- a/app/src/shared/components/StatusIcon/index.jsx
+++ b/app/src/shared/components/StatusIcon/index.jsx
@@ -40,7 +40,7 @@ const Icon = styled.div.attrs(({ theme }) => ({
     background-color: ${({ theme }) => theme.background || '#CDCDCD'};
 `
 
-const StatusIcon = ({ status, className, tooltip }) => {
+const StatusIcon = ({ status = StatusIcon.INACTIVE, className, tooltip = false }) => {
     let statusText
 
     if (tooltip) {
@@ -59,10 +59,5 @@ StatusIcon.ERROR = ErrorTheme
 StatusIcon.INACTIVE = InactiveTheme
 StatusIcon.PENDING = PendingTheme
 StatusIcon.REMOVED = RemovedTheme
-
-StatusIcon.defaultProps = {
-    status: StatusIcon.INACTIVE,
-    tooltip: false,
-}
 
 export default StatusIcon

--- a/app/src/shared/components/StreamrClientProvider.jsx
+++ b/app/src/shared/components/StreamrClientProvider.jsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 import Provider from 'streamr-client-react'
 import { getToken } from '$shared/utils/sessionToken'
 
-export default function ClientProvider({ children }) {
+export default function StreamrClientProvider({ children }) {
     const sessionToken = getToken()
 
     const auth = useMemo(() => (sessionToken == null ? {} : {

--- a/app/src/shared/components/StreamrClientProvider.jsx
+++ b/app/src/shared/components/StreamrClientProvider.jsx
@@ -1,23 +1,12 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import Provider from 'streamr-client-react'
-import { getToken } from '$shared/utils/sessionToken'
+import getClientConfig from '$shared/utils/getClientConfig'
 
 export default function StreamrClientProvider({ children }) {
-    const sessionToken = getToken()
-
-    const auth = useMemo(() => (sessionToken == null ? {} : {
-        sessionToken,
-    }), [sessionToken])
+    const config = getClientConfig()
 
     return (
-        <Provider
-            auth={auth}
-            autoConnect
-            autoDisconnect={false}
-            restUrl={process.env.STREAMR_API_URL}
-            url={process.env.STREAMR_WS_URL}
-            verifySignatures="never"
-        >
+        <Provider {...config}>
             {children}
         </Provider>
     )

--- a/app/src/shared/components/TOCPage/TOCSection.jsx
+++ b/app/src/shared/components/TOCPage/TOCSection.jsx
@@ -55,7 +55,7 @@ export const UnstyledTOCSection = ({
     onlyDesktop,
     ...props
 }: Props) => (
-    <Section {...props} onlyDesktop={onlyDesktop}>
+    <Section {...props} onlyDesktop={onlyDesktop} data-test-hook={`TOCSection ${id}`}>
         {(!!title || !!status) ? (
             <Title>
                 <TOCBusStop name={id} />

--- a/app/src/shared/flowtype/stream-types.js
+++ b/app/src/shared/flowtype/stream-types.js
@@ -16,11 +16,6 @@ export type NewStream = {
     description: ?string,
 }
 
-export type StreamStatus = {
-    ok: boolean,
-    date?: Date,
-}
-
 export type Stream = NewStream & {
     id: StreamId,
     config: {
@@ -38,8 +33,6 @@ export type Stream = NewStream & {
     requireSignedData: boolean,
     storageDays: number,
     uiChannel: boolean,
-    streamStatus?: 'ok' | 'error' | 'inactive',
-    lastData?: Date,
     requireSignedData: boolean,
     requireEncryptedData: boolean,
 }

--- a/app/src/shared/hooks/useLastMessageTimestamp.js
+++ b/app/src/shared/hooks/useLastMessageTimestamp.js
@@ -62,9 +62,10 @@ const useLastMessageTimestamp = (streamId) => {
         const attach = async () => {
             try {
                 const [message] = await get({
-                    url: routes.api.streams.lastMessage({
-                        streamId,
+                    url: routes.api.streams.data.last({
+                        count: 1,
                         partition: 0,
+                        streamId,
                     }),
                 })
                 if (isMounted()) {

--- a/app/src/shared/hooks/useLastMessageTimestamp.js
+++ b/app/src/shared/hooks/useLastMessageTimestamp.js
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { useClient } from 'streamr-client-react'
+import useIsMounted from '$shared/hooks/useIsMounted'
+
+const useLastMessageTimestamp = (streamId) => {
+    const client = useClient()
+
+    const [timestamp, setTimestamp] = useState(undefined)
+
+    const isMounted = useIsMounted()
+
+    useEffect(() => {
+        if (!client) {
+            return () => {}
+        }
+
+        let last
+
+        const onMessage = (_, { messageId: { timestamp: ts } }) => {
+            last = ts
+        }
+
+        const sub = (() => {
+            try {
+                return client.subscribe({
+                    stream: streamId,
+                    resend: {
+                        last: 1,
+                    },
+                }, onMessage)
+            } catch (e) { /**/ }
+
+            return null
+        })()
+
+        const onResendDone = () => {
+            if (isMounted()) {
+                setTimestamp(last)
+            }
+
+            sub.off('initial_resend_done', onResendDone)
+            client.unsubscribe(sub)
+        }
+
+        if (sub) {
+            sub.on('initial_resend_done', onResendDone)
+        }
+
+        return () => {
+            if (sub) {
+                sub.off('initial_resend_done', onResendDone)
+                client.unsubscribe(sub)
+            }
+        }
+    }, [client, streamId, isMounted])
+
+    return timestamp
+}
+
+export default useLastMessageTimestamp

--- a/app/src/shared/hooks/useLastMessageTimestamp.js
+++ b/app/src/shared/hooks/useLastMessageTimestamp.js
@@ -65,6 +65,8 @@ const useLastMessageTimestamp = (streamId) => {
                         last: 1,
                     },
                 }, (message, { messageId: { timestamp: ts } }) => {
+                    // Messages that arrive after unmounting and messages that come from a previous
+                    // refresh are all ignored here.
                     if (isMounted() && refreshKeyRef.current === refreshKey) {
                         dispatch({
                             type: SET_TIMESTAMP,

--- a/app/src/shared/hooks/useLastMessageTimestamp.js
+++ b/app/src/shared/hooks/useLastMessageTimestamp.js
@@ -1,13 +1,56 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useCallback, useReducer } from 'react'
 import { useClient } from 'streamr-client-react'
 import useIsMounted from '$shared/hooks/useIsMounted'
+
+const SET_TIMESTAMP = 'set timestamp'
+
+const REFRESH = 'refresh'
+
+const FAIL = 'fail'
+
+export const INVALID_TIMESTAMP = -1
+
+const initialState = {
+    refreshedAt: undefined,
+    refreshKey: 0,
+    timestamp: undefined,
+}
+
+const reducer = (state, action) => {
+    switch (action.type) {
+        case REFRESH:
+            return {
+                ...state,
+                refreshKey: state.refreshKey + 1,
+            }
+        case SET_TIMESTAMP:
+            return {
+                ...state,
+                refreshedAt: state.refreshKey ? new Date().getTime() : undefined,
+                timestamp: action.timestamp,
+            }
+        case FAIL:
+            return reducer(state, {
+                type: SET_TIMESTAMP,
+                timestamp: INVALID_TIMESTAMP,
+            })
+        default:
+            return state
+    }
+}
 
 const useLastMessageTimestamp = (streamId) => {
     const client = useClient()
 
-    const [timestamp, setTimestamp] = useState(undefined)
+    const [{ timestamp, refreshedAt, refreshKey }, dispatch] = useReducer(reducer, initialState)
 
     const isMounted = useIsMounted()
+
+    const refresh = useCallback(() => {
+        dispatch({
+            type: REFRESH,
+        })
+    }, [])
 
     useEffect(() => {
         if (!client) {
@@ -35,7 +78,10 @@ const useLastMessageTimestamp = (streamId) => {
 
         const onResendDone = () => {
             if (isMounted()) {
-                setTimestamp(last)
+                dispatch({
+                    type: SET_TIMESTAMP,
+                    timestamp: last,
+                })
             }
 
             sub.off('initial_resend_done', onResendDone)
@@ -52,9 +98,9 @@ const useLastMessageTimestamp = (streamId) => {
                 client.unsubscribe(sub)
             }
         }
-    }, [client, streamId, isMounted])
+    }, [client, streamId, isMounted, refreshKey])
 
-    return timestamp
+    return [timestamp, refresh, refreshedAt]
 }
 
 export default useLastMessageTimestamp

--- a/app/src/shared/utils/getClientConfig.js
+++ b/app/src/shared/utils/getClientConfig.js
@@ -1,0 +1,18 @@
+import { getToken } from '$shared/utils/sessionToken'
+
+export default function getClientConfig(options = {}) {
+    const sessionToken = getToken()
+
+    const auth = sessionToken == null ? {} : {
+        sessionToken,
+    }
+
+    return Object.assign({}, {
+        auth,
+        autoConnect: true,
+        autoDisconnect: false,
+        restUrl: process.env.STREAMR_API_URL,
+        url: process.env.STREAMR_WS_URL,
+        verifySignatures: 'never',
+    }, options)
+}

--- a/app/src/shared/utils/getClientConfig.js
+++ b/app/src/shared/utils/getClientConfig.js
@@ -7,7 +7,7 @@ export default function getClientConfig(options = {}) {
         sessionToken,
     }
 
-    return Object.assign({}, {
+    return Object.assign({
         auth,
         autoConnect: true,
         autoDisconnect: false,

--- a/app/src/shared/utils/getStreamActivityStatus.js
+++ b/app/src/shared/utils/getStreamActivityStatus.js
@@ -1,11 +1,6 @@
 import StatusIcon from '$shared/components/StatusIcon'
-import { INVALID_TIMESTAMP } from '../hooks/useLastMessageTimestamp'
 
 export default function getStreamActivityStatus(recentMessageTimestamp, inactivityThresholdHours = -Infinity) {
-    if (recentMessageTimestamp === INVALID_TIMESTAMP) {
-        return StatusIcon.ERROR
-    }
-
     if (new Date().getTime() - (inactivityThresholdHours * 60 * 60 * 1000) < recentMessageTimestamp) {
         return StatusIcon.OK
     }

--- a/app/src/shared/utils/getStreamActivityStatus.js
+++ b/app/src/shared/utils/getStreamActivityStatus.js
@@ -1,0 +1,9 @@
+import StatusIcon from '$shared/components/StatusIcon'
+
+export default function getStreamActivityStatus(recentMessageTimestamp, inactivityThresholdHours = Infinity) {
+    return (
+        new Date().getTime() - (inactivityThresholdHours * 60 * 60 * 1000) < recentMessageTimestamp
+            ? StatusIcon.OK
+            : StatusIcon.INACTIVE
+    )
+}

--- a/app/src/shared/utils/getStreamActivityStatus.js
+++ b/app/src/shared/utils/getStreamActivityStatus.js
@@ -1,9 +1,14 @@
 import StatusIcon from '$shared/components/StatusIcon'
+import { INVALID_TIMESTAMP } from '../hooks/useLastMessageTimestamp'
 
 export default function getStreamActivityStatus(recentMessageTimestamp, inactivityThresholdHours = Infinity) {
-    return (
-        new Date().getTime() - (inactivityThresholdHours * 60 * 60 * 1000) < recentMessageTimestamp
-            ? StatusIcon.OK
-            : StatusIcon.INACTIVE
-    )
+    if (recentMessageTimestamp === INVALID_TIMESTAMP) {
+        return StatusIcon.ERROR
+    }
+
+    if (new Date().getTime() - (inactivityThresholdHours * 60 * 60 * 1000) < recentMessageTimestamp) {
+        return StatusIcon.OK
+    }
+
+    return StatusIcon.INACTIVE
 }

--- a/app/src/shared/utils/getStreamActivityStatus.js
+++ b/app/src/shared/utils/getStreamActivityStatus.js
@@ -1,7 +1,7 @@
 import StatusIcon from '$shared/components/StatusIcon'
 import { INVALID_TIMESTAMP } from '../hooks/useLastMessageTimestamp'
 
-export default function getStreamActivityStatus(recentMessageTimestamp, inactivityThresholdHours = Infinity) {
+export default function getStreamActivityStatus(recentMessageTimestamp, inactivityThresholdHours = -Infinity) {
     if (recentMessageTimestamp === INVALID_TIMESTAMP) {
         return StatusIcon.ERROR
     }

--- a/app/src/shared/utils/getStreamActivityStatus.test.js
+++ b/app/src/shared/utils/getStreamActivityStatus.test.js
@@ -1,0 +1,24 @@
+import { INVALID_TIMESTAMP } from '../hooks/useLastMessageTimestamp'
+import getStreamActivityStatus from './getStreamActivityStatus'
+
+const now = () => new Date().getTime()
+
+const ONE_MINUTE = 60 * 1000
+
+describe('getStreamActivityStatus', () => {
+    it('gives INACTIVE if inactivityThresholdHours is undefined', () => {
+        expect(getStreamActivityStatus(now(), undefined).id).toEqual('inactive')
+    })
+
+    it('gives ERROR if recentMessageTimestamp is invalid', () => {
+        expect(getStreamActivityStatus(INVALID_TIMESTAMP, 48).id).toEqual('error')
+    })
+
+    it('gives OK if timestamp is within the threshold', () => {
+        expect(getStreamActivityStatus(now(), 1).id).toEqual('ok')
+    })
+
+    it('gives INACTIVE if timestamp crossed the threshold', () => {
+        expect(getStreamActivityStatus(now() - (ONE_MINUTE * 61), 1).id).toEqual('inactive')
+    })
+})

--- a/app/src/shared/utils/getStreamActivityStatus.test.js
+++ b/app/src/shared/utils/getStreamActivityStatus.test.js
@@ -1,4 +1,3 @@
-import { INVALID_TIMESTAMP } from '../hooks/useLastMessageTimestamp'
 import getStreamActivityStatus from './getStreamActivityStatus'
 
 const now = () => new Date().getTime()
@@ -8,10 +7,6 @@ const ONE_MINUTE = 60 * 1000
 describe('getStreamActivityStatus', () => {
     it('gives INACTIVE if inactivityThresholdHours is undefined', () => {
         expect(getStreamActivityStatus(now(), undefined).id).toEqual('inactive')
-    })
-
-    it('gives ERROR if recentMessageTimestamp is invalid', () => {
-        expect(getStreamActivityStatus(INVALID_TIMESTAMP, 48).id).toEqual('error')
     })
 
     it('gives OK if timestamp is within the threshold', () => {

--- a/app/src/userpages/components/StreamPage/Edit/PreviewView.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/PreviewView.jsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { Translate } from 'react-redux-i18n'
 import { useClient } from 'streamr-client-react'
 import Button from '$shared/components/Button'
-import ClientProvider from '$shared/components/StreamrClientProvider'
 import useModal from '$shared/hooks/useModal'
 import Subscription from '$shared/components/Subscription'
 import { Provider as SubscriptionStatusProvider } from '$shared/contexts/SubscriptionStatus'
@@ -208,8 +207,4 @@ const PreviewView = styled(UnstyledPreviewView)`
     position: relative;
 `
 
-export default (props) => (
-    <ClientProvider>
-        <PreviewView {...props} />
-    </ClientProvider>
-)
+export default PreviewView

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -25,7 +25,8 @@ import ShareSidebar from '$userpages/components/ShareSidebar'
 import BackButton from '$shared/components/BackButton'
 import Nav from '$shared/components/Layout/Nav'
 import { resetResourcePermission } from '$userpages/modules/permission/actions'
-import { mapStatus } from '../List'
+import useLastMessageTimestamp from '$shared/hooks/useLastMessageTimestamp'
+import getStreamActivityStatus from '$shared/utils/getStreamActivityStatus'
 
 import InfoView from './InfoView'
 import KeyView from './KeyView'
@@ -131,6 +132,10 @@ const Edit = ({ stream: streamProp, canShare, disabled }: any) => {
         sidebar.open('share')
     }, [sidebar])
 
+    const [timestamp] = useLastMessageTimestamp(stream.id)
+
+    const status = getStreamActivityStatus(timestamp, stream.inactivityThresholdHours)
+
     return (
         <CoreLayout
             nav={(
@@ -218,7 +223,7 @@ const Edit = ({ stream: streamProp, canShare, disabled }: any) => {
                     title={I18n.t('userpages.streams.edit.details.nav.status')}
                     status={<StatusIcon
                         tooltip
-                        status={mapStatus(stream.streamStatus)}
+                        status={status}
                     />}
                     onlyDesktop
                 >

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -132,9 +132,9 @@ const Edit = ({ stream: streamProp, canShare, disabled }: any) => {
         sidebar.open('share')
     }, [sidebar])
 
-    const [timestamp] = useLastMessageTimestamp(stream.id)
+    const [timestamp, error] = useLastMessageTimestamp(stream.id)
 
-    const status = getStreamActivityStatus(timestamp, stream.inactivityThresholdHours)
+    const status = error ? StatusIcon.ERROR : getStreamActivityStatus(timestamp, stream.inactivityThresholdHours)
 
     return (
         <CoreLayout

--- a/app/src/userpages/components/StreamPage/List/Row.jsx
+++ b/app/src/userpages/components/StreamPage/List/Row.jsx
@@ -5,7 +5,6 @@ import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
 import { titleize } from '@streamr/streamr-layout'
 import styled from 'styled-components'
-
 import routes from '$routes'
 import {
     deleteOrRemoveStream,
@@ -24,7 +23,8 @@ import { ago } from '$shared/utils/time'
 import { LG } from '$shared/utils/styled'
 import useModal from '$shared/hooks/useModal'
 import { StreamList } from '$shared/components/List'
-import { mapStatus } from '.'
+import useLastMessageTimestamp from '$shared/hooks/useLastMessageTimestamp'
+import getStreamActivityStatus from '$shared/utils/getStreamActivityStatus'
 
 const DesktopOnlyButton = styled(Button)`
     && {
@@ -147,8 +147,12 @@ const Row = ({ stream, onShareClick: onShareClickProp }) => {
         })
     }, [copy, stream.id])
 
+    const timestamp = useLastMessageTimestamp(stream.id)
+
+    const status = getStreamActivityStatus(timestamp, stream.inactivityThresholdHours)
+
     return (
-        <StreamList.Row id={stream.id} onClick={showStream}>
+        <StreamList.Row id={stream.id} onClick={showStream} data-test-hook={`Stream row for ${stream.id}`}>
             <StreamList.Title
                 description={stream.description}
                 moreInfo={stream.lastData && titleize(ago(new Date(stream.lastData)))}
@@ -161,11 +165,11 @@ const Row = ({ stream, onShareClick: onShareClickProp }) => {
             <StreamList.Item>
                 {stream.lastUpdated && titleize(ago(new Date(stream.lastUpdated)))}
             </StreamList.Item>
-            <StreamList.Item>
-                {stream.lastData && titleize(ago(new Date(stream.lastData)))}
+            <StreamList.Item data-test-hook="Last message at">
+                {timestamp && titleize(ago(new Date(timestamp)))}
             </StreamList.Item>
             <StreamList.Item>
-                <StatusIcon status={mapStatus(stream.streamStatus)} tooltip />
+                <StatusIcon status={status} tooltip />
             </StreamList.Item>
             <StreamList.Actions>
                 <Popover

--- a/app/src/userpages/components/StreamPage/List/Row.jsx
+++ b/app/src/userpages/components/StreamPage/List/Row.jsx
@@ -129,7 +129,7 @@ const Row = ({ stream, onShareClick: onShareClickProp }) => {
         })
     }, [copy, stream.id])
 
-    const [timestamp, refresh, refreshedAt] = useLastMessageTimestamp(stream.id)
+    const [timestamp, error, refresh, refreshedAt] = useLastMessageTimestamp(stream.id)
 
     useEffect(() => {
         // Initial status check is not a "refresh" that's why `refreshedAt`
@@ -143,7 +143,7 @@ const Row = ({ stream, onShareClick: onShareClickProp }) => {
         }
     }, [refreshedAt])
 
-    const status = getStreamActivityStatus(timestamp, stream.inactivityThresholdHours)
+    const status = error ? StatusIcon.ERROR : getStreamActivityStatus(timestamp, stream.inactivityThresholdHours)
 
     return (
         <StreamList.Row id={stream.id} onClick={showStream} data-test-hook={`Stream row for ${stream.id}`}>

--- a/app/src/userpages/components/StreamPage/List/Row.jsx
+++ b/app/src/userpages/components/StreamPage/List/Row.jsx
@@ -1,0 +1,204 @@
+import React, { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { push } from 'connected-react-router'
+import { Translate, I18n } from 'react-redux-i18n'
+import { Link } from 'react-router-dom'
+import { titleize } from '@streamr/streamr-layout'
+import styled from 'styled-components'
+
+import routes from '$routes'
+import {
+    deleteOrRemoveStream,
+    getStreamStatus,
+} from '$userpages/modules/userPageStreams/actions'
+import Popover from '$shared/components/Popover'
+import StatusIcon from '$shared/components/StatusIcon'
+import confirmDialog from '$shared/utils/confirm'
+import { getResourcePermissions } from '$userpages/modules/permission/actions'
+import { selectFetchingPermissions, selectStreamPermissions } from '$userpages/modules/permission/selectors'
+import { NotificationIcon } from '$shared/utils/constants'
+import Notification from '$shared/utils/Notification'
+import Button from '$shared/components/Button'
+import useCopy from '$shared/hooks/useCopy'
+import { ago } from '$shared/utils/time'
+import { LG } from '$shared/utils/styled'
+import useModal from '$shared/hooks/useModal'
+import { StreamList } from '$shared/components/List'
+import { mapStatus } from '.'
+
+const DesktopOnlyButton = styled(Button)`
+    && {
+        display: none;
+    }
+
+    @media (min-width: ${LG}px) {
+        && {
+            display: inline-flex;
+        }
+    }
+`
+
+export const CreateStreamButton = () => (
+    <DesktopOnlyButton
+        tag={Link}
+        to={routes.streams.new()}
+    >
+        <Translate value="userpages.streams.createStream" />
+    </DesktopOnlyButton>
+)
+
+const Row = ({ stream, onShareClick: onShareClickProp }) => {
+    const dispatch = useDispatch()
+    const { copy } = useCopy()
+    const fetchingPermissions = useSelector(selectFetchingPermissions)
+    const permissions = useSelector(selectStreamPermissions)
+    const { api: snippetDialog } = useModal('userpages.streamSnippet')
+
+    const canBeDeletedByCurrentUser = (
+        !fetchingPermissions &&
+        permissions[stream.id] &&
+        permissions[stream.id].includes('stream_delete')
+    )
+
+    const removeType = canBeDeletedByCurrentUser ? 'delete' : 'remove'
+
+    const confirmDeleteStream = useCallback(async () => {
+        const confirmed = await confirmDialog('stream', {
+            title: I18n.t(`userpages.streams.${removeType}.confirmTitle`),
+            message: I18n.t(`userpages.streams.${removeType}.confirmMessage`),
+            acceptButton: {
+                title: I18n.t(`userpages.streams.${removeType}.confirmButton`),
+                kind: 'destructive',
+            },
+            centerButtons: true,
+            dontShowAgain: false,
+        })
+
+        if (confirmed) {
+            try {
+                await dispatch(deleteOrRemoveStream(stream.id))
+
+                Notification.push({
+                    title: I18n.t(`userpages.streams.${removeType}.notification`),
+                    icon: NotificationIcon.CHECKMARK,
+                })
+            } catch (e) {
+                Notification.push({
+                    title: e.message,
+                    icon: NotificationIcon.ERROR,
+                })
+            }
+        }
+    }, [dispatch, stream.id, removeType])
+
+    const onToggleStreamDropdown = useCallback(async (open) => {
+        if (open && !fetchingPermissions && !permissions[stream.id]) {
+            try {
+                await dispatch(getResourcePermissions('STREAM', stream.id))
+            } catch (e) {
+                // Noop.
+            }
+        }
+    }, [dispatch, fetchingPermissions, permissions, stream.id])
+
+    const canBeSharedByCurrentUser = (
+        !fetchingPermissions &&
+        permissions[stream.id] &&
+        permissions[stream.id].includes('stream_share')
+    )
+
+    const onShareClick = useCallback(() => {
+        onShareClickProp(stream)
+    }, [onShareClickProp, stream])
+
+    const onOpenSnippetDialog = useCallback(async () => {
+        await snippetDialog.open({
+            streamId: stream.id,
+        })
+    }, [snippetDialog, stream.id])
+
+    const showStream = useCallback(() => (
+        dispatch(push(routes.streams.show({
+            id: stream.id,
+        })))
+    ), [dispatch, stream.id])
+
+    const onRefreshStatus = useCallback(() => {
+        dispatch(getStreamStatus(stream.id))
+            .then(() => {
+                Notification.push({
+                    title: I18n.t('userpages.streams.actions.refreshSuccess'),
+                    icon: NotificationIcon.CHECKMARK,
+                })
+            }, () => {
+                Notification.push({
+                    title: I18n.t('userpages.streams.actions.refreshError'),
+                    icon: NotificationIcon.ERROR,
+                })
+            })
+    }, [dispatch, stream.id])
+
+    const onCopyId = useCallback(() => {
+        copy(stream.id)
+
+        Notification.push({
+            title: I18n.t('userpages.streams.actions.idCopied'),
+            icon: NotificationIcon.CHECKMARK,
+        })
+    }, [copy, stream.id])
+
+    return (
+        <StreamList.Row id={stream.id} onClick={showStream}>
+            <StreamList.Title
+                description={stream.description}
+                moreInfo={stream.lastData && titleize(ago(new Date(stream.lastData)))}
+            >
+                {stream.name}
+            </StreamList.Title>
+            <StreamList.Item truncate title={stream.description}>
+                {stream.description}
+            </StreamList.Item>
+            <StreamList.Item>
+                {stream.lastUpdated && titleize(ago(new Date(stream.lastUpdated)))}
+            </StreamList.Item>
+            <StreamList.Item>
+                {stream.lastData && titleize(ago(new Date(stream.lastData)))}
+            </StreamList.Item>
+            <StreamList.Item>
+                <StatusIcon status={mapStatus(stream.streamStatus)} tooltip />
+            </StreamList.Item>
+            <StreamList.Actions>
+                <Popover
+                    title={I18n.t('userpages.streams.actions.title')}
+                    type="meatball"
+                    noCaret
+                    onMenuToggle={onToggleStreamDropdown}
+                    menuProps={{
+                        right: true,
+                    }}
+                >
+                    <Popover.Item onClick={showStream}>
+                        <Translate value="userpages.streams.actions.editStream" />
+                    </Popover.Item>
+                    <Popover.Item onClick={onCopyId}>
+                        <Translate value="userpages.streams.actions.copyId" />
+                    </Popover.Item>
+                    <Popover.Item onClick={onOpenSnippetDialog}>
+                        <Translate value="userpages.streams.actions.copySnippet" />
+                    </Popover.Item>
+                    <Popover.Item disabled={!canBeSharedByCurrentUser} onClick={onShareClick}>
+                        <Translate value="userpages.streams.actions.share" />
+                    </Popover.Item>
+                    <Popover.Item onClick={onRefreshStatus}>
+                        <Translate value="userpages.streams.actions.refresh" />
+                    </Popover.Item>
+                    <Popover.Item onClick={confirmDeleteStream}>
+                        <Translate value={`userpages.streams.actions.${removeType}`} />
+                    </Popover.Item>
+                </Popover>
+            </StreamList.Actions>
+        </StreamList.Row>
+    )
+}
+
+export default Row

--- a/app/src/userpages/components/StreamPage/List/Row.jsx
+++ b/app/src/userpages/components/StreamPage/List/Row.jsx
@@ -132,6 +132,9 @@ const Row = ({ stream, onShareClick: onShareClickProp }) => {
     const [timestamp, refresh, refreshedAt] = useLastMessageTimestamp(stream.id)
 
     useEffect(() => {
+        // Initial status check is not a "refresh" that's why `refreshedAt`
+        // is gonna be undefined. We're taking advantage of it here.
+
         if (refreshedAt) {
             Notification.push({
                 title: I18n.t('userpages.streams.actions.refreshSuccess'),

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -2,20 +2,14 @@
 
 import React, { Fragment, useEffect, useState, useCallback, useMemo, useContext } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { push } from 'connected-react-router'
 import { Translate, I18n } from 'react-redux-i18n'
 import Helmet from 'react-helmet'
 import { Link } from 'react-router-dom'
-import { titleize } from '@streamr/streamr-layout'
 import styled from 'styled-components'
-
-import type { Stream, StreamId } from '$shared/flowtype/stream-types'
 
 import routes from '$routes'
 import {
     getStreams,
-    deleteOrRemoveStream,
-    getStreamStatus,
     cancelStreamStatusFetch,
     clearStreamsList,
 } from '$userpages/modules/userPageStreams/actions'
@@ -25,26 +19,20 @@ import Popover from '$shared/components/Popover'
 import StatusIcon from '$shared/components/StatusIcon'
 import Layout from '$userpages/components/Layout'
 import Search from '../../Header/Search'
-import confirmDialog from '$shared/utils/confirm'
-import { getResourcePermissions, resetResourcePermission } from '$userpages/modules/permission/actions'
-import { selectFetchingPermissions, selectStreamPermissions } from '$userpages/modules/permission/selectors'
-import { NotificationIcon } from '$shared/utils/constants'
+import { resetResourcePermission } from '$userpages/modules/permission/actions'
 import NoStreamsView from './NoStreams'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
-import Notification from '$shared/utils/Notification'
 import LoadMore from '$mp/components/LoadMore'
 import ListContainer from '$shared/components/Container/List'
 import Button from '$shared/components/Button'
 import useFilterSort from '$userpages/hooks/useFilterSort'
-import useCopy from '$shared/hooks/useCopy'
 import Sidebar from '$shared/components/Sidebar'
 import SidebarProvider, { SidebarContext } from '$shared/components/Sidebar/SidebarProvider'
 import ShareSidebar from '$userpages/components/ShareSidebar'
-import { ago } from '$shared/utils/time'
 import { MD, LG } from '$shared/utils/styled'
-import useModal from '$shared/hooks/useModal'
 import SnippetDialog from './SnippetDialog'
 import { StreamList as StreamListComponent } from '$shared/components/List'
+import Row from './Row'
 
 const DesktopOnlyButton = styled(Button)`
     && {
@@ -106,10 +94,6 @@ export const mapStatus = (state: string) => {
     }
 }
 
-type TargetStream = ?Stream
-
-type TargetStreamSetter = [TargetStream, ((TargetStream => TargetStream) | TargetStream) => void]
-
 function StreamPageSidebar({ stream }) {
     const sidebar = useContext(SidebarContext)
     const dispatch = useDispatch()
@@ -142,8 +126,6 @@ function StreamPageSidebar({ stream }) {
     )
 }
 
-type RemoveOrDelete = 'remove' | 'delete'
-
 const StreamList = () => {
     const filters = useMemo(() => getFilters('stream'), [])
     const allSortOptions = useMemo(() => ([
@@ -165,17 +147,11 @@ const StreamList = () => {
         setSort,
         resetFilter,
     } = useFilterSort(allSortOptions)
-    const [dialogTargetStream, setDialogTargetStream]: TargetStreamSetter = useState(null)
+    const [dialogTargetStream, setDialogTargetStream] = useState(null)
     const dispatch = useDispatch()
-    const { copy } = useCopy()
     const streams = useSelector(selectStreams)
     const fetching = useSelector(selectFetching)
-    const fetchingPermissions = useSelector(selectFetchingPermissions)
-    const permissions = useSelector(selectStreamPermissions)
     const hasMoreResults = useSelector(selectHasMoreSearchResults)
-    const { api: snippetDialog } = useModal('userpages.streamSnippet')
-
-    const sidebar = useContext(SidebarContext)
 
     useEffect(() => () => {
         cancelStreamStatusFetch()
@@ -189,103 +165,14 @@ const StreamList = () => {
         }))
     }, [dispatch, filter])
 
-    const confirmDeleteStream = useCallback(async (stream: Stream, type: RemoveOrDelete) => {
-        const confirmed = await confirmDialog('stream', {
-            title: I18n.t(`userpages.streams.${type}.confirmTitle`),
-            message: I18n.t(`userpages.streams.${type}.confirmMessage`),
-            acceptButton: {
-                title: I18n.t(`userpages.streams.${type}.confirmButton`),
-                kind: 'destructive',
-            },
-            centerButtons: true,
-            dontShowAgain: false,
-        })
+    const [activeSort, setActiveSort] = useState(undefined)
 
-        if (confirmed) {
-            try {
-                await dispatch(deleteOrRemoveStream(stream.id))
+    const sidebar = useContext(SidebarContext)
 
-                Notification.push({
-                    title: I18n.t(`userpages.streams.${type}.notification`),
-                    icon: NotificationIcon.CHECKMARK,
-                })
-            } catch (e) {
-                Notification.push({
-                    title: e.message,
-                    icon: NotificationIcon.ERROR,
-                })
-            }
-        }
-    }, [dispatch])
-
-    const onToggleStreamDropdown = useCallback((streamId: StreamId) => async (open: boolean) => {
-        if (open && !fetchingPermissions && !permissions[streamId]) {
-            try {
-                await dispatch(getResourcePermissions('STREAM', streamId))
-            } catch (e) {
-                // Noop.
-            }
-        }
-    }, [dispatch, fetchingPermissions, permissions])
-
-    const canBeSharedByCurrentUser = useCallback((id: StreamId): boolean => (
-        !fetchingPermissions &&
-        permissions[id] &&
-        permissions[id].includes('stream_share')
-    ), [fetchingPermissions, permissions])
-
-    const canBeDeletedByCurrentUser = useCallback((id: StreamId): boolean => (
-        !fetchingPermissions &&
-        permissions[id] &&
-        permissions[id].includes('stream_delete')
-    ), [fetchingPermissions, permissions])
-
-    const onOpenShareDialog = useCallback((stream: Stream) => {
+    const onOpenShareDialog = useCallback((stream) => {
         setDialogTargetStream(stream)
         sidebar.open('share')
     }, [sidebar])
-
-    const onOpenSnippetDialog = useCallback(async (stream: Stream) => {
-        await snippetDialog.open({
-            streamId: stream.id,
-        })
-    }, [snippetDialog])
-
-    const showStream = useCallback((id: StreamId) => (
-        dispatch(push(routes.streams.show({
-            id,
-        })))
-    ), [dispatch])
-
-    const onStreamRowClick = useCallback((id: StreamId) => {
-        showStream(id)
-    }, [showStream])
-
-    const onRefreshStatus = useCallback((id: StreamId) => {
-        dispatch(getStreamStatus(id))
-            .then(() => {
-                Notification.push({
-                    title: I18n.t('userpages.streams.actions.refreshSuccess'),
-                    icon: NotificationIcon.CHECKMARK,
-                })
-            }, () => {
-                Notification.push({
-                    title: I18n.t('userpages.streams.actions.refreshError'),
-                    icon: NotificationIcon.ERROR,
-                })
-            })
-    }, [dispatch])
-
-    const onCopyId = useCallback((id: StreamId) => {
-        copy(id)
-
-        Notification.push({
-            title: I18n.t('userpages.streams.actions.idCopied'),
-            icon: NotificationIcon.CHECKMARK,
-        })
-    }, [copy])
-
-    const [activeSort, setActiveSort] = useState(undefined)
 
     const onDropdownSort = useCallback((value) => {
         setActiveSort(value)
@@ -306,56 +193,6 @@ const StreamList = () => {
             return nextSort
         })
     }, [setActiveSort, setSort, defaultFilter])
-
-    const getActions = useCallback((stream) => {
-        const removeType = canBeDeletedByCurrentUser(stream.id) ? 'delete' : 'remove'
-
-        return (
-            <Popover
-                title={I18n.t('userpages.streams.actions.title')}
-                type="meatball"
-                noCaret
-                onMenuToggle={onToggleStreamDropdown(stream.id)}
-                menuProps={{
-                    right: true,
-                }}
-            >
-                <Popover.Item onClick={() => showStream(stream.id)}>
-                    <Translate value="userpages.streams.actions.editStream" />
-                </Popover.Item>
-                <Popover.Item onClick={() => onCopyId(stream.id)}>
-                    <Translate value="userpages.streams.actions.copyId" />
-                </Popover.Item>
-                <Popover.Item onClick={() => onOpenSnippetDialog(stream)}>
-                    <Translate value="userpages.streams.actions.copySnippet" />
-                </Popover.Item>
-                <Popover.Item
-                    disabled={!canBeSharedByCurrentUser(stream.id)}
-                    onClick={() => onOpenShareDialog(stream)}
-                >
-                    <Translate value="userpages.streams.actions.share" />
-                </Popover.Item>
-                <Popover.Item onClick={() => onRefreshStatus(stream.id)}>
-                    <Translate value="userpages.streams.actions.refresh" />
-                </Popover.Item>
-                <Popover.Item
-                    onClick={() => confirmDeleteStream(stream, removeType)}
-                >
-                    <Translate value={`userpages.streams.actions.${removeType}`} />
-                </Popover.Item>
-            </Popover>
-        )
-    }, [
-        onToggleStreamDropdown,
-        showStream,
-        onCopyId,
-        onOpenSnippetDialog,
-        canBeSharedByCurrentUser,
-        onOpenShareDialog,
-        onRefreshStatus,
-        canBeDeletedByCurrentUser,
-        confirmDeleteStream,
-    ])
 
     return (
         <Layout
@@ -427,36 +264,11 @@ const StreamList = () => {
                                 </StreamListComponent.HeaderItem>
                             </StreamListComponent.Header>
                             {streams.map((stream) => (
-                                <StreamListComponent.Row
+                                <Row
                                     key={stream.id}
-                                    id={stream.id}
-                                    onClick={() => onStreamRowClick(stream.id)}
-                                >
-                                    <StreamListComponent.Title
-                                        description={stream.description}
-                                        moreInfo={stream.lastData && titleize(ago(new Date(stream.lastData)))}
-                                    >
-                                        {stream.name}
-                                    </StreamListComponent.Title>
-                                    <StreamListComponent.Item truncate title={stream.description}>
-                                        {stream.description}
-                                    </StreamListComponent.Item>
-                                    <StreamListComponent.Item>
-                                        {stream.lastUpdated && titleize(ago(new Date(stream.lastUpdated)))}
-                                    </StreamListComponent.Item>
-                                    <StreamListComponent.Item>
-                                        {stream.lastData && titleize(ago(new Date(stream.lastData)))}
-                                    </StreamListComponent.Item>
-                                    <StreamListComponent.Item>
-                                        <StatusIcon
-                                            status={mapStatus(stream.streamStatus)}
-                                            tooltip
-                                        />
-                                    </StreamListComponent.Item>
-                                    <StreamListComponent.Actions>
-                                        {getActions(stream)}
-                                    </StreamListComponent.Actions>
-                                </StreamListComponent.Row>
+                                    onShareClick={onOpenShareDialog}
+                                    stream={stream}
+                                />
                             ))}
                         </StreamListComponent>
                         <LoadMore

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -10,13 +10,11 @@ import styled from 'styled-components'
 import routes from '$routes'
 import {
     getStreams,
-    cancelStreamStatusFetch,
     clearStreamsList,
 } from '$userpages/modules/userPageStreams/actions'
 import { selectStreams, selectFetching, selectHasMoreSearchResults } from '$userpages/modules/userPageStreams/selectors'
 import { getFilters } from '$userpages/utils/constants'
 import Popover from '$shared/components/Popover'
-import StatusIcon from '$shared/components/StatusIcon'
 import Layout from '$userpages/components/Layout'
 import Search from '../../Header/Search'
 import { resetResourcePermission } from '$userpages/modules/permission/actions'
@@ -82,19 +80,6 @@ const TabletPopover = styled(Popover)`
     }
 `
 
-export const mapStatus = (state: string) => {
-    switch (state) {
-        case 'ok':
-            return StatusIcon.OK
-        case 'error':
-            return StatusIcon.ERROR
-        case 'pending':
-            return StatusIcon.PENDING
-        default:
-            return StatusIcon.INACTIVE
-    }
-}
-
 function StreamPageSidebar({ stream }) {
     const sidebar = useContext(SidebarContext)
     const dispatch = useDispatch()
@@ -155,7 +140,6 @@ const StreamList = () => {
     const hasMoreResults = useSelector(selectHasMoreSearchResults)
 
     useEffect(() => () => {
-        cancelStreamStatusFetch()
         dispatch(clearStreamsList())
     }, [dispatch])
 

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -31,7 +31,6 @@ import { MD, LG } from '$shared/utils/styled'
 import SnippetDialog from './SnippetDialog'
 import { StreamList as StreamListComponent } from '$shared/components/List'
 import Row from './Row'
-import StreamrClientProvider from '$shared/components/StreamrClientProvider'
 
 const DesktopOnlyButton = styled(Button)`
     && {
@@ -248,15 +247,13 @@ const StreamList = () => {
                                     <Translate value="userpages.streams.list.status" />
                                 </StreamListComponent.HeaderItem>
                             </StreamListComponent.Header>
-                            <StreamrClientProvider>
-                                {streams.map((stream) => (
-                                    <Row
-                                        key={stream.id}
-                                        onShareClick={onOpenShareDialog}
-                                        stream={stream}
-                                    />
-                                ))}
-                            </StreamrClientProvider>
+                            {streams.map((stream) => (
+                                <Row
+                                    key={stream.id}
+                                    onShareClick={onOpenShareDialog}
+                                    stream={stream}
+                                />
+                            ))}
                         </StreamListComponent>
                         <LoadMore
                             hasMoreSearchResults={!fetching && hasMoreResults}

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -33,6 +33,7 @@ import { MD, LG } from '$shared/utils/styled'
 import SnippetDialog from './SnippetDialog'
 import { StreamList as StreamListComponent } from '$shared/components/List'
 import Row from './Row'
+import StreamrClientProvider from '$shared/components/StreamrClientProvider'
 
 const DesktopOnlyButton = styled(Button)`
     && {
@@ -263,13 +264,15 @@ const StreamList = () => {
                                     <Translate value="userpages.streams.list.status" />
                                 </StreamListComponent.HeaderItem>
                             </StreamListComponent.Header>
-                            {streams.map((stream) => (
-                                <Row
-                                    key={stream.id}
-                                    onShareClick={onOpenShareDialog}
-                                    stream={stream}
-                                />
-                            ))}
+                            <StreamrClientProvider>
+                                {streams.map((stream) => (
+                                    <Row
+                                        key={stream.id}
+                                        onShareClick={onOpenShareDialog}
+                                        stream={stream}
+                                    />
+                                ))}
+                            </StreamrClientProvider>
                         </StreamListComponent>
                         <LoadMore
                             hasMoreSearchResults={!fetching && hasMoreResults}

--- a/app/src/userpages/components/StreamPage/index.jsx
+++ b/app/src/userpages/components/StreamPage/index.jsx
@@ -25,6 +25,7 @@ import View from './View'
 import Layout from '$shared/components/Layout/Core'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import useStreamPermissions from '$userpages/hooks/useStreamPermissions'
+import ClientProvider from '$shared/components/StreamrClientProvider'
 
 const StreamPage = (props) => {
     const { id: idProp } = props.match.params || {}
@@ -117,17 +118,21 @@ const StreamPage = (props) => {
         )
     }
 
-    return readOnly ? (
-        <View
-            stream={stream}
-            currentUser={currentUser}
-        />
-    ) : (
-        <Edit
-            stream={editedStream}
-            canShare={canShare}
-            disabled={updating}
-        />
+    return (
+        <ClientProvider>
+            {readOnly ? (
+                <View
+                    stream={stream}
+                    currentUser={currentUser}
+                />
+            ) : (
+                <Edit
+                    stream={editedStream}
+                    canShare={canShare}
+                    disabled={updating}
+                />
+            )}
+        </ClientProvider>
     )
 }
 

--- a/app/src/userpages/components/StreamPage/index.jsx
+++ b/app/src/userpages/components/StreamPage/index.jsx
@@ -3,7 +3,6 @@ import { useSelector, useDispatch } from 'react-redux'
 import {
     closeStream,
     getStream,
-    getStreamStatus,
     initEditStream,
     openStream,
     updateEditStream,
@@ -89,14 +88,6 @@ const StreamPage = (props) => {
 
     useEffect(() => {
         const initEditing = async () => {
-            // Get stream status before copying state to edit stream object.
-            try {
-                // The status query might fail due to cassandra problems. Ignore error to prevent
-                // the stream page from getting stuck while loading
-                await dispatch(getStreamStatus(id))
-            } catch (e) {
-                console.warn(e)
-            }
             if (isMounted()) {
                 dispatch(initEditStream())
             }

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -360,9 +360,6 @@ msgstr "Refresh"
 msgid "userpages.streams.actions.refreshSuccess"
 msgstr "Stream refreshed"
 
-msgid "userpages.streams.actions.refreshError"
-msgstr "Stream refresh failed"
-
 msgid "userpages.streams.actions.delete"
 msgstr "Delete"
 

--- a/app/src/userpages/modules/userPageStreams/services.js
+++ b/app/src/userpages/modules/userPageStreams/services.js
@@ -8,7 +8,6 @@ import type {
     Stream,
     StreamList,
     NewStream,
-    StreamStatus,
 } from '$shared/flowtype/stream-types'
 
 export const getStream = (id: StreamId): ApiResult<Stream> => get({
@@ -51,12 +50,6 @@ export const getStreams = (params: any, pageSize: number, offset: number): ApiRe
         streams: streams.splice(0, pageSize),
         hasMoreResults: streams.length > 0,
     }))
-
-export const getStreamStatus = (streamId: StreamId): ApiResult<StreamStatus> => get({
-    url: routes.api.streams.status({
-        streamId,
-    }),
-})
 
 export const autodetectStreamfields = (streamId: StreamId): ApiResult<Stream> => get({
     url: routes.api.streams.detectFields({


### PR DESCRIPTION
In this PR I replace fetching stream status via e&e with fetching it via ~~`streamr-client`~~ the API. Notes:

- `useLastMessageTimestamp` hook lets you determine the latest message timestamp.
- `getStreamActivityStatus` utility turns a timestamp in a proper `StatusIcon` instance.
- I extracted `ClientProvider` from `PreviewView` and wrapped everything in `StreamPage/index.jsx` with it (both `View` and `Edit` components) – see 773bb2c.
- Wrote a couple of new `cypress` commands so that you can, for example, publish a message to a stream (it waits for it to complete).

And a bunch of other things. Hope you guys like it. Cheers!