### PR TITLE
Remove connected-react-router

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12317,14 +12317,6 @@
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
-    "connected-react-router": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.8.0.tgz",
-      "integrity": "sha512-E64/6krdJM3Ag3MMmh2nKPtMbH15s3JQDuaYJvOVXzu6MbHbDyIvuwLOyhQIuP4Om9zqEfZYiVyflROibSsONg==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -140,7 +140,6 @@
     "clean-css": "^4.2.3",
     "clean-webpack-plugin": "^0.1.19",
     "colors": "^1.4.0",
-    "connected-react-router": "^6.8.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.3",
     "css-loader": "^2.1.1",

--- a/app/src/app/index.jsx
+++ b/app/src/app/index.jsx
@@ -1,8 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Route as RouterRoute, Switch, Redirect } from 'react-router-dom'
-import { ConnectedRouter } from 'connected-react-router'
+import { Router, Route as RouterRoute, Switch, Redirect } from 'react-router-dom'
 
 import '$shared/assets/stylesheets'
 import '@ibm/plex/css/ibm-plex.css'
@@ -81,7 +80,7 @@ const MiscRouter = () => ([
 ])
 
 const App = () => (
-    <ConnectedRouter history={history}>
+    <Router history={history}>
         <SessionProvider>
             <ModalPortalProvider>
                 <ModalProvider>
@@ -101,7 +100,7 @@ const App = () => (
                 </ModalProvider>
             </ModalPortalProvider>
         </SessionProvider>
-    </ConnectedRouter>
+    </Router>
 )
 
 export default App

--- a/app/src/auth/components/LogoutPage.jsx
+++ b/app/src/auth/components/LogoutPage.jsx
@@ -1,6 +1,8 @@
 // @flow
 
 import { useDispatch } from 'react-redux'
+import { useHistory } from 'react-router-dom'
+
 import { post } from '$shared/utils/api'
 import useIsMounted from '$shared/hooks/useIsMounted'
 import useOnMount from '$shared/hooks/useOnMount'
@@ -14,6 +16,7 @@ const LogoutPage = () => {
     const fail = useFailure()
 
     const dispatch = useDispatch()
+    const history = useHistory()
 
     useOnMount(async () => {
         try {
@@ -22,6 +25,7 @@ const LogoutPage = () => {
             })
             if (isMounted()) {
                 dispatch(logoutAction())
+                history.push(routes.root())
             }
         } catch (e) {
             fail(e)

--- a/app/src/marketplace/components/NewProductPage.jsx
+++ b/app/src/marketplace/components/NewProductPage.jsx
@@ -1,11 +1,9 @@
 // @flow
 
 import React, { useEffect } from 'react'
-import { type Location } from 'react-router-dom'
+import { useHistory, type Location } from 'react-router-dom'
 import styled from 'styled-components'
 import qs from 'query-string'
-import { useDispatch } from 'react-redux'
-import { replace } from 'connected-react-router'
 import { postEmptyProduct } from '$mp/modules/product/services'
 import LoadingIndicator from '$shared/components/LoadingIndicator'
 import { type ProductType } from '$mp/flowtype/product-types'
@@ -25,7 +23,7 @@ const sanitizedType = (type: ?string): ProductType => (
 )
 
 const UnstyledNewProductPage = ({ className, location: { search } }: Props) => {
-    const dispatch = useDispatch()
+    const history = useHistory()
 
     const isMounted = useIsMounted()
 
@@ -37,10 +35,10 @@ const UnstyledNewProductPage = ({ className, location: { search } }: Props) => {
         postEmptyProduct(sanitizedType(type))
             .then(({ id }) => {
                 if (isMounted()) {
-                    dispatch(replace(routes.products.edit({
+                    history.replace(routes.products.edit({
                         id,
                         newProduct: true,
-                    })))
+                    }))
                     Activity.push({
                         action: actionTypes.CREATE,
                         resourceId: id,
@@ -48,7 +46,7 @@ const UnstyledNewProductPage = ({ className, location: { search } }: Props) => {
                     })
                 }
             }, fail)
-    }, [dispatch, isMounted, search, fail])
+    }, [isMounted, search, fail, history])
 
     return (
         <LoadingIndicator className={className} loading />

--- a/app/src/marketplace/containers/ProductPage/Hero.jsx
+++ b/app/src/marketplace/containers/ProductPage/Hero.jsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { replace } from 'connected-react-router'
+import { useHistory } from 'react-router-dom'
 import moment from 'moment'
 
 import useProduct from '$mp/containers/ProductController/useProduct'
@@ -59,6 +59,7 @@ const getWhitelistStatus = async ({ productId, validate = false }: WhitelistStat
 
 const Hero = () => {
     const dispatch = useDispatch()
+    const history = useHistory()
     const product = useProduct()
     const { api: purchaseDialog } = useModal('purchase')
     const { isPending, wrap } = usePending('product.PURCHASE_DIALOG')
@@ -109,7 +110,7 @@ const Hero = () => {
 
                     if (isMounted() && !!started && !!succeeded) {
                         if (viewInCore) {
-                            dispatch(replace(routes.subscriptions()))
+                            history.replace(routes.subscriptions())
                         } else {
                             dispatch(getProductSubscription(productId))
                         }
@@ -132,15 +133,16 @@ const Hero = () => {
                     dispatch(getMyPurchases())
                 }
             } else {
-                dispatch(replace(routes.auth.login({
+                history.replace(routes.auth.login({
                     redirect: routes.marketplace.product({
                         id: productId,
                     }),
-                })))
+                }))
             }
         })
     ), [productId,
         dispatch,
+        history,
         isLoggedIn,
         purchaseDialog,
         isPaid,

--- a/app/src/shared/contexts/ModalApi/index.jsx
+++ b/app/src/shared/contexts/ModalApi/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { type Context, type Node, useState, useCallback, useMemo, useEffect } from 'react'
-import { withRouter, type History } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 
 import useIsMounted from '$shared/hooks/useIsMounted'
 
@@ -77,14 +77,17 @@ function useModalContext(path: string): ContextProps {
 
 type Props = {
     children?: Node,
-    history: History,
 }
 
-const ModalContextProvider = withRouter(({ children, history }: Props) => (
-    <ModalContext.Provider value={useModalContext(history.location.pathname)}>
-        {children || null}
-    </ModalContext.Provider>
-))
+const ModalContextProvider = ({ children }: Props) => {
+    const { pathname } = useLocation()
+
+    return (
+        <ModalContext.Provider value={useModalContext(pathname)}>
+            {children || null}
+        </ModalContext.Provider>
+    )
+}
 
 export {
     ModalContextProvider as Provider,

--- a/app/src/shared/modules/user/actions.js
+++ b/app/src/shared/modules/user/actions.js
@@ -1,14 +1,12 @@
 // @flow
 
 import { createAction } from 'redux-actions'
-import { push } from 'connected-react-router'
 import * as yup from 'yup'
 
 import type { ErrorInUi, ReduxActionCreator } from '$shared/flowtype/common-types'
 import type { User } from '$shared/flowtype/user-types'
 import { selectUserData } from '$shared/modules/user/selectors'
 import { clearStorage } from '$shared/utils/storage'
-import routes from '$routes'
 import type {
     UserErrorActionCreator,
     UserDataActionCreator,
@@ -38,7 +36,6 @@ export const resetUserData: ReduxActionCreator = createAction(RESET_USER_DATA)
 export const logout = () => (dispatch: Function) => {
     clearStorage()
     dispatch(resetUserData())
-    dispatch(push(routes.root()))
 }
 
 // Fetching user data

--- a/app/src/shared/test/modules/user/actions.test.js
+++ b/app/src/shared/test/modules/user/actions.test.js
@@ -99,20 +99,9 @@ describe('user - actions', () => {
 
             await store.dispatch(actions.logout())
 
-            const expectedActions = [
-                {
-                    type: constants.RESET_USER_DATA,
-                },
-                {
-                    type: '@@router/CALL_HISTORY_METHOD',
-                    payload: {
-                        method: 'push',
-                        args: [
-                            '/',
-                        ],
-                    },
-                },
-            ]
+            const expectedActions = [{
+                type: constants.RESET_USER_DATA,
+            }]
             expect(store.getActions()).toStrictEqual(expectedActions)
         })
     })

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -2,7 +2,6 @@
 
 import thunk from 'redux-thunk'
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux'
-import { connectRouter, routerMiddleware } from 'connected-react-router'
 
 import entitiesReducer from '$shared/modules/entities/reducer'
 import userReducer from '$shared/modules/user/reducer'
@@ -20,10 +19,9 @@ import relatedProductsReducer from './marketplace/modules/relatedProducts/reduce
 import transactionsReducer from './marketplace/modules/transactions/reducer'
 import userpagesReducers from './userpages/reducers'
 
-import history from './history'
 import analytics from './analytics'
 
-const middleware = [thunk, routerMiddleware(history), ...analytics.getMiddlewares()]
+const middleware = [thunk, ...analytics.getMiddlewares()]
 const toBeComposed = [applyMiddleware(...middleware)]
 
 /* eslint-disable no-underscore-dangle */
@@ -44,7 +42,6 @@ export function initStore() {
             myPurchaseList: myPurchasesReducer,
             product: productReducer,
             productList: productsReducer,
-            router: connectRouter(history),
             streams: streamsReducer,
             user: userReducer,
             integrationKey: integrationKeyReducer,

--- a/app/src/userpages/components/CanvasPage/List/index.jsx
+++ b/app/src/userpages/components/CanvasPage/List/index.jsx
@@ -2,8 +2,7 @@
 
 import React, { Fragment, useEffect, useMemo, useCallback, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Link as RouterLink } from 'react-router-dom'
-import { push } from 'connected-react-router'
+import { useHistory, Link as RouterLink } from 'react-router-dom'
 import styled from 'styled-components'
 
 import type { Canvas, CanvasId } from '$userpages/flowtype/canvas-types'
@@ -127,6 +126,7 @@ const CanvasList = () => {
     } = useFilterSort(sortOptions)
 
     const dispatch = useDispatch()
+    const history = useHistory()
     const { copy } = useCopy()
     const canvases = useSelector(selectCanvases)
     const fetching = useSelector(selectFetching)
@@ -209,7 +209,7 @@ const CanvasList = () => {
         permissions[id].includes('canvas_delete')
     ), [fetchingPermissions, permissions])
 
-    const navigate = useCallback((to) => dispatch(push(to)), [dispatch])
+    const navigate = useCallback((to) => history.push(to), [history])
 
     const getActions = useCallback((canvas) => {
         const hasDeletePermission = canBeDeletedByCurrentUser(canvas.id)

--- a/app/src/userpages/components/DashboardPage/List/index.jsx
+++ b/app/src/userpages/components/DashboardPage/List/index.jsx
@@ -2,8 +2,7 @@
 
 import React, { Fragment, useState, useMemo, useEffect, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { Link } from 'react-router-dom'
-import { push } from 'connected-react-router'
+import { useHistory, Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { CoreHelmet } from '$shared/components/Helmet'
@@ -132,6 +131,7 @@ const DashboardList = () => {
 
     const sidebar = useSidebar()
     const dispatch = useDispatch()
+    const history = useHistory()
 
     useEffect(() => {
         dispatch(getDashboards(filter))
@@ -207,7 +207,7 @@ const DashboardList = () => {
         permissions[id].includes('dashboard_delete')
     ), [fetchingPermissions, permissions])
 
-    const navigate = useCallback((to) => dispatch(push(to)), [dispatch])
+    const navigate = useCallback((to) => history.push(to), [history])
 
     const getActions = useCallback((dashboard) => {
         const hasDeletePermission = canBeDeletedByCurrentUser(dashboard.id)

--- a/app/src/userpages/components/ProductsPage/Header.jsx
+++ b/app/src/userpages/components/ProductsPage/Header.jsx
@@ -1,9 +1,7 @@
 // @flow
 
 import React, { type Node, useCallback } from 'react'
-import { useDispatch } from 'react-redux'
-import { push } from 'connected-react-router'
-import { Link } from 'react-router-dom'
+import { useHistory, Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import Tab from '$userpages/components/Header/Tab'
@@ -109,16 +107,16 @@ type Props = {
 }
 
 const Header = ({ className, searchComponent, filterComponent }: Props) => {
-    const dispatch = useDispatch()
+    const history = useHistory()
     const isMounted = useIsMounted()
     const product = useProduct()
 
     const redirectToProductList = useCallback(() => {
         if (!isMounted()) { return }
-        dispatch(push(routes.products.index()))
+        history.push(routes.products.index())
     }, [
         isMounted,
-        dispatch,
+        history,
     ])
 
     const {

--- a/app/src/userpages/components/ProfilePage/DeleteAccount/index.jsx
+++ b/app/src/userpages/components/ProfilePage/DeleteAccount/index.jsx
@@ -3,6 +3,7 @@
 import React, { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
 import styled from 'styled-components'
+import { useHistory } from 'react-router-dom'
 
 import Button from '$shared/components/Button'
 import useModal from '$shared/hooks/useModal'
@@ -12,6 +13,7 @@ import { logout } from '$shared/modules/user/actions'
 import Notification from '$shared/utils/Notification'
 import { NotificationIcon } from '$shared/utils/constants'
 import { MD, LG } from '$shared/utils/styled'
+import routes from '$routes'
 import Description from '../Description'
 import DeleteAccountDialog from './DeleteAccountDialog'
 
@@ -30,6 +32,7 @@ const DeleteAccount = () => {
     const { wrap, isPending: isDeleteDialogPending } = usePending('user.DELETE_ACCOUNT_DIALOG')
     const { isPending: isSavePending } = usePending('user.SAVE')
     const dispatch = useDispatch()
+    const history = useHistory()
     const isMounted = useIsMounted()
 
     const deleteAccount = useCallback(async () => (
@@ -50,12 +53,13 @@ const DeleteAccount = () => {
                     setTimeout(() => {
                         if (isMounted()) {
                             dispatch(logout())
+                            history.push(routes.root())
                         }
                     }, 500)
                 }
             }
         })
-    ), [wrap, deleteAccountDialog, isMounted, dispatch])
+    ), [wrap, deleteAccountDialog, isMounted, dispatch, history])
 
     return (
         <div>

--- a/app/src/userpages/components/ProfilePage/index.jsx
+++ b/app/src/userpages/components/ProfilePage/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { push } from 'connected-react-router'
+import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { CoreHelmet } from '$shared/components/Helmet'
@@ -38,11 +38,12 @@ export const ProfilePage = () => {
     const { isPending: isAvatarUploadPending } = usePending('user.UPLOAD_AVATAR')
     const isMounted = useIsMounted()
     const dispatch = useDispatch()
+    const history = useHistory()
     const { fetching: isLoadingEthIdentities } = useEthereumIdentities()
     const { fetching: isLoadingPrivateKeys } = usePrivateKeys()
 
     const doSaveCurrentUser = useCallback(() => dispatch(saveCurrentUser()), [dispatch])
-    const redirectToUserPages = useCallback(() => dispatch(push(routes.core())), [dispatch])
+    const redirectToUserPages = useCallback(() => history.push(routes.core()), [history])
 
     const onSave = useCallback(async () => (
         wrap(async () => {

--- a/app/src/userpages/components/StreamPage/Edit/index.jsx
+++ b/app/src/userpages/components/StreamPage/Edit/index.jsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useState, useMemo, useRef, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
-import { push } from 'connected-react-router'
+import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import cloneDeep from 'lodash/cloneDeep'
 import { useTransition, animated } from 'react-spring'
@@ -99,6 +99,7 @@ const UnstyledEdit = ({
     const { api: confirmSaveDialog } = useModal('confirmSave')
 
     const dispatch = useDispatch()
+    const history = useHistory()
 
     useEffect(() => {
         if (!streamId || !streamRef.current) { return }
@@ -148,7 +149,7 @@ const UnstyledEdit = ({
                 })
 
                 if (options.redirect) {
-                    dispatch(push(routes.streams.index()))
+                    history.push(routes.streams.index())
                 }
             }
         } catch (e) {
@@ -163,7 +164,7 @@ const UnstyledEdit = ({
                 setSpinner(false)
             }
         }
-    }, [stream, dispatch, isMounted])
+    }, [stream, dispatch, isMounted, history])
 
     const confirmIsSaved = useCallback(async () => {
         if (!didChange(originalStreamRef.current, streamRef.current)) {
@@ -187,9 +188,9 @@ const UnstyledEdit = ({
         const canProceed = await confirmIsSaved()
 
         if (isMounted() && canProceed) {
-            dispatch(push(routes.streams.index()))
+            history.push(routes.streams.index())
         }
-    }, [confirmIsSaved, dispatch, isMounted])
+    }, [confirmIsSaved, history, isMounted])
 
     const subSnippets = useMemo(() => (
         subscribeSnippets({

--- a/app/src/userpages/components/StreamPage/List/Row.jsx
+++ b/app/src/userpages/components/StreamPage/List/Row.jsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { push } from 'connected-react-router'
-import { Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
 import { titleize } from '@streamr/streamr-layout'
 import styled from 'styled-components'
 import { deleteOrRemoveStream } from '$userpages/modules/userPageStreams/actions'
@@ -46,6 +45,7 @@ export const CreateStreamButton = () => (
 
 const Row = ({ stream, onShareClick: onShareClickProp }) => {
     const dispatch = useDispatch()
+    const history = useHistory()
     const { copy } = useCopy()
     const fetchingPermissions = useSelector(selectFetchingPermissions)
     const permissions = useSelector(selectStreamPermissions)
@@ -114,10 +114,10 @@ const Row = ({ stream, onShareClick: onShareClickProp }) => {
     }, [snippetDialog, stream.id])
 
     const showStream = useCallback(() => (
-        dispatch(push(routes.streams.show({
+        history.push(routes.streams.show({
             id: stream.id,
-        })))
-    ), [dispatch, stream.id])
+        }))
+    ), [history, stream.id])
 
     const onCopyId = useCallback(() => {
         copy(stream.id)

--- a/app/src/userpages/components/StreamPage/New.jsx
+++ b/app/src/userpages/components/StreamPage/New.jsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useState, useMemo, useRef, useEffect, useReducer } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import styled from 'styled-components'
-import { push } from 'connected-react-router'
 import { useTransition, animated } from 'react-spring'
-import { Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
 
 import { MEDIUM } from '$shared/utils/styled'
 import TOCPage, { Title } from '$shared/components/TOCPage'
@@ -255,6 +254,7 @@ const UnstyledNew = ({ currentUser, ...props }) => {
     const streamDataRef = useRef()
     const contentChangedRef = useRef(false)
     const dispatch = useDispatch()
+    const history = useHistory()
     const { api: confirmExitDialog } = useModal('confirmExit')
     const { load: loadIntegrationKeys, ethereumIdentities } = useEthereumIdentities()
     const [domains, setDomains] = useState([])
@@ -361,21 +361,21 @@ const UnstyledNew = ({ currentUser, ...props }) => {
         if (isMounted() && canProceed) {
             scrollTop()
 
-            dispatch(push(routes.streams.index()))
+            history.push(routes.streams.index())
         }
-    }, [confirmIsSaved, dispatch, isMounted])
+    }, [confirmIsSaved, history, isMounted])
 
     const onDomainChange = useCallback(({ value: domain }) => {
         if (domain === ADD_ENS_DOMAIN) {
             window.open(ADD_DOMAIN_URL, '_blank', 'noopener noreferrer')
         } else if (domain === CONNECT_ETH_ACCOUNT) {
-            dispatch(push(routes.profile({}, {
+            history.push(routes.profile({}, {
                 hash: 'ethereum-accounts',
-            })))
+            }))
         } else {
             updateStream({ domain })
         }
-    }, [dispatch, updateStream])
+    }, [history, updateStream])
 
     const onPathnameChange = useCallback((e) => {
         const pathname = e.target.value
@@ -444,10 +444,10 @@ const UnstyledNew = ({ currentUser, ...props }) => {
             // give time for fadeout animation to happen
             setTimeout(() => {
                 if (isMounted()) {
-                    dispatch(push(routes.streams.show({
+                    history.push(routes.streams.show({
                         id: streamId,
                         newStream: 1,
-                    })))
+                    }))
                 }
             }, 300)
         } catch (e) {
@@ -469,7 +469,7 @@ const UnstyledNew = ({ currentUser, ...props }) => {
                 setLoading(false)
             }
         }
-    }, [dispatch, isMounted])
+    }, [dispatch, isMounted, history])
 
     useEffect(() => {
         streamDataRef.current = {

--- a/app/src/userpages/components/StreamPage/View.jsx
+++ b/app/src/userpages/components/StreamPage/View.jsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 import startCase from 'lodash/startCase'
-import { push } from 'connected-react-router'
-import { useDispatch } from 'react-redux'
+import { useHistory } from 'react-router-dom'
+
 import Layout from '$shared/components/Layout/Core'
 import Label from '$ui/Label'
 import { SM, MEDIUM } from '$shared/utils/styled'
@@ -74,17 +74,17 @@ const UnstyledView = ({ stream, currentUser, ...props }) => {
 
     const { shortDescription, longDescription } = getSecurityLevelConfig(stream)
 
-    const dispatch = useDispatch()
+    const history = useHistory()
 
     const onBack = useCallback(() => {
         scrollTop()
 
         if (currentUser) {
-            dispatch(push(routes.streams.index()))
+            history.push(routes.streams.index())
         } else {
-            dispatch(push(routes.root()))
+            history.push(routes.root())
         }
-    }, [dispatch, currentUser])
+    }, [history, currentUser])
 
     const snippets = useMemo(() => (
         subscribeSnippets({

--- a/app/src/userpages/tests/components/ProfilePage/profilePage.test.jsx
+++ b/app/src/userpages/tests/components/ProfilePage/profilePage.test.jsx
@@ -8,6 +8,16 @@ jest.mock('react-redux', () => ({
     connect: jest.fn().mockImplementation(() => (action) => action),
 }))
 
+jest.mock('react-router-dom', () => ({
+    useHistory: jest.fn().mockImplementation(() => ({
+        push: jest.fn(),
+        replace: jest.fn(),
+    })),
+    useLocation: jest.fn().mockImplementation(() => ({
+        pathname: undefined,
+    })),
+}))
+
 jest.mock('$shared/modules/integrationKey/hooks/usePrivateKeys', () => (
     jest.fn().mockImplementation(() => ({
         fetching: false,


### PR DESCRIPTION
More cleanup, this removes the `connected-react-router` lib. The only redux action where redirects were actually used was the logout action. I moved all redirects to happen at component level. One more dependency gone 🎉 