### PR TITLE
[FRONT-277] Restore gas limit for buying products

### DIFF
--- a/app/src/marketplace/modules/product/services.js
+++ b/app/src/marketplace/modules/product/services.js
@@ -155,6 +155,7 @@ export const buyProduct = (
                 ONE_DAY,
             ), {
                 value: web3.utils.toWei(price.toString()).toString(),
+                gas: gasLimits.BUY_PRODUCT_WITH_ETH,
             })
         case paymentCurrencies.DAI:
             return send(uniswapAdaptorContractMethods().buyWithERC20(
@@ -168,7 +169,9 @@ export const buyProduct = (
             })
 
         default: // Pay with DATA
-            return send(marketplaceContractMethods().buy(getValidId(id), subscriptionInSeconds.toString()))
+            return send(marketplaceContractMethods().buy(getValidId(id), subscriptionInSeconds.toString()), {
+                gas: gasLimits.BUY_PRODUCT,
+            })
     }
 }
 

--- a/app/src/shared/utils/constants.js
+++ b/app/src/shared/utils/constants.js
@@ -75,6 +75,7 @@ export const transactionTypes = {
 
 export const gasLimits = {
     BUY_PRODUCT: 3e5,
+    BUY_PRODUCT_WITH_ETH: 5e5,
     BUY_PRODUCT_WITH_ERC20: 6e5,
     APPROVE: 7e4,
 }


### PR DESCRIPTION
Gas limits restored for buying products as MP1 contract products causes problems with MetaMask gas limit estimation.