### PR TITLE
[FRONT-214] Handle route params before replacing variables

### DIFF
--- a/app/src/routes/routes.test.js
+++ b/app/src/routes/routes.test.js
@@ -103,6 +103,7 @@ describe('route utils', () => {
     describe('define', () => {
         const r = (pathstr, ...args) => define(pathstr, () => ({
             url: 'url',
+            urlWithPort: 'http://localhost:80',
         }))(...args)
 
         it('renders urls correctly', () => {
@@ -211,6 +212,12 @@ describe('route utils', () => {
                 expect(() => r('<var1>/<var2>/resource/:id', {
                     id: 1,
                 })).toThrow(/expected "var1", "var2" variable\(s\) to be defined/i)
+            })
+
+            it('returns a route with port in variable', () => {
+                expect(r('<urlWithPort>/resource/:id', {
+                    id: 1,
+                })).toEqual('http://localhost:80/resource/1')
             })
         })
     })


### PR DESCRIPTION
This PR addresses the error of defining a variable with a port:

```js
define('<api>/resource', () => ({
     api: 'http://localhost:80',
}))
```

This causes an error `Uncaught TypeError: Expected “80” to be a string` when the route is generated.

Fixed by reversing the route generation so that the route params are parsed first and then replacing the external variables.