### PR TITLE
[DEVRL-26] API Key mentions removed from Docs

### DIFF
--- a/app/src/docs/content/api/authentication.mdx
+++ b/app/src/docs/content/api/authentication.mdx
@@ -4,9 +4,11 @@ A session token is required to make requests to the REST API endpoints or over t
 
 <a name="challenge"></a>
 
-### Authenticating with Ethereum
+### Authenticating options
 
-You can use an Ethereum private key to authenticate by signing a challenge with it and providing your Ethereum public address for verification.
+The easiest way to authenticate is through the [Streamr Client](https://github.com/streamr-dev/streamr-client-javascript/) - it will handle the cryptographic signing for you. Client authentication instructions can be found in the [repo readme](https://github.com/streamr-dev/streamr-client-javascript/).
+
+If you prefer to use the REST API directly the you can use an Ethereum private key to authenticate by signing a challenge with it and providing your Ethereum public address for verification.
 
 Use the `POST` endpoint at `/api/v1/login/challenge/YOUR-PUBLIC-ADDRESS` to generate a random text called a challenge, which looks like the following: 
 

--- a/app/src/docs/content/api/authentication.mdx
+++ b/app/src/docs/content/api/authentication.mdx
@@ -1,11 +1,6 @@
 # Authentication
 
-A session token is required to make requests to the REST API endpoints or over the websocket protocol. You can obtain a session token by authenticating with either of these three methods:
-- [Signing a cryptographic challenge using an Ethereum private key](#challenge)
-- [Using a permanent secret API key](#api-key)
-- [Using a username and a password](#username-password)
-
-Once you get a session token using one of the above methods, see the section on [using it](#session-token).
+A session token is required to make requests to the REST API endpoints or over the websocket protocol. You can obtain a session token by signing a cryptographic challenge using an Ethereum private key.
 
 <a name="challenge"></a>
 
@@ -41,35 +36,6 @@ The signature must follow the convention described [here](https://github.com/eth
 `sign(keccak256("\x19Ethereum Signed Message:\n" + len(challengeText) + challengeText)))`
 
 If the signature is correct, you will receive a [session token](#session-token).
-
-<a name="api-key"></a>
-
-### Authenticating with an API key
-
-Any number of API keys can be attached to your user. You can manage your API keys on your profile page.
-
-When reading from or writing to Streams, you can use a Stream-specific anonymous key instead of your user key to avoid exposing it. Anonymous keys can be managed on the details page of a Stream.
-
-To obtain a [session token](#session-token) using an API key, send a `POST` request to the `/api/v1/login/apikey` endpoint with a JSON body like the one below:
-
-```
-{
-    "apiKey": "YOUR-API-KEY"
-}
-```
-
-<a name="username-password"></a>
-
-### Authenticating with a username and a password
-
-You can manage your username and password from your profile page. To obtain a [session token](#session-token) using your username and your password, send them as a `POST` request to the `/api/v1/login/password` endpoint with a JSON body in the following format:
-
-```
-{
-	"username": "YOUR-USERNAME",
-	"password": "YOUR-PASSWORD"
-}
-```
 
 <a name="session-token"></a>
 

--- a/app/src/docs/content/api/code/api.js
+++ b/app/src/docs/content/api/code/api.js
@@ -63,34 +63,3 @@ const sub = client.subscribe(
 
 // Unsubscribe when you don't want to receive messages anymore.
 client.unsubscribe(sub)`
-export const PythonExample =
-`# Create the client using Streamr account API key
-option = Option.get_default_option()
-option.auto_disconnect = False
-option.auto_connect = False
-option.api_key = 'your-api-key'
-client = Client(my_option)
-
-# Look up or create the stream. Can also get it by id using client.get_stream_by_id
-stream = client.get_or_create_stream('stream-test')
-
-# Create the event to publish
-msg = {
-  'temperature': 25.4,
-  'humidity': 10,
-  'happy': true
-}
-
-# Get stream id
-stream_id = stream[0]['id']
-
-# Publish it using the stream's id
-client.publish(stream_id, msg)
-
-# If we want to subscribe to a stream to receive messages instead
-# Define a callback function to react to latest message's content
-def callback(msg,_):
-  print('message received . The Cotent is : %s'%(msg))
-
-# Subscribe to receive messages published by other clients
-client.subscribe(stream_id, callback)`

--- a/app/src/docs/content/core/introToCore.mdx
+++ b/app/src/docs/content/core/introToCore.mdx
@@ -36,7 +36,7 @@ Four of the main views offer create functions; Streams, Canvases, Dashboards and
 In the case of canvases, these are built within the powerful Core visual programming editor. For more on this see Working with Canvases. Dashboards are also a unique case, because dashboards are basically view-only versions of the visualisation modules from canvases, so they have their own UI allowing you to add modules from your canvases and arrange the dashboard tiles sizes and layout. For more, see Working with Dashboards.
 
 ### User profile
-You can set or edit your profile image (useful in future iterations of the Marketplace), username, email address and ethereum address by either going to the Settings menu (at upper right with your initials) or by clicking on your profile image.
+You can set or edit your profile image (useful in future iterations of the Marketplace), username, email address and Ethereum address by either going to the Settings menu (at upper right with your Eth Address) or by clicking on your profile image.
 
 ### Filter and sort
 Live filter works to filter your current Core view by keyword. It works on either tile or list views. Just click the search icon to open the filter. Sort is a contextual function, offering different options depending on which Core view you are in.
@@ -86,7 +86,7 @@ All of the main resources types created and used within Core can be shared with 
 
 When you share a resource, you can share it either privately or publicly. A private share means the link is only accessible to the users whose Ethereum address it has been shared with. A public share means anyone with the link — and importantly, anyone using the public API — can access your resource. 
 
-To share any resource, click share, then paste in the Ethereum address of the person you want to share it with, and click +. Select the access level you want to give them (view only, can edit or can share) and hit Save to confirm.
+To share any resource, click share and paste in the Ethereum address of the person you want to share it with, and click +. Select the access level you want to give them, then hit Save to confirm.
 
 <Image
   src={ShareSettings}

--- a/app/src/docs/content/core/introToCore.mdx
+++ b/app/src/docs/content/core/introToCore.mdx
@@ -36,7 +36,7 @@ Four of the main views offer create functions; Streams, Canvases, Dashboards and
 In the case of canvases, these are built within the powerful Core visual programming editor. For more on this see Working with Canvases. Dashboards are also a unique case, because dashboards are basically view-only versions of the visualisation modules from canvases, so they have their own UI allowing you to add modules from your canvases and arrange the dashboard tiles sizes and layout. For more, see Working with Dashboards.
 
 ### User profile
-You can set or edit your profile image (useful in future iterations of the Marketplace), username, email address  and ethereum address by either going to the Settings menu (at upper right with your initials) or by clicking on your profile image.
+You can set or edit your profile image (useful in future iterations of the Marketplace), username, email address and ethereum address by either going to the Settings menu (at upper right with your initials) or by clicking on your profile image.
 
 ### Filter and sort
 Live filter works to filter your current Core view by keyword. It works on either tile or list views. Just click the search icon to open the filter. Sort is a contextual function, offering different options depending on which Core view you are in.

--- a/app/src/docs/content/core/introToCore.mdx
+++ b/app/src/docs/content/core/introToCore.mdx
@@ -84,9 +84,9 @@ All of the main resources types created and used within Core can be shared with 
   figCaption="Share button in canvas editor"
 />
 
-When you share a resource, you can share it either privately or publicly. A private share means the link is only accessible to the users whose email address it has been shared with. A public share means anyone with the link — and importantly, anyone using the public API — can access your resource. 
+When you share a resource, you can share it either privately or publicly. A private share means the link is only accessible to the users whose Ethereum address it has been shared with. A public share means anyone with the link — and importantly, anyone using the public API — can access your resource. 
 
-To share any resource, click share, then paste in the email address of the person you want to share it with, and click +. Select the access level you want to give them (view only, can edit or can share) and hit Save to confirm.
+To share any resource, click share, then paste in the Ethereum address of the person you want to share it with, and click +. Select the access level you want to give them (view only, can edit or can share) and hit Save to confirm.
 
 <Image
   src={ShareSettings}

--- a/app/src/docs/content/gettingStarted/gettingStarted.mdx
+++ b/app/src/docs/content/gettingStarted/gettingStarted.mdx
@@ -14,7 +14,9 @@ import SignatureRequest from './images/signatureRequest.png'
 import SignatureRequest2x from './images/signatureRequest@2x.png'
 
 # Getting Started
-Welcome to Streamr! To get a feel for what Streamr is, check out our <Link to={docsLinks.introduction}>intro docs</Link>. Your Streamr account is your Ethereum account - so there's no email registration, simply <Link to={routes.auth.login()}>login</Link> with your Web3 Ethereum wallet such as <a href="https://metamask.io" target="blank">Metamask</a>.
+Welcome to Streamr! To get a feel for what Streamr is, check out our <Link to={docsLinks.introduction}>intro docs</Link>. 
+
+To get started, you'll want to login to Streamr. Your Streamr account is your Ethereum account - there's no email registration, simply <Link to={routes.auth.login()}>login</Link> with your Web3 Ethereum wallet such as <a href="https://metamask.io" target="blank">Metamask</a>.
 
 <Warning>
 

--- a/app/src/docs/content/gettingStarted/gettingStarted.mdx
+++ b/app/src/docs/content/gettingStarted/gettingStarted.mdx
@@ -14,8 +14,7 @@ import SignatureRequest from './images/signatureRequest.png'
 import SignatureRequest2x from './images/signatureRequest@2x.png'
 
 # Getting Started
-Welcome to Streamr! To get a feel for what Streamr is, check out our <Link to={docsLinks.introduction}>intro docs</Link>.
-The first thing you'll want to get is a Streamr account. You can do that <Link to={routes.auth.login()}>here</Link>. Creating an account requires a Web3 Ethereum wallet, e.g. <a href="https://metamask.io" target="blank">Metamask</a>.
+Welcome to Streamr! To get a feel for what Streamr is, check out our <Link to={docsLinks.introduction}>intro docs</Link>. Your Streamr account is your Ethereum account - so there's no email registration, simply <Link to={routes.auth.login()}>login</Link> with your Web3 Ethereum wallet such as <a href="https://metamask.io" target="blank">Metamask</a>.
 
 <Warning>
 
@@ -24,9 +23,6 @@ The first thing you'll want to get is a Streamr account. You can do that <Link t
 - **Support for email/password authentication will be dropped on December 31st 2020. Cryptographic keys/wallets will be the only supported method.**
 
 </Warning>
-
-### Ethereum identity on Streamr
-You will need to have an Ethereum account on Streamr if you want to publish or buy a paid product on the Marketplace. It is optional, but recommended if you want to enjoy the full Streamr experience.
 
 ### Connect your Ethereum Account
 Checkout our intro docs if you'd like to understand more about what Ethereum is and what it means to have an account on Ethereum.
@@ -43,7 +39,7 @@ The easiest way to get started is through the free and open source Chrome browse
     />
 </div>
 
-Once you have your Ethereum account on Metamask, you can connect it to Streamr. There are two ways to do it, depending whether you already have a Streamr account or not. **If you haven't created an account yet, you can use your Ethereum account to create one**. Simply go to the <Link to={routes.auth.login()}>login page</Link> and click **Sign in with Ethereum**. A popup will ask you to sign a message with your Ethereum account to prove ownership, click **Sign**.
+Once you have your Ethereum account on Metamask, you can connect it to Streamr. A popup will ask you to sign a message with your Ethereum account to prove ownership, click **Sign**.
 
 <Image
   src={SignInWithEth}

--- a/app/src/docs/content/gettingStarted/gettingStarted.mdx
+++ b/app/src/docs/content/gettingStarted/gettingStarted.mdx
@@ -4,6 +4,7 @@ import routes from '$routes'
 import docsLinks from '$shared/../docsLinks'
 import docsStyles from '$docs/components/DocsLayout/docsLayout.pcss'
 import Image from '$docs/components/Image'
+import Warning from '$docs/components/Warning'
 
 import EthIdentities from './images/gs_eth_id_03_desktop.jpg'
 import EthIdentities2x from './images/gs_eth_id_03_desktop@2x.jpg'
@@ -14,7 +15,15 @@ import SignatureRequest2x from './images/signatureRequest@2x.png'
 
 # Getting Started
 Welcome to Streamr! To get a feel for what Streamr is, check out our <Link to={docsLinks.introduction}>intro docs</Link>.
-The first thing you'll want to get is a Streamr account. You can do that <Link to={routes.auth.login()}>here</Link>. Creating an account requires either an Email address or a Web3 Ethereum wallet, e.g. <a href="https://metamask.io" target="blank">Metamask</a>.
+The first thing you'll want to get is a Streamr account. You can do that <Link to={routes.auth.login()}>here</Link>. Creating an account requires a Web3 Ethereum wallet, e.g. <a href="https://metamask.io" target="blank">Metamask</a>.
+
+<Warning>
+
+**Upcoming deprecations and breaking changes**
+- **Authenticating with an API key has been deprecated.**
+- **Support for email/password authentication will be dropped on December 31st 2020. Cryptographic keys/wallets will be the only supported method.**
+
+</Warning>
 
 ### Ethereum identity on Streamr
 You will need to have an Ethereum account on Streamr if you want to publish or buy a paid product on the Marketplace. It is optional, but recommended if you want to enjoy the full Streamr experience.

--- a/app/src/docs/content/sdk/overview.mdx
+++ b/app/src/docs/content/sdk/overview.mdx
@@ -45,16 +45,10 @@ In addition to the SDKs, there is the <a target="_blank" href={routes.misc.cliTo
             <td><SvgIcon name="crossMedium" className={sdkStyles.cross}/></td>
         </tr>
         <tr>
-            <td>API Key Authentication</td>
-            <td><SvgIcon name="tick" className={sdkStyles.tick}/></td>
-            <td><SvgIcon name="tick" className={sdkStyles.tick}/></td>
-            <td><SvgIcon name="tick" className={sdkStyles.tick}/></td>
-        </tr>
-        <tr>
             <td>Ethereum Authentication</td>
             <td><SvgIcon name="tick" className={sdkStyles.tick}/></td>
             <td><SvgIcon name="tick" className={sdkStyles.tick}/></td>
-            <td><SvgIcon name="crossMedium" className={sdkStyles.cross}/></td>
+            <td><SvgIcon name="tick" className={sdkStyles.tick}/></td>
         </tr>
         <tr>
             <td>Duplicate Detection</td>

--- a/app/src/docs/content/sdk/python.mdx
+++ b/app/src/docs/content/sdk/python.mdx
@@ -2,20 +2,12 @@ import Warning from '$docs/components/Warning'
 import routes from '$routes'
 import { CodeSnippet } from '@streamr/streamr-layout'
 
-import { PythonExample } from '../api/code/api.js'
-
 # Python SDK
 
 The Python client library is available at this <a href="https://github.com/streamr-dev/streamr-client-python" target="_blank">GitHub repo</a>. If you are interested in contributing to this library, feel free to reach out via our <a target="_blank" href={routes.community.devForum()}>community dev forum</a> or submit directly a pull request.
 
 <Warning>
 
-This library is entirely community contributed and still work in progress. Core functionality like authentication via user API key, publish and subscribe data have been implemented. However, there are some other features available in our official libraries mentioned above that are still missing: Ethereum authentication, message verification, end-to-end encryption and historical data request.
+This library is entirely community contributed and is in the process of being phased out.
 
 </Warning>
-
-Here is an example of how to create an authenticated client, publish and subscribe data using the Python library.
-
-<CodeSnippet language="python">
-{PythonExample}
-</CodeSnippet>

--- a/app/src/docs/content/sdk/python.mdx
+++ b/app/src/docs/content/sdk/python.mdx
@@ -8,6 +8,6 @@ The Python client library is available at this <a href="https://github.com/strea
 
 <Warning>
 
-This library is entirely community contributed and is in the process of being phased out.
+This library is entirely community contributed and is being phased out.
 
 </Warning>

--- a/app/src/docs/content/streams/code/streams.js
+++ b/app/src/docs/content/streams/code/streams.js
@@ -1,11 +1,12 @@
 export const CreateJavascriptClient =
-`const client = new StreamrClient({
+`const streamr = new StreamrClient({
     auth: {
-        apiKey: 'your-api-key'
-    }
+        privateKey: 'YOUR-PRIVATE-KEY',
+    },
 })`
 
-export const CreateJavaClient = 'StreamrClient client = new StreamrClient(new ApiKeyAuthenticationMethod(myApiKey));'
+export const CreateJavaClient = `AuthenticationMethod method = new EthereumAuthenticationMethod("YOUR-PRIVATE-KEY");
+StreamrClient client = new StreamrClient(method);`
 
 export const AuthJavascriptClient =
 `new StreamrClient({

--- a/app/src/docs/content/streams/usingStreamsInCore.mdx
+++ b/app/src/docs/content/streams/usingStreamsInCore.mdx
@@ -72,14 +72,5 @@ This section is used to preview data flowing into the stream. Use the live inspe
   alt="Stream Preview"
 />
 
-### API Access
-Here you can manage API keys for your stream. Keys generated here grant access to only this stream and can have either read or write access. These keys can also be removed if for example, the key has been compromised.
-
-<Image
-  src={StreamApiAccess}
-  highResSrc={StreamApiAccess2x}
-  alt="API Access"
-/>
-
 ### Historical Data
 This section contains the stream's historical data storage settings. The historical data storage period determines how many days your data is retained before it will be removed automatically from the Streamr network. The default period is 365 days.

--- a/app/src/docs/content/streams/usingStreamsViaSdk.mdx
+++ b/app/src/docs/content/streams/usingStreamsViaSdk.mdx
@@ -20,9 +20,9 @@ The easiest way to work with streams is to use the JavaScript client, which work
 
 ### Authentication
 
-When reading from or writing to streams, you need to provide a session token or an API key, or login with an Ethereum account. To read more about API keys or obtaining a session token, refer to the <Link to={docsLinks.authentication}>Authentication section of the API docs</Link>.
+When reading from or writing to streams, you need to provide a session token, or authenticate with an Ethereum account. To read more about obtaining a session token, refer to the <Link to={docsLinks.authentication}>Authentication section of the API docs</Link>.
 
-### Creating a client instance with API key
+### Creating a client instance with a private key
 
 #### Javascript
 <CodeSnippet language="javascript">{CreateJavascriptClient}</CodeSnippet>

--- a/app/src/docs/content/tutorials/buildingPubSub.mdx
+++ b/app/src/docs/content/tutorials/buildingPubSub.mdx
@@ -25,23 +25,29 @@ The easiest way to push data to a stream is to use one of our <Link to={docsLink
 
 <CodeSnippet language="javascript" wrapLines showLineNumbers >{ClientPub}</CodeSnippet>
 
+Inside the Core app, you can select the stream and monitor the data preview - your published messages will appear here in real-time.
+
 <Image
   src={StreamEditorPreview}
   highResSrc={StreamEditorPreview2x}
   alt="Stream Editor Preview"
 />
 
-Additionally, you can interact with the Streamr API using any HTTP library of your choice. You will find all the details in the <Link to={docsLinks.api}>API section</Link>, but here’s a brief rundown. You’ll be making a `HTTP POST` request to a URL, which contains your stream ID. Please note that slashes in the stream ID should be escaped using `%2F`.
+Additionally, you can interact with the Streamr API using any HTTP library of your choice. You will find all the details in the <Link to={docsLinks.api}>API section</Link>. You will need to <Link to={docsLinks.authentication}>authenticate</Link> first before publishing data to any stream.
+
+Once autenticated, you’ll be making a `HTTP POST` request to a URL, which contains your stream ID. Please note that characters in the stream ID should be escaped using url encoding such as changing slashes to `%2F`. The body of the request will be your data payload in JSON. 
 
 <CodeSnippet language="text" wrapLines>{`https://streamr.network/api/v1/streams/MY-STREAM-ID/data`}</CodeSnippet>
 
-The body of the request will be your data payload in JSON. You will need to get a session token to publish to a stream - all the different authorization options are explained in the: <Link to={docsLinks.authentication}>API docs</Link>. Depending on the permissions you've set, you may be able to 
+You will need to get a session token to publish to a stream - all the different authorization options are explained in the: <Link to={docsLinks.authentication}>API docs</Link>.
 
 <CodeSnippet language="text" wrapLines>{`Authorization: Bearer my-session-token`}</CodeSnippet>
 
 ### Subscribe to data
-Along with publishing data to a stream, this is best done with one of our <Link to={docsLinks.sdk}>SDKs</Link>. Here is the given example from the Streamr JavaScript client <a target="_blank" href="https://github.com/streamr-dev/streamr-client-javascript">readme</a>.
+Along with publishing data to a stream, subscribing is best done with one of our <Link to={docsLinks.sdk}>SDKs</Link>. Depending on how you've configured the stream share permissions inside the core app, the subscriber may not need to authenticate. 
+
+Here is the example from the Streamr JavaScript client <a target="_blank" href="https://github.com/streamr-dev/streamr-client-javascript">readme</a> on how to subscribe to a stream.
 
 <CodeSnippet language="javascript" wrapLines showLineNumbers >{ClientSub}</CodeSnippet>
 
-
+Congratulations, you've now created a stream, published and subscribed to it 🎉

--- a/app/src/docs/content/tutorials/buildingPubSub.mdx
+++ b/app/src/docs/content/tutorials/buildingPubSub.mdx
@@ -18,14 +18,12 @@ import docsStyles from '$docs/components/DocsLayout/docsLayout.pcss'
 import tutorialStyles from '$docs/components/Pages/Tutorials/tutorials.pcss'
 
 # Building a simple pub/sub system
-Before proceeding with this tutorial, we assume you have <Link to={docsLinks.gettingStarted}>got your API key or connected your Ethereum account</Link> and that you have also <Link to={docsLinks.streams}>created your first stream</Link>.
+Before proceeding with this tutorial, we assume you have connected your Ethereum account and that you have also <Link to={docsLinks.streams}>created your first stream</Link>.
 
 ### Publish to a stream
-The easiest way to push data to a stream is to use the one of our <Link to={docsLinks.sdk}>SDKs</Link>, currently available in <a target="_blank" href="https://github.com/streamr-dev/streamr-client-javascript">Javascript</a>, <a target="_blank" href="https://github.com/streamr-dev/streamr-client-java">Java</a> and a community contributed version in <a target="_blank" href="https://github.com/streamr-dev/streamr-client-python">Python</a>. Client libraries for other languages are on the roadmap. Here is an example of publishing data to a stream using Streamr Javascript client.
+The easiest way to push data to a stream is to use one of our <Link to={docsLinks.sdk}>SDKs</Link>, currently available in <a target="_blank" href="https://github.com/streamr-dev/streamr-client-javascript">Javascript</a>, <a target="_blank" href="https://github.com/streamr-dev/streamr-client-java">Java</a>. Client libraries for other languages are on the roadmap. Here is an example of publishing data to a stream using Streamr Javascript client.
 
 <CodeSnippet language="javascript" wrapLines showLineNumbers >{ClientPub}</CodeSnippet>
-
-You can also try it locally in your browser. Just open this <a target="_blank" href="https://jsbin.com/xahoxut/edit?js,output">JS Bin</a> or <a target="_blank" href="https://gist.github.com/fonty1/f09aa09afcbae0bf5d7032163a466f76">GitHub Gist</a>, and replace `MY-STREAM-ID` and `MY-API-KEY` with your stream ID and API key. Your browser will start producing data to your stream! If you were successful, you should see something like this in your stream editor preview.
 
 <Image
   src={StreamEditorPreview}
@@ -33,25 +31,17 @@ You can also try it locally in your browser. Just open this <a target="_blank" h
   alt="Stream Editor Preview"
 />
 
-Additionally, you can interact with the Streamr API using any HTTP library of your choice. You will find all the details in the <Link to={docsLinks.api}>API section</Link>, but here’s a brief rundown. You’ll be making a `HTTP POST` request to a URL, which contains your stream ID.
+Additionally, you can interact with the Streamr API using any HTTP library of your choice. You will find all the details in the <Link to={docsLinks.api}>API section</Link>, but here’s a brief rundown. You’ll be making a `HTTP POST` request to a URL, which contains your stream ID. Please note that slashes in the stream ID should be escaped using `%2F`.
 
 <CodeSnippet language="text" wrapLines>{`https://streamr.network/api/v1/streams/MY-STREAM-ID/data`}</CodeSnippet>
 
-The body of the request will be your data payload in JSON. Add your API key to the HTTP headers as follows.
+The body of the request will be your data payload in JSON. You will need to get a session token to publish to a stream - all the different authorization options are explained in the: <Link to={docsLinks.authentication}>API docs</Link>. Depending on the permissions you've set, you may be able to 
 
-<CodeSnippet language="text" wrapLines>{`Authorization: token MY-API-KEY`}</CodeSnippet>
-
-This is how a test request would look in the fabulous <a target="_blank" href="https://www.getpostman.com/">Postman</a> app, with the URL and Authorization header set.
-
-<Image
-  src={Postman}
-  highResSrc={Postman2x}
-  alt="Postman App"
-/>
-
-All the different authorization options are explained in the: <Link to={docsLinks.api}>API docs</Link>.
+<CodeSnippet language="text" wrapLines>{`Authorization: Bearer my-session-token`}</CodeSnippet>
 
 ### Subscribe to data
 Along with publishing data to a stream, this is best done with one of our <Link to={docsLinks.sdk}>SDKs</Link>. Here is the given example from the Streamr JavaScript client <a target="_blank" href="https://github.com/streamr-dev/streamr-client-javascript">readme</a>.
 
 <CodeSnippet language="javascript" wrapLines showLineNumbers >{ClientSub}</CodeSnippet>
+
+

--- a/app/src/docs/content/tutorials/code/tutorials.js
+++ b/app/src/docs/content/tutorials/code/tutorials.js
@@ -118,7 +118,7 @@ export const ClientSub =
 
 // Subscribe to a stream
 streamr.subscribe({
-    stream: '0xb722f00ea9eecdc3d2b990789e62beaa17568123/f',
+    stream: '0xb722f00ea9eecdc3d2b990789e62beaa17568123/my-stream',
 }, (message, metadata) => {
     // Do something with the message here!
     console.log(message)

--- a/app/src/docs/content/tutorials/code/tutorials.js
+++ b/app/src/docs/content/tutorials/code/tutorials.js
@@ -110,18 +110,19 @@ public void clearState() {
 }`
 
 export const ClientSub =
-`const sub = client.subscribe(
-    {
-        stream: 'streamId',
-        apiKey: 'secret',       // Optional. If not given, uses the apiKey given at client creation time.
-        partition: 0,           // Optional, defaults to zero. Use for partitioned streams to select partition.
-        // optional resend options here
+`const streamr = new StreamrClient({
+    auth: {
+        privateKey: 'YOUR-PRIVATE-KEY',
     },
-    (message, metadata) => {
-        // This is the message handler which gets called for every incoming message in the Stream.
-        // Do something with the message here!
-    }
-)`
+})
+
+// Subscribe to a stream
+streamr.subscribe({
+    stream: '0xb722f00ea9eecdc3d2b990789e62beaa17568123/f',
+}, (message, metadata) => {
+    // Do something with the message here!
+    console.log(message)
+})`
 
 export const ClientPub =
 `// Here's our example data point


### PR DESCRIPTION
There were some mentions of API Keys that trip up external devs. 

Also removed the email/pass authentication as that gets phased out soon and replaced any email mentions with Eth address.

Also added that CLI tool can authenticate with Eth and Python library should not be used.