### PR TITLE
Fix sort by filter when Latest is selected

### DIFF
--- a/app/src/marketplace/components/ActionBar/index.jsx
+++ b/app/src/marketplace/components/ActionBar/index.jsx
@@ -25,7 +25,7 @@ export type Props = {
     onCreateProduct: () => void,
 }
 
-const sortByOptions = ['pricePerSecond', 'free', 'latest']
+const sortByOptions = ['pricePerSecond', 'free', 'dateCreated']
 
 const Filters = styled.div`
     background-color: white;
@@ -108,7 +108,7 @@ const UnstyledActionBar = ({
                 maxPrice: '0',
                 order: undefined,
             })
-        } else if (sortBy === 'latest') {
+        } else if (sortBy === 'dateCreated') {
             onFilterChangeProp({
                 maxPrice: undefined,
                 sortBy: 'dateCreated',

--- a/app/src/marketplace/i18n/en.po
+++ b/app/src/marketplace/i18n/en.po
@@ -44,7 +44,7 @@ msgstr "Free products only"
 msgid "actionBar.sortOptions.pricePerSecond"
 msgstr "Price, low to high"
 
-msgid "actionBar.sortOptions.latest"
+msgid "actionBar.sortOptions.dateCreated"
 msgstr "Latest"
 
 msgid "actionsDropdown.edit"


### PR DESCRIPTION
I noticed a bug when "Latest" sort by filter was selected, it didn't keep the label visible.