### PR TITLE
[FRONT-321] Save the new DU address immediately to product

### DIFF
--- a/app/src/marketplace/containers/EditProductPage/DeployDataUnionModal.jsx
+++ b/app/src/marketplace/containers/EditProductPage/DeployDataUnionModal.jsx
@@ -129,7 +129,9 @@ export const DeployDialog = ({ product, api, updateAddress }: DeployDialogProps)
 
     // Update beneficiary address to product as soon as it changes
     useEffect(() => {
-        updateAddress(address)
+        if (!!address && isEthereumAddress(address)) {
+            updateAddress(address)
+        }
     }, [address, updateAddress])
 
     if (!checkingWeb3 && web3Error) {

--- a/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
+++ b/app/src/marketplace/containers/EditProductPage/EditControllerProvider.jsx
@@ -230,6 +230,12 @@ function useEditController(product: Product) {
         const { beneficiaryAddress } = productRef.current
         if ((!address || isEthereumAddress(address)) && (!beneficiaryAddress || !areAddressesEqual(beneficiaryAddress, address))) {
             updateBeneficiaryAddress(address, false)
+
+            // save the new address immediately to db
+            await putProduct(State.update(productRef.current, () => ({
+                ...productRef.current,
+                beneficiaryAddress: address,
+            })), productRef.current.id || '')
         }
     }, [updateBeneficiaryAddress])
 

--- a/app/src/marketplace/containers/EditProductPage/tests/EditControllerProvider.test.jsx
+++ b/app/src/marketplace/containers/EditProductPage/tests/EditControllerProvider.test.jsx
@@ -1240,7 +1240,7 @@ describe('EditControllerProvider', () => {
 
             expect(currentContext.publishAttempted).toBe(true)
             expect(modalOpenStub).toHaveBeenCalledTimes(1)
-            expect(putProductStub).toHaveBeenCalledTimes(2)
+            expect(putProductStub).toHaveBeenCalledTimes(3)
             expect(putProductStub).toBeCalledWith(expectedProduct, product.id)
             expect(putProductStub).toBeCalledWith({
                 ...expectedProduct,


### PR DESCRIPTION
Fixes a bug when creating a Data Union, the beneficiary is only actually saved when dialog is closed. If the transaction runs long and user exits the page, DU contract address was not saved as the product's beneficiary address.

**To test**

1. Create DU product, fill fields
2. Click Continue to deploy
3. Accept transaction
4. Before transaction completes, refresh page

Product list should status as "Deployed".