### PR TITLE
[FRONT-188] Implement signup replacement notice

### DIFF
--- a/app/cypress/integration/LoginPage.spec.js
+++ b/app/cypress/integration/LoginPage.spec.js
@@ -48,14 +48,6 @@ describe('Login page', () => {
         })
     })
 
-    describe('Navigation / sign up link', () => {
-        it('takes user to the sign up page', () => {
-            cy.visit('/login')
-            cy.contains(/sign up/i).click()
-            cy.location('pathname').should('eq', '/signup')
-        })
-    })
-
     describe('Navigation / forgot password link', () => {
         it('takes user to the forgot password page', () => {
             cy.visit('/login')

--- a/app/src/auth/components/AuthPanel/index.jsx
+++ b/app/src/auth/components/AuthPanel/index.jsx
@@ -31,7 +31,6 @@ const AuthPanel = ({ children, onPrev, validationSchemas, onValidationError }: P
         <div className={styles.authPanel}>
             <AuthPanelNav
                 signin={!!child.props.showSignin}
-                signup={!!child.props.showSignup}
                 onUseEth={child.props.onEthereumClick}
                 onGoBack={child.props.showBack ? (onPrev || prev) : null}
             />

--- a/app/src/auth/components/LoginPage/index.jsx
+++ b/app/src/auth/components/LoginPage/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { useState, useCallback } from 'react'
+import qs from 'query-string'
 
 import { userIsNotAuthenticated } from '$auth/utils/userAuthenticated'
 import SessionProvider from '../SessionProvider'
@@ -8,10 +9,12 @@ import AuthLayout from '../AuthLayout'
 import UsernamePasswordLogin from '../UsernamePasswordLogin'
 import EthereumLogin from '../EthereumLogin'
 
-type Props = {}
+type LoginPageProps = {
+    preferEthereum: boolean,
+}
 
-const LoginPage = (props: Props) => {
-    const [useEthereum, setUseEthereum] = useState(false)
+const LoginPage = ({ preferEthereum, ...props }: LoginPageProps) => {
+    const [useEthereum, setUseEthereum] = useState(preferEthereum)
 
     const switchToEthereum = useCallback(() => {
         setUseEthereum(true)
@@ -34,8 +37,19 @@ const LoginPage = (props: Props) => {
 
 export { LoginPage }
 
-export default userIsNotAuthenticated((props: Props) => (
-    <SessionProvider>
-        <LoginPage {...props} />
-    </SessionProvider>
-))
+type Props = {
+    useEthereum?: string,
+    location: {
+        search: string,
+    },
+}
+
+export default userIsNotAuthenticated((props: Props) => {
+    const useEthereum = !!qs.parse(props.location.search).metamask
+
+    return (
+        <SessionProvider>
+            <LoginPage {...props} preferEthereum={useEthereum} />
+        </SessionProvider>
+    )
+})

--- a/app/src/auth/components/SignupPage/index.jsx
+++ b/app/src/auth/components/SignupPage/index.jsx
@@ -2,22 +2,20 @@
 
 import React, { useCallback, useContext } from 'react'
 import { I18n, Translate } from 'react-redux-i18n'
+import styled from 'styled-components'
+import { useDispatch } from 'react-redux'
+import { push } from 'connected-react-router'
+
 import { userIsNotAuthenticated } from '$auth/utils/userAuthenticated'
+import { SM, MD } from '$shared/utils/styled'
 
 import AuthFormProvider from '../AuthFormProvider'
 import AuthFormContext from '../../contexts/AuthForm'
 import AuthPanel from '../AuthPanel'
-import Actions from '../Actions'
-import Button from '../Button'
-import AuthStep from '../AuthStep'
+import UnstyledAuthStep from '../AuthStep'
 import AuthLayout from '../AuthLayout'
-import Text from '$ui/Text'
-import Label from '$ui/Label'
-import Underline from '$ui/Underline'
-import Errors from '$ui/Errors'
 
 import post from '../../utils/post'
-import onInputChange from '../../utils/onInputChange'
 import schemas from '../../schemas/signup'
 import routes from '$routes'
 
@@ -29,15 +27,26 @@ const initialForm: Form = {
     email: '',
 }
 
+const AuthStep = styled(UnstyledAuthStep)`
+    && {
+        text-align: center;
+        line-height: 24px;
+        padding: 34px 2.5rem 50px;
+        font-size: 14px;
+
+        @media (min-width: ${SM}px) {
+            padding: 56px 2.5rem 72px;
+            font-size: 16px;
+        }
+
+        @media (min-width: ${MD}px) {
+            padding: 72px 2.5rem 88px;
+        }
+    }
+`
+
 const SignupPage = () => {
-    const {
-        errors,
-        form,
-        isProcessing,
-        setFieldError,
-        setFormField,
-        step,
-    } = useContext(AuthFormContext)
+    const { form, setFieldError } = useContext(AuthFormContext)
     const { email: username } = form
 
     const onFailure = useCallback((error: Error) => {
@@ -50,6 +59,13 @@ const SignupPage = () => {
         }, false)
     ), [username])
 
+    const dispatch = useDispatch()
+    const onEthereumClick = useCallback(() => {
+        dispatch(push(routes.auth.login({
+            metamask: true,
+        })))
+    }, [dispatch])
+
     return (
         <AuthLayout>
             <AuthPanel
@@ -57,34 +73,16 @@ const SignupPage = () => {
                 onValidationError={setFieldError}
             >
                 <AuthStep
-                    title={I18n.t('general.signUp')}
+                    title="Authentication has changed"
                     onSubmit={submit}
                     onFailure={onFailure}
-                    showSignin
+                    onEthereumClick={onEthereumClick}
                 >
-                    <Label state={errors.email && 'ERROR'}>
-                        <Translate value="auth.labels.email" />
-                    </Label>
-                    <Text
-                        unstyled
-                        type="text"
-                        name="email"
-                        value={form.email}
-                        onChange={onInputChange(setFormField)}
-                        autoComplete="off"
-                        autoFocus
-                    />
-                    <Underline
-                        state={(step === 0 && isProcessing && 'PROCESSING') || (errors.email && 'ERROR')}
-                    />
-                    <Errors>
-                        {errors.email}
-                    </Errors>
-                    <Actions>
-                        <Button disabled={isProcessing}>
-                            <Translate value="auth.next" />
-                        </Button>
-                    </Actions>
+                    <div>
+                        Email and password-based signups have been deprecated.
+                        <br />
+                        Please install MetaMask and authenticate with Ethereum.
+                    </div>
                 </AuthStep>
                 <AuthStep
                     title={I18n.t('auth.signUp.success.title')}

--- a/app/src/auth/components/UsernamePasswordLogin/index.jsx
+++ b/app/src/auth/components/UsernamePasswordLogin/index.jsx
@@ -76,7 +76,6 @@ const UsernamePasswordLogin = ({ onEthereumClick }: Props) => {
         >
             <AuthStep
                 title={I18n.t('general.signIn')}
-                showSignup
                 onEthereumClick={onEthereumClick}
                 autoSubmitOnChange={['hiddenPassword']}
             >

--- a/app/test/unit/components/AuthPage/AuthPanel/index.test.jsx
+++ b/app/test/unit/components/AuthPage/AuthPanel/index.test.jsx
@@ -74,11 +74,6 @@ describe(AuthPanel.name, () => {
                 expect(nav.prop('signin')).toBe(false)
             })
 
-            it('sets nav#signup if step#showSignup is set', () => {
-                expect(step.prop('showSignup')).not.toBeDefined()
-                expect(nav.prop('signup')).toBe(false)
-            })
-
             it('passes (undefined) onEthereumClick to nav#onUseEth', () => {
                 expect(step.prop('onEthereumClick')).toBeUndefined()
                 expect(nav.prop('onUseEth')).toBeUndefined()
@@ -98,11 +93,6 @@ describe(AuthPanel.name, () => {
             it('sets nav#signin if step#showSignin is set', () => {
                 expect(step.prop('showSignin')).toBe(true)
                 expect(nav.prop('signin')).toBe(true)
-            })
-
-            it('sets nav#signup if step#showSignup is set', () => {
-                expect(step.prop('showSignup')).toBe(true)
-                expect(nav.prop('signup')).toBe(true)
             })
 
             it('passes given onEthereumClick to nav#onUseEth', () => {


### PR DESCRIPTION
Removes the controls from the sign up page and replace them with a notice:

![Screenshot 2020-12-08 at 10 42 17](https://user-images.githubusercontent.com/1064982/101460460-4a2cb200-3942-11eb-8a72-cdb0b7bd00a1.png)

The email & password login still works for users to be able login and add an eth account before the whole login gets replaced with the wallet-only auth (#1135).