### PR TITLE
Update react-helmet

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -39416,14 +39416,36 @@
       }
     },
     "react-helmet": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
-      "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
       "requires": {
-        "deep-equal": "^1.0.1",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.5.4",
-        "react-side-effect": "^1.1.0"
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-fast-compare": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+          "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "react-helmet-async": {
@@ -40029,13 +40051,9 @@
       }
     },
     "react-side-effect": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
-      "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
-      "requires": {
-        "exenv": "^1.2.1",
-        "shallowequal": "^1.0.1"
-      }
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
     },
     "react-sizeme": {
       "version": "2.6.10",

--- a/app/package.json
+++ b/app/package.json
@@ -221,7 +221,7 @@
     "react-full-screen": "^0.2.3",
     "react-ga": "^2.5.0",
     "react-grid-layout": "^0.16.6",
-    "react-helmet": "^5.2.0",
+    "react-helmet": "^6.1.0",
     "react-image": "^1.4.0",
     "react-in-viewport": "0.0.36",
     "react-leaflet": "^2.2.0",


### PR DESCRIPTION
I've managed to crash against the issue where dynamically changing titles via `react-helmet` (in effects, etc.) cause reaching max stack sizes. i.e. `Maximum call stack size exceeded`. See https://github.com/nfl/react-helmet/issues/437 for details.

Looks like it's a pre-v6 problem. Updating the library seems to patch it up nicely.