### PR TITLE
[FRONT-319] Fix docker build / smoke test

### DIFF
--- a/.ci_scripts/smoke_test.sh
+++ b/.ci_scripts/smoke_test.sh
@@ -2,19 +2,17 @@
 
 set -e
 
+## Get Streamr Docker dev
+git clone --depth 1 https://github.com/streamr-dev/streamr-docker-dev.git "$GITHUB_WORKSPACE/streamr-docker-dev"
+
 ## Script for preparing smoke test
 sudo ifconfig docker0 10.200.10.1/24
 
-## Get Streamr Docker dev
-if [ ! -d "$TRAVIS_BUILD_DIR/streamr-docker-dev" ]; then
-    git clone https://github.com/streamr-dev/streamr-docker-dev.git "$TRAVIS_BUILD_DIR/streamr-docker-dev"
-fi
-
 ## Switch out image for local one
-sed -i "s#$OWNER/$IMAGE_NAME:dev#$OWNER/$IMAGE_NAME:local#g" "$TRAVIS_BUILD_DIR/streamr-docker-dev/docker-compose.override.yml"
+sed -i "s#$OWNER/$IMAGE_NAME:dev#$OWNER/$IMAGE_NAME:local#g" "$GITHUB_WORKSPACE/streamr-docker-dev/docker-compose.yml"
 
 ## Start up services needed
-"$TRAVIS_BUILD_DIR/streamr-docker-dev/streamr-docker-dev/bin.sh" start --wait
+"$GITHUB_WORKSPACE/streamr-docker-dev/streamr-docker-dev/bin.sh" start --wait
 
 ## Wait for the service to come online and test
 wait_time=10;

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [ 14.x ]
 
     # run job only for master and tags
-    # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [ 14.x ]
 
     # run job only for master and tags
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+    # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -28,15 +28,15 @@ jobs:
       - name: Build Docker image
         run: docker build -t $OWNER/$IMAGE_NAME:local .
       - name: Smoke test image
-        run: .ci_scripts/smoke_test.sh
+        run: ../.ci_scripts/smoke_test.sh
       - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push streamr/platform:dev
-        run: .ci_scripts/deploy_docker.sh dev
+        run: ../.ci_scripts/deploy_docker.sh dev
       - name: Push streamr/platform:latest and streamr/platform:${GITHUB_REF/refs\/tags\//}
-        run: .ci_scripts/deploy_docker.sh production ${GITHUB_REF/refs\/tags\//}
+        run: ../.ci_scripts/deploy_docker.sh production ${GITHUB_REF/refs\/tags\//}
         if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'schedule'
     env:
       OWNER: streamr


### PR DESCRIPTION
Seems Docker build has been failing for a while due to these reasons:

- Wrong script path in github action file
- Having an old Travis var reference in it, fixed to work with Github actions
- `docker-compose.override.yml` was removed in `streamr-docker-dev`

Tried it with PR builds and seemed to work, now restored to happen only for tagged and master builds (https://github.com/streamr-dev/streamr-platform/actions/runs/704869393).