### PR TITLE
[FRONT-246] Fix deprecated web3 notification in Metamask

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -39185,23 +39185,60 @@
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
     "web3": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.4-rc.2.tgz",
-      "integrity": "sha512-fOfrN3NP2Ze+zzQMDR6T6st0acGvyuwxFPhZ8Fk50pU4cJXj6HNrtn/rqrh0eRLQn45VzuyFU2LOjxr+y1lsrw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.3.tgz",
+      "integrity": "sha512-fI/g0yC1FC0m4envv8FsPh7tbBoe/eXbEho+iY/hahs7YGgGt3nYNrAFTkR9pLhQaVMpOilhwgFxXEp+O7My/g==",
       "requires": {
-        "web3-bzz": "1.3.4-rc.2",
-        "web3-core": "1.3.4-rc.2",
-        "web3-eth": "1.3.4-rc.2",
-        "web3-eth-personal": "1.3.4-rc.2",
-        "web3-net": "1.3.4-rc.2",
-        "web3-shh": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
+        "web3-bzz": "1.3.3",
+        "web3-core": "1.3.3",
+        "web3-eth": "1.3.3",
+        "web3-eth-personal": "1.3.3",
+        "web3-net": "1.3.3",
+        "web3-shh": "1.3.3",
+        "web3-utils": "1.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-bzz": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.4-rc.2.tgz",
-      "integrity": "sha512-TbeR4CkdlvWvtrJeKSyrEPzrvxcWAllciyRlvtJL8EJMCmyXlH/J/8ZZrWzpKCPw58WuMER5zcZ13D7/7q9pkQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.3.tgz",
+      "integrity": "sha512-lFERlqnr/upJhADT6US7BGUkM5cy6idw86/GvWKo9h/uyrbV14gk+bUqcQdBBSopa1Mvvy5ZaO6rKtRe8PTsQw==",
       "requires": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
@@ -39215,9 +39252,9 @@
           "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
         },
         "@types/node": {
-          "version": "12.19.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-          "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
+          "version": "12.19.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
+          "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
         },
         "cacheable-request": {
           "version": "6.1.0",
@@ -39305,58 +39342,167 @@
       }
     },
     "web3-core": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.4-rc.2.tgz",
-      "integrity": "sha512-mL/JeYF0orZsgsU3pTk1PnF55HdVLYSb0Te+xOL99KWlQbojONA42h3rws55rY6EU0JveCBtW1sIgl+3QJQpog==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.3.tgz",
+      "integrity": "sha512-hCDWj/3PBHhSJSSBi+nV7MiW9Djf/pRuUXcVO2jWroAXqAbTSXLHpju0AWTzXnlsqs1QHK0Yk8nF9jojGUQVYg==",
       "requires": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.3.4-rc.2",
-        "web3-core-method": "1.3.4-rc.2",
-        "web3-core-requestmanager": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
+        "web3-core-helpers": "1.3.3",
+        "web3-core-method": "1.3.3",
+        "web3-core-requestmanager": "1.3.3",
+        "web3-utils": "1.3.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-          "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
+          "version": "12.19.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
+          "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
         },
         "bignumber.js": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
           "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.4-rc.2.tgz",
-      "integrity": "sha512-VfmI048cSqdFxcxLF67x6SKVzQ+2n8DkzqDrWgtLa5PT+SGkgftFDROwS1A0AeX06Qg/BN2V+EbrCd+WLCNHRg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.3.tgz",
+      "integrity": "sha512-rUTC9sgn1Wvw2KGBtc9/bsQKUd+yjzIm14mlaqqiO0vpFueTmmagwiGRE2CWzEfYg+r2jnYIIgh9qnsCykgVkQ==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-eth-iban": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
+        "web3-eth-iban": "1.3.3",
+        "web3-utils": "1.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-method": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.4-rc.2.tgz",
-      "integrity": "sha512-wYSmgUSsAGLPQ9vm4UUE0P+OPegt/Ptbhoj1/1qdFzdddpDYdj1J3jPbEiWEAbtQBF0rewJxKSMVzup3JIcZZg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.3.tgz",
+      "integrity": "sha512-d3AA1lyw0dvLs53X17pHpD5QpxJdkfolbN31UQymRF5Y+swFweqRiCuJoNTplE95ZX2uUtsLhEIbaszj7dQgFg==",
       "requires": {
         "@ethersproject/transactions": "^5.0.0-beta.135",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.3.4-rc.2",
-        "web3-core-promievent": "1.3.4-rc.2",
-        "web3-core-subscriptions": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
+        "web3-core-helpers": "1.3.3",
+        "web3-core-promievent": "1.3.3",
+        "web3-core-subscriptions": "1.3.3",
+        "web3-utils": "1.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-promievent": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.4-rc.2.tgz",
-      "integrity": "sha512-GpUbOTgdxZGlad1pUuXaECuzVsQY1Em9HB4AZ7sDjZlv0SSJ3a7CM7Nx1PKtpUnZmV7+rSL6yJe+A61IQoRokw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.3.tgz",
+      "integrity": "sha512-ARgO+BWUCxK8U/977SdJ8oyJo51mDYUzlZFoa2NFjUH+QYrFoKA7l9Hhw/vxhy13jE2LaVUM31JBLzVb+GM9dQ==",
       "requires": {
         "eventemitter3": "4.0.4"
       },
@@ -39369,16 +39515,16 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.4-rc.2.tgz",
-      "integrity": "sha512-1wIIhnp+Lffpo3tkZI6XsN6nMEUG8ep0XCkkLRiSWe3vKeXMOkROa4T5t9tIw6sQPsXgQfb2x5DeL3K0tIUDEQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.3.tgz",
+      "integrity": "sha512-4/J23wK5IXRw/1kqda7FXtvySKjX7Phcevqjx0EkcBtrxAfLedcqf8k2PlDh5LtCXfPW66u4V3fDgHdLZMrVgQ==",
       "requires": {
         "underscore": "1.9.1",
         "util": "^0.12.0",
-        "web3-core-helpers": "1.3.4-rc.2",
-        "web3-providers-http": "1.3.4-rc.2",
-        "web3-providers-ipc": "1.3.4-rc.2",
-        "web3-providers-ws": "1.3.4-rc.2"
+        "web3-core-helpers": "1.3.3",
+        "web3-providers-http": "1.3.3",
+        "web3-providers-ipc": "1.3.3",
+        "web3-providers-ws": "1.3.3"
       },
       "dependencies": {
         "util": {
@@ -39397,13 +39543,13 @@
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.4-rc.2.tgz",
-      "integrity": "sha512-GN44xEFwwj3oLtydhfLMYEj+MxpBY7wx46XPuHO61zTySUGvbKFBbfDSCP71zPx15b81IJzOopntQt2wpqOTOg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.3.tgz",
+      "integrity": "sha512-VvcPuNYcGLb6HfgMrNN6Q/1CwSk2uIqUjhrVTQ67JIxIddsEdV1f6SsQH9MX1cmwi39ffGsYtssOT1pht4Zc8g==",
       "requires": {
         "eventemitter3": "4.0.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.3.4-rc.2"
+        "web3-core-helpers": "1.3.3"
       },
       "dependencies": {
         "eventemitter3": {
@@ -39414,69 +39560,23 @@
       }
     },
     "web3-eth": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.4-rc.2.tgz",
-      "integrity": "sha512-EtMh7q+WuqPyjX6NVioD191YefczNnAY4Um+oLxsrhCn0KtsK39vAJU60ecMmS7KAWBbvMFXELSFU5MYBxnCFA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.3.tgz",
+      "integrity": "sha512-NvbkCaN26o7f9EogsRsA/lbwF+8dXimJWsaGpZK3ANa+AZrYkWj3NuaxfPO/S/RLsC9ptJdt7id72qxT40r5QQ==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core": "1.3.4-rc.2",
-        "web3-core-helpers": "1.3.4-rc.2",
-        "web3-core-method": "1.3.4-rc.2",
-        "web3-core-subscriptions": "1.3.4-rc.2",
-        "web3-eth-abi": "1.3.4-rc.2",
-        "web3-eth-accounts": "1.3.4-rc.2",
-        "web3-eth-contract": "1.3.4-rc.2",
-        "web3-eth-ens": "1.3.4-rc.2",
-        "web3-eth-iban": "1.3.4-rc.2",
-        "web3-eth-personal": "1.3.4-rc.2",
-        "web3-net": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.4-rc.2.tgz",
-      "integrity": "sha512-XlzL32uhK3ymgdFGTOpBdCWLpBT3S3Zs26mU3pRWbVjAGRJhy43qeMKBz0eJelw9bZe0hkav5ZiYqIZ0SCfGiA==",
-      "requires": {
-        "@ethersproject/abi": "5.0.7",
-        "underscore": "1.9.1",
-        "web3-utils": "1.3.4-rc.2"
-      },
-      "dependencies": {
-        "@ethersproject/abi": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
-          "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
-          "requires": {
-            "@ethersproject/address": "^5.0.4",
-            "@ethersproject/bignumber": "^5.0.7",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.4",
-            "@ethersproject/hash": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/strings": "^5.0.4"
-          }
-        }
-      }
-    },
-    "web3-eth-accounts": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.4-rc.2.tgz",
-      "integrity": "sha512-WKhexEUs2+FG8t6UGyxTJ96GASHN7zyM6mtLjwx5/GV0lVOeeQsSdMqGh6yLg1YMIHT/SuF5CXmrXzU39Vjhnw==",
-      "requires": {
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "ethereumjs-common": "^1.3.2",
-        "ethereumjs-tx": "^2.1.1",
-        "scrypt-js": "^3.0.1",
-        "underscore": "1.9.1",
-        "uuid": "3.3.2",
-        "web3-core": "1.3.4-rc.2",
-        "web3-core-helpers": "1.3.4-rc.2",
-        "web3-core-method": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
+        "web3-core": "1.3.3",
+        "web3-core-helpers": "1.3.3",
+        "web3-core-method": "1.3.3",
+        "web3-core-subscriptions": "1.3.3",
+        "web3-eth-abi": "1.3.3",
+        "web3-eth-accounts": "1.3.3",
+        "web3-eth-contract": "1.3.3",
+        "web3-eth-ens": "1.3.3",
+        "web3-eth-iban": "1.3.3",
+        "web3-eth-personal": "1.3.3",
+        "web3-net": "1.3.3",
+        "web3-utils": "1.3.3"
       },
       "dependencies": {
         "bn.js": {
@@ -39494,78 +39594,355 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
-    "web3-eth-contract": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.4-rc.2.tgz",
-      "integrity": "sha512-qMv9ZxLNkJGJpdFE4kg5wgf8O+76GAHy4yY6w4lgya22xWMlfScpyx/f26auBor4MKmOX0uRaB7PZ5Dquz+pTA==",
+    "web3-eth-abi": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.3.tgz",
+      "integrity": "sha512-9GQ7YTALt1uxGwdMBpBHlagCj4yn0fPUT2wDDAGoyJFVJMsUt3arF855zsVpJL3zfhHmUgRNoVrAkobRR2YYLw==",
       "requires": {
-        "@types/bn.js": "^4.11.5",
+        "@ethersproject/abi": "5.0.7",
         "underscore": "1.9.1",
-        "web3-core": "1.3.4-rc.2",
-        "web3-core-helpers": "1.3.4-rc.2",
-        "web3-core-method": "1.3.4-rc.2",
-        "web3-core-promievent": "1.3.4-rc.2",
-        "web3-core-subscriptions": "1.3.4-rc.2",
-        "web3-eth-abi": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
+        "web3-utils": "1.3.3"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+          "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
-    "web3-eth-ens": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.4-rc.2.tgz",
-      "integrity": "sha512-vIFYq6Vz+gewM56v0M0wm2ynIA2Wdmurqz1GvYwOxm0u1P66PSclgUGkZ169S4fQogKZo3evgl8y5vsQG8gpfw==",
+    "web3-eth-accounts": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.3.tgz",
+      "integrity": "sha512-Jn9nguNsCLnY7Po6lv7Mg5JDaYuKdvL0Ezv1V2LTLy+EhcVt5i19h+/3M92Xynpe5Tx+WY/ELfeA2jLTeP5jRg==",
       "requires": {
-        "content-hash": "^2.5.2",
-        "eth-ens-namehash": "2.0.8",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "ethereumjs-common": "^1.3.2",
+        "ethereumjs-tx": "^2.1.1",
+        "scrypt-js": "^3.0.1",
         "underscore": "1.9.1",
-        "web3-core": "1.3.4-rc.2",
-        "web3-core-helpers": "1.3.4-rc.2",
-        "web3-core-promievent": "1.3.4-rc.2",
-        "web3-eth-abi": "1.3.4-rc.2",
-        "web3-eth-contract": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.4-rc.2.tgz",
-      "integrity": "sha512-n/pn7PFxUBfiLC2kUuBoovzS4K8wPoz0ptqaxhwyH0zTq2YiTfGtuPWOMm6Un6cXyenjLw2+FXLSe5NL/xQwog==",
-      "requires": {
-        "bn.js": "^4.11.9",
-        "web3-utils": "1.3.4-rc.2"
+        "uuid": "3.3.2",
+        "web3-core": "1.3.3",
+        "web3-core-helpers": "1.3.3",
+        "web3-core-method": "1.3.3",
+        "web3-utils": "1.3.3"
       },
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-contract": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.3.tgz",
+      "integrity": "sha512-TKGs1qvc/v7TriyGKtnTqVrB3J/mWSeqLkWtLY60lGqY8KopZ9k7dZ/g5Cvfiox57VHWkpOk0xDwUQjlIe4Ikg==",
+      "requires": {
+        "@types/bn.js": "^4.11.5",
+        "underscore": "1.9.1",
+        "web3-core": "1.3.3",
+        "web3-core-helpers": "1.3.3",
+        "web3-core-method": "1.3.3",
+        "web3-core-promievent": "1.3.3",
+        "web3-core-subscriptions": "1.3.3",
+        "web3-eth-abi": "1.3.3",
+        "web3-utils": "1.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-ens": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.3.tgz",
+      "integrity": "sha512-tresrI1CM6RbxsUCM6kfG1W10LDMqWJnU+lNhfaD5mt5IzJ4GcfDAHO9WzoYl8Esh+Epj/jD+vI30clI4j90Vg==",
+      "requires": {
+        "content-hash": "^2.5.2",
+        "eth-ens-namehash": "2.0.8",
+        "underscore": "1.9.1",
+        "web3-core": "1.3.3",
+        "web3-core-helpers": "1.3.3",
+        "web3-core-promievent": "1.3.3",
+        "web3-eth-abi": "1.3.3",
+        "web3-eth-contract": "1.3.3",
+        "web3-utils": "1.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.3.tgz",
+      "integrity": "sha512-+9a+bZHAKQ4oBcRxiGbC1MC8S2cOgDlXo8qcw0XpMhLJZ3c/brZM7ZbPdiuU8Z7AMYf3PknaGFQyVmedZhrauA==",
+      "requires": {
+        "bn.js": "^4.11.9",
+        "web3-utils": "1.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-eth-personal": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.4-rc.2.tgz",
-      "integrity": "sha512-WPIS9TkX+mTGTmn8mvmL+vUcY6maxdm7ix6FGT9Mz35x8HIycjkeNf9NUtLMD2JVEFs78r3Eo33t/hA8UuT5CA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.3.tgz",
+      "integrity": "sha512-S/TSGTm7x9oHRXUHXi8f+y187RKpn5aqYJRlSoyTmB3B4EMrv9NcZZQmHaiXwM48wkFdRhTMECW1Ar8E5zZLFw==",
       "requires": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.3.4-rc.2",
-        "web3-core-helpers": "1.3.4-rc.2",
-        "web3-core-method": "1.3.4-rc.2",
-        "web3-net": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
+        "web3-core": "1.3.3",
+        "web3-core-helpers": "1.3.3",
+        "web3-core-method": "1.3.3",
+        "web3-net": "1.3.3",
+        "web3-utils": "1.3.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-          "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
+          "version": "12.19.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
+          "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -39575,42 +39952,79 @@
       "integrity": "sha1-JarudSSGTFSyaSm123JdKSV6+DI="
     },
     "web3-net": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.4-rc.2.tgz",
-      "integrity": "sha512-Ziviwp3cXSQvLzv7dYwFd+yBp2KYqt6G7iH8kP3NC9ZzzSKZYjFe6KOOf5hFObC9kI9OUaREQaoQHIQ6AJAwCw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.3.tgz",
+      "integrity": "sha512-GcPj2lyAC5CP6FOCwoURCRMFsh0khWBi6sGqiKtUPMa7dKnLw8CLCAFcwX//d3ucnn1E7I78Va6k8liKjj87sA==",
       "requires": {
-        "web3-core": "1.3.4-rc.2",
-        "web3-core-method": "1.3.4-rc.2",
-        "web3-utils": "1.3.4-rc.2"
+        "web3-core": "1.3.3",
+        "web3-core-method": "1.3.3",
+        "web3-utils": "1.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
+          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-providers-http": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.4-rc.2.tgz",
-      "integrity": "sha512-0qmbnv2oC6JqlPGvzV4IklMOwZaZouRF/YPf6tsKVmU8EIRZq6idjgtWFpqj2swVHeheSrnbEuyVuCPCCW7Rsg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.3.tgz",
+      "integrity": "sha512-V2x27IFXQqsaZrAbA4GJurKuyrNXapmmpSJ7jxPDOxewOy9dEURlKIg5W1bb4QXGh2YSCksuH9fKquvTfPfc/A==",
       "requires": {
-        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-helpers": "1.3.3",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.4-rc.2.tgz",
-      "integrity": "sha512-uCElMBq5QR0aMtG6sp1xAXKP8bT1p2lcYfl83jSMM5ieQvqgo2Auvug9znib8b3B5DFC9Bz0T6WQN3Ea4h/+OA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.3.tgz",
+      "integrity": "sha512-XMQo/YsH/2lBaRlkYa5d/Q+2EJ2RTzVjio1i2G9TESESfHCj0l2AWLb3zet+f/QRVxfvXGmGlZuf99diof2a1g==",
       "requires": {
         "oboe": "2.1.5",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.3.4-rc.2"
+        "web3-core-helpers": "1.3.3"
       }
     },
     "web3-providers-ws": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.4-rc.2.tgz",
-      "integrity": "sha512-8CxMI8mz7G1i5iViEjoB21SQRurOy/K3PBj1BwvCqneUjMy1RM9QHHuQS/v+9N18JNs6q8PuEjEYLgMS/AzlHA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.3.tgz",
+      "integrity": "sha512-yuzqB3jST9JS19oOR1FRaARM7JBeP6cbKffM8HoWp4Y98/OowjW1mbDQVS47YTSHBP2QiLzSrwBxjIEPm8f48Q==",
       "requires": {
         "eventemitter3": "4.0.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-helpers": "1.3.3",
         "websocket": "^1.0.32"
       },
       "dependencies": {
@@ -39622,14 +40036,14 @@
       }
     },
     "web3-shh": {
-      "version": "1.3.4-rc.2",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.4-rc.2.tgz",
-      "integrity": "sha512-tyVEN0sKTFFO+Q+GS4fvwJcAOPSqrpsYliyd3+NepmgKR54vOqAtzC2WBE4xhtmXByWVRVTAQ/TIlbk6T1JG6w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.3.tgz",
+      "integrity": "sha512-byp2+sHnc8UAj6sNcVFacF3pmRzIaMATsI4ARfU+0S8EpaQ3trojww2QBYPnZ4r0QOMH+I6+bVl8qTu0Zz4eoA==",
       "requires": {
-        "web3-core": "1.3.4-rc.2",
-        "web3-core-method": "1.3.4-rc.2",
-        "web3-core-subscriptions": "1.3.4-rc.2",
-        "web3-net": "1.3.4-rc.2"
+        "web3-core": "1.3.3",
+        "web3-core-method": "1.3.3",
+        "web3-core-subscriptions": "1.3.3",
+        "web3-net": "1.3.3"
       }
     },
     "web3-utils": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9220,7 +9220,7 @@
       "dependencies": {
         "babylon": {
           "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
           "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
         }
       }
@@ -9252,7 +9252,7 @@
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
@@ -9716,12 +9716,12 @@
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-flow-comments": {
@@ -10546,7 +10546,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -12630,7 +12630,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -12642,7 +12642,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -14172,7 +14172,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -18482,7 +18482,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "requires": {
         "html-minifier": "^3.2.3",
@@ -19713,7 +19713,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
@@ -34035,7 +34035,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -37971,7 +37971,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -39185,60 +39185,23 @@
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
     "web3": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.3.tgz",
-      "integrity": "sha512-fI/g0yC1FC0m4envv8FsPh7tbBoe/eXbEho+iY/hahs7YGgGt3nYNrAFTkR9pLhQaVMpOilhwgFxXEp+O7My/g==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.4-rc.2.tgz",
+      "integrity": "sha512-fOfrN3NP2Ze+zzQMDR6T6st0acGvyuwxFPhZ8Fk50pU4cJXj6HNrtn/rqrh0eRLQn45VzuyFU2LOjxr+y1lsrw==",
       "requires": {
-        "web3-bzz": "1.3.3",
-        "web3-core": "1.3.3",
-        "web3-eth": "1.3.3",
-        "web3-eth-personal": "1.3.3",
-        "web3-net": "1.3.3",
-        "web3-shh": "1.3.3",
-        "web3-utils": "1.3.3"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-bzz": "1.3.4-rc.2",
+        "web3-core": "1.3.4-rc.2",
+        "web3-eth": "1.3.4-rc.2",
+        "web3-eth-personal": "1.3.4-rc.2",
+        "web3-net": "1.3.4-rc.2",
+        "web3-shh": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       }
     },
     "web3-bzz": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.3.tgz",
-      "integrity": "sha512-lFERlqnr/upJhADT6US7BGUkM5cy6idw86/GvWKo9h/uyrbV14gk+bUqcQdBBSopa1Mvvy5ZaO6rKtRe8PTsQw==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.4-rc.2.tgz",
+      "integrity": "sha512-TbeR4CkdlvWvtrJeKSyrEPzrvxcWAllciyRlvtJL8EJMCmyXlH/J/8ZZrWzpKCPw58WuMER5zcZ13D7/7q9pkQ==",
       "requires": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
@@ -39342,17 +39305,17 @@
       }
     },
     "web3-core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.3.tgz",
-      "integrity": "sha512-hCDWj/3PBHhSJSSBi+nV7MiW9Djf/pRuUXcVO2jWroAXqAbTSXLHpju0AWTzXnlsqs1QHK0Yk8nF9jojGUQVYg==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.4-rc.2.tgz",
+      "integrity": "sha512-mL/JeYF0orZsgsU3pTk1PnF55HdVLYSb0Te+xOL99KWlQbojONA42h3rws55rY6EU0JveCBtW1sIgl+3QJQpog==",
       "requires": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.3.3",
-        "web3-core-method": "1.3.3",
-        "web3-core-requestmanager": "1.3.3",
-        "web3-utils": "1.3.3"
+        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-method": "1.3.4-rc.2",
+        "web3-core-requestmanager": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       },
       "dependencies": {
         "@types/node": {
@@ -39364,145 +39327,36 @@
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
           "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-        },
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.3.tgz",
-      "integrity": "sha512-rUTC9sgn1Wvw2KGBtc9/bsQKUd+yjzIm14mlaqqiO0vpFueTmmagwiGRE2CWzEfYg+r2jnYIIgh9qnsCykgVkQ==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.4-rc.2.tgz",
+      "integrity": "sha512-VfmI048cSqdFxcxLF67x6SKVzQ+2n8DkzqDrWgtLa5PT+SGkgftFDROwS1A0AeX06Qg/BN2V+EbrCd+WLCNHRg==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-eth-iban": "1.3.3",
-        "web3-utils": "1.3.3"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-eth-iban": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       }
     },
     "web3-core-method": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.3.tgz",
-      "integrity": "sha512-d3AA1lyw0dvLs53X17pHpD5QpxJdkfolbN31UQymRF5Y+swFweqRiCuJoNTplE95ZX2uUtsLhEIbaszj7dQgFg==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.4-rc.2.tgz",
+      "integrity": "sha512-wYSmgUSsAGLPQ9vm4UUE0P+OPegt/Ptbhoj1/1qdFzdddpDYdj1J3jPbEiWEAbtQBF0rewJxKSMVzup3JIcZZg==",
       "requires": {
         "@ethersproject/transactions": "^5.0.0-beta.135",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.3.3",
-        "web3-core-promievent": "1.3.3",
-        "web3-core-subscriptions": "1.3.3",
-        "web3-utils": "1.3.3"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-promievent": "1.3.4-rc.2",
+        "web3-core-subscriptions": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       }
     },
     "web3-core-promievent": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.3.tgz",
-      "integrity": "sha512-ARgO+BWUCxK8U/977SdJ8oyJo51mDYUzlZFoa2NFjUH+QYrFoKA7l9Hhw/vxhy13jE2LaVUM31JBLzVb+GM9dQ==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.4-rc.2.tgz",
+      "integrity": "sha512-GpUbOTgdxZGlad1pUuXaECuzVsQY1Em9HB4AZ7sDjZlv0SSJ3a7CM7Nx1PKtpUnZmV7+rSL6yJe+A61IQoRokw==",
       "requires": {
         "eventemitter3": "4.0.4"
       },
@@ -39515,16 +39369,16 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.3.tgz",
-      "integrity": "sha512-4/J23wK5IXRw/1kqda7FXtvySKjX7Phcevqjx0EkcBtrxAfLedcqf8k2PlDh5LtCXfPW66u4V3fDgHdLZMrVgQ==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.4-rc.2.tgz",
+      "integrity": "sha512-1wIIhnp+Lffpo3tkZI6XsN6nMEUG8ep0XCkkLRiSWe3vKeXMOkROa4T5t9tIw6sQPsXgQfb2x5DeL3K0tIUDEQ==",
       "requires": {
         "underscore": "1.9.1",
         "util": "^0.12.0",
-        "web3-core-helpers": "1.3.3",
-        "web3-providers-http": "1.3.3",
-        "web3-providers-ipc": "1.3.3",
-        "web3-providers-ws": "1.3.3"
+        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-providers-http": "1.3.4-rc.2",
+        "web3-providers-ipc": "1.3.4-rc.2",
+        "web3-providers-ws": "1.3.4-rc.2"
       },
       "dependencies": {
         "util": {
@@ -39543,13 +39397,13 @@
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.3.tgz",
-      "integrity": "sha512-VvcPuNYcGLb6HfgMrNN6Q/1CwSk2uIqUjhrVTQ67JIxIddsEdV1f6SsQH9MX1cmwi39ffGsYtssOT1pht4Zc8g==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.4-rc.2.tgz",
+      "integrity": "sha512-GN44xEFwwj3oLtydhfLMYEj+MxpBY7wx46XPuHO61zTySUGvbKFBbfDSCP71zPx15b81IJzOopntQt2wpqOTOg==",
       "requires": {
         "eventemitter3": "4.0.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.3.3"
+        "web3-core-helpers": "1.3.4-rc.2"
       },
       "dependencies": {
         "eventemitter3": {
@@ -39560,70 +39414,33 @@
       }
     },
     "web3-eth": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.3.tgz",
-      "integrity": "sha512-NvbkCaN26o7f9EogsRsA/lbwF+8dXimJWsaGpZK3ANa+AZrYkWj3NuaxfPO/S/RLsC9ptJdt7id72qxT40r5QQ==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.4-rc.2.tgz",
+      "integrity": "sha512-EtMh7q+WuqPyjX6NVioD191YefczNnAY4Um+oLxsrhCn0KtsK39vAJU60ecMmS7KAWBbvMFXELSFU5MYBxnCFA==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core": "1.3.3",
-        "web3-core-helpers": "1.3.3",
-        "web3-core-method": "1.3.3",
-        "web3-core-subscriptions": "1.3.3",
-        "web3-eth-abi": "1.3.3",
-        "web3-eth-accounts": "1.3.3",
-        "web3-eth-contract": "1.3.3",
-        "web3-eth-ens": "1.3.3",
-        "web3-eth-iban": "1.3.3",
-        "web3-eth-personal": "1.3.3",
-        "web3-net": "1.3.3",
-        "web3-utils": "1.3.3"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-core": "1.3.4-rc.2",
+        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-method": "1.3.4-rc.2",
+        "web3-core-subscriptions": "1.3.4-rc.2",
+        "web3-eth-abi": "1.3.4-rc.2",
+        "web3-eth-accounts": "1.3.4-rc.2",
+        "web3-eth-contract": "1.3.4-rc.2",
+        "web3-eth-ens": "1.3.4-rc.2",
+        "web3-eth-iban": "1.3.4-rc.2",
+        "web3-eth-personal": "1.3.4-rc.2",
+        "web3-net": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       }
     },
     "web3-eth-abi": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.3.tgz",
-      "integrity": "sha512-9GQ7YTALt1uxGwdMBpBHlagCj4yn0fPUT2wDDAGoyJFVJMsUt3arF855zsVpJL3zfhHmUgRNoVrAkobRR2YYLw==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.4-rc.2.tgz",
+      "integrity": "sha512-XlzL32uhK3ymgdFGTOpBdCWLpBT3S3Zs26mU3pRWbVjAGRJhy43qeMKBz0eJelw9bZe0hkav5ZiYqIZ0SCfGiA==",
       "requires": {
         "@ethersproject/abi": "5.0.7",
         "underscore": "1.9.1",
-        "web3-utils": "1.3.3"
+        "web3-utils": "1.3.4-rc.2"
       },
       "dependencies": {
         "@ethersproject/abi": {
@@ -39641,48 +39458,13 @@
             "@ethersproject/properties": "^5.0.3",
             "@ethersproject/strings": "^5.0.4"
           }
-        },
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
         }
       }
     },
     "web3-eth-accounts": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.3.tgz",
-      "integrity": "sha512-Jn9nguNsCLnY7Po6lv7Mg5JDaYuKdvL0Ezv1V2LTLy+EhcVt5i19h+/3M92Xynpe5Tx+WY/ELfeA2jLTeP5jRg==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.4-rc.2.tgz",
+      "integrity": "sha512-WKhexEUs2+FG8t6UGyxTJ96GASHN7zyM6mtLjwx5/GV0lVOeeQsSdMqGh6yLg1YMIHT/SuF5CXmrXzU39Vjhnw==",
       "requires": {
         "crypto-browserify": "3.12.0",
         "eth-lib": "0.2.8",
@@ -39691,10 +39473,10 @@
         "scrypt-js": "^3.0.1",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
-        "web3-core": "1.3.3",
-        "web3-core-helpers": "1.3.3",
-        "web3-core-method": "1.3.3",
-        "web3-utils": "1.3.3"
+        "web3-core": "1.3.4-rc.2",
+        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-method": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       },
       "dependencies": {
         "bn.js": {
@@ -39711,238 +39493,79 @@
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
         },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
         }
       }
     },
     "web3-eth-contract": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.3.tgz",
-      "integrity": "sha512-TKGs1qvc/v7TriyGKtnTqVrB3J/mWSeqLkWtLY60lGqY8KopZ9k7dZ/g5Cvfiox57VHWkpOk0xDwUQjlIe4Ikg==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.4-rc.2.tgz",
+      "integrity": "sha512-qMv9ZxLNkJGJpdFE4kg5wgf8O+76GAHy4yY6w4lgya22xWMlfScpyx/f26auBor4MKmOX0uRaB7PZ5Dquz+pTA==",
       "requires": {
         "@types/bn.js": "^4.11.5",
         "underscore": "1.9.1",
-        "web3-core": "1.3.3",
-        "web3-core-helpers": "1.3.3",
-        "web3-core-method": "1.3.3",
-        "web3-core-promievent": "1.3.3",
-        "web3-core-subscriptions": "1.3.3",
-        "web3-eth-abi": "1.3.3",
-        "web3-utils": "1.3.3"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-core": "1.3.4-rc.2",
+        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-method": "1.3.4-rc.2",
+        "web3-core-promievent": "1.3.4-rc.2",
+        "web3-core-subscriptions": "1.3.4-rc.2",
+        "web3-eth-abi": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       }
     },
     "web3-eth-ens": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.3.tgz",
-      "integrity": "sha512-tresrI1CM6RbxsUCM6kfG1W10LDMqWJnU+lNhfaD5mt5IzJ4GcfDAHO9WzoYl8Esh+Epj/jD+vI30clI4j90Vg==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.4-rc.2.tgz",
+      "integrity": "sha512-vIFYq6Vz+gewM56v0M0wm2ynIA2Wdmurqz1GvYwOxm0u1P66PSclgUGkZ169S4fQogKZo3evgl8y5vsQG8gpfw==",
       "requires": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
         "underscore": "1.9.1",
-        "web3-core": "1.3.3",
-        "web3-core-helpers": "1.3.3",
-        "web3-core-promievent": "1.3.3",
-        "web3-eth-abi": "1.3.3",
-        "web3-eth-contract": "1.3.3",
-        "web3-utils": "1.3.3"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-core": "1.3.4-rc.2",
+        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-promievent": "1.3.4-rc.2",
+        "web3-eth-abi": "1.3.4-rc.2",
+        "web3-eth-contract": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       }
     },
     "web3-eth-iban": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.3.tgz",
-      "integrity": "sha512-+9a+bZHAKQ4oBcRxiGbC1MC8S2cOgDlXo8qcw0XpMhLJZ3c/brZM7ZbPdiuU8Z7AMYf3PknaGFQyVmedZhrauA==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.4-rc.2.tgz",
+      "integrity": "sha512-n/pn7PFxUBfiLC2kUuBoovzS4K8wPoz0ptqaxhwyH0zTq2YiTfGtuPWOMm6Un6cXyenjLw2+FXLSe5NL/xQwog==",
       "requires": {
         "bn.js": "^4.11.9",
-        "web3-utils": "1.3.3"
+        "web3-utils": "1.3.4-rc.2"
       },
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
         }
       }
     },
     "web3-eth-personal": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.3.tgz",
-      "integrity": "sha512-S/TSGTm7x9oHRXUHXi8f+y187RKpn5aqYJRlSoyTmB3B4EMrv9NcZZQmHaiXwM48wkFdRhTMECW1Ar8E5zZLFw==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.4-rc.2.tgz",
+      "integrity": "sha512-WPIS9TkX+mTGTmn8mvmL+vUcY6maxdm7ix6FGT9Mz35x8HIycjkeNf9NUtLMD2JVEFs78r3Eo33t/hA8UuT5CA==",
       "requires": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.3.3",
-        "web3-core-helpers": "1.3.3",
-        "web3-core-method": "1.3.3",
-        "web3-net": "1.3.3",
-        "web3-utils": "1.3.3"
+        "web3-core": "1.3.4-rc.2",
+        "web3-core-helpers": "1.3.4-rc.2",
+        "web3-core-method": "1.3.4-rc.2",
+        "web3-net": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       },
       "dependencies": {
         "@types/node": {
           "version": "12.19.16",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
           "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
-        },
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
         }
       }
     },
@@ -39952,79 +39575,42 @@
       "integrity": "sha1-JarudSSGTFSyaSm123JdKSV6+DI="
     },
     "web3-net": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.3.tgz",
-      "integrity": "sha512-GcPj2lyAC5CP6FOCwoURCRMFsh0khWBi6sGqiKtUPMa7dKnLw8CLCAFcwX//d3ucnn1E7I78Va6k8liKjj87sA==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.4-rc.2.tgz",
+      "integrity": "sha512-Ziviwp3cXSQvLzv7dYwFd+yBp2KYqt6G7iH8kP3NC9ZzzSKZYjFe6KOOf5hFObC9kI9OUaREQaoQHIQ6AJAwCw==",
       "requires": {
-        "web3-core": "1.3.3",
-        "web3-core-method": "1.3.3",
-        "web3-utils": "1.3.3"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "web3-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.3.tgz",
-          "integrity": "sha512-ZwpdqEcBBzqRgXUbCj+kyu1jFnsDauURSQ79yVqgnTKSI4C3s0Qjpp4WLThV+LKhCKR5GZtBTkgGHeiq0FT88A==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-core": "1.3.4-rc.2",
+        "web3-core-method": "1.3.4-rc.2",
+        "web3-utils": "1.3.4-rc.2"
       }
     },
     "web3-providers-http": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.3.tgz",
-      "integrity": "sha512-V2x27IFXQqsaZrAbA4GJurKuyrNXapmmpSJ7jxPDOxewOy9dEURlKIg5W1bb4QXGh2YSCksuH9fKquvTfPfc/A==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.4-rc.2.tgz",
+      "integrity": "sha512-0qmbnv2oC6JqlPGvzV4IklMOwZaZouRF/YPf6tsKVmU8EIRZq6idjgtWFpqj2swVHeheSrnbEuyVuCPCCW7Rsg==",
       "requires": {
-        "web3-core-helpers": "1.3.3",
+        "web3-core-helpers": "1.3.4-rc.2",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.3.tgz",
-      "integrity": "sha512-XMQo/YsH/2lBaRlkYa5d/Q+2EJ2RTzVjio1i2G9TESESfHCj0l2AWLb3zet+f/QRVxfvXGmGlZuf99diof2a1g==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.4-rc.2.tgz",
+      "integrity": "sha512-uCElMBq5QR0aMtG6sp1xAXKP8bT1p2lcYfl83jSMM5ieQvqgo2Auvug9znib8b3B5DFC9Bz0T6WQN3Ea4h/+OA==",
       "requires": {
         "oboe": "2.1.5",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.3.3"
+        "web3-core-helpers": "1.3.4-rc.2"
       }
     },
     "web3-providers-ws": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.3.tgz",
-      "integrity": "sha512-yuzqB3jST9JS19oOR1FRaARM7JBeP6cbKffM8HoWp4Y98/OowjW1mbDQVS47YTSHBP2QiLzSrwBxjIEPm8f48Q==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.4-rc.2.tgz",
+      "integrity": "sha512-8CxMI8mz7G1i5iViEjoB21SQRurOy/K3PBj1BwvCqneUjMy1RM9QHHuQS/v+9N18JNs6q8PuEjEYLgMS/AzlHA==",
       "requires": {
         "eventemitter3": "4.0.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.3.3",
+        "web3-core-helpers": "1.3.4-rc.2",
         "websocket": "^1.0.32"
       },
       "dependencies": {
@@ -40036,14 +39622,14 @@
       }
     },
     "web3-shh": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.3.tgz",
-      "integrity": "sha512-byp2+sHnc8UAj6sNcVFacF3pmRzIaMATsI4ARfU+0S8EpaQ3trojww2QBYPnZ4r0QOMH+I6+bVl8qTu0Zz4eoA==",
+      "version": "1.3.4-rc.2",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.4-rc.2.tgz",
+      "integrity": "sha512-tyVEN0sKTFFO+Q+GS4fvwJcAOPSqrpsYliyd3+NepmgKR54vOqAtzC2WBE4xhtmXByWVRVTAQ/TIlbk6T1JG6w==",
       "requires": {
-        "web3-core": "1.3.3",
-        "web3-core-method": "1.3.3",
-        "web3-core-subscriptions": "1.3.3",
-        "web3-net": "1.3.3"
+        "web3-core": "1.3.4-rc.2",
+        "web3-core-method": "1.3.4-rc.2",
+        "web3-core-subscriptions": "1.3.4-rc.2",
+        "web3-net": "1.3.4-rc.2"
       }
     },
     "web3-utils": {

--- a/app/package.json
+++ b/app/package.json
@@ -280,7 +280,7 @@
     "unused-files-webpack-plugin": "^3.4.0",
     "url-loader": "^1.1.2",
     "uuid": "^3.4.0",
-    "web3": "^1.3.3",
+    "web3": "^1.3.4-rc.2",
     "web3-fake-provider": "^0.1.0",
     "web3-utils": "1.3.4-rc.2",
     "webpack": "^4.46.0",

--- a/app/package.json
+++ b/app/package.json
@@ -280,7 +280,7 @@
     "unused-files-webpack-plugin": "^3.4.0",
     "url-loader": "^1.1.2",
     "uuid": "^3.4.0",
-    "web3": "1.3.4-rc.2",
+    "web3": "^1.3.3",
     "web3-fake-provider": "^0.1.0",
     "web3-utils": "1.3.4-rc.2",
     "webpack": "^4.46.0",

--- a/app/src/marketplace/modules/dataUnion/services.js
+++ b/app/src/marketplace/modules/dataUnion/services.js
@@ -162,7 +162,7 @@ export const getCommunityContract = (address: DataUnionId, usePublicNode: boolea
 
 export const getDataUnionOwner = async (address: DataUnionId, usePublicNode: boolean = false) => {
     const contract = getCommunityContract(address, usePublicNode)
-    const owner = await call(contract.methods.owner)
+    const owner = await call(contract.methods.owner())
 
     return owner
 }
@@ -174,7 +174,7 @@ export const isDataUnionDeployed = async (address: DataUnionId, usePublicNode: b
 export const getAdminFee = async (address: DataUnionId, usePublicNode: boolean = false) => {
     const web3 = usePublicNode ? getPublicWeb3() : getWeb3()
     const contract = getCommunityContract(address, usePublicNode)
-    const adminFee = await call(contract.methods.adminFee)
+    const adminFee = await call(contract.methods.adminFee())
 
     return web3.utils.fromWei(web3.utils.toBN(adminFee), 'ether')
 }


### PR DESCRIPTION
Updates Web3 to version `1.3.3`, this fixes the notification in Metamask about using deprecated Web3 API. This was actually a Metamask bug (https://github.com/MetaMask/metamask-extension/issues/10356) which manifested itself by using an older version of web3.

![Screenshot 2021-02-03 at 15 32 28](https://user-images.githubusercontent.com/1064982/107006105-580f7f80-6799-11eb-8cc2-439f46f4a3d0.png)

Metamask will include that fix in a future release but this should get rid of the notification by using a newer version which doesn't trigger that notification. All transactions seemed to work normally but please have a look if something is misbehaving.

NOTE: PR based on #1162, use node 12 or 14 to compile