### PR TITLE
[FRONT-320] Reload DU stats when returning marketplace

### DIFF
--- a/app/src/marketplace/containers/Products/index.jsx
+++ b/app/src/marketplace/containers/Products/index.jsx
@@ -92,8 +92,11 @@ const Products = () => {
 
         if (productsRef.current && productsRef.current.length === 0) {
             clearFiltersAndReloadProducts()
+        } else if (productsRef.current && productsRef.current.length > 0) {
+            // just reload DU stats if product list was cached
+            loadDataUnionStats(productsRef.current.map(({ id }) => id))
         }
-    }, [loadCategories, clearFiltersAndReloadProducts])
+    }, [loadCategories, clearFiltersAndReloadProducts, loadDataUnionStats])
 
     useEffect(() => () => {
         resetStats()


### PR DESCRIPTION
Small fix to improve #1209, reload DU stats when returning to Marketplace (eg. by back button) when the whole product list does not need to be fetched.