### PR TITLE
Prefer 'eth_requestAccounts' RPC method instead of etherum.enable()

### DIFF
--- a/app/src/marketplace/containers/ProductPage/PurchaseModal.jsx
+++ b/app/src/marketplace/containers/ProductPage/PurchaseModal.jsx
@@ -92,6 +92,8 @@ export const PurchaseDialog = ({ productId, api }: Props) => {
     }, [dispatch, loadEthIdentities, loadContractProduct, productId, isMounted])
 
     useEffect(() => {
+        if (!account) { return }
+
         getBalances()
             .then(([eth, data, dai]) => {
                 setBalances({

--- a/app/src/shared/web3/web3Provider.js
+++ b/app/src/shared/web3/web3Provider.js
@@ -88,7 +88,16 @@ export const validateWeb3 = async ({ web3: _web3, checkNetwork = true }: Validat
     // enable metamask
     if (!_web3.isLegacy) {
         try {
-            await ethereum.enable()
+            // ethereum.enable() is deprecated and may be removed in the future.
+            // Prefer 'eth_requestAccounts' RPC method instead
+            if (typeof ethereum.request === 'function') {
+                await ethereum.request({
+                    method: 'eth_requestAccounts',
+                })
+            } else {
+                // ethereum.request is available since MetaMask v. 8, fallback to ethereum.enable()
+                await ethereum.enable()
+            }
         } catch (e) {
             console.warn(e)
             throw new Web3NotEnabledError()


### PR DESCRIPTION
You might have seen this warning in console:
<img width="941" alt="Screenshot 2020-11-17 at 13 50 00" src="https://user-images.githubusercontent.com/1064982/99387570-e54ee080-28dc-11eb-90a7-a23f6e27df8b.png">

https://eips.ethereum.org/EIPS/eip-1102

This adds the new call to use `ethereum.request` to make the `eth_requestAccounts` request and prompt Metamask usage. The `request` method exists since Metamask 8 so I left the old method as fallback just in case.