### PR TITLE
[FRONT-125] Add 'Edit on GitHub' button to documentation pages

### DIFF
--- a/app/src/docs/components/DocsLayout/docsLayout.pcss
+++ b/app/src/docs/components/DocsLayout/docsLayout.pcss
@@ -321,6 +321,24 @@
   display: none !important;
 }
 
+.githubIcon {
+  height: 12px;
+  width: 12px;
+  margin-right: 6px;
+}
+
+.editButton {
+  position: absolute;
+  top: 8rem;
+  overflow: none;
+}
+
+@media (--md-down) {
+  .editButton {
+    display: none;
+  }
+}
+
 @media (--md-down) {
   .docsLayout {
     padding: 0 0 2.5rem;

--- a/app/src/docs/components/DocsLayout/index.jsx
+++ b/app/src/docs/components/DocsLayout/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { MDXProvider } from '@mdx-js/react'
 import SimpleReactLightbox from 'simple-react-lightbox'
 import { withRouter } from 'react-router-dom'
@@ -15,15 +15,18 @@ import Button from '$shared/components/Button'
 import SvgIcon from '$shared/components/SvgIcon'
 
 const DocsLayout = ({ nav = <DocsNav />, location, staticContext, ...props }) => {
-    let editFilePath = null
-    Object.values(docsMap).some((doc) => {
-        const found = Object.values(doc).find((subdoc) => subdoc.path === location.pathname)
-        if (found) {
-            editFilePath = found.filePath
-            return true
-        }
-        return false
-    })
+    const editFilePath = useMemo(() => {
+        let path = null
+        Object.values(docsMap).some((doc) => {
+            const found = Object.values(doc).find((subdoc) => subdoc.path === location.pathname)
+            if (found) {
+                path = found.filePath
+                return true
+            }
+            return false
+        })
+        return path
+    }, [location])
 
     return (
         <SimpleReactLightbox>
@@ -48,6 +51,8 @@ const DocsLayout = ({ nav = <DocsNav />, location, staticContext, ...props }) =>
                                     href={`https://github.com/streamr-dev/streamr-platform/edit/development/app/src/docs/content/${editFilePath}`}
                                     kind="secondary"
                                     size="mini"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
                                 >
                                     <SvgIcon name="github" className={styles.githubIcon} />
                                     Edit on GitHub

--- a/app/src/docs/components/DocsLayout/index.jsx
+++ b/app/src/docs/components/DocsLayout/index.jsx
@@ -1,42 +1,70 @@
 import React from 'react'
 import { MDXProvider } from '@mdx-js/react'
 import SimpleReactLightbox from 'simple-react-lightbox'
+import { withRouter } from 'react-router-dom'
 import Layout from '$shared/components/Layout'
 import Navigation from './Navigation'
 import Components from '$docs/mdxConfig'
+import docsMap from '$docs/docsMap'
 import PageTurner from '$docs/components/PageTurner'
 import DocsContainer from '$shared/components/Container/Docs'
 import styles from './docsLayout.pcss'
 import DocsNav from './DocsNav'
 import BusLine from '$shared/components/BusLine'
+import Button from '$shared/components/Button'
+import SvgIcon from '$shared/components/SvgIcon'
 
-const DocsLayout = ({ nav = <DocsNav />, ...props }) => (
-    <SimpleReactLightbox>
-        <Layout
-            className={styles.docsLayout}
-            footer
-            nav={nav}
-        >
-            <Navigation
-                responsive
-            />
-            <DocsContainer>
-                <div className={styles.grid}>
-                    <div>
-                        <Navigation />
-                    </div>
-                    <div className={styles.content}>
-                        <BusLine dynamicScrollPosition>
-                            <MDXProvider components={Components}>
-                                <div {...props} />
-                            </MDXProvider>
-                        </BusLine>
-                        <PageTurner />
-                    </div>
-                </div>
-            </DocsContainer>
-        </Layout>
-    </SimpleReactLightbox>
-)
+const DocsLayout = ({ nav = <DocsNav />, location, staticContext, ...props }) => {
+    let editFilePath = null
+    Object.values(docsMap).some((doc) => {
+        const found = Object.values(doc).find((subdoc) => subdoc.path === location.pathname)
+        if (found) {
+            editFilePath = found.filePath
+            return true
+        }
+        return false
+    })
 
-export default DocsLayout
+    return (
+        <SimpleReactLightbox>
+            <Layout
+                className={styles.docsLayout}
+                footer
+                nav={nav}
+            >
+                <Navigation
+                    responsive
+                />
+                <DocsContainer>
+                    <div className={styles.grid}>
+                        <div>
+                            <Navigation />
+                        </div>
+                        <div className={styles.content}>
+                            {editFilePath && (
+                                <Button
+                                    className={styles.editButton}
+                                    tag="a"
+                                    href={`https://github.com/streamr-dev/streamr-platform/edit/development/app/src/docs/content/${editFilePath}`}
+                                    kind="secondary"
+                                    size="mini"
+                                >
+                                    <SvgIcon name="github" className={styles.githubIcon} />
+                                    Edit on GitHub
+                                </Button>
+                            )}
+                            <BusLine dynamicScrollPosition>
+                                <MDXProvider components={Components}>
+                                    <div {...props} />
+                                </MDXProvider>
+                            </BusLine>
+                            <PageTurner />
+                        </div>
+                    </div>
+                </DocsContainer>
+            </Layout>
+        </SimpleReactLightbox>
+    )
+}
+
+export default withRouter(DocsLayout)


### PR DESCRIPTION
Uses `docsMap` to extract underlying file path for editing on GitHub and shows button when the path is available. This means that _Module Reference_ definitions are not currently editable.