### PR TITLE
[WIP][FRONT-73] Share sidebar: support large number of permissions

### DIFF
--- a/app/src/userpages/components/ShareSidebar/Pagination.jsx
+++ b/app/src/userpages/components/ShareSidebar/Pagination.jsx
@@ -1,0 +1,114 @@
+import React, { useCallback, useState, useEffect, useRef } from 'react'
+import { Button } from '@streamr/streamr-layout'
+import styled, { css } from 'styled-components'
+import Sidebar from '$shared/components/Sidebar'
+import { MEDIUM } from '$shared/utils/styled'
+
+const PER_PAGE = 10
+
+const Buttons = styled.div`
+    transform: translateX(12px);
+
+    button {
+        width: 32px;
+    }
+`
+
+const Inner = styled.div`
+    display: flex;
+
+    > span {
+        flex-grow: 1;
+    }
+`
+
+const UnstyledArrow = ({ flip, ...props }) => (
+    <svg {...props} width="14" height="8" viewBox="0 0 14 8" xmlns="http://www.w3.org/2000/svg">
+        <path
+            // eslint-disable-next-line max-len
+            d="M0.811223 7.52969C0.51833 7.2368 0.518329 6.76193 0.811223 6.46903L6.47123 0.809025C6.76412 0.516132 7.239 0.516132 7.53189 0.809025L13.1887 6.46588C13.4816 6.75877 13.4816 7.23365 13.1887 7.52654C12.8959 7.81943 12.421 7.81943 12.1281 7.52654L7.00156 2.40002L1.87188 7.52969C1.57899 7.82259 1.10412 7.82259 0.811223 7.52969Z"
+            fill="currentColor"
+        />
+    </svg>
+)
+
+const Arrow = styled(UnstyledArrow)`
+    display: block;
+    transform: rotate(-90deg);
+
+    ${({ flip }) => !!flip && css`
+        transform: rotate(90deg);
+    `}
+`
+
+const subcollection = (collection, startAt) => (
+    collection.slice(startAt, startAt + PER_PAGE)
+)
+
+const UnstyledPagination = ({ collection = [], onPage, selectedUserId: selectedId, ...props }) => {
+    const [page, setPage] = useState(0)
+
+    const maxPage = Math.max(0, Math.ceil(collection.length / PER_PAGE) - 1)
+
+    const next = useCallback(() => {
+        setPage((current) => Math.min(current + 1, maxPage))
+    }, [maxPage])
+
+    const prev = useCallback(() => {
+        setPage((current) => Math.max(0, current - 1))
+    }, [])
+
+    const from = collection.length ? 1 + (page * PER_PAGE) : 0
+
+    const to = Math.min(PER_PAGE + (page * PER_PAGE), collection.length)
+
+    useEffect(() => {
+        if (onPage) {
+            onPage(subcollection(collection, page * PER_PAGE))
+        }
+    }, [page, onPage, collection])
+
+    const collectionLengthRef = useRef(collection.length)
+
+    useEffect(() => {
+        if (selectedId != null) {
+            const index = collection.findIndex(([id]) => id === selectedId)
+
+            if (index !== -1) {
+                setPage(Math.floor(index / PER_PAGE))
+            }
+        } else if (collectionLengthRef.current !== collection.length) {
+            setPage(0)
+        }
+
+        collectionLengthRef.current = collection.length
+    }, [collection, selectedId])
+
+    return maxPage > 0 && (
+        <Sidebar.Container {...props}>
+            <Inner>
+                <span>Displaying <strong>{from}-{to}</strong> out of <strong>{collection.length}</strong></span>
+                <Buttons>
+                    <Button type="button" onClick={prev}>
+                        <Arrow />
+                    </Button>
+                    <Button type="button" onClick={next}>
+                        <Arrow flip />
+                    </Button>
+                </Buttons>
+            </Inner>
+        </Sidebar.Container>
+    )
+}
+
+const Pagination = styled(UnstyledPagination)`
+    strong {
+        font-weight: ${MEDIUM};
+    }
+`
+
+Object.assign(Pagination, {
+    subcollection,
+})
+
+export default Pagination

--- a/app/src/userpages/components/ShareSidebar/UserList.jsx
+++ b/app/src/userpages/components/ShareSidebar/UserList.jsx
@@ -54,7 +54,7 @@ const UnstyledUserList = ({
                     )}
                 </React.Fragment>
             ))}
-            <Pagination collection={items} onPage={setSubitems} selectedUserId={selectedUserId} />
+            <Pagination collection={items} onPage={setSubitems} onUserSelect={onSelect} selectedUserId={selectedUserId} />
         </div>
     )
 }

--- a/app/src/userpages/components/ShareSidebar/UserList.jsx
+++ b/app/src/userpages/components/ShareSidebar/UserList.jsx
@@ -1,8 +1,9 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import Sidebar from '$shared/components/Sidebar'
 import UserPermissions from './UserPermissions'
 import ErrorMessage from './ErrorMessage'
+import Pagination from './Pagination'
 
 const UnstyledUserList = ({
     currentUser,
@@ -23,13 +24,15 @@ const UnstyledUserList = ({
         }
     }, [onSelect])
 
+    const [subitems, setSubitems] = useState(Pagination.subcollection(items, 0))
+
     return (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
         <div
             {...props}
             onClick={onClick}
         >
-            {items.map(([userId, userPermissions]) => (
+            {subitems.map(([userId, userPermissions]) => (
                 <React.Fragment key={userId}>
                     <Sidebar.Container
                         as={UserPermissions}
@@ -51,6 +54,7 @@ const UnstyledUserList = ({
                     )}
                 </React.Fragment>
             ))}
+            <Pagination collection={items} onPage={setSubitems} selectedUserId={selectedUserId} />
         </div>
     )
 }


### PR DESCRIPTION
There's no server-side pagination and all entries load at once. It's failry quick though so I decided to go with a simple client-side pagination component for permissions.

![Nov-05-2020 14-50-41](https://user-images.githubusercontent.com/320066/98249654-cb291000-1f76-11eb-8e61-bcdb1474ba96.gif)

Also, created [`FRONT-151`](https://linear.app/streamr/issue/FRONT-151/closing-share-sidebar-re-renders-the-entire-stream-edit-page).

@mattatgit for `<` and `>` buttons I use shape we recently used for the "go to top" button for the public site. It's improvised though so feel free to tag in.

---

### How to test?

I used `cypress` to generate a bunch of users for one of my test streams:

```js
it.only('creates a whole bunch of users for a stream', () => {
    const streamId = 'jLPOfPM8Qx-YzHQGiqtJog' // <- has to be set manually
    const howMany = 100

    cy.login()
    for (let i = 0; i < howMany; i += 1) {
        cy.createStreamPermission(streamId, `tester${10 + i}@streamr.com`)
    }
})
```

Add it to `cypress/integration/StreamPage.spec.js` and run
```bash
npx cypress run --headless --spec "cypress/integration/StreamPage.spec.js"
```