### PR TITLE
Share sidebar tweaks

### DIFF
--- a/app/src/shared/utils/sharing/canShareToUserId.js
+++ b/app/src/shared/utils/sharing/canShareToUserId.js
@@ -1,0 +1,5 @@
+import isValidUserId from './isValidUserId'
+
+export default function canShareToUserId(value) {
+    return isValidUserId(value) && value !== 'anonymous'
+}

--- a/app/src/shared/utils/sharing/isValidUserId.js
+++ b/app/src/shared/utils/sharing/isValidUserId.js
@@ -1,0 +1,4 @@
+export default function isValidUserId(value) {
+    const v = typeof value === 'string' ? value.trim() : ''
+    return v === 'anonymous' || v.startsWith('0x') || v.includes('@')
+}

--- a/app/src/userpages/components/ShareSidebar/InputNewShare.jsx
+++ b/app/src/userpages/components/ShareSidebar/InputNewShare.jsx
@@ -6,14 +6,15 @@ import SvgIcon from '$shared/components/SvgIcon'
 import TextInput from '$ui/Text'
 import Errors from '$ui/Errors'
 import Label from '$ui/Label'
-import * as State from './state'
 import styles from './ShareSidebar.pcss'
+import isValidUserId from '$shared/utils/sharing/isValidUserId'
+import canShareToUserId from '$shared/utils/sharing/canShareToUserId'
 
 /**
  * Input for adding new users.
  */
 
-export default function InputNewShare({ currentUser, onChange, canShareToUser }) {
+export default function InputNewShare({ currentUser, onChange }) {
     const [value, setValue] = useState('')
     const onChangeValue = useCallback((e) => {
         setValue(e.target.value.trim())
@@ -26,7 +27,7 @@ export default function InputNewShare({ currentUser, onChange, canShareToUser })
     const uid = useUniqueId('InputNewShare')
 
     function getShareToUserError({ currentUser, userId }) {
-        if (!State.isValidUserId(userId)) { return I18n.t('share.error.invalidUserError') }
+        if (!isValidUserId(userId)) { return I18n.t('share.error.invalidUserError') }
         if (userId === 'anonymous') { return I18n.t('share.error.anonymousUserError') }
         if (userId === currentUser) { return I18n.t('share.error.currentUserError') }
     }
@@ -36,7 +37,7 @@ export default function InputNewShare({ currentUser, onChange, canShareToUser })
         userId: value,
     })
 
-    const isValid = canShareToUser(value)
+    const isValid = canShareToUserId(value)
     const [trySubmit, setTrySubmit] = useState(false)
 
     // only show validation when not focussed

--- a/app/src/userpages/components/ShareSidebar/Sidebar.jsx
+++ b/app/src/userpages/components/ShareSidebar/Sidebar.jsx
@@ -47,7 +47,6 @@ const UnstyledShareSidebar = (({ className, ...props }) => {
     const {
         permissions,
         currentUsers,
-        canShareToUser,
         addUser,
         removeUser,
         updatePermission,
@@ -209,7 +208,7 @@ const UnstyledShareSidebar = (({ className, ...props }) => {
                     isSearchable={false}
                     controlClassName={styles.anonSelectControl}
                 />
-                <InputNewShare currentUser={currentUser} onChange={addUser} canShareToUser={canShareToUser} />
+                <InputNewShare currentUser={currentUser} onChange={addUser} />
             </Sidebar.Container>
             <UserList
                 items={userEntries}

--- a/app/src/userpages/components/ShareSidebar/Sidebar.jsx
+++ b/app/src/userpages/components/ShareSidebar/Sidebar.jsx
@@ -181,29 +181,17 @@ const UnstyledShareSidebar = (({ className, ...props }) => {
     const editableUsers = Object.assign({}, currentUsers)
     delete editableUsers.anonymous
 
-    // current user (own permission) is displayed on top
-    let currentUserId = []
+    const userSet = new Set([
+        currentUser,
+        ...newUserIdList,
+        ...Object.keys(editableUsers).sort(),
+    ])
 
-    if (editableUsers[currentUser]) {
-        currentUserId = [currentUser]
+    if (!editableUsers[currentUser]) {
+        userSet.delete(currentUser)
     }
 
-    // users are listed in order:
-    // current user, if exists
-    // new users in order added
-    // old users in alphabetical order
-    const oldUserIdList = Object.keys(editableUsers)
-        .filter((userId) => !newUserIdList.includes(userId) && userId !== currentUser)
-        .sort()
-
-    // remove current user
-    const newUserIdListFiltered = newUserIdList.filter((userId) => userId !== currentUser)
-
-    const userEntries = [
-        ...currentUserId,
-        ...newUserIdListFiltered,
-        ...oldUserIdList,
-    ].map((userId) => [userId, editableUsers[userId]])
+    const userEntries = [...userSet].map((userId) => [userId, editableUsers[userId]])
 
     return (
         <div className={className}>

--- a/app/src/userpages/components/ShareSidebar/state.js
+++ b/app/src/userpages/components/ShareSidebar/state.js
@@ -1,6 +1,7 @@
 import groupBy from 'lodash/groupBy'
 import isEqual from 'lodash/isEqual'
 import mapValues from 'lodash/mapValues'
+import isValidUserId from '$shared/utils/sharing/isValidUserId'
 
 // List of all permissions
 // TODO: this should probably come from backend
@@ -174,17 +175,6 @@ export function findPermissionGroupName(resourceType, userPermissions = {}) {
 //
 // CRUD Operations
 //
-
-export function isValidUserId(userId) {
-    if (!userId || typeof userId !== 'string') { return false }
-    userId = userId.trim()
-    if (!userId) { return false }
-    if (userId === 'anonymous') { return true }
-    if (!userId.startsWith('0x') && !userId.includes('@')) {
-        return false
-    }
-    return true
-}
 
 function validateUserId(userId) {
     if (!isValidUserId(userId)) {
@@ -367,12 +357,4 @@ export function toAnonymousPermission(permission) {
     delete anonymousPermission.user
     anonymousPermission.anonymous = true
     return anonymousPermission
-}
-
-/**
- * True for non-empty userIds other than currentUser and anonymous
- */
-
-export function canShareToUser(userId) {
-    return isValidUserId(userId) && userId !== 'anonymous'
 }


### PR DESCRIPTION
Doing a small refactoring to the share sidebar. A couple of tweaks I want to merge in as part of the first small wave:

- I move `isValidUserId` out of `state.js` and simplify it.
- I move `canShareToUser` out of `state.js` and rename it to `canShareToUserId`.
- I refactor ordering of permissions using `Set` to skip filtering intermediate collections.

Hope you like it. I'll merge it soon.