### PR TITLE
[FRONT-158] Add ENS domain fetching

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -3,7 +3,6 @@
 import React, { useContext, Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import cx from 'classnames'
 import { Translate, I18n } from 'react-redux-i18n'
-import { useSelector, useDispatch } from 'react-redux'
 import styled from 'styled-components'
 
 import useValidation from '../ProductController/useValidation'
@@ -14,8 +13,7 @@ import Popover from '$shared/components/Popover'
 import useCopy from '$shared/hooks/useCopy'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
-import { selectEthereumIdentities } from '$shared/modules/integrationKey/selectors'
-import { fetchIntegrationKeys } from '$shared/modules/integrationKey/actions'
+import useEthereumIdentities from '$shared/modules/integrationKey/hooks/useEthereumIdentities'
 import { truncate } from '$shared/utils/text'
 import useAccountAddress from '$shared/hooks/useAccountAddress'
 import Label from '$ui/Label'
@@ -31,8 +29,6 @@ type Props = {
     onFocus?: ?(SyntheticFocusEvent<EventTarget>) => void,
     onBlur?: ?(SyntheticFocusEvent<EventTarget>) => void,
 }
-
-const EMPTY = []
 
 type AddressItemProps = {
     address?: ?string,
@@ -79,13 +75,11 @@ const BeneficiaryAddress = ({
 
     const { copy } = useCopy()
 
-    const dispatch = useDispatch()
-
-    const integrationKeys = useSelector(selectEthereumIdentities) || EMPTY
+    const { ethereumIdentities } = useEthereumIdentities()
 
     const integrationKeysFiltered = useMemo(() => (
-        integrationKeys.filter(({ json }) => json && json.address)
-    ), [integrationKeys])
+        ethereumIdentities.filter(({ json }) => json && json.address)
+    ), [ethereumIdentities])
 
     const onCopy = useCallback(() => {
         if (!addressProp) {
@@ -99,10 +93,6 @@ const BeneficiaryAddress = ({
             icon: NotificationIcon.CHECKMARK,
         })
     }, [copy, addressProp])
-
-    useEffect(() => {
-        dispatch(fetchIntegrationKeys())
-    }, [dispatch])
 
     const accountAddress = useAccountAddress()
 

--- a/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx
+++ b/app/src/marketplace/containers/GlobalInfoWatcher/index.jsx
@@ -11,13 +11,13 @@ import {
     completeTransaction,
     transactionError,
 } from '$mp/modules/transactions/actions'
-import { fetchIntegrationKeys } from '$shared/modules/integrationKey/actions'
 import { getTransactionsFromSessionStorage } from '$shared/utils/transactions'
 import TransactionError from '$shared/errors/TransactionError'
 import Web3Poller from '$shared/web3/web3Poller'
 import { useBalances } from '$shared/hooks/useBalances'
 import { selectUserData } from '$shared/modules/user/selectors'
 import type { NumberString } from '$shared/flowtype/common-types'
+import useEthereumIdentities from '$shared/modules/integrationKey/hooks/useEthereumIdentities'
 
 type Props = {
     children?: Node,
@@ -99,6 +99,7 @@ export const GlobalInfoWatcher = ({ children }: Props) => {
     }, [handleTransactionComplete, handleTransactionError])
 
     // Fetch integrations keys and poll balances
+    const { load: loadIntegrationKeys } = useEthereumIdentities()
     const { update: updateBalances } = useBalances()
     const balanceTimeout = useRef()
     const balancePoll = useCallback(() => {
@@ -114,7 +115,7 @@ export const GlobalInfoWatcher = ({ children }: Props) => {
         if (!username) { return () => {} }
 
         // fetch the integration keys first and then start polling for the balance
-        dispatch(fetchIntegrationKeys())
+        loadIntegrationKeys()
             .then(() => {
                 balancePoll()
             })
@@ -122,7 +123,7 @@ export const GlobalInfoWatcher = ({ children }: Props) => {
         return () => {
             clearTimeout(balanceTimeout.current)
         }
-    }, [dispatch, balancePoll, username])
+    }, [loadIntegrationKeys, balancePoll, username])
 
     // Poll network
     useEffect(() => {

--- a/app/src/shared/modules/integrationKey/actions.js
+++ b/app/src/shared/modules/integrationKey/actions.js
@@ -172,6 +172,11 @@ export const fetchIntegrationKeys = () => (dispatch: Function) => {
             })
 
             dispatch(integrationKeysSuccess(ethereumIdentities, privateKeys))
+
+            return {
+                ethereumIdentities,
+                privateKeys,
+            }
         }, (error) => {
             dispatch(integrationKeysError({
                 message: error.message,

--- a/app/src/shared/modules/integrationKey/services.js
+++ b/app/src/shared/modules/integrationKey/services.js
@@ -21,6 +21,8 @@ import {
     IdentityExistsError,
 } from '$shared/errors/Web3'
 
+const GRAPH_API_URL = 'https://api.thegraph.com/subgraphs/name/ensdomains/ens'
+
 export const getIntegrationKeys = (): ApiResult<Array<IntegrationKey>> => get({
     url: routes.api.integrationKeys.index(),
 })
@@ -125,3 +127,25 @@ export async function getBalance({ address, type, usePublicNode = false }: GetBa
 
     return balance
 }
+
+export const getEnsDomains = ({ addresses }: {
+    addresses: Array<Address>,
+}): ApiResult<IntegrationKey> => post({
+    url: GRAPH_API_URL,
+    data: {
+        query: `
+            query {
+                domains(
+                    where: { owner_in: [${(addresses || []).map((address) => `"${address}"`).join(', ')}]}
+                    orderBy: name
+                ) {
+                    id
+                    name
+                    labelName
+                    labelhash
+                }
+            }
+        `,
+    },
+    useAuthorization: false,
+})

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -439,7 +439,7 @@ msgid "userpages.streams.edit.details.info.description"
 msgstr ""
 "All streams require a unique path in the format <strong>domain/pathname</strong>. Choose a unique name, "
 "and create your stream in the default <strong>%{defaultDomain}</strong> domain or "
-"<a href=\"https://ens.domains\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">register and use your own domain</a>."
+"<a href=\"%{addDomainUrl}\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">register and use your own domain</a>."
 
 msgid "userpages.streams.edit.details.domain.label"
 msgstr "Domain"


### PR DESCRIPTION
Add fetching of ENS domains owned by the Streamr user. Uses the API from https://thegraph.com/explorer/subgraph/ensdomains/ens to query the domains.

Since that API is connected to the mainnet, I couldn't test a real world case. I used a hardcoded address to test it and separately verified that the query sends the addresses (= connected accounts) of the current user.

![ezgif-2-ba813058a32a](https://user-images.githubusercontent.com/1064982/99374467-45d52200-28cb-11eb-9dd7-cb32d6b058d0.gif)
