### PR TITLE
[FRONT-151] Reasonable permission refreshing vs Share sidebar

### DIFF
--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -23,7 +23,7 @@ import SidebarProvider, { SidebarContext } from '$shared/components/Sidebar/Side
 import ShareSidebar from '$userpages/components/ShareSidebar'
 import BackButton from '$shared/components/BackButton'
 import Nav from '$shared/components/Layout/Nav'
-import { resetResourcePermission } from '$userpages/modules/permission/actions'
+import { getResourcePermissions } from '$userpages/modules/permission/actions'
 import useLastMessageTimestamp from '$shared/hooks/useLastMessageTimestamp'
 import getStreamActivityStatus from '$shared/utils/getStreamActivityStatus'
 import Notification from '$shared/utils/Notification'
@@ -53,7 +53,7 @@ function StreamPageSidebar({ stream }) {
         sidebar.close()
 
         if (streamId) {
-            dispatch(resetResourcePermission('STREAM', streamId))
+            dispatch(getResourcePermissions('STREAM', streamId))
         }
     }, [sidebar, dispatch, streamId])
 

--- a/app/src/userpages/modules/permission/reducer.js
+++ b/app/src/userpages/modules/permission/reducer.js
@@ -16,6 +16,18 @@ const initialState = {
     fetching: false,
 }
 
+const updatePermissions = (state, type, id, newPermissions) => {
+    const prevPermissions = (state.byTypeAndId[type] || {})[id]
+
+    return (
+        prevPermissions == null || prevPermissions.join(',') !== newPermissions.join(',') ? (
+            newPermissions
+        ) : (
+            prevPermissions
+        )
+    )
+}
+
 export default function (state: PermissionState = initialState, action: PermissionAction): PermissionState {
     switch (action.type) {
         case GET_RESOURCE_PERMISSIONS_REQUEST:
@@ -31,7 +43,14 @@ export default function (state: PermissionState = initialState, action: Permissi
                     ...state.byTypeAndId,
                     [(action.resourceType: string)]: {
                         ...(state.byTypeAndId[action.resourceType] || {}),
-                        [action.resourceId]: action.permissions.map(({ operation }) => operation),
+                        [action.resourceId]: (
+                            updatePermissions(
+                                state,
+                                action.resourceType,
+                                action.resourceId,
+                                action.permissions.map(({ operation }) => operation).sort(),
+                            )
+                        ),
                     },
                 },
                 fetching: false,
@@ -47,7 +66,14 @@ export default function (state: PermissionState = initialState, action: Permissi
                     ...state.byTypeAndId,
                     [(action.resourceType: string)]: {
                         ...(state.byTypeAndId[action.resourceType] || {}),
-                        [action.resourceId]: [],
+                        [action.resourceId]: (
+                            updatePermissions(
+                                state,
+                                action.resourceType,
+                                action.resourceId,
+                                [],
+                            )
+                        ),
                     },
                 },
             }

--- a/app/src/userpages/modules/permission/reducer.js
+++ b/app/src/userpages/modules/permission/reducer.js
@@ -16,17 +16,15 @@ const initialState = {
     fetching: false,
 }
 
-const newPermissions = (state, type, id, nextPermissions) => {
-    const prevPermissions = (state.byTypeAndId[type] || {})[id]
-
-    return (
+const getNewPermissions = (prevPermissions, nextPermissions) => (
+    (
         prevPermissions == null || prevPermissions.join(',') !== nextPermissions.join(',') ? (
             nextPermissions
         ) : (
             prevPermissions
         )
     )
-}
+)
 
 export default function (state: PermissionState = initialState, action: PermissionAction): PermissionState {
     switch (action.type) {
@@ -44,10 +42,8 @@ export default function (state: PermissionState = initialState, action: Permissi
                     [(action.resourceType: string)]: {
                         ...(state.byTypeAndId[action.resourceType] || {}),
                         [action.resourceId]: (
-                            newPermissions(
-                                state,
-                                action.resourceType,
-                                action.resourceId,
+                            getNewPermissions(
+                                (state.byTypeAndId[action.resourceType] || {})[action.resourceId],
                                 action.permissions.map(({ operation }) => operation).sort(),
                             )
                         ),
@@ -67,10 +63,8 @@ export default function (state: PermissionState = initialState, action: Permissi
                     [(action.resourceType: string)]: {
                         ...(state.byTypeAndId[action.resourceType] || {}),
                         [action.resourceId]: (
-                            newPermissions(
-                                state,
-                                action.resourceType,
-                                action.resourceId,
+                            getNewPermissions(
+                                (state.byTypeAndId[action.resourceType] || {})[action.resourceId],
                                 [],
                             )
                         ),

--- a/app/src/userpages/modules/permission/reducer.js
+++ b/app/src/userpages/modules/permission/reducer.js
@@ -17,12 +17,10 @@ const initialState = {
 }
 
 const getNewPermissions = (prevPermissions, nextPermissions) => (
-    (
-        prevPermissions == null || prevPermissions.join(',') !== nextPermissions.join(',') ? (
-            nextPermissions
-        ) : (
-            prevPermissions
-        )
+    prevPermissions == null || prevPermissions.join(',') !== nextPermissions.join(',') ? (
+        nextPermissions
+    ) : (
+        prevPermissions
     )
 )
 

--- a/app/src/userpages/modules/permission/reducer.js
+++ b/app/src/userpages/modules/permission/reducer.js
@@ -16,12 +16,12 @@ const initialState = {
     fetching: false,
 }
 
-const updatePermissions = (state, type, id, newPermissions) => {
+const newPermissions = (state, type, id, nextPermissions) => {
     const prevPermissions = (state.byTypeAndId[type] || {})[id]
 
     return (
-        prevPermissions == null || prevPermissions.join(',') !== newPermissions.join(',') ? (
-            newPermissions
+        prevPermissions == null || prevPermissions.join(',') !== nextPermissions.join(',') ? (
+            nextPermissions
         ) : (
             prevPermissions
         )
@@ -44,7 +44,7 @@ export default function (state: PermissionState = initialState, action: Permissi
                     [(action.resourceType: string)]: {
                         ...(state.byTypeAndId[action.resourceType] || {}),
                         [action.resourceId]: (
-                            updatePermissions(
+                            newPermissions(
                                 state,
                                 action.resourceType,
                                 action.resourceId,
@@ -67,7 +67,7 @@ export default function (state: PermissionState = initialState, action: Permissi
                     [(action.resourceType: string)]: {
                         ...(state.byTypeAndId[action.resourceType] || {}),
                         [action.resourceId]: (
-                            updatePermissions(
+                            newPermissions(
                                 state,
                                 action.resourceType,
                                 action.resourceId,


### PR DESCRIPTION
For color… `StreamPage/index` uses current user's permissions to render either the `View` or the `Edit` component. Before this PR closing the share sidebar caused user's own permission to be reset. `StreamPage/index` would then have to re-fetch permissions and rebuild the page. It looked strange. Lotta flashing of the loading state, etc.

This PR is a quick fix. Instead of resetting permissions I refetch them right away. I also make sure that if permissions coming from the server match the ones we currently hold we skip an update.