### PR TITLE
[FRONT-249] Fix terms & conditions formatting

### DIFF
--- a/app/src/marketplace/components/ProductPage/DataUnionPending/index.jsx
+++ b/app/src/marketplace/components/ProductPage/DataUnionPending/index.jsx
@@ -1,33 +1,58 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Translate } from 'react-redux-i18n'
-import DeploySpinner from '$shared/components/DeploySpinner'
+import UnstyledDeploySpinner from '$shared/components/DeploySpinner'
+import { MD } from '$shared/utils/styled'
 
 const Heading = styled.div`
-    font-size: 30px;
     letter-spacing: 0;
-    line-height: 32px;
+    font-size: 1rem;
+    line-height: 1rem;
+`
+
+const DeploySpinner = styled(UnstyledDeploySpinner)``
+
+const DeploySpinnerWrapper = styled.div`
 `
 
 const UnstyledDataUnionPending = (props) => (
     <div {...props}>
-        <div>
+        <DeploySpinnerWrapper>
             <DeploySpinner isRunning showCounter={false} />
-        </div>
-        <div>
-            <Heading>
-                <Translate value="productPage.dataUnionPending.title" />
-            </Heading>
-        </div>
+        </DeploySpinnerWrapper>
+        <Heading>
+            <Translate value="productPage.dataUnionPending.title" />
+        </Heading>
     </div>
 )
 
 const DataUnionPending = styled(UnstyledDataUnionPending)`
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    display: grid;
-    grid-column-gap: 4em;
-    grid-template-columns: 160px 500px;
     justify-content: center;
+
+    ${DeploySpinnerWrapper} {
+        max-width: 160px;
+    }
+
+    ${DeploySpinnerWrapper} + ${Heading} {
+        margin-top: 1rem;
+    }
+
+    @media (min-width: ${MD}px) {
+        flex-direction: row;
+
+        ${Heading} {
+            font-size: 30px;
+            line-height: 32px;
+        }
+
+        ${DeploySpinnerWrapper} + ${Heading} {
+            margin-top: 0;
+            margin-left: 4rem;
+        }
+    }
 `
 
 Object.assign(DataUnionPending, {

--- a/app/src/marketplace/components/ProductPage/Terms.jsx
+++ b/app/src/marketplace/components/ProductPage/Terms.jsx
@@ -24,6 +24,16 @@ const getTermStrings = (ids: Array<string>) => (
     }).join('')
 )
 
+const Body = styled(Segment.Body)`
+    p {
+        margin: 0;
+    }
+
+    p + p {
+        margin-top: 1rem;
+    }
+`
+
 const UnstyledTerms = ({ product, ...props }: Props) => {
     const terms = product.termsOfUse || {}
     const entries = Object.entries(terms)
@@ -41,28 +51,30 @@ const UnstyledTerms = ({ product, ...props }: Props) => {
             <Segment.Header>
                 <Translate value="productPage.termsOfUse.title" />
             </Segment.Header>
-            <Segment.Body pad>
-                <strong>
-                    <Translate value="productPage.termsOfUse.basic" />
-                </strong>
-                {' '}
-                {permitted.length > 0 && (
-                    <React.Fragment>
-                        {I18n.t('productPage.termsOfUse.permitted', {
-                            count: permitted.length,
-                            permissions: permittedStr,
-                        })}
-                        {' '}
-                    </React.Fragment>
-                )}
-                {notPermitted.length > 0 && I18n.t('productPage.termsOfUse.notPermitted', {
-                    count: notPermitted.length,
-                    permissions: notPermittedStr,
-                })}
-                {permitted.length === 0 && ` ${I18n.t('productPage.termsOfUse.postfix')}`}
-                {notPermitted.length > 0 && '.'}
+            <Body pad>
+                <p>
+                    <strong>
+                        <Translate value="productPage.termsOfUse.basic" />
+                    </strong>
+                    {' '}
+                    {permitted.length > 0 && (
+                        <React.Fragment>
+                            {I18n.t('productPage.termsOfUse.permitted', {
+                                count: permitted.length,
+                                permissions: permittedStr,
+                            })}
+                            {' '}
+                        </React.Fragment>
+                    )}
+                    {notPermitted.length > 0 && I18n.t('productPage.termsOfUse.notPermitted', {
+                        count: notPermitted.length,
+                        permissions: notPermittedStr,
+                    })}
+                    {permitted.length === 0 && ` ${I18n.t('productPage.termsOfUse.postfix')}`}
+                    {notPermitted.length > 0 && '.'}
+                </p>
                 {!!terms.termsUrl && (
-                    <React.Fragment>
+                    <p>
                         <strong>
                             <Translate value="productPage.termsOfUse.detailed" />
                         </strong>
@@ -72,9 +84,9 @@ const UnstyledTerms = ({ product, ...props }: Props) => {
                                 {terms.termsName != null && terms.termsName.length > 0 ? terms.termsName : terms.termsUrl}
                             </a>
                         </strong>
-                    </React.Fragment>
+                    </p>
                 )}
-            </Segment.Body>
+            </Body>
         </Segment>
     )
 }

--- a/app/src/marketplace/containers/EditProductPage/TermsOfUse.jsx
+++ b/app/src/marketplace/containers/EditProductPage/TermsOfUse.jsx
@@ -21,18 +21,6 @@ const Section = styled.section`
     background: none;
 `
 
-const CheckboxContainer = styled.div`
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    grid-gap: 16px;
-    margin: 40px 0;
-`
-
-const CheckboxLabel = styled.label`
-    display: flex;
-    margin: 0;
-`
-
 const DetailsContainer = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -44,8 +32,14 @@ const StyledCheckbox = styled(Checkbox)`
     height: 24px !important;
 `
 
-const TermCheckbox = ({ id, product, updateTermsOfUse, disabled }: { id: string, product: any, updateTermsOfUse: any, disabled: boolean }) => (
-    <CheckboxLabel htmlFor={id}>
+const UnstyledTermCheckbox = ({
+    id,
+    product,
+    updateTermsOfUse,
+    disabled,
+    ...props
+}: { id: string, product: any, updateTermsOfUse: any, disabled: boolean }) => (
+    <label {...props} htmlFor={id}>
         <StyledCheckbox
             id={id}
             name={id}
@@ -62,8 +56,26 @@ const TermCheckbox = ({ id, product, updateTermsOfUse, disabled }: { id: string,
             value={`editProductPage.terms.${id}`}
             dangerousHTML
         />
-    </CheckboxLabel>
+    </label>
 )
+
+const TermCheckbox = styled(UnstyledTermCheckbox)`
+    display: flex;
+    margin: 0;
+`
+
+const CheckboxContainer = styled.div`
+    margin: 40px 0;
+    background: #F1F1F1;
+    border-radius: 4px;
+    padding: 20px 24px;
+    display: flex;
+    justify-content: space-between;
+
+    ${TermCheckbox} + ${TermCheckbox} {
+        margin-left: 1rem;
+    }
+`
 
 const TermsOfUse = ({ className, disabled }: Props) => {
     const product = useEditableProduct()

--- a/app/src/shared/components/DeploySpinner/index.jsx
+++ b/app/src/shared/components/DeploySpinner/index.jsx
@@ -122,9 +122,10 @@ const SpinnerSvg = () => (
 export type Props = {
     isRunning: boolean,
     showCounter: boolean,
+    className?: string,
 }
 
-const DeploySpinner = ({ isRunning, showCounter }: Props) => {
+const DeploySpinner = ({ isRunning, showCounter, className }: Props) => {
     const [elapsedSecs, setElapsedSecs] = useState(0)
 
     useInterval(() => {
@@ -142,7 +143,7 @@ const DeploySpinner = ({ isRunning, showCounter }: Props) => {
         <div
             className={cx(styles.root, {
                 [styles.isRunning]: !!isRunning,
-            })}
+            }, className)}
         >
             <SpinnerSvg />
             {showCounter && (

--- a/app/src/userpages/components/ProductsPage/Members/index.jsx
+++ b/app/src/userpages/components/ProductsPage/Members/index.jsx
@@ -314,7 +314,7 @@ const Members = () => {
                 />
             )}
             loading={fetchingMembers}
-            contentClassname={coreLayoutStyles.pad}
+            contentClassname={cx(styles.contentArea, coreLayoutStyles.pad)}
         >
             <CoreHelmet title={I18n.t('userpages.title.members')} />
             <StyledListContainer className={cx(styles.container, {

--- a/app/src/userpages/components/ProductsPage/Members/members.pcss
+++ b/app/src/userpages/components/ProductsPage/Members/members.pcss
@@ -3,6 +3,10 @@
   transition: all 0.3s ease 0.1s;
 }
 
+.contentArea {
+  padding-top: 1px;
+}
+
 .containerWithSelected {
   margin-bottom: calc(40px + 3rem) !important;
 }
@@ -58,6 +62,10 @@
 }
 
 @media (--md-up) {
+  .contentArea {
+    padding-top: 1.5rem;
+  }
+
   .selectedToolbarInner {
     display: grid;
     grid-template-columns: 1fr auto;


### PR DESCRIPTION
Fixes Terms & conditions formatting in the product editor and product page:

![Screenshot 2021-02-12 at 10 22 29](https://user-images.githubusercontent.com/1064982/107744959-42133900-6d1c-11eb-86a9-b3051fb60a97.png)

![Screenshot 2021-02-12 at 10 20 09](https://user-images.githubusercontent.com/1064982/107744973-45a6c000-6d1c-11eb-8622-f682ad3f226a.png)

Also added minor tweaks for DU deployment spinner as it broke the page in smaller displays... in real life it probably won't ever happen.