### PR TITLE
[FRONT-263] Sidebar truncations

### DIFF
--- a/app/src/shared/utils/text.js
+++ b/app/src/shared/utils/text.js
@@ -11,7 +11,7 @@ export const truncate = (path: string, options: Options = {}) => {
     const { length = 5, separator = '...' } = options
 
     return typeof path !== 'string' ? path : path.replace(/0x[a-f\d]{40,}/ig, (match) => {
-        const l = Math.min(length, Math.floor((match.length - separator.length) / 2))
+        const l = Math.min(Math.max(3, length), Math.floor((match.length - separator.length) / 2))
 
         return match.substr(0, l) + separator + match.substring(match.length - l)
     })

--- a/app/src/shared/utils/text.js
+++ b/app/src/shared/utils/text.js
@@ -2,24 +2,11 @@
 
 import { I18n } from 'react-redux-i18n'
 
-type Options = {
-    length: number,
-    separator?: string,
-}
-
-export const truncate = (path: string, options: Options = {}) => {
-    const { length = 5, separator = '...' } = options
-
-    return typeof path !== 'string' ? path : path.replace(/0x[a-f\d]{40,}/ig, (match) => {
-        if (length > Math.floor((match.length - separator.length) / 2)) {
-            return match
-        }
-
-        const l = Math.max(3, length)
-
-        return match.substr(0, l) + separator + match.substring(match.length - l)
-    })
-}
+export const truncate = (path: string) => (
+    typeof path !== 'string' ? path : path.replace(/0x[a-f\d]{40,}/ig, (match) => (
+        `${match.substr(0, 5)}...${match.substring(match.length - 5)}`
+    ))
+)
 
 export const numberToText = (number: number): string => {
     const numberStr = String(number)

--- a/app/src/shared/utils/text.js
+++ b/app/src/shared/utils/text.js
@@ -8,19 +8,13 @@ type Options = {
 }
 
 export const truncate = (path: string, options: Options = {}) => {
-    const { length, separator } = {
-        separator: '...',
-        length: 5,
-        ...options,
-    }
+    const { length = 5, separator = '...' } = options
 
-    if (typeof path === 'string' && path.indexOf('0x') >= 0) {
-        const search = new RegExp(`0x([A-Fa-f0-9]{${length - 2}})[A-Fa-f0-9]{32,}([A-Fa-f0-9]{${length}})`, 'g')
+    return typeof path !== 'string' ? path : path.replace(/0x[a-f\d]{40,}/ig, (match) => {
+        const l = Math.min(length, Math.floor((match.length - separator.length) / 2))
 
-        return path.replace(search, `0x$1${separator}$2`)
-    }
-
-    return path
+        return match.substr(0, l) + separator + match.substring(match.length - l)
+    })
 }
 
 export const numberToText = (number: number): string => {

--- a/app/src/shared/utils/text.js
+++ b/app/src/shared/utils/text.js
@@ -11,7 +11,11 @@ export const truncate = (path: string, options: Options = {}) => {
     const { length = 5, separator = '...' } = options
 
     return typeof path !== 'string' ? path : path.replace(/0x[a-f\d]{40,}/ig, (match) => {
-        const l = Math.min(Math.max(3, length), Math.floor((match.length - separator.length) / 2))
+        if (length > Math.floor((match.length - separator.length) / 2)) {
+            return match
+        }
+
+        const l = Math.max(3, length)
 
         return match.substr(0, l) + separator + match.substring(match.length - l)
     })

--- a/app/src/userpages/components/ShareSidebar/Share.jsx
+++ b/app/src/userpages/components/ShareSidebar/Share.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, Fragment, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import styled, { css, keyframes } from 'styled-components'
 import { Button as LayoutButton } from '@streamr/streamr-layout'
+import { truncate } from '$shared/utils/text'
 import { usePermissionsState, usePermissionsDispatch } from '$shared/components/PermissionsProvider'
 import { UPDATE_PERMISSION } from '$shared/components/PermissionsProvider/utils/reducer'
 import groups, { NAMES } from '$shared/components/PermissionsProvider/groups'
@@ -279,7 +280,9 @@ const UnstyledShare = ({ className, userId, onSelect, selected }) => {
                 <Header>
                     <div>
                         <h4 title={userId}>
-                            {userId}
+                            {truncate(userId, {
+                                length: 10,
+                            })}
                             {currentUserId === userId && ' (You)'}
                         </h4>
                         <Role visible={!selected}>

--- a/app/src/userpages/components/ShareSidebar/Share.jsx
+++ b/app/src/userpages/components/ShareSidebar/Share.jsx
@@ -280,9 +280,7 @@ const UnstyledShare = ({ className, userId, onSelect, selected }) => {
                 <Header>
                     <div>
                         <h4 title={userId}>
-                            {truncate(userId, {
-                                length: 10,
-                            })}
+                            {truncate(userId)}
                             {currentUserId === userId && ' (You)'}
                         </h4>
                         <Role visible={!selected}>

--- a/app/test/unit/utils/text.test.js
+++ b/app/test/unit/utils/text.test.js
@@ -7,6 +7,13 @@ describe('text utils', () => {
             expect(all.truncate(123)).toBe(123)
         })
 
+        it('does not truncate hashes that are too short', () => {
+            expect(all.truncate('0x0123456789abcdef0123456789abcdef01234567'))
+                .toBe('0x012...34567')
+            expect(all.truncate('0x0123456789abcdef0123456789abcdef0123456'))
+                .toBe('0x0123456789abcdef0123456789abcdef0123456')
+        })
+
         it('does not truncate non-eth address', () => {
             expect(all.truncate('sandbox/test/my-stream')).toBe('sandbox/test/my-stream')
             expect(all.truncate('FwhuQBTrtfkddf2542asd')).toBe('FwhuQBTrtfkddf2542asd')
@@ -36,66 +43,9 @@ describe('text utils', () => {
             expect(all.truncate('0xA3D1F77ACFF0060F7213D7BF3C7fEC78DF847DE1')).toBe('0xA3D...47DE1')
         })
 
-        it('truncates using custom separator', () => {
-            expect(all.truncate('0xa3d1F77ACfF0060F7213D7BF3c7fEC78df847De1/path/to/stream', {
-                separator: '---',
-            })).toBe('0xa3d---47De1/path/to/stream')
-        })
-
         it('truncates transaction hash', () => {
             expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2c283b6d35cf41fe9c95b1e606ff1'))
                 .toBe('0x8b5...06ff1')
-        })
-
-        it('truncates to custom length', () => {
-            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2c283b6d35cf41fe9c95b1e606ff1', {
-                length: 10,
-            }))
-                .toBe('0x8b549d15...5b1e606ff1')
-
-            expect(all.truncate('address is 0x8b549d1526d0f6168eed061041d6cb5243c2c283b6d35cf41fe9c95b1e606ff1 inside text', {
-                length: 10,
-            }))
-                .toBe('address is 0x8b549d15...5b1e606ff1 inside text')
-        })
-
-        it('truncates to custom length (40 characters vs less)', () => {
-            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
-                length: 12,
-            }))
-                .toBe('0x8b549d1526...cb5243c2cf40')
-
-            expect(all.truncate('address is 0x8b549d1526d0f6168eed061041d6cb5243c2cf40 inside text', {
-                length: 12,
-            }))
-                .toBe('address is 0x8b549d1526...cb5243c2cf40 inside text')
-
-            // 39 characters
-            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2c39', {
-                length: 12,
-            }))
-                .toBe('0x8b549d1526d0f6168eed061041d6cb5243c2c39')
-
-            expect(all.truncate('address is 0x8b549d1526d0f6168eed061041d6cb5243c2c39 inside text', {
-                length: 12,
-            }))
-                .toBe('address is 0x8b549d1526d0f6168eed061041d6cb5243c2c39 inside text')
-        })
-
-        it('respects the implicit maximum length', () => {
-            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
-                length: 20,
-            })).toBe('0x8b549d1526d0f6168eed061041d6cb5243c2cf40')
-
-            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
-                length: 19,
-            })).toBe('0x8b549d1526d0f6168...61041d6cb5243c2cf40')
-        })
-
-        it('respects the implicit minimum length of 3', () => {
-            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
-                length: 0,
-            })).toBe('0x8...f40')
         })
     })
 

--- a/app/test/unit/utils/text.test.js
+++ b/app/test/unit/utils/text.test.js
@@ -87,6 +87,12 @@ describe('text utils', () => {
                 length: 100,
             })).toBe('0x8b549d1526d0f6168...61041d6cb5243c2cf40')
         })
+
+        it('respects the implicit minimum length of 3', () => {
+            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
+                length: 0,
+            })).toBe('0x8...f40')
+        })
     })
 
     describe('numberToText', () => {

--- a/app/test/unit/utils/text.test.js
+++ b/app/test/unit/utils/text.test.js
@@ -58,6 +58,35 @@ describe('text utils', () => {
             }))
                 .toBe('address is 0x8b549d15...5b1e606ff1 inside text')
         })
+
+        it('truncates to custom length (40 characters vs less)', () => {
+            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
+                length: 12,
+            }))
+                .toBe('0x8b549d1526...cb5243c2cf40')
+
+            expect(all.truncate('address is 0x8b549d1526d0f6168eed061041d6cb5243c2cf40 inside text', {
+                length: 12,
+            }))
+                .toBe('address is 0x8b549d1526...cb5243c2cf40 inside text')
+
+            // 39 characters
+            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2c39', {
+                length: 12,
+            }))
+                .toBe('0x8b549d1526d0f6168eed061041d6cb5243c2c39')
+
+            expect(all.truncate('address is 0x8b549d1526d0f6168eed061041d6cb5243c2c39 inside text', {
+                length: 12,
+            }))
+                .toBe('address is 0x8b549d1526d0f6168eed061041d6cb5243c2c39 inside text')
+        })
+
+        it('respects the implicit maximum length', () => {
+            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
+                length: 100,
+            })).toBe('0x8b549d1526d0f6168...61041d6cb5243c2cf40')
+        })
     })
 
     describe('numberToText', () => {

--- a/app/test/unit/utils/text.test.js
+++ b/app/test/unit/utils/text.test.js
@@ -84,7 +84,11 @@ describe('text utils', () => {
 
         it('respects the implicit maximum length', () => {
             expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
-                length: 100,
+                length: 20,
+            })).toBe('0x8b549d1526d0f6168eed061041d6cb5243c2cf40')
+
+            expect(all.truncate('0x8b549d1526d0f6168eed061041d6cb5243c2cf40', {
+                length: 19,
             })).toBe('0x8b549d1526d0f6168...61041d6cb5243c2cf40')
         })
 


### PR DESCRIPTION
~I wanted to use a slightly larger `length` parameter just because we got room for it (see the attached image). `truncate` function didn't let me though. Apparently if you go with an address that's 42-char long (0x+40 chars) it does not let you use larger `length` than 5 (regular expression doesn't match because of the hardcoded `32`; `32 + 5 + (5 - 2)` → `40`).~
 
~Updated the function so it doesn't work on addresses shorter than 40 but accepts any length larger than 2 and respects the implicit max. length.~

<img width="422" alt="Screen Shot 2021-02-15 at 12 35 47 PM" src="https://user-images.githubusercontent.com/320066/107941938-ccf96b00-6f8a-11eb-880c-5fd79e439e81.png">

cc @mattatgit 