### PR TITLE
[FRONT-177] Improve stream namespace create process

### DIFF
--- a/app/src/shared/components/CodeSnippets.jsx
+++ b/app/src/shared/components/CodeSnippets.jsx
@@ -5,7 +5,7 @@ import useCopy from '$shared/hooks/useCopy'
 import { css } from 'styled-components'
 import { MEDIUM } from '$shared/utils/styled'
 
-const CodeSnippets = ({ items, title, ...props }) => {
+const CodeSnippets = ({ items, title, disabled, ...props }) => {
     const { copy, isCopied } = useCopy()
 
     const [[initial]] = items
@@ -77,7 +77,7 @@ const CodeSnippets = ({ items, title, ...props }) => {
                                 )}
                             </svg>
                         </Button>
-                        <Button kind="secondary" onClick={onCopyClick}>
+                        <Button kind="secondary" onClick={onCopyClick} disabled={!!disabled}>
                             {isCopied ? 'Copied' : 'Copy'}
                         </Button>
                     </div>

--- a/app/src/shared/components/TOCPage/TOCNav.jsx
+++ b/app/src/shared/components/TOCPage/TOCNav.jsx
@@ -1,8 +1,13 @@
 // @flow
 
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 export const Link = styled.a`
+    ${({ disabled }) => !!disabled && css`
+        pointer-events: none;
+        opacity: 0.5;
+    `}
+
     color: #${({ active }) => (active ? '0324ff' : '323232')} !important;
 `
 

--- a/app/src/shared/components/TOCPage/index.jsx
+++ b/app/src/shared/components/TOCPage/index.jsx
@@ -76,6 +76,7 @@ const UnstyledTOCPage = ({ children, title, ...props }: Props) => {
                                 <Link
                                     active={stop === child.props.id}
                                     href={`#${child.props.id}`}
+                                    disabled={!!child.props.disabled}
                                 >
                                     {child.props.linkTitle || child.props.title}
                                 </Link>

--- a/app/src/userpages/components/StreamPage/New.jsx
+++ b/app/src/userpages/components/StreamPage/New.jsx
@@ -47,8 +47,9 @@ import Spinner from '$shared/components/Spinner'
 import Button from '$shared/components/Button'
 import { truncate } from '$shared/utils/text'
 import { isEthereumAddress } from '$mp/utils/validate'
+import CodeSnippets from '$shared/components/CodeSnippets'
 
-const Description = styled(Translate)`
+const Description = styled.p`
     margin-bottom: 3rem;
 `
 
@@ -482,6 +483,10 @@ const UnstyledNew = ({ currentUser, ...props }) => {
         () => contentChangedRef.current,
     )
 
+    const newStreamSnippet = useMemo(() => `
+        // ${I18n.t('userpages.streams.edit.codeSnippets.newStream')}
+    `, [])
+
     const saveEnabled = !!pathname && !!domain && !loading
     const isDisabled = !!loading
     const isDomainDisabled = isDisabled || domainOptions.length <= 1 || loadingDomains
@@ -544,12 +549,15 @@ const UnstyledNew = ({ currentUser, ...props }) => {
                                 id="details"
                                 title={I18n.t('userpages.streams.edit.details.nav.details')}
                             >
-                                <Description
-                                    value="userpages.streams.edit.details.info.description"
-                                    tag="p"
-                                    addDomainUrl={ADD_DOMAIN_URL}
-                                    dangerousHTML
-                                />
+                                <Description>
+                                    <Translate
+                                        value="userpages.streams.edit.details.info.description"
+                                        addDomainUrl={ADD_DOMAIN_URL}
+                                        dangerousHTML
+                                    />
+                                    &nbsp;
+                                    <Translate value="userpages.streams.edit.details.info.descriptionNewStream" />
+                                </Description>
                                 <StreamIdFormGroup hasDomain data-test-hook="StreamId">
                                     <Field
                                         label={I18n.t('userpages.streams.edit.details.domain.label')}
@@ -629,8 +637,31 @@ const UnstyledNew = ({ currentUser, ...props }) => {
                                 </FormGroup>
                             </TOCSection>
                             <TOCSection
+                                id="snippets"
+                                title={I18n.t('general.codeSnippets')}
+                                disabled
+                            >
+                                <CodeSnippets
+                                    items={[
+                                        ['javascript', 'Js', newStreamSnippet],
+                                        ['java', 'Java', newStreamSnippet],
+                                    ]}
+                                    title="Subscribe"
+                                    disabled
+                                />
+                                <CodeSnippets
+                                    items={[
+                                        ['javascript', 'Js', newStreamSnippet],
+                                        ['java', 'Java', newStreamSnippet],
+                                    ]}
+                                    title="Publish"
+                                    disabled
+                                />
+                            </TOCSection>
+                            <TOCSection
                                 id="security"
                                 title={I18n.t('userpages.streams.edit.details.nav.security')}
+                                disabled
                             >
                                 <SecurityView
                                     stream={defaultStreamData}
@@ -641,6 +672,7 @@ const UnstyledNew = ({ currentUser, ...props }) => {
                                 id="configure"
                                 title={I18n.t('userpages.streams.edit.details.nav.fields')}
                                 onlyDesktop
+                                disabled
                             >
                                 <ConfigureView
                                     stream={defaultStreamData}
@@ -655,12 +687,14 @@ const UnstyledNew = ({ currentUser, ...props }) => {
                                     status="inactive"
                                 />}
                                 onlyDesktop
+                                disabled
                             >
                                 <StatusView disabled stream={defaultStreamData} />
                             </TOCPage.Section>
                             <TOCSection
                                 id="preview"
                                 title={I18n.t('userpages.streams.edit.details.nav.preview')}
+                                disabled
                             >
                                 <Preview
                                     stream={defaultStreamData}
@@ -670,6 +704,7 @@ const UnstyledNew = ({ currentUser, ...props }) => {
                             <TOCSection
                                 id="historicalData"
                                 title={I18n.t('userpages.streams.edit.details.nav.historicalData')}
+                                disabled
                             >
                                 <HistoryView
                                     stream={defaultStreamData}
@@ -682,6 +717,7 @@ const UnstyledNew = ({ currentUser, ...props }) => {
                                 title={I18n.t('userpages.streams.edit.details.nav.streamPartitions')}
                                 linkTitle={I18n.t('userpages.streams.edit.details.nav.partitions')}
                                 status={(<StatusLabel.Advanced />)}
+                                disabled
                             >
                                 <PartitionsView
                                     stream={defaultStreamData}

--- a/app/src/userpages/i18n/en.po
+++ b/app/src/userpages/i18n/en.po
@@ -441,8 +441,11 @@ msgstr "Stream partitions"
 msgid "userpages.streams.edit.details.info.description"
 msgstr ""
 "All streams require a unique path in the format <strong>domain/pathname</strong>. Your default domain will "
-"be an Eth address, but you can also use an ENS domain or "
+"be an Eth address, but you can also use an existing ENS domain or "
 "<a href=\"%{addDomainUrl}\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">register a new one</a>."
+
+msgid "userpages.streams.edit.details.info.descriptionNewStream"
+msgstr "Choose your stream name & create it in order to adjust stream settings."
 
 msgid "userpages.streams.edit.details.domain.label"
 msgstr "Domain"
@@ -488,10 +491,10 @@ msgstr "Partitions"
 
 msgid "userpages.streams.edit.details.tooltip"
 msgstr ""
-"Stream paths can be single level like<br/>"
-"<strong>sandbox/mycoffeemachine</strong> or structured<br/>"
-"like <strong>crypto/oracles/btcprice</strong>. For more<br/>"
-"information, see the <a href=\"%{docsLink}\">docs</a>."
+"Stream paths can be single or multi-level.<br/>"
+"Single <strong>streamr.eth/coffeemachine</strong><br/>"
+"Multi <strong>oxd93...52874/oracles/price</strong><br/>"
+"For more information, see the <a href=\"%{docsLink}\">docs</a>."
 
 msgid "userpages.streams.edit.details.copyStreamId"
 msgstr "Copy Stream ID"
@@ -576,6 +579,9 @@ msgstr "Stop"
 
 msgid "userpages.streams.edit.codeSnippets.description"
 msgstr "You can grab the code (JS & Java) you’ll need to use this stream in your applications below. Everyone can subscribe, but only users with permission can publish."
+
+msgid "userpages.streams.edit.codeSnippets.newStream"
+msgstr "Create your stream above in order to get your code snippet."
 
 msgid "userpages.streams.delete.confirmTitle"
 msgstr "Delete this stream?"


### PR DESCRIPTION
Improvements from [FRONT-177](https://linear.app/streamr/issue/FRONT-177/improve-stream-namespace-create-process):

* Grey out the other side nav menu items (apart from details) until stream has been created
* Have Code Snippets already on the page, but empty and with comment inside the widget “Create your stream above in order to get your code snippet”
* Add some extra intro text “Choose your stream path name & create it in order to adjust stream settings”
* Update the tooltip (remove mention of "sandbox" domain)

**Not** implemented:

* Don’t have the page refresh on creation

Too much hassle atm to rethink the stream loading.
