### PR TITLE
Define useSidebar and useBeforeClose

### DIFF
--- a/app/src/editor/canvas/index.jsx
+++ b/app/src/editor/canvas/index.jsx
@@ -50,7 +50,7 @@ import CanvasStatus, { CannotSaveStatus } from '$editor/shared/components/Status
 import ModuleSearch from './components/ModuleSearch'
 import EmbedToolbar from './components/EmbedToolbar'
 import ResourceNotFoundError from '$shared/errors/ResourceNotFoundError'
-import SidebarProvider, { SidebarContext } from '$shared/components/Sidebar/SidebarProvider'
+import SidebarProvider, { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
 
 import useCanvasNotifications, { pushErrorNotification, pushWarningNotification } from './hooks/useCanvasNotifications'
 
@@ -515,7 +515,7 @@ const CanvasEdit = withRouter((props) => {
     useCanvasNotifications(canvas)
     useCanvasCameraEffects()
     const selection = useCanvasSelection()
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
     const { loadPermissions } = useCanvasPermissions()
 
     return (

--- a/app/src/editor/dashboard/index.jsx
+++ b/app/src/editor/dashboard/index.jsx
@@ -16,7 +16,7 @@ import { Provider as PendingProvider } from '$shared/contexts/Pending'
 import { useAnyPending } from '$shared/hooks/usePending'
 import CanvasStyles from '$editor/canvas/index.pcss'
 import Sidebar from '$shared/components/Sidebar'
-import SidebarProvider, { SidebarContext } from '$shared/components/Sidebar/SidebarProvider'
+import SidebarProvider, { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
 import { canHandleLoadError, handleLoadError } from '$auth/utils/loginInterceptor'
 import BodyClass from '$shared/components/BodyClass'
 import DashboardStatus from '$editor/shared/components/Status'
@@ -358,7 +358,7 @@ const DashboardLoader = withRouter(withErrorBoundary(ErrorComponent)(class Dashb
 }))
 
 const DashboardEditWrap = () => {
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
     const { undo, push, replace, state: dashboard } = useContext(UndoContext)
 
     const [{ result: permissions }, loadPermissions] = usePermissionsLoader({

--- a/app/src/shared/components/Sidebar/SidebarProvider.jsx
+++ b/app/src/shared/components/Sidebar/SidebarProvider.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type Context, type Node, useContext } from 'react'
+import React, { type Context, type Node, useContext, useRef, useEffect } from 'react'
 
 type SidebarContextType = {
     open: (string, ?boolean) => void,
@@ -30,6 +30,20 @@ export const SidebarContext: Context<SidebarContextType> = React.createContext({
 })
 
 export const useSidebar = () => useContext(SidebarContext)
+
+export const useBeforeClose = (fn: Function) => {
+    const { addTransitionCheck, removeTransitionCheck } = useSidebar()
+
+    const fnRef = useRef(fn)
+
+    fnRef.current = fn
+
+    useEffect(() => {
+        const check = () => fnRef.current()
+        addTransitionCheck(check)
+        return () => removeTransitionCheck(check)
+    }, [addTransitionCheck, removeTransitionCheck])
+}
 
 export type Props = {
     children?: Node,

--- a/app/src/shared/components/Sidebar/SidebarProvider.jsx
+++ b/app/src/shared/components/Sidebar/SidebarProvider.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type Context, type Node } from 'react'
+import React, { type Context, type Node, useContext } from 'react'
 
 type SidebarContextType = {
     open: (string, ?boolean) => void,
@@ -28,6 +28,8 @@ export const SidebarContext: Context<SidebarContextType> = React.createContext({
     addTransitionCheck: notInitialized,
     removeTransitionCheck: notInitialized,
 })
+
+export const useSidebar = () => useContext(SidebarContext)
 
 export type Props = {
     children?: Node,

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Fragment, useEffect, useMemo, useCallback, useState, useContext } from 'react'
+import React, { Fragment, useEffect, useMemo, useCallback, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link as RouterLink } from 'react-router-dom'
 import { push } from 'connected-react-router'
@@ -30,7 +30,7 @@ import useCopy from '$shared/hooks/useCopy'
 import { CanvasTile } from '$shared/components/Tile'
 import Grid from '$shared/components/Tile/Grid'
 import Sidebar from '$shared/components/Sidebar'
-import SidebarProvider, { SidebarContext } from '$shared/components/Sidebar/SidebarProvider'
+import SidebarProvider, { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
 import ShareSidebar from '$userpages/components/ShareSidebar'
 import routes from '$routes'
 import resourceUrl from '$shared/utils/resourceUrl'
@@ -67,7 +67,7 @@ const StyledListContainer = styled(ListContainer)`
 `
 
 function CanvasPageSidebar({ canvas }) {
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
     const dispatch = useDispatch()
 
     const canvasId = canvas && canvas.id
@@ -136,7 +136,7 @@ const CanvasList = () => {
     const fetchingPermissions = useSelector(selectFetchingPermissions)
     const permissions = useSelector(selectCanvasPermissions)
 
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
 
     useEffect(() => {
         dispatch(getCanvases(filter))

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Fragment, useState, useMemo, useEffect, useCallback, useContext } from 'react'
+import React, { Fragment, useState, useMemo, useEffect, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
@@ -27,7 +27,7 @@ import { getResourcePermissions, resetResourcePermission } from '$userpages/modu
 import { selectFetchingPermissions, selectDashboardPermissions } from '$userpages/modules/permission/selectors'
 import Grid from '$shared/components/Tile/Grid'
 import Sidebar from '$shared/components/Sidebar'
-import SidebarProvider, { SidebarContext } from '$shared/components/Sidebar/SidebarProvider'
+import SidebarProvider, { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
 import ShareSidebar from '$userpages/components/ShareSidebar'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
@@ -67,7 +67,7 @@ const StyledListContainer = styled(ListContainer)`
 `
 
 function DashboardPageSidebar({ dashboard }) {
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
     const dispatch = useDispatch()
 
     const dashboardId = dashboard && dashboard.id
@@ -133,7 +133,7 @@ const DashboardList = () => {
     const fetchingPermissions = useSelector(selectFetchingPermissions)
     const permissions = useSelector(selectDashboardPermissions)
 
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
     const dispatch = useDispatch()
 
     useEffect(() => {

--- a/app/src/userpages/components/ShareSidebar/Sidebar.jsx
+++ b/app/src/userpages/components/ShareSidebar/Sidebar.jsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import Label from '$ui/Label'
 import Sidebar from '$shared/components/Sidebar'
-import { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
+import { useBeforeClose } from '$shared/components/Sidebar/SidebarProvider'
 import { selectUserData } from '$shared/modules/user/selectors'
 
 import * as State from './state'
@@ -121,22 +121,15 @@ const UnstyledShareSidebar = (({ className, ...props }) => {
     }, [onClose])
 
     // prevent sidebar closing if unsaved changes
-    const { addTransitionCheck, removeTransitionCheck } = useSidebar()
+    useBeforeClose(() => {
+        const canClose = !hasChanges || shouldForceCloseRef.current
 
-    // true if sidebar can close safely without cancel
-    const checkCanClose = useCallback(() => {
-        if (!hasChanges) { return true }
-        if (shouldForceCloseRef.current) { return true }
-        setDidTryClose(true)
-        if (isSaving) { return false }
-        return false
-    }, [hasChanges, isSaving, setDidTryClose])
+        if (!canClose) {
+            setDidTryClose(true)
+        }
 
-    // block closing sidebar unless checkCanClose passes
-    useEffect(() => {
-        addTransitionCheck(checkCanClose)
-        return () => removeTransitionCheck(checkCanClose)
-    }, [checkCanClose, addTransitionCheck, removeTransitionCheck])
+        return canClose
+    })
 
     // hide 'save or cancel' warning message after change
     useEffect(() => {

--- a/app/src/userpages/components/ShareSidebar/Sidebar.jsx
+++ b/app/src/userpages/components/ShareSidebar/Sidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useRef, useEffect, useContext } from 'react'
+import React, { useCallback, useState, useRef, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { Translate, I18n } from 'react-redux-i18n'
 import cx from 'classnames'
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import Label from '$ui/Label'
 import Sidebar from '$shared/components/Sidebar'
-import { SidebarContext } from '$shared/components/Sidebar/SidebarProvider'
+import { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
 import { selectUserData } from '$shared/modules/user/selectors'
 
 import * as State from './state'
@@ -121,7 +121,7 @@ const UnstyledShareSidebar = (({ className, ...props }) => {
     }, [onClose])
 
     // prevent sidebar closing if unsaved changes
-    const { addTransitionCheck, removeTransitionCheck } = useContext(SidebarContext)
+    const { addTransitionCheck, removeTransitionCheck } = useSidebar()
 
     // true if sidebar can close safely without cancel
     const checkCanClose = useCallback(() => {

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback, useState, useMemo, useContext, useRef, useEffect } from 'react'
+import React, { useCallback, useState, useMemo, useRef, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { I18n, Translate } from 'react-redux-i18n'
 import { push } from 'connected-react-router'
@@ -19,7 +19,7 @@ import CoreLayout from '$shared/components/Layout/Core'
 import CodeSnippets from '$shared/components/CodeSnippets'
 import { subscribeSnippets, publishSnippets } from '$utils/streamSnippets'
 import Sidebar from '$shared/components/Sidebar'
-import SidebarProvider, { SidebarContext } from '$shared/components/Sidebar/SidebarProvider'
+import SidebarProvider, { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
 import ShareSidebar from '$userpages/components/ShareSidebar'
 import BackButton from '$shared/components/BackButton'
 import Nav from '$shared/components/Layout/Nav'
@@ -46,7 +46,7 @@ import usePreventNavigatingAway from '$shared/hooks/usePreventNavigatingAway'
 import styles from './edit.pcss'
 
 function StreamPageSidebar({ stream }) {
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
     const dispatch = useDispatch()
 
     const streamId = stream && stream.id
@@ -91,7 +91,7 @@ const UnstyledEdit = ({
     isNewStream,
     ...props
 }: any) => {
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
     const { id: streamId } = stream
     const streamRef = useRef()
     streamRef.current = stream

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Fragment, useEffect, useState, useCallback, useMemo, useContext } from 'react'
+import React, { Fragment, useEffect, useState, useCallback, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Translate, I18n } from 'react-redux-i18n'
 import { Link } from 'react-router-dom'
@@ -25,7 +25,7 @@ import ListContainer from '$shared/components/Container/List'
 import Button from '$shared/components/Button'
 import useFilterSort from '$userpages/hooks/useFilterSort'
 import Sidebar from '$shared/components/Sidebar'
-import SidebarProvider, { SidebarContext } from '$shared/components/Sidebar/SidebarProvider'
+import SidebarProvider, { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
 import ShareSidebar from '$userpages/components/ShareSidebar'
 import { MD, LG } from '$shared/utils/styled'
 import SnippetDialog from './SnippetDialog'
@@ -82,7 +82,7 @@ const TabletPopover = styled(Popover)`
 `
 
 function StreamPageSidebar({ stream }) {
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
     const dispatch = useDispatch()
 
     const streamId = stream && stream.id
@@ -164,7 +164,7 @@ const StreamList = () => {
 
     const [activeSort, setActiveSort] = useState(undefined)
 
-    const sidebar = useContext(SidebarContext)
+    const sidebar = useSidebar()
 
     const onOpenShareDialog = useCallback((stream) => {
         setDialogTargetStream(stream)


### PR DESCRIPTION
`useBeforeClose` is a wrapper for sidebar's `addTransitionCheck` and `removeTransitionCheck`. Makes it easy to define transition checks.

```js
const Sidebarowsky = () => {
    useBeforeClose(() => false) // block closing the sidebar
    // …
}
```