### PR TITLE
[FRONT-107] Improve consistency of truncation of Eth addresses

### DIFF
--- a/app/src/editor/canvas/components/ModuleSearch.jsx
+++ b/app/src/editor/canvas/components/ModuleSearch.jsx
@@ -18,6 +18,7 @@ import { getModuleCategories, getStreams } from '../services'
 import { moduleSearch } from '../state'
 import CanvasStyles from '$editor/canvas/components/Canvas.pcss'
 import SearchPanel, { SearchRow } from '$editor/shared/components/SearchPanel'
+import { truncate } from '$shared/utils/text'
 import { useCameraContext } from './Camera'
 
 import styles from './ModuleSearch.pcss'
@@ -371,7 +372,7 @@ class ModuleSearch extends React.PureComponent<Props, State> {
                         onClick={() => this.addModule(STREAM_MODULE_ID, null, null, stream.id)}
                         title={stream.description}
                     >
-                        <span className={styles.StreamName}>{stream.id}</span>
+                        <span className={styles.StreamName}>{truncate(stream.id)}</span>
                         <div className={styles.Description}>{stream.description || 'No description'}</div>
                     </SearchRow>
                 ))}

--- a/app/src/editor/shared/components/StreamSelector.jsx
+++ b/app/src/editor/shared/components/StreamSelector.jsx
@@ -4,6 +4,8 @@ import React from 'react'
 import Text from '$editor/canvas/components/Ports/Value/Text'
 import debounce from 'lodash/debounce'
 
+import { truncate } from '$shared/utils/text'
+
 import { getStreams, getStream } from '../../canvas/services'
 
 import styles from './StreamSelector.pcss'
@@ -175,7 +177,7 @@ export default class StreamSelector extends React.Component<Props, State> {
                                 tabIndex="0"
                                 title={stream.description}
                             >
-                                <div>{stream.id}</div>
+                                <div>{truncate(stream.id)}</div>
                                 {!!stream.description && (
                                     <div title={stream.description} className={styles.description}>{stream.description}</div>
                                 )}

--- a/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
+++ b/app/src/marketplace/components/ProductPage/StreamListing/index.jsx
@@ -5,6 +5,7 @@ import styled, { css } from 'styled-components'
 import SvgIcon from '$shared/components/SvgIcon'
 import { SM, LG } from '$shared/utils/styled'
 import Segment from '$shared/components/Segment'
+import { truncate } from '$shared/utils/text'
 
 const StreamCount = styled.span`
     display: inline-block;
@@ -224,7 +225,9 @@ export const StreamListing = ({
                     <TableBody>
                         {streams.map(({ id: streamId, description }) => (
                             <DataRow key={streamId} locked={locked} clickable={!locked && !!showPreview}>
-                                <TitleItem title={description}>{streamId}</TitleItem>
+                                <TitleItem title={description}>
+                                    {truncate(streamId)}
+                                </TitleItem>
                                 <DescriptionItem title={description}>{description}</DescriptionItem>
                                 {(!!showPreview || !!showSettings) && (
                                     <RowButtons>

--- a/app/src/marketplace/components/StreamSelector/index.jsx
+++ b/app/src/marketplace/components/StreamSelector/index.jsx
@@ -13,6 +13,7 @@ import Popover from '$shared/components/Popover'
 import SvgIcon from '$shared/components/SvgIcon'
 import Errors from '$ui/Errors'
 import LoadingIndicator from '$shared/components/LoadingIndicator'
+import { truncate } from '$shared/utils/text'
 
 import routes from '$routes'
 import { useLastError, type LastErrorProps } from '$shared/hooks/useLastError'
@@ -186,7 +187,7 @@ export const StreamSelector = (props: Props) => {
                                     }}
                                     disabled={!!isDisabled}
                                 >
-                                    {stream.id}
+                                    {truncate(stream.id)}
                                 </button>
                             </div>
                         ))}

--- a/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
+++ b/app/src/marketplace/containers/EditProductPage/BeneficiaryAddress.jsx
@@ -41,9 +41,7 @@ const UnstyledAddressItem = ({ className, name, address }: AddressItemProps) => 
         <div>{`Fill ${name}`}</div>
         {!!address && (
             <div className="address">
-                {truncate(address, {
-                    maxLength: 15,
-                })}
+                {truncate(address)}
             </div>
         )}
     </div>
@@ -115,9 +113,7 @@ const BeneficiaryAddress = ({
     }, [])
 
     const address: string = useMemo(() => (
-        focused ? ownAddress : truncate(ownAddress, {
-            maxLength: 30,
-        })
+        focused ? ownAddress : truncate(ownAddress)
     ), [focused, ownAddress])
 
     const onFocus = useCallback((e: SyntheticFocusEvent<EventTarget>) => {

--- a/app/src/shared/components/Layout/User.jsx
+++ b/app/src/shared/components/Layout/User.jsx
@@ -31,13 +31,7 @@ const UnstyledAvatarless = ({ source = EmptyUser, ...props }) => (
             &zwnj;
         </Name>
         <Username title={source.username}>
-            {isEthereumAddress(source.username) ? (
-                truncate(source.username, {
-                    maxLength: 14,
-                })
-            ) : (
-                source.username
-            )}
+            {truncate(source.username)}
             &zwnj;
         </Username>
     </div>
@@ -88,13 +82,7 @@ const UnstyledUsernameCopy = ({ children, username, ...props }) => {
                     type="button"
                     onClick={() => copy(username)}
                 >
-                    {isAddress ? (
-                        truncate(username, {
-                            maxLength: 14,
-                        })
-                    ) : (
-                        username
-                    )}
+                    {truncate(username)}
                     &zwnj;
                 </UsernameButton>
             </Tooltip>

--- a/app/src/shared/components/StreamPreview/index.jsx
+++ b/app/src/shared/components/StreamPreview/index.jsx
@@ -12,6 +12,7 @@ import LoadingIndicator from '$shared/components/LoadingIndicator'
 import Skeleton from '$shared/components/Skeleton'
 import useCopy from '$shared/hooks/useCopy'
 import { formatDateTime } from '$mp/utils/time'
+import { truncate } from '$shared/utils/text'
 
 import {
     SecurityIcon,
@@ -682,7 +683,7 @@ const StreamPreview = ({
                             {!!titlePrefix && (
                                 <StreamName>{titlePrefix} &rarr; </StreamName>
                             )}
-                            {streamId}
+                            {truncate(streamId)}
                         </Title>
                         <Description title={description}>{description}</Description>
                     </React.Fragment>

--- a/app/src/shared/components/Web3ErrorDialog/UnlockWalletDialog/index.jsx
+++ b/app/src/shared/components/Web3ErrorDialog/UnlockWalletDialog/index.jsx
@@ -45,9 +45,7 @@ const UnlockWalletDialog = ({
                         className={styles.address}
                         title={requiredAddress}
                     >
-                        {truncate(requiredAddress, {
-                            maxLength: 15,
-                        })}
+                        {truncate(requiredAddress)}
                     </span>
                 </div>
             )}

--- a/app/src/shared/utils/diagnostics.js
+++ b/app/src/shared/utils/diagnostics.js
@@ -54,7 +54,7 @@ global.streamr = Object.assign(global.streamr || {}, {
         const [versionNumber, , hash] = version.split('-')
 
         // hash minus leading 'g', not shown on master
-        const displayHash = isMaster ? '' : hash.slice(1)
+        const displayHash = isMaster ? '' : hash && hash.slice(1)
 
         // don't show branch if master
         let displayBranch = branch === 'master' ? '' : branch

--- a/app/src/shared/utils/text.js
+++ b/app/src/shared/utils/text.js
@@ -3,27 +3,24 @@
 import { I18n } from 'react-redux-i18n'
 
 type Options = {
-    minLength?: number,
-    maxLength?: number,
+    length: number,
     separator?: string,
 }
 
-export const truncate = (text: string, options: Options = {}) => {
-    const { minLength, maxLength, separator } = {
-        minLength: 20,
-        maxLength: 30,
+export const truncate = (path: string, options: Options = {}) => {
+    const { length, separator } = {
         separator: '...',
+        length: 5,
         ...options,
     }
 
-    if (text.length < minLength) {
-        return text
+    if (typeof path === 'string' && path.indexOf('0x') >= 0) {
+        const search = new RegExp(`0x([A-Fa-f0-9]{${length - 2}})[A-Fa-f0-9]{32,}([A-Fa-f0-9]{${length}})`, 'g')
+
+        return path.replace(search, `0x$1${separator}$2`)
     }
 
-    const maxLengthWithoutSeparator = Math.min(maxLength, text.length) - separator.length
-    const sideLength = Math.floor(maxLengthWithoutSeparator / 2)
-
-    return text.substr(0, sideLength) + separator + text.substr(-sideLength)
+    return path
 }
 
 export const numberToText = (number: number): string => {

--- a/app/src/userpages/components/KeyField/index.jsx
+++ b/app/src/userpages/components/KeyField/index.jsx
@@ -22,7 +22,6 @@ type Props = {
     keyName: string,
     value?: string,
     hideValue?: boolean,
-    truncateValue?: boolean,
     className?: string,
     allowEdit?: boolean,
     onSave?: (?string, ?string) => Promise<void>,
@@ -41,7 +40,6 @@ const KeyField = ({
     keyName,
     value,
     hideValue,
-    truncateValue,
     className,
     allowEdit,
     onSave: onSaveProp,
@@ -153,12 +151,6 @@ const KeyField = ({
         ...includeIf(!!allowDelete, [deleteAction]),
     ]), [hideValue, revealAction, onCopy, allowEdit, editAction, allowDelete, deleteAction])
 
-    const displayValue = useMemo(() => (
-        value && (!truncateValue ? value : truncate(value, {
-            maxLength: 15,
-        }))
-    ), [truncateValue, value])
-
     return (
         <div className={cx(styles.root, styles.KeyField, className)}>
             {!editing ? (
@@ -179,7 +171,7 @@ const KeyField = ({
                     </div>
                     <WithInputActions actions={inputActions}>
                         <Text
-                            value={displayValue}
+                            value={value && truncate(value)}
                             readOnly
                             type={hidden ? 'password' : 'text'}
                         />

--- a/app/src/userpages/components/KeyField/keyField.stories.jsx
+++ b/app/src/userpages/components/KeyField/keyField.stories.jsx
@@ -52,32 +52,6 @@ stories.add('editable', () => {
     )
 })
 
-stories.add('truncated value', () => (
-    <KeyField
-        keyName="Key name"
-        value={text('Value', 'Long value which will truncate')}
-        truncateValue
-    />
-))
-
-stories.add('truncated value (editable)', () => {
-    const saveAction = action('onSave')
-    const onSave = (...args) => new Promise((resolve) => {
-        saveAction(...args)
-        setTimeout(resolve, 500)
-    })
-
-    return (
-        <KeyField
-            keyName="Key name"
-            value={text('Value', 'Long value which will truncate')}
-            allowEdit
-            onSave={onSave}
-            truncateValue
-        />
-    )
-})
-
 stories.add('active', () => (
     <KeyField
         keyName="Key name"

--- a/app/src/userpages/components/ProductsPage/Header/index.jsx
+++ b/app/src/userpages/components/ProductsPage/Header/index.jsx
@@ -75,9 +75,7 @@ const Header = ({ className, searchComponent, filterComponent }: Props) => {
                         <NameAndUsername name={name}>
                             {!!beneficiaryAddress && (
                                 <HoverCopy value={beneficiaryAddress}>
-                                    {truncate(beneficiaryAddress, {
-                                        maxLength: 20,
-                                    })}
+                                    {truncate(beneficiaryAddress)}
                                 </HoverCopy>
                             )}
                         </NameAndUsername>

--- a/app/src/userpages/components/ProductsPage/Members/index.jsx
+++ b/app/src/userpages/components/ProductsPage/Members/index.jsx
@@ -370,9 +370,7 @@ const Members = () => {
                                     >
                                         <FullAddress>{member.memberAddress}</FullAddress>
                                         <TruncatedAddress>
-                                            {truncate(member.memberAddress, {
-                                                maxLength: 15,
-                                            })}
+                                            {truncate(member.memberAddress)}
                                         </TruncatedAddress>
                                     </MemberList.Title>
                                     <MemberList.Item>

--- a/app/src/userpages/components/ProfilePage/IdentityHandler/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IdentityHandler/index.jsx
@@ -114,7 +114,6 @@ const IdentityHandler = () => {
                 onDelete={wrappedRemove}
                 onEdit={wrappedEdit}
                 integrationKeys={ethereumIdentities || []}
-                truncateValues
                 disabled={isDisabled}
                 activeKeyId={user && user.username}
             />

--- a/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/index.jsx
@@ -18,7 +18,6 @@ import KeyList from '../../KeyList'
 
 type CommonProps = {|
     hideValues?: boolean,
-    truncateValues?: boolean,
     onDelete: (IntegrationKeyId: IntegrationKeyId) => Promise<void>,
     onEdit: (IntegrationKeyId: IntegrationKeyId, keyName: string) => Promise<void>,
     disabled?: boolean,
@@ -49,7 +48,6 @@ const StyledBalance = styled(Balance)`
 const IntegrationKeyItem = ({
     item,
     hideValues,
-    truncateValues,
     onDelete,
     onEdit,
     disabled,
@@ -69,7 +67,6 @@ const IntegrationKeyItem = ({
                 allowDelete={!disabled}
                 allowEdit={!disabled}
                 hideValue={hideValues}
-                truncateValue={truncateValues}
                 onDelete={() => onDelete(item.id)}
                 onSave={(keyName) => onEdit(item.id, keyName || '')}
                 onToggleEditor={setEditing}

--- a/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/integrationKeyList.stories.jsx
+++ b/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/integrationKeyList.stories.jsx
@@ -91,12 +91,11 @@ const stories =
 
 type Props = {
     hideValues?: boolean,
-    truncateValues?: boolean,
     disabled?: boolean,
     activeKeyId?: string,
 }
 
-const IntegrationKeyListController = ({ hideValues, truncateValues, disabled, activeKeyId }: Props) => {
+const IntegrationKeyListController = ({ hideValues, disabled, activeKeyId }: Props) => {
     const editAction = action('onEdit')
     const onEdit = (...args) => new Promise((resolve) => {
         editAction(...args)
@@ -111,7 +110,6 @@ const IntegrationKeyListController = ({ hideValues, truncateValues, disabled, ac
             onEdit={onEdit}
             onDelete={action('onDelete')}
             hideValues={hideValues}
-            truncateValues={truncateValues}
             disabled={disabled}
             activeKeyId={activeKeyId}
         />
@@ -126,12 +124,8 @@ stories.add('values hidden', () => (
     <IntegrationKeyListController hideValues />
 ))
 
-stories.add('truncated values', () => (
-    <IntegrationKeyListController truncateValues />
-))
-
 stories.add('disabled', () => (
-    <IntegrationKeyListController truncateValues disabled />
+    <IntegrationKeyListController disabled />
 ))
 
 stories.add('active key highlight', () => (

--- a/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IntegrationKeyHandler/index.jsx
@@ -83,7 +83,6 @@ export const IntegrationKeyHandler = () => {
                 integrationKeys={privateKeys}
                 onDelete={wrappedRemove}
                 onEdit={wrappedEdit}
-                truncateValues
                 disabled={isDisabled}
                 activeKeyId={user && user.username}
             />

--- a/app/src/userpages/components/ShareSidebar/UserPermissions.jsx
+++ b/app/src/userpages/components/ShareSidebar/UserPermissions.jsx
@@ -14,6 +14,7 @@ import useMeasure from './hooks/useMeasure'
 import usePrevious from './hooks/usePrevious'
 import { MEDIUM } from '$shared/utils/styled'
 import { selectUsername } from '$shared/modules/user/selectors'
+import { truncate } from '$shared/utils/text'
 import ErrorMessage from './ErrorMessage'
 
 const noop = () => {}
@@ -228,7 +229,7 @@ const UnstyledUserPermissions = ({
             <Header>
                 <div>
                     <h4 title={userId}>
-                        {userId}
+                        {truncate(userId)}
                         {currentUserId === userId && ' (You)'}
                     </h4>
                     <Role visible={!isSelected}>

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -31,6 +31,8 @@ import { NotificationIcon } from '$shared/utils/constants'
 import { MEDIUM } from '$shared/utils/styled'
 import useModal from '$shared/hooks/useModal'
 import { CoreHelmet } from '$shared/components/Helmet'
+import usePreventNavigatingAway from '$shared/hooks/usePreventNavigatingAway'
+import { truncate } from '$shared/utils/text'
 
 import InfoView from './InfoView'
 import ConfigureView from './ConfigureView'
@@ -41,7 +43,6 @@ import SecurityView from './SecurityView'
 import StatusView from './StatusView'
 import ConfirmSaveModal from './ConfirmSaveModal'
 import useNewStreamMode from './useNewStreamMode'
-import usePreventNavigatingAway from '$shared/hooks/usePreventNavigatingAway'
 
 import styles from './edit.pcss'
 
@@ -67,7 +68,7 @@ function StreamPageSidebar({ stream }) {
             {sidebar.isOpen('share') && (
                 <ShareSidebar
                     sidebarName="share"
-                    resourceTitle={stream && stream.id}
+                    resourceTitle={stream && truncate(stream.id)}
                     resourceType="STREAM"
                     resourceId={stream && stream.id}
                     onClose={onClose}

--- a/app/src/userpages/components/StreamPage/List/index.jsx
+++ b/app/src/userpages/components/StreamPage/List/index.jsx
@@ -16,9 +16,7 @@ import { selectStreams, selectFetching, selectHasMoreSearchResults } from '$user
 import { getFilters } from '$userpages/utils/constants'
 import Popover from '$shared/components/Popover'
 import Layout from '$userpages/components/Layout'
-import Search from '../../Header/Search'
 import { resetResourcePermission } from '$userpages/modules/permission/actions'
-import NoStreamsView from './NoStreams'
 import DocsShortcuts from '$userpages/components/DocsShortcuts'
 import LoadMore from '$mp/components/LoadMore'
 import ListContainer from '$shared/components/Container/List'
@@ -28,11 +26,16 @@ import Sidebar from '$shared/components/Sidebar'
 import SidebarProvider, { useSidebar } from '$shared/components/Sidebar/SidebarProvider'
 import ShareSidebar from '$userpages/components/ShareSidebar'
 import { MD, LG } from '$shared/utils/styled'
-import SnippetDialog from './SnippetDialog'
 import { StreamList as StreamListComponent } from '$shared/components/List'
-import Row from './Row'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
+import { truncate } from '$shared/utils/text'
+
+import Search from '../../Header/Search'
+
+import SnippetDialog from './SnippetDialog'
+import Row from './Row'
+import NoStreamsView from './NoStreams'
 
 const DesktopOnlyButton = styled(Button)`
     && {
@@ -103,7 +106,7 @@ function StreamPageSidebar({ stream }) {
             {sidebar.isOpen('share') && (
                 <ShareSidebar
                     sidebarName="share"
-                    resourceTitle={stream && stream.id}
+                    resourceTitle={stream && truncate(stream.id)}
                     resourceType="STREAM"
                     resourceId={stream && stream.id}
                     onClose={onClose}

--- a/app/src/userpages/components/StreamPage/New.jsx
+++ b/app/src/userpages/components/StreamPage/New.jsx
@@ -288,7 +288,7 @@ const UnstyledNew = ({ currentUser, ...props }) => {
 
     const [groupedOptions, domainOptions] = useMemo(() => {
         const ethAccountOptions = ethereumIdentities.map(({ json }) => ({
-            label: truncate(json.address, { maxLength: 15 }),
+            label: truncate(json.address),
             value: json.address,
         }))
 

--- a/app/src/userpages/components/StreamPage/shared/useStreamPath.jsx
+++ b/app/src/userpages/components/StreamPage/shared/useStreamPath.jsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 
 import { truncate } from '$shared/utils/text'
-import { isEthereumAddress } from '$mp/utils/validate'
 
 export default function useStreamPath(streamId) {
     return useMemo(() => {
@@ -18,13 +17,8 @@ export default function useStreamPath(streamId) {
 
         const domain = streamId.slice(0, firstSlashPos)
         const pathname = streamId.slice(firstSlashPos + 1)
-        let truncatedDomain = domain
-        let truncatedId = streamId
-
-        if (isEthereumAddress(domain)) {
-            truncatedDomain = truncate(domain, { maxLength: 15 })
-            truncatedId = `${truncatedDomain}/${pathname}`
-        }
+        const truncatedDomain = truncate(domain)
+        const truncatedId = [truncatedDomain, pathname].filter(Boolean).join('/')
 
         return {
             domain,

--- a/app/src/userpages/components/StreamPage/shared/useStreamPath.test.jsx
+++ b/app/src/userpages/components/StreamPage/shared/useStreamPath.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import useStreamPath from './useStreamPath'
+
+describe('useStreamPath', () => {
+    it('returns legacy id without domain', () => {
+        let result
+
+        function Test() {
+            result = useStreamPath('mystream-123')
+
+            return null
+        }
+
+        mount((
+            <Test />
+        ))
+
+        expect(result.domain).toBe(undefined)
+        expect(result.truncatedDomain).toBe(undefined)
+        expect(result.pathname).toBe('mystream-123')
+        expect(result.truncatedId).toBe('mystream-123')
+    })
+
+    it('returns ENS path without truncation', () => {
+        let result
+
+        function Test() {
+            result = useStreamPath('streamr.eth/mystream-123')
+
+            return null
+        }
+
+        mount((
+            <Test />
+        ))
+
+        expect(result.domain).toBe('streamr.eth')
+        expect(result.truncatedDomain).toBe('streamr.eth')
+        expect(result.pathname).toBe('mystream-123')
+        expect(result.truncatedId).toBe('streamr.eth/mystream-123')
+    })
+
+    it('returns ETH address path with truncation', () => {
+        let result
+
+        function Test() {
+            result = useStreamPath('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1/mystream-123')
+
+            return null
+        }
+
+        mount((
+            <Test />
+        ))
+
+        expect(result.domain).toBe('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1')
+        expect(result.truncatedDomain).toBe('0xa3d...47De1')
+        expect(result.pathname).toBe('mystream-123')
+        expect(result.truncatedId).toBe('0xa3d...47De1/mystream-123')
+    })
+})

--- a/app/src/userpages/components/TransactionPage/List/index.jsx
+++ b/app/src/userpages/components/TransactionPage/List/index.jsx
@@ -211,7 +211,7 @@ const TransactionList = () => {
                                         {eventType}
                                     </TransactionListComponent.Item>
                                     <TransactionListComponent.Item title={hash}>
-                                        {truncate(hash, { maxLength: 15 })}
+                                        {truncate(hash, { length: 10 })}
                                     </TransactionListComponent.Item>
                                     <TransactionListComponent.Item>
                                         {timestamp ? titleize(ago(new Date(timestamp))) : '-'}

--- a/app/src/userpages/tests/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/integrationKeyList.test.jsx
+++ b/app/src/userpages/tests/components/ProfilePage/IntegrationKeyHandler/IntegrationKeyList/integrationKeyList.test.jsx
@@ -23,7 +23,6 @@ describe('IntegrationKeyHandler', () => {
                 onDelete={onDelete}
                 onEdit={onEdit}
                 hideValues
-                truncateValues
                 className="extra"
             />)
             const keyFields = el.find('KeyField')

--- a/app/test/unit/utils/text.test.js
+++ b/app/test/unit/utils/text.test.js
@@ -2,44 +2,61 @@ import * as all from '$shared/utils/text'
 
 describe('text utils', () => {
     describe('truncate', () => {
-        it('does not truncate short string', () => {
-            const str = 'short'
-            expect(all.truncate(str)).toBe(str)
+        it('does not truncate non-strings', () => {
+            expect(all.truncate()).toBe(undefined)
+            expect(all.truncate(123)).toBe(123)
         })
 
-        it('truncates long string', () => {
-            const str = 'really long string that should truncate'
-            const match = /.+\.\.\..+$/
-            expect(match.test(all.truncate(str))).toBe(true)
+        it('does not truncate non-eth address', () => {
+            expect(all.truncate('sandbox/test/my-stream')).toBe('sandbox/test/my-stream')
+            expect(all.truncate('FwhuQBTrtfkddf2542asd')).toBe('FwhuQBTrtfkddf2542asd')
         })
 
-        it('allows changing minimum length', () => {
-            const str = 'really long string that should truncate'
-            expect(all.truncate(str, {
-                minLength: 50,
-            })).toBe(str)
+        it('truncates paths starting with eth address', () => {
+            expect(all.truncate('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1/test/my-stream')).toBe('0xa3d...47De1/test/my-stream')
+            expect(all.truncate('0xA3D1F77ACFF0060F7213D7BF3C7fEC78DF847DE1/test/my-stream')).toBe('0xA3D...47DE1/test/my-stream')
         })
 
-        it('allows changing maximum length', () => {
-            const str = 'really long string that should truncate'
-            expect(all.truncate(str, {
-                maxLength: 15,
-            })).toBe('really...uncate')
+        it('truncates address in the middle of text', () => {
+            expect(all.truncate('address is 0xA3D1F77ACFF0060F7213D7BF3C7fEC78DF847DE1 inside text'))
+                .toBe('address is 0xA3D...47DE1 inside text')
         })
 
-        it('truncates to minimum length', () => {
-            const str = 'short'
-            expect(all.truncate(str, {
-                minLength: 5,
-            })).toBe('s...t')
+        it('truncates paths with mutiple eth address', () => {
+            expect(all.truncate('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1/test/0x13581255eE2D20e780B0cD3D07fac018241B5E03/path'))
+                .toBe('0xa3d...47De1/test/0x135...B5E03/path')
         })
 
-        it('allows changing the separator', () => {
-            const str = 'really long string that should truncate'
-            const match = /.+\[separator\].+$/
-            expect(match.test(all.truncate(str, {
-                separator: '[separator]',
-            }))).toBe(true)
+        it('only truncates valid eth addresses', () => {
+            expect(all.truncate('0xa3d1F77ACfF3c7fEC78df847De1/test/my-stream')).toBe('0xa3d1F77ACfF3c7fEC78df847De1/test/my-stream')
+        })
+
+        it('truncates single eth address', () => {
+            expect(all.truncate('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1')).toBe('0xa3d...47De1')
+            expect(all.truncate('0xA3D1F77ACFF0060F7213D7BF3C7fEC78DF847DE1')).toBe('0xA3D...47DE1')
+        })
+
+        it('truncates using custom separator', () => {
+            expect(all.truncate('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1/path/to/stream', {
+                separator: '---',
+            })).toBe('0xa3d---47De1/path/to/stream')
+        })
+
+        it('truncates transaction hash', () => {
+            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2c283b6d35cf41fe9c95b1e606ff1'))
+                .toBe('0x8b5...06ff1')
+        })
+
+        it('truncates to custom length', () => {
+            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2c283b6d35cf41fe9c95b1e606ff1', {
+                length: 10,
+            }))
+                .toBe('0x8b549d15...5b1e606ff1')
+
+            expect(all.truncate('address is 0x8b549d1526d0f6168eed061041d6cb5243c2c283b6d35cf41fe9c95b1e606ff1 inside text', {
+                length: 10,
+            }))
+                .toBe('address is 0x8b549d15...5b1e606ff1 inside text')
         })
     })
 


### PR DESCRIPTION
Replaces the old `truncate` method so that it will replace any instance of an ETH address or transaction hash and truncate it given length. By default, the format is first 5 characters, ellipsis, 5 last characters which applied to all addresses and stream paths. The expection is the transaction hash, which i left at 10 chars per "side".

Let me know if I missed any 👍 