### PR TITLE
[FRONT-121] Add metamask provider, fix product page Metamask prompt

### DIFF
--- a/app/src/auth/components/EthereumLogin/index.jsx
+++ b/app/src/auth/components/EthereumLogin/index.jsx
@@ -60,9 +60,7 @@ const EthereumLogin = ({ onBackClick }: Props) => {
         const token: ?string = await (async () => {
             try {
                 return await getSessionToken({
-                    // TODO: this is a hack, we pass an instance of the web3 injected by Metamask directly because the wrapped object
-                    // in web3-beta.55 does not work (https://github.com/MetaMask/metamask-extension/issues/6080).
-                    provider: window.web3.currentProvider,
+                    provider: web3.metamaskProvider,
                 })
             } catch (e) {
                 if (mountedRef.current) {

--- a/app/src/docs/content/streams/code/streams.js
+++ b/app/src/docs/content/streams/code/streams.js
@@ -10,7 +10,7 @@ export const CreateJavaClient = 'StreamrClient client = new StreamrClient(new Ap
 export const AuthJavascriptClient =
 `new StreamrClient({
     auth: {
-        provider: web3.currentProvider,
+        provider: window.ethereum,
     }
 })`
 

--- a/app/src/marketplace/components/ProductPage/Description.jsx
+++ b/app/src/marketplace/components/ProductPage/Description.jsx
@@ -55,7 +55,6 @@ const SideBar = styled.div`
     background-color: #EFEFEF;
     font-size: 1em;
     line-height: 1.5em;
-    max-height: 15.5em;
     padding: 1.5em;
 
     @media (min-width: ${SM}px) {

--- a/app/src/marketplace/containers/ProductController/index.jsx
+++ b/app/src/marketplace/containers/ProductController/index.jsx
@@ -9,6 +9,7 @@ import { Provider as ValidationContextProvider } from './ValidationContextProvid
 import { Provider as PermissionsProvider } from './useProductPermissions'
 import { usePending } from '$shared/hooks/usePending'
 import { resetProduct } from '$mp/modules/product/actions'
+import useIsMounted from '$shared/hooks/useIsMounted'
 
 import useProductLoadCallback from './useProductLoadCallback'
 import useContractProductLoadCallback from './useContractProductLoadCallback'
@@ -51,6 +52,7 @@ function useProductLoadEffect({ ignoreUnauthorized, requirePublished }: EffectPr
     const { match } = useContext(RouterContext.Context)
     const { setHasLoaded } = useContext(ProductControllerContext)
     const { isPending } = usePending('product.LOAD')
+    const isMounted = useIsMounted()
 
     const { id: urlId } = match.params
 
@@ -61,7 +63,11 @@ function useProductLoadEffect({ ignoreUnauthorized, requirePublished }: EffectPr
                 productId: urlId,
                 ignoreUnauthorized,
                 requirePublished,
-            }).then(() => setHasLoaded(true))
+            }).then(() => {
+                if (isMounted()) {
+                    setHasLoaded(true)
+                }
+            })
             loadContractProduct(urlId)
             setLoadedOnce(true)
         }
@@ -74,6 +80,7 @@ function useProductLoadEffect({ ignoreUnauthorized, requirePublished }: EffectPr
         ignoreUnauthorized,
         requirePublished,
         setHasLoaded,
+        isMounted,
     ])
 }
 

--- a/app/src/marketplace/containers/ProductController/index.jsx
+++ b/app/src/marketplace/containers/ProductController/index.jsx
@@ -23,6 +23,8 @@ import useLoadStreamsCallback from './useLoadStreamsCallback'
 import useClearStreamsCallback from './useClearStreamsCallback'
 
 type ContextProps = {
+    hasLoaded: boolean,
+    setHasLoaded: Function,
     loadProduct: Function,
     loadContractProduct: Function,
     loadContractProductSubscription: Function,
@@ -47,6 +49,7 @@ function useProductLoadEffect({ ignoreUnauthorized, requirePublished }: EffectPr
     const loadProduct = useProductLoadCallback()
     const loadContractProduct = useContractProductLoadCallback()
     const { match } = useContext(RouterContext.Context)
+    const { setHasLoaded } = useContext(ProductControllerContext)
     const { isPending } = usePending('product.LOAD')
 
     const { id: urlId } = match.params
@@ -58,11 +61,20 @@ function useProductLoadEffect({ ignoreUnauthorized, requirePublished }: EffectPr
                 productId: urlId,
                 ignoreUnauthorized,
                 requirePublished,
-            })
+            }).then(() => setHasLoaded(true))
             loadContractProduct(urlId)
             setLoadedOnce(true)
         }
-    }, [urlId, loadedOnce, loadProduct, loadContractProduct, isPending, ignoreUnauthorized, requirePublished])
+    }, [
+        urlId,
+        loadedOnce,
+        loadProduct,
+        loadContractProduct,
+        isPending,
+        ignoreUnauthorized,
+        requirePublished,
+        setHasLoaded,
+    ])
 }
 
 function ProductEffects({ ignoreUnauthorized, requirePublished }: EffectProps) {
@@ -84,6 +96,7 @@ export function useController() {
 }
 
 function useProductController() {
+    const [hasLoaded, setHasLoaded] = useState(false)
     const loadProduct = useProductLoadCallback()
     const loadContractProduct = useContractProductLoadCallback()
     const loadContractProductSubscription = useContractProductSubscriptionLoadCallback()
@@ -96,6 +109,8 @@ function useProductController() {
     const clearStreams = useClearStreamsCallback()
 
     return useMemo(() => ({
+        hasLoaded,
+        setHasLoaded,
         loadProduct,
         loadContractProduct,
         loadContractProductSubscription,
@@ -107,6 +122,8 @@ function useProductController() {
         loadStreams,
         clearStreams,
     }), [
+        hasLoaded,
+        setHasLoaded,
         loadProduct,
         loadContractProduct,
         loadContractProductSubscription,

--- a/app/src/marketplace/containers/ProductPage/Hero.jsx
+++ b/app/src/marketplace/containers/ProductPage/Hero.jsx
@@ -26,9 +26,37 @@ import { ImageTile } from '$shared/components/Tile'
 import { NotificationIcon } from '$shared/utils/constants'
 import Notification from '$shared/utils/Notification'
 import { isAddressWhitelisted } from '$mp/modules/contractProduct/services'
-import useWeb3Status from '$shared/hooks/useWeb3Status'
+import useAccountAddress from '$shared/hooks/useAccountAddress'
+import type { ProductId } from '$mp/flowtype/product-types'
+import { getWeb3, validateWeb3 } from '$shared/web3/web3Provider'
 
 import routes from '$routes'
+
+type WhitelistStatus = {
+    productId: ProductId,
+    validate?: boolean,
+}
+
+const getWhitelistStatus = async ({ productId, validate = false }: WhitelistStatus) => {
+    const web3 = getWeb3()
+
+    try {
+        if (validate) {
+            await validateWeb3({
+                web3,
+                checkNetwork: false, // network check is done later if purchase is possible
+            })
+        }
+        const account = await web3.getDefaultAccount()
+
+        return !!account && isAddressWhitelisted(productId, account)
+    } catch (e) {
+        // log error but ignore otherwise
+        console.warn(e)
+    }
+
+    return false
+}
 
 const Hero = () => {
     const dispatch = useDispatch()
@@ -43,7 +71,7 @@ const Hero = () => {
     const isDataUnion = !!(product && isDataUnionProduct(product))
     const isProductSubscriptionValid = useSelector(selectSubscriptionIsValid)
     const subscription = useSelector(selectContractSubscription)
-    const { account } = useWeb3Status()
+    const account = useAccountAddress()
 
     const productId = product.id
     const contactEmail = product && product.contact && product.contact.email
@@ -57,11 +85,20 @@ const Hero = () => {
             if (isLoggedIn) {
                 if (isPaid) {
                     if (isWhitelistEnabled && !isWhitelisted) {
-                        await requestAccessDialog.open({
-                            contactEmail,
-                            productName,
+                        // at this point we know either that user has access or Metamask was locked
+                        // do a another check but this time validate web3 which will prompt Metamask
+                        const canPurchase = await getWhitelistStatus({
+                            productId,
+                            validate: true, // prompts metamask if locked
                         })
-                        return
+
+                        if (!canPurchase) {
+                            await requestAccessDialog.open({
+                                contactEmail,
+                                productName,
+                            })
+                            return
+                        }
                     }
 
                     // Paid product has to be bought with Metamask
@@ -116,16 +153,21 @@ const Hero = () => {
     ])
 
     useEffect(() => {
-        const loadWhitelistStatus = async (targetAccount) => {
-            const whitelisted = !isWhitelistEnabled || await isAddressWhitelisted(productId, targetAccount)
+        const loadWhitelistStatus = async () => {
+            // set product as whitelisted if that feature is enabled, and if
+            // 1) metamask is locked -> clicking request access will prompt Metamask
+            // 2) metamask is unlocked and user has access
+            const whitelisted = !isWhitelistEnabled || await getWhitelistStatus({
+                productId,
+            })
 
             setIsWhitelisted(whitelisted)
         }
 
-        if (productId && account) {
-            loadWhitelistStatus(account)
+        if (productId && !isPending) {
+            loadWhitelistStatus()
         }
-    }, [productId, account, isWhitelistEnabled])
+    }, [productId, account, isWhitelistEnabled, isPending])
 
     return (
         <HeroComponent

--- a/app/src/marketplace/containers/ProductPage/Hero.jsx
+++ b/app/src/marketplace/containers/ProductPage/Hero.jsx
@@ -92,6 +92,8 @@ const Hero = () => {
                             validate: true, // prompts metamask if locked
                         })
 
+                        if (!isMounted()) { return }
+
                         if (!canPurchase) {
                             await requestAccessDialog.open({
                                 contactEmail,
@@ -161,13 +163,15 @@ const Hero = () => {
                 productId,
             })
 
-            setIsWhitelisted(whitelisted)
+            if (isMounted()) {
+                setIsWhitelisted(whitelisted)
+            }
         }
 
         if (productId && !isPending) {
             loadWhitelistStatus()
         }
-    }, [productId, account, isWhitelistEnabled, isPending])
+    }, [productId, account, isWhitelistEnabled, isPending, isMounted])
 
     return (
         <HeroComponent

--- a/app/src/marketplace/containers/ProductPage/PurchaseModal.jsx
+++ b/app/src/marketplace/containers/ProductPage/PurchaseModal.jsx
@@ -53,7 +53,7 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
     const isMounted = useIsMounted()
     const contractProduct = useSelector(selectContractProduct)
     const contractProductError = useSelector(selectContractProductError)
-    const { load: loadEthIdentities, isLinked, create: createIdentity } = useEthereumIdentities()
+    const { load: loadEthIdentities, isLinked, connect: connectIdentity } = useEthereumIdentities()
     const accessPeriodParams: Ref<AccessPeriod> = useRef({
         time: '1',
         timeUnit: 'hour',
@@ -109,7 +109,7 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
             let succeeded = false
 
             try {
-                await createIdentity(account || 'Account name')
+                await connectIdentity(account || 'Account name')
                 succeeded = true
             } catch (e) {
                 console.warn(e)
@@ -123,7 +123,7 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
                 }
             }
         })
-    ), [wrapLinkAccount, account, isMounted, createIdentity])
+    ), [wrapLinkAccount, account, isMounted, connectIdentity])
 
     const onSetAccessPeriod = useCallback(async (accessPeriod: AccessPeriod) => {
         accessPeriodParams.current = accessPeriod

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -96,10 +96,11 @@ const LoadingView = () => (
 
 const EditWrap = () => {
     const product = useProduct()
+    const { hasLoaded } = useController()
     const { isPending: loadPending } = usePending('product.LOAD')
     const { isPending: permissionsPending } = usePending('product.PERMISSIONS')
 
-    if (!product || loadPending || permissionsPending) {
+    if (!hasLoaded || loadPending || permissionsPending) {
         return <LoadingView />
     }
 

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -250,7 +250,7 @@ msgid "editProductPage.sidebar.activeSubscribers"
 msgstr "Active subscribers"
 
 msgid "editProductPage.sidebar.mostRecentSubscription"
-msgstr "Most recent purchase"
+msgstr "Last purchased"
 
 msgid "editProductPage.terms.title"
 msgstr "Set terms of use"

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -250,7 +250,7 @@ msgid "editProductPage.sidebar.activeSubscribers"
 msgstr "Active subscribers"
 
 msgid "editProductPage.sidebar.mostRecentSubscription"
-msgstr "Most recent subscription"
+msgstr "Most recent purchase"
 
 msgid "editProductPage.terms.title"
 msgstr "Set terms of use"

--- a/app/src/marketplace/modules/contractProduct/services.js
+++ b/app/src/marketplace/modules/contractProduct/services.js
@@ -304,7 +304,8 @@ export const getWhitelistAddresses = async (id: ProductId, usePublicNode: boolea
     return whitelist
 }
 
-export const isAddressWhitelisted = async (id: ProductId, address: Address) => {
-    const whitelist = await getWhitelistAddresses(id, true)
-    return whitelist.map((item) => item.status !== 'removed' && item.address.toLowerCase()).includes(address.toLowerCase())
+export const isAddressWhitelisted = async (id: ProductId, address: Address, usePublicNode: boolean = true) => {
+    const isWhitelistStatus = await call(contractMethods(usePublicNode).getWhitelistState(getValidId(id), address))
+
+    return !!(isWhitelistStatus === 2)
 }

--- a/app/src/shared/web3/web3Provider.js
+++ b/app/src/shared/web3/web3Provider.js
@@ -21,9 +21,11 @@ type StreamrWeb3Options = {
 
 export class StreamrWeb3 extends Web3 {
     isLegacy: boolean
+    metamaskProvider: any
 
     constructor(provider: any, options: StreamrWeb3Options = {}) {
         super(provider)
+        this.metamaskProvider = provider
         this.isLegacy = options && !!options.isLegacy
         // Set number of desired confirmations for transactions.
         // This needs to be 1 for local Ganache chain. Default is 24.


### PR DESCRIPTION
I checked the `web3` Metamask provider injection and we should we quite safe with our implementation since everywhere the Web3 wrapped lib is used instead of the one provided by Metamask. I added a convenience property `metamaskProvider` to our `StreamrWeb3` object that is given to eg. Streamr client.

I made two other fixes to the product page here that I noticed while testing:
- Product page prompts immediately for Metamask if locked. I changed it so that the metamask is not prompted, if whitelisted the button will still say "Request access" but Metamask is prompted only when clicking it. If user is whitelisted, the purchase can continue - if not, it will show the email dialog
- Having a non-linked account created a new account instead of connecting the current one.