### PR TITLE
usePreventNavigatingAway hook

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type Node, type Context, useEffect, useState, useMemo, useCallback, useContext, useRef } from 'react'
+import React, { type Node, type Context, useState, useMemo, useCallback, useContext, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { I18n } from 'react-redux-i18n'
 
@@ -28,6 +28,7 @@ import { isEthereumAddress } from '$mp/utils/validate'
 import { areAddressesEqual } from '$mp/utils/smartContract'
 import useEditableProductUpdater from '../ProductController/useEditableProductUpdater'
 import Activity, { actionTypes, resourceTypes } from '$shared/utils/Activity'
+import usePreventNavigatingAway from '$shared/hooks/usePreventNavigatingAway'
 
 import * as State from '../EditProductPage/state'
 import useModal from '$shared/hooks/useModal'
@@ -64,23 +65,7 @@ function useEditController(product: Product) {
     const [publishAttempted, setPublishAttempted] = useState(false)
     const [preferredCurrency, setPreferredCurrency] = useState(product.priceCurrency || DEFAULT_CURRENCY)
 
-    useEffect(() => {
-        const handleBeforeunload = (event) => {
-            if (isAnyTouched()) {
-                const confirmationMessage = 'You have unsaved changes'
-                const evt = (event || window.event)
-                evt.returnValue = confirmationMessage // Gecko + IE
-                return confirmationMessage // Webkit, Safari, Chrome etc.
-            }
-            return ''
-        }
-
-        window.addEventListener('beforeunload', handleBeforeunload)
-
-        return () => {
-            window.removeEventListener('beforeunload', handleBeforeunload)
-        }
-    }, [isAnyTouched])
+    usePreventNavigatingAway('You have unsaved changes', isAnyTouched)
 
     const productRef = useRef(product)
     productRef.current = product

--- a/app/src/shared/hooks/usePreventNavigatingAway.js
+++ b/app/src/shared/hooks/usePreventNavigatingAway.js
@@ -1,0 +1,27 @@
+import { useRef, useEffect } from 'react'
+
+export default function usePreventNavigatingAway(message, fn) {
+    const fnRef = useRef()
+    fnRef.current = fn
+
+    const messageRef = useRef()
+    messageRef.current = message
+
+    useEffect(() => {
+        const onBeforeUnload = (e) => {
+            if (fnRef.current()) {
+                const event = e || window.event
+                event.returnValue = messageRef.current // Gecko + IE
+                return messageRef.current // Webkit, Safari, Chrome etc.
+            }
+
+            return ''
+        }
+
+        window.addEventListener('beforeunload', onBeforeUnload)
+
+        return () => {
+            window.removeEventListener('beforeunload', onBeforeUnload)
+        }
+    }, [])
+}

--- a/app/src/userpages/components/ShareSidebar/Sidebar.jsx
+++ b/app/src/userpages/components/ShareSidebar/Sidebar.jsx
@@ -26,15 +26,9 @@ import UserList from './UserList'
 import Footer from './Footer'
 import ErrorMessage from './ErrorMessage'
 import Md from '$shared/components/Md'
+import usePreventNavigatingAway from '$shared/hooks/usePreventNavigatingAway'
 
 const options = ['onlyInvited', 'withLink']
-
-function unsavedUnloadWarning(event) {
-    const confirmationMessage = 'You have unsaved changes'
-    const evt = (event || window.event)
-    evt.returnValue = confirmationMessage // Gecko + IE
-    return confirmationMessage // Webkit, Safari, Chrome etc.
-}
 
 const UnstyledShareSidebar = (({ className, ...props }) => {
     const currentUser = (useSelector(selectUserData) || {}).username
@@ -153,14 +147,7 @@ const UnstyledShareSidebar = (({ className, ...props }) => {
         setDidTryClose(false)
     }, [setDidTryClose, currentUsers])
 
-    // browser warning if user navigating away before saving complete
-    useEffect(() => {
-        if (!hasChanges && !isSaving) { return }
-        window.addEventListener('beforeunload', unsavedUnloadWarning)
-        return () => {
-            window.removeEventListener('beforeunload', unsavedUnloadWarning)
-        }
-    }, [hasChanges, isSaving])
+    usePreventNavigatingAway('You have unsaved changes', () => hasChanges || isSaving)
 
     const [bindWarningMessages, warningMessagesStyle] = useSlideIn({ isVisible: didTryClose || hasCurrentUserChanges })
 

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -40,6 +40,7 @@ import SecurityView from './SecurityView'
 import StatusView from './StatusView'
 import ConfirmSaveModal from './ConfirmSaveModal'
 import useNewStreamMode from './useNewStreamMode'
+import usePreventNavigatingAway from '$shared/hooks/usePreventNavigatingAway'
 
 import styles from './edit.pcss'
 
@@ -122,23 +123,10 @@ const UnstyledEdit = ({
         }
     }, [dispatch])
 
-    useEffect(() => {
-        const handleBeforeunload = (event) => {
-            if (didChange(originalStreamRef.current, streamRef.current)) {
-                const message = I18n.t('userpages.streams.edit.unsavedChanges')
-                const evt = (event || window.event)
-                evt.returnValue = message // Gecko + IE
-                return message // Webkit, Safari, Chrome etc.
-            }
-            return ''
-        }
-
-        window.addEventListener('beforeunload', handleBeforeunload)
-
-        return () => {
-            window.removeEventListener('beforeunload', handleBeforeunload)
-        }
-    }, [])
+    usePreventNavigatingAway(
+        I18n.t('userpages.streams.edit.unsavedChanges'),
+        () => didChange(originalStreamRef.current, streamRef.current),
+    )
 
     const isMounted = useIsMounted()
 

--- a/app/src/userpages/components/StreamPage/New.jsx
+++ b/app/src/userpages/components/StreamPage/New.jsx
@@ -39,6 +39,7 @@ import Errors, { MarketplaceTheme } from '$ui/Errors'
 import useModal from '$shared/hooks/useModal'
 import ConfirmDialog from '$shared/components/ConfirmDialog'
 import SvgIcon from '$shared/components/SvgIcon'
+import usePreventNavigatingAway from '$shared/hooks/usePreventNavigatingAway'
 
 const Description = styled(Translate)`
     margin-bottom: 3rem;
@@ -316,23 +317,10 @@ const UnstyledNew = (props) => {
         contentChangedRef.current = !!(pathname || description)
     }, [domain, pathname, description])
 
-    useEffect(() => {
-        const handleBeforeunload = (event) => {
-            if (contentChangedRef.current) {
-                const message = I18n.t('userpages.streams.edit.unsavedChanges')
-                const evt = (event || window.event)
-                evt.returnValue = message // Gecko + IE
-                return message // Webkit, Safari, Chrome etc.
-            }
-            return ''
-        }
-
-        window.addEventListener('beforeunload', handleBeforeunload)
-
-        return () => {
-            window.removeEventListener('beforeunload', handleBeforeunload)
-        }
-    }, [])
+    usePreventNavigatingAway(
+        I18n.t('userpages.streams.edit.unsavedChanges'),
+        () => contentChangedRef.current,
+    )
 
     const saveEnabled = !!pathname && !loading
     const isDisabled = !!loading


### PR DESCRIPTION
Certain areas of the app ask users to confirm a reload. `usePreventNavigatingAway` hook's here to help. I replaced all eligible instances of the same logic with the new hook.

Less code. Same effect.