### PR TITLE
Fix Client tests

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -43363,9 +43363,9 @@
       }
     },
     "streamr-client-react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamr-client-react/-/streamr-client-react-1.1.0.tgz",
-      "integrity": "sha512-Uub1VAaz3xV1qbfMLvED75zbO/pbKbzUPpqkz5CNW1QEK6ABvgose7s2e9vwWHxOqNcFe1lFaGH/35UQIJ941A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/streamr-client-react/-/streamr-client-react-1.1.1.tgz",
+      "integrity": "sha512-RajgofJylXjIhNcMsWq1n4MDFEuMYu7S7lo5l6nG+0Wc3Zkfu8GUyk3OzqmMwrnTN6WzPOPISievkA2SiAgyrA==",
       "requires": {
         "deep-equal": "^2.0.3"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -266,7 +266,7 @@
     "storybook-addon-jsx": "^5.4.0",
     "storybook-react-router": "^1.0.1",
     "streamr-client": "^4.1.1",
-    "streamr-client-react": "^1.1.0",
+    "streamr-client-react": "^1.1.1",
     "stringify-object": "^3.2.2",
     "style-loader": "^0.21.0",
     "styled-components": "^4.4.1",

--- a/app/src/editor/shared/tests/Client.test.jsx
+++ b/app/src/editor/shared/tests/Client.test.jsx
@@ -43,7 +43,7 @@ describe('Client', () => {
             done()
         })
 
-        it('creates new client after disconnect', async (done) => {
+        it('holds the same client after disconnect', async (done) => {
             let client
             function Test() {
                 client = useClient()
@@ -72,7 +72,7 @@ describe('Client', () => {
                 await prevClient.ensureDisconnected()
             })
             expect(prevClient.connection.state).toBe('disconnected')
-            expect(client).not.toBe(prevClient)
+            expect(client).toBe(prevClient)
             result.unmount()
             await prevClient.ensureDisconnected()
             await client.ensureDisconnected()


### PR DESCRIPTION
`streamr-client-react` no longer recreates clients on disconnection and failures. Now it's reflected in local tests.