### PR TITLE
[FRONT-122] Reload page on network change

### DIFF
--- a/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx
+++ b/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx
@@ -17,6 +17,7 @@ import TransactionError from '$shared/errors/TransactionError'
 import Web3Poller from '$shared/web3/web3Poller'
 import { useBalances } from '$shared/hooks/useBalances'
 import { selectUserData } from '$shared/modules/user/selectors'
+import type { NumberString } from '$shared/flowtype/common-types'
 
 type Props = {
     children?: Node,
@@ -122,6 +123,27 @@ export const GlobalInfoWatcher = ({ children }: Props) => {
             clearTimeout(balanceTimeout.current)
         }
     }, [dispatch, balancePoll, username])
+
+    // Poll network
+    useEffect(() => {
+        let currentNetworkId
+
+        const onNetworkChange = (networkId: NumberString) => {
+            if (currentNetworkId && networkId && currentNetworkId !== networkId) {
+                window.location.reload()
+            }
+
+            currentNetworkId = networkId
+        }
+
+        Web3Poller.subscribe(Web3Poller.events.NETWORK, onNetworkChange)
+        Web3Poller.subscribe(Web3Poller.events.NETWORK_ERROR, onNetworkChange)
+
+        return () => {
+            Web3Poller.unsubscribe(Web3Poller.events.NETWORK, onNetworkChange)
+            Web3Poller.unsubscribe(Web3Poller.events.NETWORK_ERROR, onNetworkChange)
+        }
+    }, [])
 
     return children || null
 }

--- a/app/src/shared/web3/web3Poller/web3Poller.js
+++ b/app/src/shared/web3/web3Poller/web3Poller.js
@@ -145,11 +145,7 @@ export default class Web3Poller {
             }, () => {
                 this.web3.getDefaultAccount()
                     .catch((err) => {
-                        if (this.account) {
-                            this.emitter.emit(events.NETWORK_ERROR, err)
-                        } else {
-                            warnOnce(err)
-                        }
+                        this.emitter.emit(events.NETWORK_ERROR, err)
                     })
             })
     )

--- a/app/src/shared/web3/web3Provider.js
+++ b/app/src/shared/web3/web3Provider.js
@@ -15,6 +15,12 @@ import FakeProvider from 'web3-fake-provider'
 declare var ethereum: Web3
 declare var web3: Web3
 
+// Disable automatic reload when network is changed in Metamask,
+// reload is handled in GlobalInfoWatcher component
+if (window.ethereum) {
+    window.ethereum.autoRefreshOnNetworkChange = false
+}
+
 type StreamrWeb3Options = {
     isLegacy?: boolean,
 }


### PR DESCRIPTION
Disables Metamask's auto reload feature that will soon be deprecated, now we handle the reload in `GlobalInfoWatcher`. We wouldn't need to necessarily reload always, just would have to make sure all places that make transaction have validated the web3 instance before usage. 