### PR TITLE
[FRONT-230] Remove hardcoded gas limits

### DIFF
--- a/app/src/marketplace/modules/contractProduct/services.js
+++ b/app/src/marketplace/modules/contractProduct/services.js
@@ -16,7 +16,7 @@ import {
 import type { WhitelistItem } from '$mp/modules/contractProduct/types'
 
 import { getWeb3, getPublicWeb3 } from '$shared/web3/web3Provider'
-import { contractCurrencies as currencies, gasLimits } from '$shared/utils/constants'
+import { contractCurrencies as currencies } from '$shared/utils/constants'
 
 const contractMethods = (usePublicNode: boolean = false) => getContract(getConfig().marketplace, usePublicNode).methods
 
@@ -165,9 +165,7 @@ const createContractProductWithoutWhitelist = (product: SmartContractProduct): S
         currencyIndex,
         minimumSubscriptionInSeconds,
     )
-    return send(methodToSend, {
-        gas: gasLimits.CREATE_PRODUCT,
-    })
+    return send(methodToSend)
 }
 
 const createContractProductWithWhitelist = (product: SmartContractProduct): SmartContractTransaction => {
@@ -191,9 +189,7 @@ const createContractProductWithWhitelist = (product: SmartContractProduct): Smar
         currencyIndex,
         minimumSubscriptionInSeconds,
     )
-    return send(methodToSend, {
-        gas: gasLimits.CREATE_PRODUCT,
-    })
+    return send(methodToSend)
 }
 
 export const createContractProduct = (product: SmartContractProduct): SmartContractTransaction => {
@@ -225,15 +221,11 @@ export const updateContractProduct = (product: SmartContractProduct, redeploy: b
         minimumSubscriptionInSeconds,
         redeploy,
     )
-    return send(methodToSend, {
-        gas: gasLimits.UPDATE_PRODUCT,
-    })
+    return send(methodToSend)
 }
 
 export const deleteProduct = (id: ProductId): SmartContractTransaction => (
-    send(contractMethods().deleteProduct(getValidId(id)), {
-        gas: gasLimits.DELETE_PRODUCT,
-    })
+    send(contractMethods().deleteProduct(getValidId(id)))
 )
 
 export const redeployProduct = (id: ProductId): SmartContractTransaction => (
@@ -241,27 +233,19 @@ export const redeployProduct = (id: ProductId): SmartContractTransaction => (
 )
 
 export const setRequiresWhitelist = (id: ProductId, requiresWhitelist: boolean): SmartContractTransaction => (
-    send(contractMethods(false).setRequiresWhitelist(getValidId(id), requiresWhitelist), {
-        gas: gasLimits.SET_REQUIRES_WHITELIST,
-    })
+    send(contractMethods(false).setRequiresWhitelist(getValidId(id), requiresWhitelist))
 )
 
 export const whitelistApprove = (id: ProductId, address: Address): SmartContractTransaction => (
-    send(contractMethods(false).whitelistApprove(getValidId(id), address), {
-        gas: gasLimits.WHITELIST_OPERATION,
-    })
+    send(contractMethods(false).whitelistApprove(getValidId(id), address))
 )
 
 export const whitelistReject = (id: ProductId, address: Address): SmartContractTransaction => (
-    send(contractMethods(false).whitelistReject(getValidId(id), address), {
-        gas: gasLimits.WHITELIST_OPERATION,
-    })
+    send(contractMethods(false).whitelistReject(getValidId(id), address))
 )
 
 export const whitelistRequest = (id: ProductId, address: Address): SmartContractTransaction => (
-    send(contractMethods(false).whitelistRequest(getValidId(id), address), {
-        gas: gasLimits.WHITELIST_OPERATION,
-    })
+    send(contractMethods(false).whitelistRequest(getValidId(id), address))
 )
 
 export const getWhitelistAddresses = async (id: ProductId, usePublicNode: boolean = true): Promise<Array<WhitelistItem>> => {

--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -8,7 +8,6 @@ import type { Stream, NewStream } from '$shared/flowtype/stream-types'
 import type { ProductId, DataUnionId } from '$mp/flowtype/product-types'
 import type { Permission } from '$userpages/flowtype/permission-types'
 import type { ApiResult } from '$shared/flowtype/common-types'
-import { gasLimits } from '$shared/utils/constants'
 
 import { post, del, get, put } from '$shared/utils/api'
 import { postStream, getStream } from '$userpages/modules/userPageStreams/services'
@@ -186,9 +185,7 @@ export const getAdminFee = async (address: DataUnionId, usePublicNode: boolean =
 }
 
 export const setAdminFee = (address: DataUnionId, adminFee: number): SmartContractTransaction => (
-    send(getCommunityContract(address).methods.setAdminFee(getAdminFeeInEther(adminFee)), {
-        gas: gasLimits.UPDATE_ADMIN_FEE,
-    })
+    send(getCommunityContract(address).methods.setAdminFee(getAdminFeeInEther(adminFee)))
 )
 
 export const getJoinPartStreamId = (address: DataUnionId, usePublicNode: boolean = false) =>

--- a/app/src/marketplace/modules/product/services.js
+++ b/app/src/marketplace/modules/product/services.js
@@ -154,7 +154,6 @@ export const buyProduct = (
                 subscriptionInSeconds.toString(),
                 ONE_DAY,
             ), {
-                gas: gasLimits.BUY_PRODUCT_WITH_ETH,
                 value: web3.utils.toWei(price.toString()).toString(),
             })
         case paymentCurrencies.DAI:
@@ -169,9 +168,7 @@ export const buyProduct = (
             })
 
         default: // Pay with DATA
-            return send(marketplaceContractMethods().buy(getValidId(id), subscriptionInSeconds.toString()), {
-                gas: gasLimits.BUY_PRODUCT,
-            })
+            return send(marketplaceContractMethods().buy(getValidId(id), subscriptionInSeconds.toString()))
     }
 }
 
@@ -188,9 +185,7 @@ export const setMyDataAllowance = (amount: string | BN): SmartContractTransactio
     }
 
     const method = dataTokenContractMethods().approve(marketplaceContract().options.address, toAtto(amount).toFixed(0))
-    return send(method, {
-        gas: gasLimits.APPROVE,
-    })
+    return send(method)
 }
 
 export const getMyDaiAllowance = (): SmartContractCall<BN> => {
@@ -206,7 +201,5 @@ export const setMyDaiAllowance = (amount: string | BN): SmartContractTransaction
     }
 
     const method = daiTokenContractMethods().approve(process.env.UNISWAP_ADAPTOR_CONTRACT_ADDRESS, toAtto(amount).toFixed(0))
-    return send(method, {
-        gas: gasLimits.APPROVE,
-    })
+    return send(method)
 }

--- a/app/src/marketplace/utils/smartContract.js
+++ b/app/src/marketplace/utils/smartContract.js
@@ -23,7 +23,6 @@ import type { NumberString } from '$shared/flowtype/common-types'
 
 import Transaction from '$shared/utils/Transaction'
 import DeployTransaction from '$shared/utils/DeployTransaction'
-import { gasLimits } from '$shared/utils/constants'
 import type { Product, SmartContractProduct } from '../flowtype/product-types'
 import { arePricesEqual } from '../utils/price'
 
@@ -95,7 +94,7 @@ export const send = (method: Sendable, options?: {
     ])
         .then(([account]) => (
             method.send({
-                gas: (options && options.gas) || gasLimits.DEFAULT,
+                gas: (options && options.gas) || undefined,
                 from: account,
                 value: options && options.value,
             })
@@ -150,7 +149,7 @@ export const deploy = (contract: SmartContractMetadata, args: Array<any>, option
             })
             return deployer
                 .send({
-                    gas: (options && options.gas) || gasLimits.DEPLOY_DATA_UNION,
+                    gas: (options && options.gas) || undefined,
                     from: account,
                 })
                 .on('error', errorHandler)

--- a/app/src/marketplace/utils/smartContract.js
+++ b/app/src/marketplace/utils/smartContract.js
@@ -94,7 +94,7 @@ export const send = (method: Sendable, options?: {
     ])
         .then(([account]) => (
             method.send({
-                gas: (options && options.gas) || undefined,
+                gas: (options && options.gas),
                 from: account,
                 value: options && options.value,
             })
@@ -149,7 +149,7 @@ export const deploy = (contract: SmartContractMetadata, args: Array<any>, option
             })
             return deployer
                 .send({
-                    gas: (options && options.gas) || undefined,
+                    gas: (options && options.gas),
                     from: account,
                 })
                 .on('error', errorHandler)

--- a/app/src/shared/utils/constants.js
+++ b/app/src/shared/utils/constants.js
@@ -74,18 +74,18 @@ export const transactionTypes = {
 }
 
 export const gasLimits = {
-    DEFAULT: 3e5,
-    CREATE_PRODUCT: 4e5,
-    UPDATE_PRODUCT: 3e5,
+    // DEFAULT: 3e5,
+    // CREATE_PRODUCT: 4e5,
+    // UPDATE_PRODUCT: 3e5,
     BUY_PRODUCT: 3e5,
-    BUY_PRODUCT_WITH_ETH: 5e5,
+    // BUY_PRODUCT_WITH_ETH: 5e5,
     BUY_PRODUCT_WITH_ERC20: 6e5,
-    DELETE_PRODUCT: 3e5,
+    // DELETE_PRODUCT: 3e5,
     APPROVE: 7e4,
-    DEPLOY_DATA_UNION: 4e6,
-    UPDATE_ADMIN_FEE: 4e5,
-    SET_REQUIRES_WHITELIST: 1e5,
-    WHITELIST_OPERATION: 1e5,
+    // DEPLOY_DATA_UNION: 4e6,
+    // UPDATE_ADMIN_FEE: 4e5,
+    // SET_REQUIRES_WHITELIST: 1e5,
+    // WHITELIST_OPERATION: 1e5,
 }
 
 export const dialogAutoCloseTimeout = 2000 // in milliseconds

--- a/app/src/shared/utils/constants.js
+++ b/app/src/shared/utils/constants.js
@@ -74,18 +74,9 @@ export const transactionTypes = {
 }
 
 export const gasLimits = {
-    // DEFAULT: 3e5,
-    // CREATE_PRODUCT: 4e5,
-    // UPDATE_PRODUCT: 3e5,
     BUY_PRODUCT: 3e5,
-    // BUY_PRODUCT_WITH_ETH: 5e5,
     BUY_PRODUCT_WITH_ERC20: 6e5,
-    // DELETE_PRODUCT: 3e5,
     APPROVE: 7e4,
-    // DEPLOY_DATA_UNION: 4e6,
-    // UPDATE_ADMIN_FEE: 4e5,
-    // SET_REQUIRES_WHITELIST: 1e5,
-    // WHITELIST_OPERATION: 1e5,
 }
 
 export const dialogAutoCloseTimeout = 2000 // in milliseconds


### PR DESCRIPTION
Here are results of testing MetaMask gas limit estimation:

Operation | Hardcoded value | MetaMask estimate
-- | -- | --
Deploy data union | 4 000 000 | 4 242 412
Publish product | 400 000 | 237 276
Unpublish product | 300 000 | 74 178
Update product | 300 000 | 79 182
Update DU admin fee | 400 000 | 43 972
Buy product with DATA | 300 000 | 140 668
Buy product with ETH | 500 000 | 273 357
Buy product with DAI | 600 000 | 7 600 000
Whitelist enable/disable | 100 000 | 61 975
Whitelist add/remove address | 100 000 | 64 251

DU deploy estimate is only a bit higher than our hardcoded value. Buying product with DAI (or other ERC20) estimate is crazy probably due to Uniswap. We should keep our hardcoded value there.

Other values are a good 👍

PS. This was tested on local Parity network but I checked that estimates were exactly same on Mainnet at least for those couple operations I tried.