### PR TITLE
[FRONT-228] Copy private key without 0x prefix

### DIFF
--- a/app/src/userpages/components/ProfilePage/IdentityHandler/CopyPrivateKeyDialog/index.jsx
+++ b/app/src/userpages/components/ProfilePage/IdentityHandler/CopyPrivateKeyDialog/index.jsx
@@ -46,7 +46,7 @@ const CopyPrivateKeyDialog = ({ onClose: onCloseProp, privateKey }: Props) => {
 
     const onKeyCopy = useCallback(() => {
         setCopiedOnce(true)
-        copy(privateKey)
+        copy(privateKey.slice(2))
     }, [copy, privateKey])
 
     const onClose = useCallback(() => {


### PR DESCRIPTION
> When creating a new Ethereum account via the profile page, the copy private key button at the end of the wizard copies the address with the "0x" prefix. This is not wrong, but the "0x" is usually omitted for private key hex representations to clearly distinguish it from addresses. We could follow this convention.

Fixes private key copying.