### PR TITLE
[FRONT-176] Fix Pan+Zoom performance for Canvases

### DIFF
--- a/app/src/editor/canvas/components/Camera/index.jsx
+++ b/app/src/editor/canvas/components/Camera/index.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useCallback, useLayoutEffect, useEffect, useMemo, useContext } from 'react'
 import { useSpring, animated, interpolate } from 'react-spring'
 import cx from 'classnames'
-import { useThrottled } from '$shared/hooks/wrapCallback'
+import { useDebounced } from '$shared/hooks/wrapCallback'
 
 import * as State from './state'
 import styles from './Camera.pcss'
@@ -25,7 +25,7 @@ const defaultCameraConfig = {
 
 function useCameraSimpleApi(opts) {
     const elRef = useRef()
-    const [state, setActualState] = useState(State.createCamera({
+    const [state, setActualState] = useState(() => State.createCamera({
         ...opts,
         elRef,
     }))
@@ -53,7 +53,7 @@ function useCameraSimpleApi(opts) {
     }, [])
 
     // commit to react state once every 500ms
-    const commitThrottled = useThrottled(useCallback(() => {
+    const commitThrottled = useDebounced(useCallback(() => {
         commit()
     }, [commit]), 500)
 
@@ -63,7 +63,7 @@ function useCameraSimpleApi(opts) {
             x: state.x,
             y: state.y,
             scale: state.scale,
-            onRest: commit,
+            onRest: commitThrottled,
             ...cameraConfig,
         }
     }

--- a/app/src/editor/canvas/components/Camera/index.jsx
+++ b/app/src/editor/canvas/components/Camera/index.jsx
@@ -182,6 +182,16 @@ function useCameraSimpleApi(opts) {
 
 export const CameraContext = React.createContext({})
 
+export function useCameraScale() {
+    const { scale } = useContext(CameraContext)
+    return scale
+}
+
+export function useCameraGetCurrentScale() {
+    const { getCurrentScale } = useContext(CameraContext)
+    return getCurrentScale
+}
+
 export function useCameraState() {
     const { x, y, scale, getCurrentScale } = useContext(CameraContext)
     return useMemo(() => ({
@@ -255,8 +265,8 @@ function usePanControls(elRef) {
             !event.target.classList.contains(styles.cameraControl)
         ) { return }
 
-        if (isPanning) { return }
         event.stopPropagation()
+        if (isPanning) { return }
         const el = elRef.current
         const { left, top } = el.getBoundingClientRect()
         // find current location on screen
@@ -287,6 +297,9 @@ function usePanControls(elRef) {
 
     const onPan = useCallback((event) => {
         if (!isPanning) { return }
+        event.preventDefault()
+        event.stopPropagation()
+        event.stopImmediatePropagation()
         if (event.buttons !== 1) {
             stopPanning(event)
             return

--- a/app/src/editor/canvas/components/Camera/state.js
+++ b/app/src/editor/canvas/components/Camera/state.js
@@ -177,6 +177,7 @@ export function zoomOut(state) {
 
 // changes current camera offset i.e. pans camera
 export function pan(state, { x = 0, y = 0 } = {}) {
+    if (Math.abs(x) < 1 && Math.abs(y) < 1) { return state }
     return setState(state, (s) => ({
         ...s,
         x: s.x + x,

--- a/app/src/editor/canvas/components/Canvas.jsx
+++ b/app/src/editor/canvas/components/Canvas.jsx
@@ -11,7 +11,7 @@ import { CanvasWindowProvider } from './CanvasWindow'
 import Cables from './Cables'
 
 import styles from './Canvas.pcss'
-import Camera, { useCameraState, cameraControl } from './Camera'
+import Camera, { useCameraGetCurrentScale, cameraControl } from './Camera'
 
 export default function Canvas(props) {
     const propsRef = useRef()
@@ -129,9 +129,9 @@ const CanvasElements = React.memo(function CanvasElements(props) { /* eslint-dis
     const [positions, setPositions] = useState({})
     const updatePositionsRef = useRef()
 
-    const camera = useCameraState()
+    const getCurrentScale = useCameraGetCurrentScale()
     const getCurrentScaleRef = useRef()
-    getCurrentScaleRef.current = camera.getCurrentScale
+    getCurrentScaleRef.current = getCurrentScale
 
     const updatePositionsNow = useCallback(() => {
         if (updatePositionsRef.current) {

--- a/app/src/editor/canvas/components/CanvasWindow.jsx
+++ b/app/src/editor/canvas/components/CanvasWindow.jsx
@@ -7,7 +7,8 @@ import styles from './CanvasWindow.pcss'
 
 export const CanvasWindowContext = React.createContext()
 
-export function CanvasWindowProvider({ className, children }) {
+// eslint-disable-next-line prefer-arrow-callback
+export const CanvasWindowProvider = React.memo(function CanvasWindowProvider({ className, children }) {
     const elRef = useRef()
     return (
         <CanvasWindowContext.Provider value={elRef}>
@@ -17,7 +18,7 @@ export function CanvasWindowProvider({ className, children }) {
             </SelectionProvider>
         </CanvasWindowContext.Provider>
     )
-}
+})
 
 function useSelectHandlers({ uid, elRef }) {
     const Selection = useSelectionContext()

--- a/app/src/editor/canvas/components/DragDropContext.jsx
+++ b/app/src/editor/canvas/components/DragDropContext.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unused-state */
 import React from 'react'
 import Draggable from 'react-draggable'
-import { useCameraState } from './Camera'
+import { useCameraScale } from './Camera'
 
 const DragDropContext = React.createContext({})
 
@@ -286,7 +286,7 @@ class EditorDraggable extends React.PureComponent {
 }
 
 function EditorDraggableWithScale(props) {
-    const { scale } = useCameraState()
+    const scale = useCameraScale()
     return (
         <EditorDraggable
             {...props}

--- a/app/src/editor/canvas/components/DraggableCanvasWindow.jsx
+++ b/app/src/editor/canvas/components/DraggableCanvasWindow.jsx
@@ -4,7 +4,7 @@ import React, { useState, useCallback, useMemo, type Node } from 'react'
 import cx from 'classnames'
 import { DraggableCore } from 'react-draggable'
 import { Resizable } from 'react-resizable'
-import { useCameraState } from './Camera'
+import { useCameraScale } from './Camera'
 
 import SvgIcon from '$shared/components/SvgIcon'
 
@@ -83,7 +83,7 @@ export const DraggableCanvasWindow = ({
     onChangeSize,
     children,
 }: CanvasWindowProps) => {
-    const { scale } = useCameraState()
+    const scale = useCameraScale()
     const { position, setPosition, size, setSize } = useLayoutState({
         x,
         y,

--- a/app/src/editor/canvas/components/Module.jsx
+++ b/app/src/editor/canvas/components/Module.jsx
@@ -209,7 +209,8 @@ function ModuleError(props) {
 
 const CanvasModuleWithErrorBoundary = React.memo(withErrorBoundary(ModuleError)(CanvasModule))
 
-export default React.memo(withErrorBoundary(ModuleError)((props) => {
+// eslint-disable-next-line prefer-arrow-callback
+const ModuleWrapMemo = React.memo(withErrorBoundary(ModuleError)(function ModuleWrap(props) {
     const { module } = props
     const { scale } = useCameraState()
     const { moduleNeedsUpdate, moduleJustAdded } = useContext(AutosaveContext)
@@ -221,3 +222,5 @@ export default React.memo(withErrorBoundary(ModuleError)((props) => {
         </ModuleDragger>
     )
 }))
+
+export default ModuleWrapMemo

--- a/app/src/editor/canvas/components/ModuleRenderer/index.jsx
+++ b/app/src/editor/canvas/components/ModuleRenderer/index.jsx
@@ -195,7 +195,7 @@ const ModuleRenderer = React.memo(({
     )
 })
 
-export default (React.memo(({
+const ModuleRendererWrap: any = React.memo(({
     api,
     module,
     canvasEditable: isCanvasEditable,
@@ -225,4 +225,6 @@ export default (React.memo(({
             </ModuleContext.Provider>
         </ModuleApiContext.Provider>
     )
-}): any)
+})
+
+export default ModuleRendererWrap

--- a/app/src/editor/canvas/tests/diff.test.js
+++ b/app/src/editor/canvas/tests/diff.test.js
@@ -42,6 +42,14 @@ describe('Canvas Diff', () => {
             const savedCanvas2 = State.updateCanvas(await Services.saveNow(savedCanvas1))
             expect(isEqualCanvas(savedCanvas1, savedCanvas2)).toBe(true)
         })
+
+        it('false for missing canvas', async () => {
+            const canvas = State.emptyCanvas()
+            expect(isEqualCanvas(canvas, undefined)).toBe(false)
+            expect(isEqualCanvas(undefined, canvas)).toBe(false)
+            expect(isEqualCanvas(canvas, null)).toBe(false)
+            expect(isEqualCanvas(null, canvas)).toBe(false)
+        })
     })
 
     describe('changedModules', () => {
@@ -77,6 +85,14 @@ describe('Canvas Diff', () => {
             }
             expect(changedModules(canvas, canvas2)).toEqual([])
             expect(changedModules(canvas2, canvas)).toEqual([])
+        })
+
+        it('false for missing canvas', async () => {
+            const canvas = State.emptyCanvas()
+            expect(changedModules(canvas, undefined)).toEqual([])
+            expect(changedModules(undefined, canvas)).toEqual([])
+            expect(changedModules(canvas, null)).toEqual([])
+            expect(changedModules(null, canvas)).toEqual([])
         })
     })
 

--- a/app/src/shared/utils/withErrorBoundary.jsx
+++ b/app/src/shared/utils/withErrorBoundary.jsx
@@ -12,8 +12,12 @@ type State = {
     error: ?Error,
 }
 
+function getDisplayName(WrappedComponent) {
+    return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
 const withErrorBoundary = (ErrorComponent: ComponentType<any>) => (
-    (OriginalComponent: ComponentType<any>) => (
+    (OriginalComponent: ComponentType<any>) => {
         class ErrorBoundary extends Component<Props, State> {
             state = {
                 error: undefined,
@@ -55,7 +59,9 @@ const withErrorBoundary = (ErrorComponent: ComponentType<any>) => (
                 )
             }
         }
-    )
+        ErrorBoundary.displayName = `With${getDisplayName(ErrorComponent)}(${getDisplayName(OriginalComponent)})`
+        return ErrorBoundary
+    }
 )
 
 export default withErrorBoundary


### PR DESCRIPTION
Both panning and zooming should be silky smooth now, 99% of the time (it will still jank for some frames whenever the canvas updates).

The fix is changing the spring's `onRest` handler to use the debounced commit, rather than commit immediately. See ef7c27a. Also added some debug names for components & some other minor perf improvements and that I looked at before narrowing down the major actual fix.

Note: There might have been a reason that I've forgotten as to why this was using throttle, not debounce, but I could not figure out how to break it while using debounce. Perhaps something to do with receiving delayed updates while dragging? Possible some hybrid approach is required.

Closes FRONT-176.