### PR TITLE
[FRONT-274] Fix Cypress tests

### DIFF
--- a/app/cypress/integration/StreamPage.spec.js
+++ b/app/cypress/integration/StreamPage.spec.js
@@ -2,6 +2,9 @@ import qs from 'query-string'
 import { matchPath } from 'react-router-dom'
 import uuid from 'uuid'
 
+// This is needed to get around missing regeneratorRuntime
+require('@babel/polyfill')
+
 it.skip('creates a whole bunch of users for a stream', () => {
     const streamId = '0xa3d1f77acff0060f7213d7bf3c7fec78df847de1/dontcare' // <- has to be set manually
     const howMany = 300
@@ -398,10 +401,11 @@ describe('Stream read-only page (no edit permission)', () => {
                 },
             },
         }).then((streamId) => {
+            cy.log('Created stream', streamId)
             const encodedId = encodeURIComponent(streamId)
             const pathname = streamId.slice(streamId.indexOf('/') + 1)
 
-            cy.createStreamPermission(streamId, 'tester2@streamr.com', 'stream_get')
+            cy.createStreamPermission(streamId, 'tester two', 'stream_get')
             cy.logout()
             cy.login('tester two')
             cy.visit(`/core/streams/${encodedId}`)
@@ -429,7 +433,7 @@ describe('Stream read-only page (no edit permission)', () => {
             const encodedId = encodeURIComponent(streamId)
             const pathname = streamId.slice(streamId.indexOf('/') + 1)
 
-            cy.createStreamPermission(streamId, 'tester2@streamr.com', 'stream_get')
+            cy.createStreamPermission(streamId, 'tester two', 'stream_get')
             cy.logout()
             cy.login('tester two')
             cy.visit(`/core/streams/${encodedId}`)
@@ -515,7 +519,7 @@ describe('Stream read-only page (no edit permission)', () => {
             cy.login()
             cy.createStream().then((streamId) => {
                 const encodedId = encodeURIComponent(streamId)
-                cy.createStreamPermission(streamId, 'tester2@streamr.com', 'stream_get')
+                cy.createStreamPermission(streamId, 'tester two', 'stream_get')
                 cy.logout()
                 cy.login('tester two')
                 cy.visit(`/core/streams/${encodedId}`)
@@ -542,7 +546,7 @@ describe('Stream read-only page (no edit permission)', () => {
             cy.login()
             cy.createStream().then((streamId) => {
                 const encodedId = encodeURIComponent(streamId)
-                cy.createStreamPermission(streamId, 'tester2@streamr.com', 'stream_get')
+                cy.createStreamPermission(streamId, 'tester two', 'stream_get')
                 cy.logout()
                 cy.login('tester two')
 
@@ -566,7 +570,7 @@ describe('Stream read-only page (no edit permission)', () => {
             cy.createStream().then((streamId) => {
                 const encodedId = encodeURIComponent(streamId)
                 cy.enableStorageNode(streamId, '0xde1112f631486CfC759A50196853011528bC5FA0')
-                cy.createStreamPermission(streamId, 'tester2@streamr.com', 'stream_get')
+                cy.createStreamPermission(streamId, 'tester two', 'stream_get')
                 cy.logout()
                 cy.login('tester two')
 
@@ -604,8 +608,8 @@ describe('Stream edit page', () => {
             const encodedId = encodeURIComponent(streamId)
             // Having `edit` permission doesn't mean you can open the stream page w/o a 404. In
             // order to access it at all you need to be able to `get`. :/
-            cy.createStreamPermission(streamId, 'tester2@streamr.com', 'stream_get')
-            cy.createStreamPermission(streamId, 'tester2@streamr.com', 'stream_edit')
+            cy.createStreamPermission(streamId, 'tester two', 'stream_get')
+            cy.createStreamPermission(streamId, 'tester two', 'stream_edit')
             cy.logout()
             cy.login('tester two')
             cy.visit(`/core/streams/${encodedId}`)

--- a/app/cypress/support/commands.js
+++ b/app/cypress/support/commands.js
@@ -21,15 +21,6 @@ const generatePrivateKey = (mnemonic) => {
     return cache[mnemonic]
 }
 
-const getAddress = (mnemonic = 'tester one') => {
-    if (!cache[mnemonic]) {
-        generatePrivateKey(mnemonic)
-    }
-
-    const wallet = getWallet(mnemonic)
-    return wallet.getAddressString()
-}
-
 Cypress.Commands.add('login', (mnemonic = 'tester one') => (
     new StreamrClient({
         restUrl: 'http://localhost/api/v1',
@@ -134,7 +125,7 @@ Cypress.Commands.add('createStreamPermission', (streamId, user = null, operation
                 anonymous: !user,
                 new: true,
                 operation,
-                user: user != null ? getAddress(user) : null,
+                user: user != null ? getWallet(user).getAddressString() : null,
             },
         })
 ))

--- a/app/cypress/support/commands.js
+++ b/app/cypress/support/commands.js
@@ -8,22 +8,33 @@ import getClientConfig from '$shared/utils/getClientConfig'
 
 const cache = {}
 
+const getWallet = (mnemonic) => {
+    const hdwallet = hdkey.fromMasterSeed(mnemonicToSeedSync(mnemonic))
+    return hdwallet.derivePath("m/44'/60'/0'/0").getWallet()
+}
+
 const generatePrivateKey = (mnemonic) => {
     if (!cache[mnemonic]) {
-        const hdwallet = hdkey.fromMasterSeed(mnemonicToSeedSync(mnemonic))
-        const wallet = hdwallet.derivePath("m/44'/60'/0'/0").getWallet()
-
+        const wallet = getWallet(mnemonic)
         cache[mnemonic] = wallet.getPrivateKey().toString('hex')
     }
-
     return cache[mnemonic]
+}
+
+const getAddress = (mnemonic = 'tester one') => {
+    if (!cache[mnemonic]) {
+        generatePrivateKey(mnemonic)
+    }
+
+    const wallet = getWallet(mnemonic)
+    return wallet.getAddressString()
 }
 
 Cypress.Commands.add('login', (mnemonic = 'tester one') => (
     new StreamrClient({
         restUrl: 'http://localhost/api/v1',
         auth: {
-            privateKey: generatePrivateKey(`auto generated user ${mnemonic}`),
+            privateKey: generatePrivateKey(mnemonic),
         },
     }).session.getSessionToken().then(setToken)
 ))
@@ -123,7 +134,7 @@ Cypress.Commands.add('createStreamPermission', (streamId, user = null, operation
                 anonymous: !user,
                 new: true,
                 operation,
-                user,
+                user: user != null ? getAddress(user) : null,
             },
         })
 ))


### PR DESCRIPTION
Fix missing `regeneratorRuntime` and permissions to be handled with Ethereum identities.

PS. Do you have problems getting Cypress tests to run consistently? I seem to get a couple of failing test cases per run with timeouts and It's not the same cases every time. They will pass when retrying the run.